### PR TITLE
Fix some issues on Windows with removed context filenames

### DIFF
--- a/vscode/webviews/utils/displayPath.test.ts
+++ b/vscode/webviews/utils/displayPath.test.ts
@@ -10,18 +10,14 @@ describe('displayPathForWebviews', () => {
     test('no workspace folders', () => {
         updateWorkspaceFolderUris([])
         expect(displayPathForWebviews(URI.file('/foo/bar.ts'))).toBe('/foo/bar.ts')
-        expect(displayPathForWebviews(URI.parse('https://example.com/foo/bar.ts'))).toBe(
-            'https://example.com/foo/bar.ts'
-        )
+        expect(displayPathForWebviews(URI.parse('https://ex.com/foo/bar.ts'))).toBe('https://ex.com/foo/bar.ts')
     })
 
     test('1 workspace folder', () => {
         updateWorkspaceFolderUris(['file:///workspace'])
         expect(displayPathForWebviews(URI.file('/workspace/foo/bar.ts'))).toBe('foo/bar.ts')
         expect(displayPathForWebviews(URI.file('/other/foo/bar.ts'))).toBe('/other/foo/bar.ts')
-        expect(displayPathForWebviews(URI.parse('https://example.com/foo/bar.ts'))).toBe(
-            'https://example.com/foo/bar.ts'
-        )
+        expect(displayPathForWebviews(URI.parse('https://ex.com/foo/bar.ts'))).toBe('https://ex.com/foo/bar.ts')
     })
 
     test('2 workspace folders', () => {
@@ -29,21 +25,29 @@ describe('displayPathForWebviews', () => {
         expect(displayPathForWebviews(URI.file('/workspace1/foo/bar.ts'))).toBe('workspace1/foo/bar.ts')
         expect(displayPathForWebviews(URI.file('/workspace2/foo/bar.ts'))).toBe('workspace2/foo/bar.ts')
         expect(displayPathForWebviews(URI.file('/other/foo/bar.ts'))).toBe('/other/foo/bar.ts')
-        expect(displayPathForWebviews(URI.parse('https://example.com/foo/bar.ts'))).toBe(
-            'https://example.com/foo/bar.ts'
-        )
+        expect(displayPathForWebviews(URI.parse('https://ex.com/foo/bar.ts'))).toBe('https://ex.com/foo/bar.ts')
     })
 })
 
 describe('uriHasPrefix', () => {
     test('same url', () =>
-        expect(uriHasPrefix(URI.parse('https://example.com/a/b'), URI.parse('https://example.com/a/b'))).toBe(true))
+        expect(uriHasPrefix(URI.parse('https://ex.com/a/b'), URI.parse('https://ex.com/a/b'), false)).toBe(true))
 
-    test('path prefix', () => {
-        expect(uriHasPrefix(URI.parse('https://example.com/a/b'), URI.parse('https://example.com/a'))).toBe(true)
-        expect(uriHasPrefix(URI.parse('https://example.com/a/b'), URI.parse('other://example.com/a'))).toBe(false)
-        expect(uriHasPrefix(URI.parse('https://example.com/a/b'), URI.parse('https://example.com/a/'))).toBe(true)
-        expect(uriHasPrefix(URI.parse('https://example.com/a'), URI.parse('https://example.com/a/'))).toBe(true)
-        expect(uriHasPrefix(URI.parse('https://example.com/a-b'), URI.parse('https://example.com/a'))).toBe(false)
+    test('https path prefix', () => {
+        expect(uriHasPrefix(URI.parse('https://ex.com/a/b'), URI.parse('https://ex.com/a'), false)).toBe(true)
+        expect(uriHasPrefix(URI.parse('https://ex.com/a/b'), URI.parse('other://ex.com/a'), false)).toBe(false)
+        expect(uriHasPrefix(URI.parse('https://ex.com/a/b'), URI.parse('https://ex.com/a/'), false)).toBe(true)
+        expect(uriHasPrefix(URI.parse('https://ex.com/a'), URI.parse('https://ex.com/a/'), false)).toBe(true)
+        expect(uriHasPrefix(URI.parse('https://ex.com/a-b'), URI.parse('https://ex.com/a'), false)).toBe(false)
+    })
+
+    test('file path prefix', () => {
+        expect(uriHasPrefix(URI.parse('file:///a/b'), URI.parse('file:///a'), false)).toBe(true)
+        expect(uriHasPrefix(URI.parse('file:///a/b'), URI.parse('file:///A'), false)).toBe(false)
+        expect(uriHasPrefix(URI.parse('file:///a/b'), URI.parse('file:///b'), false)).toBe(false)
+        expect(uriHasPrefix(URI.parse('file:///c:/a/b'), URI.parse('file:///c:/a'), true)).toBe(true)
+        expect(uriHasPrefix(URI.parse('file:///c:/a/b'), URI.parse('file:///C:/a'), true)).toBe(true)
+        expect(uriHasPrefix(URI.parse('file:///c:/a/b'), URI.parse('file:///c:/A'), true)).toBe(false)
+        expect(uriHasPrefix(URI.parse('file:///c:/a/b'), URI.parse('file:///c:/b'), true)).toBe(false)
     })
 })

--- a/vscode/webviews/utils/displayPath.ts
+++ b/vscode/webviews/utils/displayPath.ts
@@ -8,30 +8,47 @@ export function updateWorkspaceFolderUris(workspaceFolderUris: string[]): void {
     workspaceFolders = workspaceFolderUris.map(uri => URI.parse(uri))
 }
 
-const PATH_SEP = '/' // TODO(sqs): should be backslash for windows
-
 setDisplayPathFn(displayPathForWebviews)
 
 export function displayPathForWebviews(location: URI | string): string {
     const uri = typeof location === 'string' ? URI.parse(location) : URI.from(location)
+    // If the URI paths starts with "/c:/" (where C is any letter), it's a Windows
+    // file URI.
+    const isWindows = !!uri.path.match(/^\/\w:\//)
+    const pathSeparator = isWindows ? '\\' : '/'
 
     // Mimic the behavior of vscode.workspace.asRelativePath.
     const includeWorkspaceFolder = workspaceFolders.length >= 2
     for (const folder of workspaceFolders) {
-        const workspaceFolderPrefix = includeWorkspaceFolder ? basename(folder.path) + PATH_SEP : ''
-        if (uriHasPrefix(uri, folder)) {
-            return workspaceFolderPrefix + uri.path.slice(folder.path.length + 1)
+        const workspaceFolderName = basename(folder.path)
+        if (uriHasPrefix(uri, folder, isWindows)) {
+            const workspaceFolderPrefix = includeWorkspaceFolder ? workspaceFolderName + pathSeparator : ''
+            return workspaceFolderPrefix + uri.path.slice(folder.path.length + 1).replaceAll('/', pathSeparator)
         }
     }
-    return uri.scheme === 'file' ? uri.path : uri.toString()
+    // Absolute paths
+    if (uri.scheme === 'file') {
+        // Remove the leading slash on Windows
+        return isWindows ? uri.path.slice(1).replaceAll('/', pathSeparator) : uri.path
+    }
+    return uri.toString()
 }
 
-export function uriHasPrefix(uri: URI, prefix: URI): boolean {
+export function uriHasPrefix(uri: URI, prefix: URI, isWindows: boolean): boolean {
+    // On Windows, it's common to have drive letter casing mismatches (VS Code's APIs tend to normalize
+    // to lowercase, but many other tools use uppercase and we don't know where the context file came
+    // from).
+    const uriPath =
+        isWindows && uri.scheme === 'file' ? uri.path.slice(0, 2).toUpperCase() + uri.path.slice(2) : uri.path
+    const prefixPath =
+        isWindows && prefix.scheme === 'file'
+            ? prefix.path.slice(0, 2).toUpperCase() + prefix.path.slice(2)
+            : prefix.path
     return (
         uri.scheme === prefix.scheme &&
         (uri.authority || '') === (prefix.authority || '') && // different URI impls treat empty different
-        (uri.path === prefix.path ||
-            uri.path.startsWith(prefix.path.endsWith('/') ? prefix.path : prefix.path + '/') ||
-            (prefix.path.endsWith('/') && uri.path === prefix.path.slice(0, -1)))
+        (uriPath === prefixPath ||
+            uriPath.startsWith(prefixPath.endsWith('/') ? prefixPath : prefixPath + '/') ||
+            (prefixPath.endsWith('/') && uriPath === prefixPath.slice(0, -1)))
     )
 }


### PR DESCRIPTION
This makes some fixes to https://github.com/sourcegraph/cody/pull/2653 for Windows where the paths were appearing incorrectly (wrong slash direction, or not detected as part of the workspace so showing as absolute paths).

This PR is targetting @sqs rm-filename branch since it's fixed to unmerged changes.


## Test plan

- Run `pnpm test:e2e` on Windows and verify all is green