### PR TITLE
Fix Semgrep pull request event 

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,9 @@
 name: Semgrep - SAST Scan
 
-on: [pull_request]
+on:
+  pull_request_target:
+    types: [ closed, edited, opened, synchronize, ready_for_review ]
+  workflow_dispatch:
 
 jobs:
   semgrep:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -3,7 +3,6 @@ name: Semgrep - SAST Scan
 on:
   pull_request_target:
     types: [ closed, edited, opened, synchronize, ready_for_review ]
-  workflow_dispatch:
 
 jobs:
   semgrep:


### PR DESCRIPTION
Instead of `pull_request` event, I have moved the semgrep SAST scan to `pull_request_target` similar to `pr-auditor` which consumes extra secret to clone and scan using private semgrep rules.

P.S: this Semgrep Scan should [trigger](https://stackoverflow.com/a/77069245) after merged to main

## Test plan

CI 🟢  and external contributors should be able to execute semgrep scan
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
