### PR TITLE
Agent: add new `chat/restore` endpoint

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -5,7 +5,7 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 8a049c80771d508a499a55e49d24b525
+    - _id: fcca5fb83a32d07929e4efe13707abcd
       _order: 0
       cache: {}
       request:
@@ -31,7 +31,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "1273"
+            value: "1228"
           - name: host
             value: sourcegraph.com
         headersSize: 0
@@ -73,12 +73,6 @@ log:
                   ```
               - speaker: assistant
                 text: "<CODE5711>export function sum(a: number, b: number): number {"
-            stopSequences:
-              - |-
-                
-
-                Human:
-              - </CODE5711>
             stream: true
             temperature: 0.5
             timeoutMs: 15000
@@ -88,7 +82,7 @@ log:
       response:
         content:
           mimeType: text/event-stream
-          size: 619
+          size: 1023
           text: >+
             event: completion
 
@@ -122,12 +116,32 @@ log:
 
             event: completion
 
-            data: {"completion":"\n  return a + b;\n}","stopReason":""}
+            data: {"completion":"\n  return a + b;\n}\u003c/","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n  return a + b;\n}","stopReason":"stop_sequence"}
+            data: {"completion":"\n  return a + b;\n}\u003c/CODE","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n  return a + b;\n}\u003c/CODE57","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n  return a + b;\n}\u003c/CODE5711","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n  return a + b;\n}\u003c/CODE5711\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n  return a + b;\n}\u003c/CODE5711\u003e","stopReason":"stop_sequence"}
 
 
             event: done
@@ -217,71 +231,296 @@ log:
       response:
         content:
           mimeType: text/event-stream
-          size: 1187
+          size: 232
+          text: |+
+            event: completion
+            data: {"completion":" Hello","stopReason":""}
+
+            event: completion
+            data: {"completion":" Hello!","stopReason":""}
+
+            event: completion
+            data: {"completion":" Hello!","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: fece36b889d50c30ff71490dd58a3123
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: My name is Lars Monsen
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 637
           text: >+
             event: completion
 
-            data: {"completion":" Hello","stopReason":""}
+            data: {"completion":" Nice","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there","stopReason":""}
+            data: {"completion":" Nice to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there!","stopReason":""}
+            data: {"completion":" Nice to meet","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How","stopReason":""}
+            data: {"completion":" Nice to meet you","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can","stopReason":""}
+            data: {"completion":" Nice to meet you L","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can I","stopReason":""}
+            data: {"completion":" Nice to meet you Lars","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can I help","stopReason":""}
+            data: {"completion":" Nice to meet you Lars!","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can I help you","stopReason":""}
+            data: {"completion":" Nice to meet you Lars!","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 709610ab90fe7a9b084d94f0d9d1cf49
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: My name is Lars Monsen
+              - speaker: assistant
+                text: " Nice to meet you Lars!"
+              - speaker: human
+                text: What is my name?
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 1036
+          text: >+
+            event: completion
+
+            data: {"completion":" You","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can I help you with","stopReason":""}
+            data: {"completion":" You told","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can I help you with coding","stopReason":""}
+            data: {"completion":" You told me","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can I help you with coding today","stopReason":""}
+            data: {"completion":" You told me your","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can I help you with coding today?","stopReason":""}
+            data: {"completion":" You told me your name","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Hello there! How can I help you with coding today?","stopReason":"stop_sequence"}
+            data: {"completion":" You told me your name is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" You told me your name is L","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" You told me your name is Lars","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" You told me your name is Lars Mon","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" You told me your name is Lars Monsen","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" You told me your name is Lars Monsen.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" You told me your name is Lars Monsen.","stopReason":"stop_sequence"}
 
 
             event: done
@@ -371,7 +610,7 @@ log:
       response:
         content:
           mimeType: text/event-stream
-          size: 47761
+          size: 59837
           text: >+
             event: completion
 
@@ -405,647 +644,722 @@ log:
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n ","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[]","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[]","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args)","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args)","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n   ","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n   ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\");","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\");","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n ","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method,","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main,","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method,","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The print","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with:","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `jav","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: jav","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java`","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` ","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with:","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\"","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console when","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console when executed","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console when executed.","stopReason":""}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is a simple Hello World function in Java:\n\n```java\npublic class Main {\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n}\n```\n\nThis defines a Main class with a main method, which is the entry point for a Java program. Inside the main method, it prints \"Hello World!\" to the console using System.out.println.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with `javac Main.java` \n3. Run it with `java Main`\n\nThis will print \"Hello World!\" to the console when executed.","stopReason":"stop_sequence"}
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clar","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have additional","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have additional requirements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have additional requirements for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have additional requirements for the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have additional requirements for the Java","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have additional requirements for the Java program","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have additional requirements for the Java program!","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is a simple Hello World program in Java:\n\n```java\npublic class Main {\n\n  public static void main(String[] args) {\n    System.out.println(\"Hello World!\"); \n  }\n\n}\n```\n\nThis program prints \"Hello World!\" to the console when run. It contains a main method inside a class called Main, as all Java programs require. The println statement prints the text to the console.\n\nTo run this:\n\n1. Save the code in a file called Main.java\n2. Compile it with: javac Main.java\n3. Run it with: java Main\n\nThe \"Hello World!\" text will be printed to the console.\n\nLet me know if you need any clarification or have additional requirements for the Java program!","stopReason":"stop_sequence"}
 
 
             event: done
@@ -1062,8 +1376,6 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2084,8 +2396,6 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2160,7 +2470,7 @@ log:
       response:
         content:
           mimeType: text/event-stream
-          size: 15726
+          size: 15742
           text: >+
             event: completion
 
@@ -2399,112 +2709,112 @@ log:
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n ","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move()","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move()","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n   ","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n   ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The dog","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The dog runs","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The dog runs\");","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n ","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The dog runs\");\n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n  }","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The dog runs\");\n  }","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n  }\n\n}","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The dog runs\");\n  }\n\n}","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n  }\n\n}\n```","stopReason":""}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The dog runs\");\n  }\n\n}\n```","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override\n  public void move() {\n    System.out.println(\"The dog runs.\");\n  }\n\n}\n```","stopReason":"stop_sequence"}
+            data: {"completion":" Here is the code for the Dog class implementing the Animal interface:\n\n```java\npublic class Dog implements Animal {\n\n  @Override\n  public void makeSound() {\n    System.out.println(\"Woof!\"); \n  }\n\n  @Override \n  public void move() {\n    System.out.println(\"The dog runs\");\n  }\n\n}\n```","stopReason":"stop_sequence"}
 
 
             event: done
