### PR TITLE
bump symf version -> 0.0.4

### DIFF
--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -13,7 +13,7 @@ import { logDebug } from '../log'
 import { getOSArch } from '../os'
 import { captureException } from '../services/sentry/sentry'
 
-const symfVersion = 'v0.0.2'
+const symfVersion = 'v0.0.4'
 
 /**
  * Get the path to `symf`. If the symf binary is not found, download it.


### PR DESCRIPTION
Bump `symf` version to pick up the following improvements:
- Markdown support
- TSX support
- Cody no longer shows an error when there are no symbols extracted and indexed

## Test plan

- Check out branch and make sure Cody fuzzy search still works
- Try searching for contents in markdown and tsx files—these should now work