### PR TITLE
Autocomplete: Add support for Starcoder Enterprise virtual model identifier

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Added support for the new `fireworks/starcoder` virtual model name when used in combination with an Enterprise instance. [pull/2714](https://github.com/sourcegraph/cody/pull/2714)
+
 ### Fixed
 
 - Autocomplete: Fixes an issue where the context retriever would truncate the results too aggressively. [pull/2652](https://github.com/sourcegraph/cody/pull/2652)

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -55,13 +55,13 @@ describe('createProviderConfig', () => {
             const provider = await createProviderConfig(
                 getVSCodeSettings({
                     autocompleteAdvancedProvider: 'fireworks',
-                    autocompleteAdvancedModel: 'starcoder-3b',
+                    autocompleteAdvancedModel: 'starcoder-7b',
                 }),
                 dummyCodeCompletionsClient,
                 {}
             )
             expect(provider?.identifier).toBe('fireworks')
-            expect(provider?.model).toBe('starcoder-3b')
+            expect(provider?.model).toBe('starcoder-7b')
         })
 
         it('returns "fireworks" provider config if specified in settings and default model', async () => {
@@ -131,6 +131,10 @@ describe('createProviderConfig', () => {
                 {
                     codyLLMConfig: { provider: 'sourcegraph', completionModel: '/claude-instant-1.2' },
                     expected: null,
+                },
+                {
+                    codyLLMConfig: { provider: 'sourcegraph', completionModel: 'fireworks/starcoder' },
+                    expected: { provider: 'fireworks', model: 'starcoder' },
                 },
 
                 // aws-bedrock

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -38,13 +38,12 @@ const EOT_LLAMA_CODE = ' <EOT>'
 // Model identifiers can be found in https://docs.fireworks.ai/explore/ and in our internal
 // conversations
 const MODEL_MAP = {
-    // Models in production
+    // Virtual model strings. Cody Gateway will map to an actual model
+    starcoder: 'fireworks/starcoder',
     'starcoder-16b': 'fireworks/starcoder-16b',
     'starcoder-7b': 'fireworks/starcoder-7b',
 
-    // Models in evaluation
-    'starcoder-3b': 'fireworks/accounts/fireworks/models/starcoder-3b-w8a16',
-    'starcoder-1b': 'fireworks/accounts/fireworks/models/starcoder-1b-w8a16',
+    // Fireworks model identifiers
     'llama-code-7b': 'fireworks/accounts/fireworks/models/llama-v2-7b-code',
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
     'llama-code-13b-instruct': 'fireworks/accounts/fireworks/models/llama-v2-13b-code-instruct',
@@ -58,11 +57,10 @@ type FireworksModel =
 
 function getMaxContextTokens(model: FireworksModel): number {
     switch (model) {
+        case 'starcoder':
         case 'starcoder-hybrid':
         case 'starcoder-16b':
-        case 'starcoder-7b':
-        case 'starcoder-3b':
-        case 'starcoder-1b': {
+        case 'starcoder-7b': {
             // StarCoder supports up to 8k tokens, we limit it to ~2k for evaluation against
             // other providers.
             return 2048


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/sourcegraph/pull/59522

This PR adds support for a new model identifier inside the Fireworks setup: `fireworks/starcoder`. Read more about the new flag, here: https://github.com/sourcegraph/sourcegraph/pull/59522

This PR makes it so that if an enterprise instance has `fireworks/starcoder` set as their default code completion model, the client will pick it up and use the Fireworks provider to build the prompt and send it with the `fireworks/starcoder` model identifier.

## Test plan

1. Be on https://github.com/sourcegraph/sourcegraph/pull/59522 on your backend
2. Configure your Cody Gateway license to allow `fireworks/starcoder`: <img width="889" alt="Screenshot 2024-01-12 at 17 50 19" src="https://github.com/sourcegraph/cody/assets/458591/ec1a0637-191b-42a2-a28e-985346175841">
3. Set your site-config's completion model to `fireworks/starcoder` <img width="380" alt="Screenshot 2024-01-12 at 17 51 21" src="https://github.com/sourcegraph/cody/assets/458591/a86fda70-024c-4faf-9f84-c507ab5377b5">
4. Make sure neither the `cody-pro` feature flag nor any `cody-autocomplete` feature flags are enabled.
5. Open the VS Code extension and connect to your local instance
6. Observe that the right model identifier is picked and you can see completions

<img width="2346" alt="Screenshot 2024-01-12 at 17 47 43" src="https://github.com/sourcegraph/cody/assets/458591/a033aae0-7068-4a3a-a5a3-84fa49b85a47">

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