@@ -2521,8 +2831,6 @@ log:
             value: chunked
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -2724,13 +3032,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 128
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA=="]'
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  provider: sourcegraph
+          size: 131
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmV","Pj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -3082,7 +3385,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f183d7475b363dc45d23134c3118a915
+    - _id: 7e2cae0c3275084cb257ee48fead6fb9
       _order: 0
       cache: {}
       request:
@@ -3102,7 +3405,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "180"
+            value: "187"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -3124,7 +3427,7 @@ log:
                       evaluateFeatureFlag(flagName: $flagName)
                   }
             variables:
-              flagName: cody-autocomplete-hot-streak
+              flagName: cody-autocomplete-context-bfg-mixed
         queryString:
           - name: EvaluateFeatureFlag
             value: null
@@ -3176,7 +3479,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7e2cae0c3275084cb257ee48fead6fb9
+    - _id: 439739878f840e0513a8e492c2f6d215
       _order: 0
       cache: {}
       request:
@@ -3196,7 +3499,7 @@ log:
             value: "*/*"
           - _fromType: array
             name: content-length
-            value: "187"
+            value: "192"
           - _fromType: array
             name: accept-encoding
             value: gzip,deflate
@@ -3218,7 +3521,7 @@ log:
                       evaluateFeatureFlag(flagName: $flagName)
                   }
             variables:
-              flagName: cody-autocomplete-context-bfg-mixed
+              flagName: cody-autocomplete-new-jaccard-similarity
         queryString:
           - name: EvaluateFeatureFlag
             value: null
@@ -3226,8 +3529,8 @@ log:
       response:
         content:
           mimeType: application/json
-          size: 38
-          text: '{"data":{"evaluateFeatureFlag":false}}'
+          size: 37
+          text: '{"data":{"evaluateFeatureFlag":null}}'
         cookies: []
         headers:
           - name: date
@@ -3235,7 +3538,7 @@ log:
           - name: content-type
             value: application/json
           - name: content-length
-            value: "38"
+            value: "37"
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -3320,8 +3623,8 @@ log:
       response:
         content:
           mimeType: application/json
-          size: 38
-          text: '{"data":{"evaluateFeatureFlag":false}}'
+          size: 37
+          text: '{"data":{"evaluateFeatureFlag":true}}'
         cookies: []
         headers:
           - name: date
@@ -3329,7 +3632,101 @@ log:
           - name: content-type
             value: application/json
           - name: content-length
-            value: "38"
+            value: "37"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: f183d7475b363dc45d23134c3118a915
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "180"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |2
+              
+                  query EvaluateFeatureFlag($flagName: String!) {
+                      evaluateFeatureFlag(flagName: $flagName)
+                  }
+            variables:
+              flagName: cody-autocomplete-hot-streak
+        queryString:
+          - name: EvaluateFeatureFlag
+            value: null
+        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
+      response:
+        content:
+          mimeType: application/json
+          size: 37
+          text: '{"data":{"evaluateFeatureFlag":true}}'
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "37"
           - name: connection
             value: close
           - name: access-control-allow-credentials
@@ -3511,8 +3908,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 815
-          text: '["H4sIAAAAAAAA/5RVW3LcOAy8i76DC/gAucTWfoA=","ZI+EHYpUAHBmtC7ffYvyVCr2RpLzpyo2H93obr0OiZ2Hl9cBN86NHek72Jvie+bRhpe/XofCM4aXYdQlDt+GDsPw4trw9u3nooE1TlTvBWqTLLvAWNNKi9ZjADevsc5LhoMyl7Hx2D8cJa7HW+8IhCRelRRRFtgu3pExw3UlPJaq/gdvSmvhWSLNLbtkKaDnktTyy4UXzvbrQXVBiTVhVF6m3etCroGWztju4nEiVrCRTVU9Nt8ntL0zTuw013glh+1zek5MytK8H32nScyrnsj7QYVYi+PhFC4jzfJA2mduMpa2kDW9YSUUDvkIzjHCTEIGXSSDXIHzuXPOZ3ynNaikXRSnWQpx4by6RPv/Qz/hfzSJVzJndfLalC5Vu0YTikvscaJm0ANLdA2Vzd8NJFycbC3OD5pknLKMk0sZ9/ejvF9BtYTKmj6ATyfoyvHw+N9YX6xr0tO1xixlpHqhRXGT2owUPxrMDwm/NwD9Aw/KUvb9/JyZcrme0To3R8/F2U0JoR2I8UQV3OmK9V71wMGL1tSik7VgUWXZmoEUnKBk0JtEEMdYW/H9U5R7AcosboRHBBLS5rGe7cPB9bqmfyuu+6Q/mz1ynH7O94DaJikeC1RmFOf90P3GPbhwy75FpjehPhNJVpvGz8X4NVG/rObXn3NuJ5OEwHrmqK0ii1NgQ9p+ZZTgiP3lB/UX6Ca2/cS2VrmLT1SqI9R63c/Le1uRuYLnnsxRnELuix+3/P329l8AAAD//3p5sfn6BwAA"]'
+          size: 711
+          text: '["H4sIAAAAAAA=","AP+MlFFy2zAMRO+i7+ACPkAu0ekHSK5F1BSpAqAdN5O7d+Rk0iYN5X5zAZIPi32eEjtPh+cJZy6dHekR7F3xWHi26fDteaq8YDpMsaUrrdroBzwoS7XpYdqKMB1cO14e3qUcI8wkFNBRCsgVGIqVHVRkETfCUwQSEh2bksNc6vyn8MjF/q6cdY3DtiZz7StZ1zOuhMqhII17oSbqBqVWQ2NNHy7+1Hq7l341nHwo2WDtHm4kh4JQWqCVZ5BdxGMmVrCR5aYeu4/BtxU1toRZec1D1aot9ehkPVhUWV1aNVJwgpJBzxJBHGPr1cfEbr/g7i22ZS1wUMKRe3EyZ91eoZSvQSXtg8DTCpUF1bnsKy8IxGUsMrDGTAmh77iGA53FxDeHta50Ec9UmyO0dhqjfWsude2+TeJCWcybjsf8Neb/5vt2YcWFTrhemu649x2PSUJgvc8R6UZAEWXFzianRSpx5XJ1iUaRYwYlsTvrFFt1ZXO6mUO4Otm1Oj9RljkXmfP+ar99/o5/Pr/uny3/6vcxs9PS4ukWMPfmrVxPe1nwDnRrO1Q5Cha43tzedCz82SWebgvkr+7cgpC7Z1SXuMXzLaXsLrltAKhOgQ2JCteZEhxxM+Hd4napUMuyDt/5SprMFbxInWkWp1C2w11SH/LCleMXLvj+8vI7AAD//zCSuUqXBgAA"]'
         cookies: []
         headers:
           - name: date
