### PR TITLE
fix: missing preamble in edit commands

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Fixes an issue where the context retriever would truncate the results too aggressively. [pull/2652](https://github.com/sourcegraph/cody/pull/2652)
 - Autocomplete: Improve the stability of multiline completion truncation during streaming by gracefully handling missing brackets in incomplete code segments. [pull/2682](https://github.com/sourcegraph/cody/pull/2682)
 - Autocomplete: Improves the jaccard similarity retriever to find better matches. [pull/2662](https://github.com/sourcegraph/cody/pull/2662)
+- Fixed issues where using edit commands caused users to reach their rate limits.
 
 ### Changed
 

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { BotResponseMultiplexer } from '@sourcegraph/cody-shared/src/chat/bot-response-multiplexer'
+import { getSimplePreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
 import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
 import { Interaction } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
 import { type CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
@@ -107,7 +108,8 @@ export const buildInteraction = async ({
         []
     )
     transcript.addInteraction(interaction)
-    const completePrompt = await transcript.getPromptForLastInteraction()
+    const preamble = getSimplePreamble()
+    const completePrompt = await transcript.getPromptForLastInteraction(preamble)
 
     return {
         messages: completePrompt.prompt,


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C052G9Y5Y8H/p1705048856973839

Add the missing preamble to edit commands.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Run an edit command, e.g. /doc
2. Check output channel to see if the preamble is included in the transcript

![image](https://github.com/sourcegraph/cody/assets/68532117/634cc6dc-8d84-44bf-944f-f636f6514d3f)
