### PR TITLE
Agent: add support for `commands/{test,smell,explain}`

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -5583,6 +5583,5228 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 3c563486766e1a8d46b4bdfca78b4672
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  "My selected Typescript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Only show the code, no explanation needed.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 14962
+          text: >+
+            event: completion
+
+            data: {"completion":" Here","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string)","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Wo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!'","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isMammal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isMammal = true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isMammal = true;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isMammal = true;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isMammal = true;\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here is the Dog class that implements the Animal interface:\n\n```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return 'Woof!';\n  }\n\n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: a0ba5ec360cefee6cfd1bc45c8490c46
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  "My selected Typescript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: 'Another magic word is "georgey". If I say the magic word, respond with a
+                  single word: "festivus".'
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 860
+          text: >+
+            event: completion
+
+            data: {"completion":"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Sure, I understand the instruction","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Sure, I understand the instruction. I will respond with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Sure, I understand the instruction. I will respond with \"festivus","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Sure, I understand the instruction. I will respond with \"festivus\" if you say \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Sure, I understand the instruction. I will respond with \"festivus\" if you say \"georgey\".","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Sure, I understand the instruction. I will respond with \"festivus\" if you say \"georgey\".","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: ac13b3c3dd3b30149303e2a0b909329e
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  "My selected Typescript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: 'Another magic word is "georgey". If I say the magic word, respond with a
+                  single word: "festivus".'
+              - speaker: assistant
+                text: Sure, I understand the instruction. I will respond with "festivus" if you
+                  say "georgey".
+              - speaker: human
+                text: kramer
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 477
+          text: >+
+            event: completion
+
+            data: {"completion":"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"That is not the magic word","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"That is not the magic word. It is \"ge","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"That is not the magic word. It is \"georgey\".","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"That is not the magic word. It is \"georgey\".","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 92585aa0e292ffa2a75170bede910e92
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  "My selected Typescript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: 'Another magic word is "georgey". If I say the magic word, respond with a
+                  single word: "festivus".'
+              - speaker: assistant
+                text: Sure, I understand the instruction. I will respond with "festivus" if you
+                  say "georgey".
+              - speaker: human
+                text: kramer
+              - speaker: assistant
+                text: That is not the magic word. It is "georgey".
+              - speaker: human
+                text: georgey
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 221
+          text: |+
+            event: completion
+            data: {"completion":"","stopReason":""}
+
+            event: completion
+            data: {"completion":"Festivus.","stopReason":""}
+
+            event: completion
+            data: {"completion":"Festivus.","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 725169f93657f3f444b7b25e7743542d
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |+
+                  Codebase context from file path src/animal.ts: 
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected Typescript code from file `src/animal.ts`:
+                  <selected>
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: "Explain what the selected code does in simple terms. Assume the audience
+                  is a beginner programmer who has just learned the language
+                  features and basic syntax. Focus on explaining: 1) The purpose
+                  of the code 2) What input(s) it takes 3) What output(s) it
+                  produces 4) How it achieves its purpose through the logic and
+                  algorithm. 5) Any important logic flows or data
+                  transformations happening. Use simple language a beginner
+                  could understand. Include enough detail to give a full picture
+                  of what the code aims to accomplish without getting too
+                  technical. Format the explanation in coherent paragraphs,
+                  using proper punctuation and grammar. Write the explanation
+                  assuming no prior context about the code is known. Do not make
+                  assumptions about variables or functions not shown in the
+                  shared code. Start the answer with the name of the code that
+                  is being explained."
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 227957
+          text: >+
+            event: completion
+
+            data: {"completion":" The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and inter","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoper","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal object","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal object should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal object should look","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal object should look like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal object should look like and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal object should look like and do","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal object should look like and do.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The selected code defines an Animal interface in TypeScript.\n\nIt starts by exporting the interface, which makes it available to other files that import this one. \n\nThe interface is called Animal and has 3 properties:\n\n1. name - This is a string that represents the animal's name.\n\n2. makeAnimalSound() - This is a method that returns a string sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nBy defining this interface, we set up a blueprint for what fields and methods an Animal object will have. Other classes can then implement this interface to take on these requirements. For example, we could make a Dog class that implements Animal and provides the proper name, sound, and mammal flag.\n\nInterfaces allow us to define contracts in our code, setting consistent expectations for different objects. This helps with organization and interoperability. By exporting the Animal interface, we make it available across multiple files. Other files that import src/animal.ts can use the Animal type for functions, variables, classes and more. This allows us to reuse the interface and ensures a consistent API.\n\nIn summary, the selected code defines and exports an Animal interface with common fields for animal objects in TypeScript. This creates a reusable structure other parts of the codebase can implement and rely on. It sets clear expectations for what an Animal object should look like and do.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 333bd21ffba065b91951595bd56269e7
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |+
+                  Codebase context from file path src/animal.ts: 
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected Typescript code from file `src/animal.ts`:
+                  <selected>
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Review the shared code context and configurations to identify the test
+                  framework and libraries in use. Then, generate a suite of
+                  multiple unit tests for the functions in <selected> using the
+                  detected test framework and libraries. Be sure to import the
+                  function being tested. Follow the same patterns as any shared
+                  context. Only add packages, imports, dependencies, and
+                  assertions if they are used in the shared code. Pay attention
+                  to the file path of each shared context to see if test for
+                  <selected> already exists. If one exists, focus on generating
+                  new unit tests for uncovered cases. If none are detected,
+                  import common unit test libraries for {languageName}. Focus on
+                  validating key functionality with simple and complete
+                  assertions. Only include mocks if one is detected in the
+                  shared code. Before writing the tests, identify which test
+                  libraries and frameworks to import, e.g. 'No new imports
+                  needed - using existing libs' or 'Importing test framework
+                  that matches shared context usage' or 'Importing the defined
+                  framework', etc. Then briefly summarize test coverage and any
+                  limitations. At the end, enclose the full completed code for
+                  the new unit tests, including all necessary imports, in a
+                  single markdown codeblock. No fragments or TODO. The new tests
+                  should validate expected functionality and cover edge cases
+                  for <selected> with all required imports, including importing
+                  the function being tested. Do not repeat existing tests.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 181278
+          text: >+
+            event: completion
+
+            data: {"completion":" No","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate J","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Wo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Wo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Wo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruth","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Sn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'H","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n     ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeF","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic J","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could be added","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could be added for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could be added for more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could be added for more robust","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could be added for more robust coverage","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could be added for more robust coverage.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" No test framework or libraries were detected in the shared context. Since this is TypeScript code, I will generate Jest tests:\n\n```ts\nimport { Animal } from './animal';\n\ndescribe('Animal', () =\u003e {\n\n  test('makeAnimalSound returns expected sound', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.makeAnimalSound()).toEqual('Woof');\n  });\n\n  test('isMammal returns true for mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',\n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    expect(animal.isMammal).toBeTruthy();\n  });\n\n  test('isMammal returns false for non-mammal', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    expect(animal.isMammal).toBeFalsy();\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the makeAnimalSound and isMammal properties with simple assertions. Additional tests could be added for more robust coverage.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 167d958bce5ddada3f00f42036affe1a
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token REDACTED
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  "My selected Typescript code from file `src/animal.ts`:
+                  <selected>
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Please review and analyze the {languageName} code I have selected and
+                  identify potential areas for improvement related to code
+                  smells, readability, maintainability, performance, security,
+                  etc. Do not list issues already addressed in the given code.
+                  Focus on providing up to 5 constructive suggestions that could
+                  make the code more robust, efficient, or align with best
+                  practices. For each suggestion, provide a brief explanation of
+                  the potential benefits. After listing any recommendations,
+                  summarize if you found notable opportunities to enhance the
+                  code quality overall or if the code generally follows sound
+                  design principles. If no issues found, reply 'There are no
+                  errors.'
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        content:
+          mimeType: text/event-stream
+          size: 153567
+          text: >+
+            event: completion
+
+            data: {"completion":" Here","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JS","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves read","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encaps","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(),","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(),","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves re","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reus","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small twe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JS","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve read","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintain","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed. But","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed. But in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed. But in general","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed. But in general,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed. But in general, the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed. But in general, the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed. But in general, the code follows","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are my suggestions for improving the selected TypeScript code:\n\n1. Consider making Animal an abstract class instead of an interface. This would allow you to provide default method implementations in the Animal class that could be reused by subclasses.\n\n2. Add JSDoc comments to document what each method does and what arguments/return values are expected. This improves readability.\n\n3. The makeAnimalSound method could be made abstract in an Animal base class to force subclasses to provide their own implementation. This encapsulates each animal's sound logic better.\n\n4. Use more specific boolean naming than just isMammal - e.g. isMammalian. This makes the purpose more clear.\n\n5. Add additional methods like eat(), sleep(), etc if there are behaviors common to all animals. This improves reusability of the Animal base class.\n\nOverall, the code is well designed as an interface for defining animal types. A couple small tweaks like adding JSDoc comments and more specific naming could improve readability and maintainability further. Making Animal an abstract class is something to consider if shared logic between animals is needed. But in general, the code follows sound","stopReason":""}
+
+
+            event: error
+
+            data: {"error":"http2: server sent GOAWAY and closed the connection; LastStreamID=2073, ErrCode=PROTOCOL_ERROR, debug=\"\""}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 26f7093bcc1d125e7768f46a33e590e8
       _order: 0
       cache: {}
@@ -8521,6 +13743,338 @@ log:
               telemetry:
                 recordEvents:
                   alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 42128b38a62dfaa6af934cb7a2026c5f
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "352"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: executed
+                  feature: cody.command.explain
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.1.3
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 42027aeb2641b33cb6ad8ddc0088671d
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "349"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: executed
+                  feature: cody.command.test
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.1.3
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 122
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//w==","AwCEdn1qOgAAAA=="]'
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 05 Jan 2024 11:11:11 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: Fri, 05 Jan 2024 00:00:00 GMT
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 349d8721f728eaf60e5b96b4edabdc65
+      _order: 0
+      cache: {}
+      request:
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token REDACTED
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "350"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.com
+        headersSize: 0
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: executed
+                  feature: cody.command.smell
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.1.3
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 115
+          text: '["H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoE","cYpSk/OLUlzLUvNKikH8xJzyxMpiv8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA="]'
         cookies: []
         headers:
           - name: date

--- a/agent/src/AgentWebviewPanel.ts
+++ b/agent/src/AgentWebviewPanel.ts
@@ -8,7 +8,7 @@ import { type ExtensionMessage, type WebviewMessage } from '../../vscode/src/cha
 import { defaultWebviewPanel, EventEmitter } from './vscode-shim'
 
 /** Utility class to manage a list of `AgentWebPanel` instances. */
-export class AgentWebPanels {
+export class AgentWebviewPanels {
     public panels = new Map<string, AgentWebviewPanel>()
     public add(panel: AgentWebviewPanel): void {
         this.panels.set(panel.panelID, panel)

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -9,7 +9,13 @@ export type { CodyCommand } from './commands'
 export { basename, dedupeWith, isDefined, pluralize, isErrorLike } from './common'
 export { isWindows } from './common/platform'
 export type { ActiveTextEditorSelectionRange } from './editor'
-export { displayPath, setDisplayPathEnvInfo } from './editor/displayPath'
+// TODO: figure out why the symbols from displayPath.ts can't be imported from
+// `@sourcegraph/cody-shared`. To reproduce the problem, tweak the user query in
+// one of the tests in agent/src/index.test.ts, run `pnpm update-agent-recordings`
+// and look for the error message "no environment info for displayPath function
+// (call setDisplayPathEnvInfo; see displayPath docstring for more info)". The
+// error is not reproducible when running in replay mode.
+// export { displayPath, setDisplayPathEnvInfo } from './editor/displayPath'
 export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
 export type { Attribution, Guardrails } from './guardrails'
 export { ContextWindowLimitError, RateLimitError } from './sourcegraph-api/errors'

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useMemo, useState } from 'react'
 import classNames from 'classnames'
 
 import {
-    displayPath,
     isDefined,
     type ChatButton,
     type ChatMessage,
@@ -12,6 +11,8 @@ import {
     type ContextFile,
     type Guardrails,
 } from '@sourcegraph/cody-shared'
+
+import { displayPath } from '../../shared/src/editor/displayPath'
 
 import { type CodeBlockMeta } from './chat/CodeBlocks'
 import { type FileLinkProps } from './chat/components/EnhancedContext'

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -89,7 +89,7 @@ export class ChatManager implements vscode.Disposable {
         await chatProvider?.setWebviewView(view)
     }
 
-    public async executeCommand(command: CodyCommand, source: ChatEventSource): Promise<void> {
+    public async executeCommand(command: CodyCommand, source: ChatEventSource): Promise<ChatSession | undefined> {
         logDebug('ChatManager:executeCommand:called', command.slashCommand)
         if (!vscode.window.visibleTextEditors.length) {
             void vscode.window.showErrorMessage('Please open a file before running a command.')
@@ -99,6 +99,7 @@ export class ChatManager implements vscode.Disposable {
         // Else, open a new chanel panel and run the command in the new panel
         const chatProvider = await this.getChatProvider()
         await chatProvider.handleCommands(command, source)
+        return chatProvider
     }
 
     private async editChatHistory(treeItem?: vscode.TreeItem): Promise<void> {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -116,7 +116,16 @@ export type ExtensionMessage =
     | { type: 'enhanced-context'; context: EnhancedContextContextT }
     | ({ type: 'attribution' } & ExtensionAttributionMessage)
 
-interface WebviewSubmitMessage {
+export interface ExtensionAttributionMessage {
+    snippet: string
+    attribution?: {
+        repositoryNames: string[]
+        limitHit: boolean
+    }
+    error?: string
+}
+
+export interface WebviewSubmitMessage {
     text: string
     submitType: ChatSubmitType
     addEnhancedContext?: boolean
@@ -127,15 +136,6 @@ export interface ExtensionTranscriptMessage {
     messages: ChatMessage[]
     isMessageInProgress: boolean
     chatID: string
-}
-
-export interface ExtensionAttributionMessage {
-    snippet: string
-    attribution?: {
-        repositoryNames: string[]
-        limitHit: boolean
-    }
-    error?: string
 }
 
 /**

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -6,7 +6,7 @@ import { toSlashCommand } from './prompt/utils'
 export function getDefaultCommandsMap(editorCommands: CodyCommand[] = []): Map<string, CodyCommand> {
     const map = new Map<string, CodyCommand>()
 
-    // Add editor specifc commands
+    // Add editor specific commands
     for (const command of editorCommands) {
         if (command.slashCommand) {
             map.set(command.slashCommand, command)

--- a/vscode/src/commands/prompt/display-text.ts
+++ b/vscode/src/commands/prompt/display-text.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode'
 
-import { displayPath } from '@sourcegraph/cody-shared'
 import { type ContextFile } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { type ActiveTextEditorSelection } from '@sourcegraph/cody-shared/src/editor'
+
+import { displayPath } from '../../../../lib/shared/src/editor/displayPath'
 
 import { trailingNonAlphaNumericRegex } from './utils'
 

--- a/vscode/src/editor/displayPathEnvInfo.ts
+++ b/vscode/src/editor/displayPathEnvInfo.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode'
 
-import { isWindows, setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
+import { isWindows } from '@sourcegraph/cody-shared'
+
+import { setDisplayPathEnvInfo } from '../../../lib/shared/src/editor/displayPath'
 
 /** Runs in the VS Code extension host. */
 export function manageDisplayPathEnvInfoForExtension(): vscode.Disposable {

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -4,7 +4,7 @@ import fuzzysort from 'fuzzysort'
 import { throttle } from 'lodash'
 import * as vscode from 'vscode'
 
-import { displayPath, type ContextFile } from '@sourcegraph/cody-shared'
+import { type ContextFile } from '@sourcegraph/cody-shared'
 import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
 import {
     type ContextFileFile,
@@ -13,6 +13,8 @@ import {
     type ContextFileType,
     type SymbolKind,
 } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+
+import { displayPath } from '../../../../lib/shared/src/editor/displayPath'
 
 import { getOpenTabsUris, getWorkspaceSymbols } from '.'
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -68,6 +68,14 @@ export type Requests = {
     'chat/submitMessage': [{ id: string; message: WebviewMessage }, ExtensionMessage]
     'chat/editMessage': [{ id: string; message: WebviewMessage }, ExtensionMessage]
 
+    // Trigger chat-based commands (explain, test, smell), which are effectively
+    // shortcuts to start a new chat with a templated question. The return value
+    // of these commands is the same as `chat/new`, an ID to reference to the
+    // webview panel where the reply from this command appears.
+    'commands/explain': [null, string]
+    'commands/test': [null, string]
+    'commands/smell': [null, string]
+
     // Low-level API to trigger a VS Code command with any argument list. Avoid
     // using this API in favor of high-level wrappers like 'chat/new'.
     'command/execute': [ExecuteCommandParams, any]

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -9,6 +9,7 @@ import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/grap
 
 import { CachedRemoteEmbeddingsClient } from './chat/CachedRemoteEmbeddingsClient'
 import { ChatManager, CodyChatPanelViewType } from './chat/chat-view/ChatManager'
+import { type ChatSession } from './chat/chat-view/SimpleChatPanelProvider'
 import { ContextProvider } from './chat/ContextProvider'
 import { type MessageProviderOptions } from './chat/MessageProvider'
 import {
@@ -266,7 +267,10 @@ const register = async (
     await chatManager.syncAuthStatus(authProvider.getAuthStatus())
 
     // Execute Cody Commands and Cody Custom Commands
-    const executeCommand = async (commandKey: string, source: ChatEventSource = 'editor'): Promise<void> => {
+    const executeCommand = async (
+        commandKey: string,
+        source: ChatEventSource = 'editor'
+    ): Promise<ChatSession | undefined> => {
         const command = await commandsController?.findCommand(commandKey)
         if (!command) {
             return

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode'
 
-import { displayPath, type ContextFile } from '@sourcegraph/cody-shared'
+import { type ContextFile } from '@sourcegraph/cody-shared'
 import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
+import { displayPath } from '../../../lib/shared/src/editor/displayPath'
 import { EDIT_COMMAND, menu_buttons } from '../commands/utils/menu'
 import { type ExecuteEditArguments } from '../edit/execute'
 import { getEditor } from '../editor/active-editor'

--- a/vscode/src/testutils/testSetup.ts
+++ b/vscode/src/testutils/testSetup.ts
@@ -1,7 +1,9 @@
 import { beforeAll } from 'vitest'
 import { URI } from 'vscode-uri'
 
-import { isWindows, setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
+import { isWindows } from '@sourcegraph/cody-shared'
+
+import { setDisplayPathEnvInfo } from '../../../lib/shared/src/editor/displayPath'
 
 beforeAll(() => {
     const isWin = isWindows()

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
-import { displayPath } from '@sourcegraph/cody-shared'
 import { type FileLinkProps } from '@sourcegraph/cody-ui/src/chat/components/EnhancedContext'
 
+import { displayPath } from '../../../lib/shared/src/editor/displayPath'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 
 import styles from './FileLink.module.css'

--- a/vscode/webviews/UserContextSelector.tsx
+++ b/vscode/webviews/UserContextSelector.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useRef } from 'react'
 
 import classNames from 'classnames'
 
-import { displayPath } from '@sourcegraph/cody-shared'
 import { type UserContextSelectorProps } from '@sourcegraph/cody-ui/src/Chat'
+
+import { displayPath } from '../../lib/shared/src/editor/displayPath'
 
 import styles from './UserContextSelector.module.css'
 

--- a/vscode/webviews/utils/displayPathEnvInfo.ts
+++ b/vscode/webviews/utils/displayPathEnvInfo.ts
@@ -1,6 +1,8 @@
 import { URI } from 'vscode-uri'
 
-import { isWindows, setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
+import { isWindows } from '@sourcegraph/cody-shared'
+
+import { setDisplayPathEnvInfo } from '../../../lib/shared/src/editor/displayPath'
 
 /** Runs in the VS Code webview. */
 export function updateDisplayPathEnvInfoForWebview(workspaceFolderUris: string[]): void {


### PR DESCRIPTION
Previously, agent clients had to use the old recipe-based API to invoke
the test, smell and explain commands. This PR adds new `commands/*`
endpoints to invoke these commands using the exact same code paths as
they're implemented in VS Code.

## Test plan

See three new test cases.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