@@ -4064,8 +4461,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 122
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 112
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
         cookies: []
         headers:
           - name: date
@@ -4173,8 +4575,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 122
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 112
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
         cookies: []
         headers:
           - name: date
@@ -4282,8 +4689,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 115
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          size: 112
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
         cookies: []
         headers:
           - name: date
@@ -4391,8 +4803,13 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 122
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 112
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
         cookies: []
         headers:
           - name: date
@@ -4609,13 +5026,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 112
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
-          textDecoded:
-            data:
-              telemetry:
-                recordEvents:
-                  alwaysNil: null
+          size: 115
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
         cookies: []
         headers:
           - name: date
@@ -4626,8 +5038,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -4820,8 +5230,12 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 123
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q","BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA=="]'
+          size: 120
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VamtrAQAAAP//AwDHAhygPQAAAA=="]'
+          textDecoded:
+            data:
+              repository:
+                id: UmVwb3NpdG9yeTo2MTMyNTMyOA==
         cookies: []
         headers:
           - name: date
@@ -4923,15 +5337,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 212
-          text: '["H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaRwfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA"]'
-          textDecoded:
-            data:
-              site:
-                productSubscription:
-                  license:
-                    hashedKey: bd8965b2eef3a61b4e05647a401026066c88116c8594a0c10b09cfb38b9e1669
-                siteID: SourcegraphWeb
+          size: 215
+          text: '["H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52aGFcrbMLoaR","wfnuekgTA6QtgyG+u8HEf/mn74BIlaA/oKSq/99v0MO47ln0mWmbH8pwgS2vcZc67lwkp62mdTnBK4ku5WdnKrPGQd/QA0cfsONGdWoJLTs1HborOWNNgwZRvLcWxXfBkRFr2ASZuPUc1CIG+Jx9AQAA//8DAGHOuFqgAAAA"]'
         cookies: []
         headers:
           - name: date
@@ -5029,7 +5436,7 @@ log:
           encoding: base64
           mimeType: application/json
           size: 139
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp","pcklYalFxZn5eUpWSkam5qZGFvFGBkYmugaGuoaG8aZ6RroGlgZmxmmplpYpRqlKtbW1AAAAAP//AwDzjpyXSQAAAA=="]'
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkp","pcklYalFxZn5eUpWSkam5mbmJvFGBkYmugaGuoZG8aZ6Rrpp5ikWackGaYmGiYlKtbW1AAAAAP//AwCdi4Q5SQAAAA=="]'
         cookies: []
         headers:
           - name: date

--- a/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
+++ b/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
@@ -57,14 +57,14 @@ log:
             value: "0"
           - name: connection
             value: keep-alive
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
             value: ""
           - name: cache-control
             value: no-cache, max-age=0
+          - name: retry-after
+            value: "0"
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
           - name: vary
@@ -158,8 +158,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 219
-          text: '["H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UFjiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//w==","AwCpmMLNBAEAAA=="]'
+          size: 215
+          text: '["H4sIAAAAAAAAA4zOsQqDMBDG8Xe5WW10a1ZXs/UF","jiTW0PROzAktkncvulgylE4HH39+3AYOBUFvkIL4/Vp272EwPdMY7uuCEpiOfUIx7HwEDUgyLTwHe7ERV+frrlFQnYnB140fnhLotlNKVTBikv6XECgJktQtFPGXdT0oy885+v2tv7AiL7icc/4AAAD//wMAqZjCzQQBAAA="]'
         cookies: []
         headers:
           - name: date
@@ -170,8 +170,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -261,7 +259,7 @@ log:
           encoding: base64
           mimeType: application/json
           size: 131
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//","AwAfFAXARQAAAA=="]'
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmV","Pj6+zvl5aZnppUWJJZn5eSDxgqL8ssyU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -272,8 +270,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -367,8 +363,18 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 347
-          text: '["H4sIAAAAAAAAA2yOzUrDQBSF3+Wu84PYljhQMGgXBYmoTdBVuZ25JlNnMunMZLAJeRifxReT0C7dnR8O5xtBoEdgI/DeWmp96cjOVgpgUL0Xih/N9/OuvCkGvoYIGnQVWfkpSWw0SgXM254iENJ1Cs8FagIGj78/QQqIoHdk20smMEiRBHIDKRPc8CUhAgzo0ZavT8Cg8b5zLE1Vc5vUxtSK5jU3rafWJ9zoFNP8oc4M3+aL2OxV1p3iPj7mzZvamuViZ18qn1Ur+jgM4aT7uNkf1u5uFXOIoLNSoz1fmUegi/iH6r6eq/kPpmma/gAAAP//","AwAWfOcnIgEAAA=="]'
+          size: 344
+          text: '["H4sIAAAAAAAAA2yOzUrDQBSF3+Wu84PYljhQMGgXBYmoTdBVuZ25JlNnMunMZLAJeRifxReT0C7dnR8O5xtBoEdgI/DeWmp96cjOVgpgUL0Xih/N9/OuvCkGvoYIGnQVWfkpSWw0SgXM254iENJ1Cs8FagIGj78/QQqIoHdk20smMEiRBHIDKRPc8CUhAgzo0ZavT8Cg8b5zLE1Vc5vUxtSK5jU3rafWJ9zoFNP8oc4M3+aL2OxV1p3iPj7mzZvamuViZ18qn1Ur+jgM4aT7uNkf1u5uFXOIoLNSoz1fmUegi/iH6r6eq/kPpmma/gAAAP//AwAWfOcnIgEAAA=="]'
+          textDecoded:
+            data:
+              currentUser:
+                avatarURL: https://lh3.googleusercontent.com/a/ACg8ocIA4-o_l8pq-u-jAhSlIo54TrQVt8V6eYbzvqmu-h_b=s96-c
+                displayName: Dávid
+                hasVerifiedEmail: true
+                id: VXNlcjoxOTU1Nzc=
+                primaryEmail:
+                  email: david.veszelovszki@gmail.com
+                username: david.veszelovszki
         cookies: []
         headers:
           - name: date
@@ -379,8 +385,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -467,12 +471,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 100
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1OLQJz81MqA4ryXfMSk3JSU5SsSopKU2trawEAAAD//wMAqqwCpjAAAAA="]'
-          textDecoded:
-            data:
-              currentUser:
-                codyProEnabled: true
+          size: 110
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlZKLi0qSs0rCS1O","LQJz81MqA4ryXfMSk3JSU5SsSopKU2trawEAAAD//w==","AwCqrAKmMAAAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -483,8 +483,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -581,8 +579,288 @@ log:
             value: "38"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 7e2cae0c3275084cb257ee48fead6fb9
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: rateLimitedClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "187"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |2
+              
+                  query EvaluateFeatureFlag($flagName: String!) {
+                      evaluateFeatureFlag(flagName: $flagName)
+                  }
+            variables:
+              flagName: cody-autocomplete-context-bfg-mixed
+        queryString:
+          - name: EvaluateFeatureFlag
+            value: null
+        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
+      response:
+        content:
+          mimeType: application/json
+          size: 37
+          text: '{"data":{"evaluateFeatureFlag":null}}'
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "37"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 439739878f840e0513a8e492c2f6d215
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: rateLimitedClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "192"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |2
+              
+                  query EvaluateFeatureFlag($flagName: String!) {
+                      evaluateFeatureFlag(flagName: $flagName)
+                  }
+            variables:
+              flagName: cody-autocomplete-new-jaccard-similarity
+        queryString:
+          - name: EvaluateFeatureFlag
+            value: null
+        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
+      response:
+        content:
+          mimeType: application/json
+          size: 37
+          text: '{"data":{"evaluateFeatureFlag":null}}'
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "37"
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 2bbf280183fdae3c39a73013105339ae
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: rateLimitedClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "199"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |2
+              
+                  query EvaluateFeatureFlag($flagName: String!) {
+                      evaluateFeatureFlag(flagName: $flagName)
+                  }
+            variables:
+              flagName: cody-autocomplete-dynamic-multiline-completions
+        queryString:
+          - name: EvaluateFeatureFlag
+            value: null
+        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
+      response:
+        content:
+          mimeType: application/json
+          size: 37
+          text: '{"data":{"evaluateFeatureFlag":true}}'
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "37"
+          - name: connection
+            value: close
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -666,7 +944,7 @@ log:
         content:
           mimeType: application/json
           size: 37
-          text: '{"data":{"evaluateFeatureFlag":null}}'
+          text: '{"data":{"evaluateFeatureFlag":true}}'
         cookies: []
         headers:
           - name: date
@@ -677,200 +955,6 @@ log:
             value: "37"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 7e2cae0c3275084cb257ee48fead6fb9
-      _order: 0
-      cache: {}
-      request:
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token REDACTED
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: rateLimitedClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "187"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-autocomplete-context-bfg-mixed
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        content:
-          mimeType: application/json
-          size: 38
-          text: '{"data":{"evaluateFeatureFlag":false}}'
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 05 Jan 2024 11:11:11 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: close
-          - name: retry-after
-            value: "0"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 2bbf280183fdae3c39a73013105339ae
-      _order: 0
-      cache: {}
-      request:
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token REDACTED
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: rateLimitedClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "199"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-        headersSize: 0
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |2
-              
-                  query EvaluateFeatureFlag($flagName: String!) {
-                      evaluateFeatureFlag(flagName: $flagName)
-                  }
-            variables:
-              flagName: cody-autocomplete-dynamic-multiline-completions
-        queryString:
-          - name: EvaluateFeatureFlag
-            value: null
-        url: https://sourcegraph.com/.api/graphql?EvaluateFeatureFlag
-      response:
-        content:
-          mimeType: application/json
-          size: 38
-          text: '{"data":{"evaluateFeatureFlag":false}}'
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 05 Jan 2024 11:11:11 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -956,41 +1040,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 452
-          text: '["H4sIAAAAAAAAA6ySQW7jMAxF76J1eYEcoJcouqClb4mtLHlIKrER5O5FZwq0QZFkM2t+PvLz8xwSO4fDOeDIdbAjPYN9KJ4rZwuHl3NovCAcQuxpJx7eY1/WCgelvfEikZZRXao00FdJerPwFD6JCIeZq+HydA1atX8rXMdPgbKDqiziRtgikJBo7koOc2n5ZqOBNRZqONE79lPX9GCLWNhp6fH9L/qB+Mp77M2xOU1zpkU23Jk01T7RyhlkJ/FYiBVsZKWrx+F3LmWS21jJhh6xExpPFXctNVc2/xeDcHOyvTlvVCSXKrlcX++xy4SZR3UyZ409Qansk0q6mcBvhCvH/zSVrA+NyMpruc1zVCxw3Qnb2tXv77pqpzf4pCw/f/ahrST2mQYp4h6rtEx9plVxlD6MFH8G7He0r5fLBwAAAP//AwBVv5cKcgMAAA=="]'
-          textDecoded:
-            data:
-              evaluatedFeatureFlags:
-                - name: cody-autocomplete-dynamic-multiline-completions
-                  value: false
-                - name: cody-pro
-                  value: true
-                - name: rate-limits-exceeded-for-testing
-                  value: true
-                - name: search-new-keyword
-                  value: false
-                - name: cody-chat-mock-test
-                  value: false
-                - name: cody-autocomplete-context-bfg-mixed
-                  value: false
-                - name: blob-page-switch-areas-shortcuts
-                  value: false
-                - name: signup-survey-enabled
-                  value: false
-                - name: contrast-compliant-syntax-highlighting
-                  value: false
-                - name: cody-autocomplete-default-starcoder-hybrid
-                  value: true
-                - name: cody-autocomplete-tracing
-                  value: false
-                - name: cody-autocomplete-default-starcoder-hybrid-sourcegraph
-                  value: false
-                - name: telemetry-export
-                  value: true
-                - name: cody-pro-jetbrains
-                  value: true
-                - name: cody-autocomplete-disable-recycling-of-previous-requests
-                  value: false
+          size: 382
+          text: '["H4sIAAAAAAAAA4yRO3LDMAxE78LaKNKk0AF8CU8=","Cohci4wpUgOAtjUe3T0TFUk8iez07+Gze3OBjV13czhzbmwIe7A1wT7zoK473FzhEa5zhowRJjPhOlUxt3OfClxn0rDsvkBfw0yT1AdAMWE18nWccuJipHMxvlJMQ8xpiJbK8K0fOetPX8HiIxVc6IT5UiVss32uPU08gPSSzEdiAStprGK+mW6b6xs+stFY/YkMatuwsIFyGpMp4eqBgEDHKqt298xfYXGzumYBAwUcuWUjNRZfA4ReXvsnZ94NMGH/ML//7IxzLyk87ZjeYb1wKrqJahpKm0ibnDETCvcZvwp7W5YPAAAA//8=","AwCiqgRMiwIAAA=="]'
         cookies: []
         headers:
           - name: date
@@ -1001,8 +1052,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1116,8 +1165,6 @@ log:
             value: "26"
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1230,8 +1277,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1329,8 +1374,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 119
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+          size: 115
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
         cookies: []
         headers:
           - name: date
@@ -1341,8 +1386,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1431,8 +1474,8 @@ log:
         content:
           encoding: base64
           mimeType: application/json
-          size: 155
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+qBPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8=","AwD/h5WCVAAAAA=="]'
+          size: 151
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSi3IL84syS+q","BPEyU5SslEJzw8qTjP0KUtwtK1ND8o18Q3wr/UJ8K/0dbW2VdJRSc5NSU1Iy89JdKzKLS4qVrEqKSlNra2sBAAAA//8DAP+HlYJUAAAA"]'
         cookies: []
         headers:
           - name: date
@@ -1443,8 +1486,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1548,8 +1589,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1660,8 +1699,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1749,11 +1786,11 @@ log:
           encoding: base64
           mimeType: application/json
           size: 136
-          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkam5qZGFvFGBkYmugaGuoaG8aZ6RroGlgZmxmmplpYpRqlKtbW1AAAAAP//AwDzjpyXSQAAAA=="]'
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkam5mbmJvFGBkYmugaGuoZG8aZ6Rrpp5ikWackGaYmGiYlKtbW1AAAAAP//AwCdi4Q5SQAAAA=="]'
           textDecoded:
             data:
               site:
-                productVersion: 257528_2024-01-11_5.2-09063fe99d2e
+                productVersion: 257674_2024-01-12_5.2-f7d8fc0fa1aa
         cookies: []
         headers:
           - name: date
@@ -1764,8 +1801,6 @@ log:
             value: chunked
           - name: connection
             value: close
-          - name: retry-after
-            value: "0"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin

--- a/agent/src/AgentGlobalState.ts
+++ b/agent/src/AgentGlobalState.ts
@@ -1,0 +1,45 @@
+import type * as vscode from 'vscode'
+
+import { localStorage } from '../../vscode/src/services/LocalStorageProvider'
+
+import * as vscode_shim from './vscode-shim'
+
+/**
+ * Implementation of `vscode.ExtensionContext.globalState` with a JSON file
+ * that's persisted to disk.
+ */
+export class AgentGlobalState implements vscode.Memento {
+    private globalStorage = new Map<string, any>()
+
+    constructor() {
+        // Disable the feature that opens a webview when the user accepts their first
+        // autocomplete request.  Removing this line should fail the agent integration
+        // tests with the following error message "chat/new: command finished executing
+        // without creating a webview" because we reuse the webview when sending
+        // chat/new.
+        this.globalStorage.set('completion.inline.hasAcceptedFirstCompletion', true)
+    }
+
+    public keys(): readonly string[] {
+        return [localStorage.LAST_USED_ENDPOINT, localStorage.ANONYMOUS_USER_ID_KEY, ...this.globalStorage.keys()]
+    }
+
+    public get<T>(key: string, defaultValue?: unknown): any {
+        switch (key) {
+            case localStorage.ANONYMOUS_USER_ID_KEY:
+                return vscode_shim.extensionConfiguration?.anonymousUserID
+            case localStorage.LAST_USED_ENDPOINT:
+                return vscode_shim.extensionConfiguration?.serverEndpoint
+            default:
+                return this.globalStorage.get(key) ?? defaultValue
+        }
+    }
+
+    public async update(key: string, value: any): Promise<void> {
+        this.globalStorage.set(key, value)
+    }
+
+    public setKeysForSync(): void {
+        // Not used (yet) by the Cody extension
+    }
+}

--- a/agent/src/AgentGlobalState.ts
+++ b/agent/src/AgentGlobalState.ts
@@ -35,8 +35,9 @@ export class AgentGlobalState implements vscode.Memento {
         }
     }
 
-    public async update(key: string, value: any): Promise<void> {
+    public update(key: string, value: any): Promise<void> {
         this.globalStorage.set(key, value)
+        return Promise.resolve()
     }
 
     public setKeysForSync(): void {

--- a/agent/src/AgentWebviewPanel.ts
+++ b/agent/src/AgentWebviewPanel.ts
@@ -1,15 +1,24 @@
 import * as uuid from 'uuid'
 import type * as vscode from 'vscode'
 
+import { ChatModelProvider } from '@sourcegraph/cody-shared'
+
 import { type ExtensionMessage, type WebviewMessage } from '../../vscode/src/chat/protocol'
 
 import { defaultWebviewPanel, EventEmitter } from './vscode-shim'
 
 /** Utility class to manage a list of `AgentWebPanel` instances. */
 export class AgentWebPanels {
-    public panels = new Map<string, AgentWebPanel>()
-    public add(panel: AgentWebPanel): void {
+    public panels = new Map<string, AgentWebviewPanel>()
+    public add(panel: AgentWebviewPanel): void {
         this.panels.set(panel.panelID, panel)
+    }
+    public getPanelOrError(id: string): AgentWebviewPanel {
+        const result = this.panels.get(id)
+        if (!result) {
+            throw new Error('No panel with ID' + id)
+        }
+        return result
     }
 }
 
@@ -18,9 +27,11 @@ export class AgentWebPanels {
  * delegate the implementation to the remote JSON-RPC client via the custom
  * `receiveMessage` and `postMessage` event emitters.
  */
-export class AgentWebPanel implements vscode.WebviewPanel {
+export class AgentWebviewPanel implements vscode.WebviewPanel {
     public panelID = uuid.v4()
-    public chatID: string | undefined
+    public chatID: string | undefined // also known as `sessionID` in some parts of the Cody codebase
+    public models: ChatModelProvider[] | undefined
+    public isInitialized = false
     public isMessageInProgress: undefined | boolean
     // Event that fires whenever the `isMessageInProgress` value changes from the `type: 'transcript'` message.
     public messageInProgressChange = new EventEmitter<ExtensionMessage>()
@@ -43,6 +54,14 @@ export class AgentWebPanel implements vscode.WebviewPanel {
             onDidReceiveMessage: this.receiveMessage,
             onDidPostMessage: this.postMessage,
         })
+    }
+
+    public initialize(): void {
+        if (!this.isInitialized) {
+            this.receiveMessage.fire({ command: 'ready' })
+            this.receiveMessage.fire({ command: 'initialized' })
+            this.isInitialized = true
+        }
     }
 
     public get viewType(): string {

--- a/agent/src/AgentWebviewPanel.ts
+++ b/agent/src/AgentWebviewPanel.ts
@@ -1,7 +1,7 @@
 import * as uuid from 'uuid'
 import type * as vscode from 'vscode'
 
-import { ChatModelProvider } from '@sourcegraph/cody-shared'
+import { type ChatModelProvider } from '@sourcegraph/cody-shared'
 
 import { type ExtensionMessage, type WebviewMessage } from '../../vscode/src/chat/protocol'
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -17,30 +17,30 @@ import { NoOpTelemetryRecorderProvider } from '@sourcegraph/cody-shared/src/tele
 import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared/src/utils'
 import { type TelemetryEventParameters } from '@sourcegraph/telemetry'
 
-import { type ExtensionMessage, type WebviewMessage } from '../../vscode/src/chat/protocol'
+import { chatHistory } from '../../vscode/src/chat/chat-view/ChatHistoryManager'
+import { SimpleChatModel } from '../../vscode/src/chat/chat-view/SimpleChatModel'
+import { ChatSession } from '../../vscode/src/chat/chat-view/SimpleChatPanelProvider'
+import { AuthStatus, type ExtensionMessage, type WebviewMessage } from '../../vscode/src/chat/protocol'
 import { activate } from '../../vscode/src/extension.node'
 import { TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
-import { localStorage } from '../../vscode/src/services/LocalStorageProvider'
 
+import { AgentGlobalState } from './AgentGlobalState'
 import { newTextEditor } from './AgentTextEditor'
-import { AgentWebPanel, AgentWebPanels } from './AgentWebPanel'
+import { AgentWebPanels, AgentWebviewPanel } from './AgentWebviewPanel'
 import { AgentWorkspaceDocuments } from './AgentWorkspaceDocuments'
 import { AgentEditor } from './editor'
 import { MessageHandler } from './jsonrpc-alias'
-import { type AutocompleteItem, type ClientInfo, type ExtensionConfiguration, type RecipeInfo } from './protocol-alias'
+import {
+    ClientCapabilities,
+    type AutocompleteItem,
+    type ClientInfo,
+    type ExtensionConfiguration,
+    type RecipeInfo,
+} from './protocol-alias'
 import { AgentHandlerTelemetryRecorderProvider } from './telemetry'
 import * as vscode_shim from './vscode-shim'
 
 const secretStorage = new Map<string, string>()
-
-const globalStorage = new Map<string, any>()
-
-// Disable the feature that opens a webview when the user accepts their first
-// autocomplete request.  Removing this line should fail the agent integration
-// tests with the following error message "chat/new: command finished executing
-// without creating a webview" because we reuse the webview when sending
-// chat/new.
-globalStorage.set('completion.inline.hasAcceptedFirstCompletion', true)
 
 export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Promise<void> {
     const paths = envPaths('Cody')
@@ -63,24 +63,7 @@ export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Prom
         // types but don't have to point to a meaningful path/URI.
         extensionPath: paths.config,
         extensionUri: vscode.Uri.file(paths.config),
-        globalState: {
-            keys: () => [localStorage.ANONYMOUS_USER_ID_KEY, ...globalStorage.keys()],
-            get: key => {
-                switch (key) {
-                    case localStorage.ANONYMOUS_USER_ID_KEY:
-                        return vscode_shim.extensionConfiguration?.anonymousUserID
-                    case localStorage.LAST_USED_ENDPOINT:
-                        return vscode_shim.extensionConfiguration?.serverEndpoint
-                    default:
-                        return globalStorage.get(key)
-                }
-            },
-            update: (key, value) => {
-                globalStorage.set(key, value)
-                return Promise.resolve()
-            },
-            setKeysForSync: () => {},
-        },
+        globalState: new AgentGlobalState(),
         logUri: vscode.Uri.file(paths.log),
         logPath: paths.log,
         secrets: {
@@ -173,8 +156,6 @@ export class Agent extends MessageHandler {
                 ),
         },
     ])
-
-    private resolveChatPanelId: ((chatPanelId: string) => void) | null = null
 
     constructor(private readonly params?: { polly?: Polly | undefined }) {
         super()
@@ -583,47 +564,40 @@ export class Agent extends MessageHandler {
             return Promise.resolve(null)
         })
 
-        this.registerRequest('chat/new', async () => {
-            const id = await new Promise<string>((resolve, reject) => {
-                // HACK: when triggering this command, Cody creates a webview under the hood and there's
-                // no clean way for us (yet) to pair the webview with this command invocation.
-                // To work around this limitation, we hijack the `webview/create` handler to capture
-                // the webview that's created from executing this command.
-                this.resolveChatPanelId = resolve
+        this.registerRequest('chat/new', () => {
+            return this.createChatPanel(vscode.commands.executeCommand('cody.chat.panel.new'))
+        })
 
-                vscode.commands.executeCommand('cody.chat.panel.new').then(
-                    () => reject(new Error('chat/new: command finished executing without creating a webview')),
-                    error => reject(error)
-                )
+        this.registerRequest('chat/restore', async ({ modelID, messages, chatID }) => {
+            const chatModel = new SimpleChatModel(modelID, [], chatID, undefined)
+            for (const message of messages) {
+                if (message.error) {
+                    chatModel.addErrorAsBotMessage(message.error)
+                } else if (message.speaker === 'assistant') {
+                    chatModel.addBotMessage(message)
+                } else if (message.speaker === 'human') {
+                    chatModel.addHumanMessage(message)
+                }
+            }
+            const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
+            chatHistory.saveChat(authStatus, chatModel.toTranscriptJSON())
+            return this.createChatPanel(vscode.commands.executeCommand('cody.chat.panel.restore', [chatID]))
+        })
 
-                setTimeout(() => {
-                    reject(new Error('chat/new: timed out waiting for chat panel to be created'))
-                }, 1000)
-            })
-
-            // Important: this request never responds if we await on the messages here.
-            this.receiveWebviewMessage(id, { command: 'ready' }).then(
-                () => {},
-                () => {}
-            )
-            this.receiveWebviewMessage(id, { command: 'initialized' }).then(
-                () => {},
-                () => {}
-            )
-            return id
+        this.registerRequest('chat/models', async ({ id }) => {
+            const panel = this.webPanels.getPanelOrError(id)
+            if (panel.models) {
+                return { models: panel.models }
+            }
+            await this.receiveWebviewMessage(id, { command: 'get-chat-models' })
+            return { models: panel.models ?? [] }
         })
 
         this.registerRequest('chat/submitMessage', async ({ id, message }, token) => {
             if (message.command !== 'submit') {
                 throw new Error('Invalid message, must have a command of "submit"')
             }
-            const panel = this.webPanels.panels.get(id)
-            if (!panel) {
-                return Promise.resolve({
-                    type: 'errors',
-                    errors: `No panel with id ${id} found`,
-                } satisfies ExtensionMessage)
-            }
+            const panel = this.webPanels.getPanelOrError(id)
             if (panel.isMessageInProgress) {
                 throw new Error('Message is already in progress')
             }
@@ -672,7 +646,7 @@ export class Agent extends MessageHandler {
     private registerWebviewHandlers(): void {
         const webPanels = this.webPanels
         vscode_shim.setCreateWebviewPanel((viewType, title, showOptions, options) => {
-            const panel = new AgentWebPanel(viewType, title, showOptions, options)
+            const panel = new AgentWebviewPanel(viewType, title, showOptions, options)
             webPanels.add(panel)
 
             panel.onDidPostMessage(message => {
@@ -696,6 +670,8 @@ export class Agent extends MessageHandler {
                         panel.isMessageInProgress = message.isMessageInProgress
                         panel.messageInProgressChange.fire(message)
                     }
+                } else if (message.type === 'chatModels') {
+                    panel.models = message.models
                 }
 
                 this.notify('webview/postMessage', {
@@ -704,18 +680,6 @@ export class Agent extends MessageHandler {
                 })
             })
 
-            if (this.resolveChatPanelId) {
-                this.resolveChatPanelId(panel.panelID)
-                this.resolveChatPanelId = null
-            } else {
-                this.request('webview/create', {
-                    id: panel.panelID,
-                    data: { viewType, title, showOptions, options },
-                }).then(
-                    () => {},
-                    () => {}
-                )
-            }
             return panel
         })
     }
@@ -785,12 +749,35 @@ export class Agent extends MessageHandler {
         return client
     }
 
+    private async createChatPanel(commandResult: Thenable<ChatSession | undefined>): Promise<string> {
+        const { sessionID, webviewPanel } = (await commandResult) ?? {}
+        if (sessionID === undefined) {
+            throw new Error('chatID is undefined')
+        }
+        if (webviewPanel === undefined) {
+            throw new Error(`No webview panel for sessionID ${sessionID}`)
+        }
+        if (!(webviewPanel instanceof AgentWebviewPanel)) {
+            throw new Error(`Expected AgentWebviewPanel, received ${webviewPanel}`)
+        }
+        if (webviewPanel.chatID === undefined) {
+            webviewPanel.chatID = sessionID
+        }
+        if (sessionID !== webviewPanel.chatID) {
+            throw new Error(
+                `Mismatching chatID, (sessionID) ${sessionID} !== ${webviewPanel.chatID} (webviewPanel.chatID)`
+            )
+        }
+        webviewPanel.initialize()
+        return webviewPanel.panelID
+    }
+
     private async reloadAuth(): Promise<void> {
-        await vscode_shim.commands.executeCommand('agent.auth.reload').then(() => {
-            // TODO(#56621): JetBrains: persistent chat history:
-            // This is a temporary workaround to ensure that a new chat panel is created and properly initialized after the auth change.
-            this.webPanels.panels.clear()
-        })
+        await vscode_shim.commands.executeCommand('agent.auth.reload')
+
+        // TODO(#56621): JetBrains: persistent chat history:
+        // This is a temporary workaround to ensure that a new chat panel is created and properly initialized after the auth change.
+        this.webPanels.panels.clear()
     }
 
     /**

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -19,8 +19,8 @@ import { type TelemetryEventParameters } from '@sourcegraph/telemetry'
 
 import { chatHistory } from '../../vscode/src/chat/chat-view/ChatHistoryManager'
 import { SimpleChatModel } from '../../vscode/src/chat/chat-view/SimpleChatModel'
-import { ChatSession } from '../../vscode/src/chat/chat-view/SimpleChatPanelProvider'
-import { AuthStatus, type ExtensionMessage, type WebviewMessage } from '../../vscode/src/chat/protocol'
+import { type ChatSession } from '../../vscode/src/chat/chat-view/SimpleChatPanelProvider'
+import { type AuthStatus, type ExtensionMessage, type WebviewMessage } from '../../vscode/src/chat/protocol'
 import { activate } from '../../vscode/src/extension.node'
 import { TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
 
@@ -30,13 +30,7 @@ import { AgentWebPanels, AgentWebviewPanel } from './AgentWebviewPanel'
 import { AgentWorkspaceDocuments } from './AgentWorkspaceDocuments'
 import { AgentEditor } from './editor'
 import { MessageHandler } from './jsonrpc-alias'
-import {
-    ClientCapabilities,
-    type AutocompleteItem,
-    type ClientInfo,
-    type ExtensionConfiguration,
-    type RecipeInfo,
-} from './protocol-alias'
+import { type AutocompleteItem, type ClientInfo, type ExtensionConfiguration, type RecipeInfo } from './protocol-alias'
 import { AgentHandlerTelemetryRecorderProvider } from './telemetry'
 import * as vscode_shim from './vscode-shim'
 
@@ -580,7 +574,7 @@ export class Agent extends MessageHandler {
                 }
             }
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
-            chatHistory.saveChat(authStatus, chatModel.toTranscriptJSON())
+            await chatHistory.saveChat(authStatus, chatModel.toTranscriptJSON())
             return this.createChatPanel(vscode.commands.executeCommand('cody.chat.panel.restore', [chatID]))
         })
 
@@ -758,13 +752,13 @@ export class Agent extends MessageHandler {
             throw new Error(`No webview panel for sessionID ${sessionID}`)
         }
         if (!(webviewPanel instanceof AgentWebviewPanel)) {
-            throw new Error(`Expected AgentWebviewPanel, received ${webviewPanel}`)
+            throw new TypeError(`Expected AgentWebviewPanel, received ${JSON.stringify(webviewPanel)}`)
         }
         if (webviewPanel.chatID === undefined) {
             webviewPanel.chatID = sessionID
         }
         if (sessionID !== webviewPanel.chatID) {
-            throw new Error(
+            throw new TypeError(
                 `Mismatching chatID, (sessionID) ${sessionID} !== ${webviewPanel.chatID} (webviewPanel.chatID)`
             )
         }

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -15,11 +15,11 @@ import type { ExtensionMessage, ExtensionTranscriptMessage } from '../../vscode/
 import { AgentTextDocument } from './AgentTextDocument'
 import { MessageHandler } from './jsonrpc-alias'
 import {
-    WebviewPostMessageParams,
     type ClientInfo,
     type ProgressReportParams,
     type ProgressStartParams,
     type ServerInfo,
+    type WebviewPostMessageParams,
 } from './protocol-alias'
 
 type ProgressMessage = ProgressStartMessage | ProgressReportMessage | ProgressEndMessage

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -18,7 +18,7 @@ import { type AuthStatus } from '../protocol'
 
 import { ChatPanelsManager } from './ChatPanelsManager'
 import { SidebarViewController, type SidebarViewOptions } from './SidebarViewController'
-import { type SimpleChatPanelProvider } from './SimpleChatPanelProvider'
+import { type ChatSession, type SimpleChatPanelProvider } from './SimpleChatPanelProvider'
 
 export const CodyChatPanelViewType = 'cody.chatPanel'
 /**
@@ -215,32 +215,29 @@ export class ChatManager implements vscode.Disposable {
     }
 
     // For registering the commands for chat panels in advance
-    private async createNewWebviewPanel(): Promise<void> {
-        const debounceCreatePanel = debounce(
-            async () => {
-                await this.chatPanelsManager.createWebviewPanel()
-            },
-            250,
-            { leading: true, trailing: true }
-        )
+    private async createNewWebviewPanel(): Promise<ChatSession | undefined> {
+        const debounceCreatePanel = debounce(() => this.chatPanelsManager.createWebviewPanel(), 250, {
+            leading: true,
+            trailing: true,
+        })
 
         if (this.chatPanelsManager) {
-            await debounceCreatePanel()
+            return debounceCreatePanel()
         }
+        return undefined
     }
 
-    private async restorePanel(chatID: string, chatQuestion?: string): Promise<void> {
+    private async restorePanel(chatID: string, chatQuestion?: string): Promise<ChatSession | undefined> {
         const debounceRestore = debounce(
-            async (chatID: string, chatQuestion?: string) => {
-                await this.chatPanelsManager.restorePanel(chatID, chatQuestion)
-            },
+            async (chatID: string, chatQuestion?: string) => this.chatPanelsManager.restorePanel(chatID, chatQuestion),
             250,
             { leading: true, trailing: true }
         )
 
         if (this.chatPanelsManager) {
-            await debounceRestore(chatID, chatQuestion)
+            return debounceRestore(chatID, chatQuestion)
         }
+        return undefined
     }
 
     public dispose(): void {

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -264,18 +264,19 @@ export class ChatPanelsManager implements vscode.Disposable {
         await chatProvider.clearAndRestartSession()
     }
 
-    public async restorePanel(chatID: string, chatQuestion?: string): Promise<void> {
+    public async restorePanel(chatID: string, chatQuestion?: string): Promise<SimpleChatPanelProvider | undefined> {
         try {
             logDebug('ChatPanelsManager', 'restorePanel')
             // Panel already exists, just reveal it
             const provider = this.panelProvidersMap.get(chatID)
             if (provider) {
                 provider.webviewPanel?.reveal()
-                return
+                return provider
             }
-            await this.createWebviewPanel(chatID, chatQuestion)
+            return await this.createWebviewPanel(chatID, chatQuestion)
         } catch (error) {
             console.error(error, 'errored restoring panel')
+            return undefined
         }
     }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -96,7 +96,12 @@ interface SimpleChatPanelProviderOptions {
     models: ChatModelProvider[]
 }
 
-export class SimpleChatPanelProvider implements vscode.Disposable {
+export interface ChatSession {
+    webviewPanel?: vscode.WebviewPanel
+    sessionID: string
+}
+
+export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private _webviewPanel?: vscode.WebviewPanel
     public get webviewPanel(): vscode.WebviewPanel | undefined {
         return this._webviewPanel
@@ -633,6 +638,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable {
         // The text we will use to send to LLM
         const promptText = command ? [command.prompt, command.additionalInput].join(' ')?.trim() : inputText
         this.chatModel.addHumanMessage({ text: promptText }, displayText)
+
         await this.saveSession(inputText)
         // trigger the context progress indicator
         this.postViewTranscript({ speaker: 'assistant' })

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -26,13 +26,7 @@ export type WebviewMessage =
           eventName: string
           properties: TelemetryEventProperties | undefined
       } // new event log internal API (use createWebviewTelemetryService wrapper)
-    | {
-          command: 'submit'
-          text: string
-          submitType: ChatSubmitType
-          addEnhancedContext?: boolean
-          contextFiles?: ContextFile[]
-      }
+    | ({ command: 'submit' } & WebviewSubmitMessage)
     | { command: 'executeRecipe'; recipe: RecipeID }
     | { command: 'history'; action: 'clear' | 'export' }
     | { command: 'restoreHistory'; chatID: string }
@@ -104,7 +98,7 @@ export type WebviewMessage =
 export type ExtensionMessage =
     | { type: 'config'; config: ConfigurationSubsetForWebview & LocalEnv; authStatus: AuthStatus }
     | { type: 'history'; messages: UserLocalHistory | null }
-    | { type: 'transcript'; messages: ChatMessage[]; isMessageInProgress: boolean; chatID: string }
+    | ({ type: 'transcript' } & ExtensionTranscriptMessage)
     | { type: 'view'; messages: View }
     | { type: 'errors'; errors: string }
     | { type: 'suggestions'; suggestions: string[] }
@@ -125,6 +119,19 @@ export type ExtensionMessage =
           }
           error?: string
       }
+
+export interface WebviewSubmitMessage {
+    text: string
+    submitType: ChatSubmitType
+    addEnhancedContext?: boolean
+    contextFiles?: ContextFile[]
+}
+
+export interface ExtensionTranscriptMessage {
+    messages: ChatMessage[]
+    isMessageInProgress: boolean
+    chatID: string
+}
 
 /**
  * The subset of configuration that is visible to the webview.

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 
-import { ChatModelProvider } from '@sourcegraph/cody-shared'
+import { type ChatModelProvider } from '@sourcegraph/cody-shared'
 import type { RecipeID } from '@sourcegraph/cody-shared/src/chat/recipes/recipe'
 import type { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 import type { event } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -289,6 +289,7 @@ const register = async (
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),
         vscode.commands.registerCommand('cody.auth.account', () => authProvider.accountMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
+        vscode.commands.registerCommand('cody.auth.status', () => authProvider.getAuthStatus()), // Used by the agent
         // Commands
         vscode.commands.registerCommand('cody.chat.restart', async () => {
             const confirmation = await vscode.window.showWarningMessage(


### PR DESCRIPTION
Previously, it was not possible to start a chat session with context from another conversation. The lack of this feature prevented clients like JetBrains from supporting preserving the chat history after restarting the IDE. This PR fixes the problem by adding a new `chat/restore` endpoint that allows the client to pass the transcript of an old conversation.

This PR also makes the logic related to creating new chats more robust. Previously, it relied on racing promises aginst hardcoded timeouts to capture webview instances. Now, the chat-related commands return the webview directly avoiding the need for brittle logic inside the agent.


## Test plan

See newly added tests.

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
