### PR TITLE
Autocomplete: clean up streaming unit tests

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
@@ -11,7 +11,7 @@ describe('[getInlineCompletions] streaming', () => {
         expect(
             await getInlineCompletions({
                 ...params('const x = █', [completion`├1337\nconsole.log('what?');┤`], {
-                    async onNetworkRequest(_params, onPartialResponse) {
+                    onNetworkRequest(_params, onPartialResponse) {
                         onPartialResponse?.(completion`├1337\ncon┤`)
                     },
                 }),
@@ -26,7 +26,7 @@ describe('[getInlineCompletions] streaming', () => {
         expect(
             await getInlineCompletions({
                 ...params('const x = █', [completion`├1337\nconsole.log('what?');┤`], {
-                    async onNetworkRequest(_params, onPartialResponse) {
+                    onNetworkRequest(_params, onPartialResponse) {
                         onPartialResponse?.(completion`├13┤`)
                         onPartialResponse?.(completion`├1337\n┤`)
                     },
@@ -55,7 +55,7 @@ describe('[getInlineCompletions] streaming', () => {
                             `,
                 ],
                 {
-                    async onNetworkRequest(_params, onPartialResponse) {
+                    onNetworkRequest(_params, onPartialResponse) {
                         onPartialResponse?.(completion`
                                         ├console.log('what?')┤
                                     ┴┴┴┴
@@ -93,7 +93,7 @@ describe('[getInlineCompletions] streaming', () => {
                             `,
                     ],
                     {
-                        async onNetworkRequest(_params, onPartialResponse) {
+                        onNetworkRequest(_params, onPartialResponse) {
                             onPartialResponse?.(completion`
                                         ├const a = new Array()
                                         console.log('oh no')┤
@@ -126,7 +126,7 @@ describe('[getInlineCompletions] streaming', () => {
                     completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (true) {}\n  }\n}\nconsole.log()`,
                 ],
                 {
-                    async onNetworkRequest(_params, onPartialResponse) {
+                    onNetworkRequest(_params, onPartialResponse) {
                         onPartialResponse?.(
                             completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (`
                         )
@@ -158,7 +158,7 @@ describe('[getInlineCompletions] streaming', () => {
                 `,
                 [completion`// Bubble sort algorithm\nconst numbers = [5, 3, 6, 2, 10];\n`],
                 {
-                    async onNetworkRequest(_params, onPartialResponse) {
+                    onNetworkRequest(_params, onPartialResponse) {
                         onPartialResponse?.(completion`// Bubble sort algorithm\nconst numbers = [5, 3, 6, 2, 10];\n`)
                     },
                 }

--- a/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
@@ -2,23 +2,19 @@ import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
 import { InlineCompletionsResultSource } from '../get-inline-completions'
-import { completion, nextTick } from '../test-helpers'
+import { completion } from '../test-helpers'
 
 import { getInlineCompletions, params, type V } from './helpers'
 
 describe('[getInlineCompletions] streaming', () => {
     it('terminates early for a single-line request', async () => {
-        const abortController = new AbortController()
         expect(
             await getInlineCompletions({
                 ...params('const x = █', [completion`├1337\nconsole.log('what?');┤`], {
                     async onNetworkRequest(_params, onPartialResponse) {
                         onPartialResponse?.(completion`├1337\ncon┤`)
-                        await nextTick()
-                        expect(abortController.signal.aborted).toBe(true)
                     },
                 }),
-                abortSignal: abortController.signal,
             })
         ).toEqual<V>({
             items: [{ insertText: '1337' }],
@@ -27,20 +23,14 @@ describe('[getInlineCompletions] streaming', () => {
     })
 
     it('does not include unfinished lines in results', async () => {
-        const abortController = new AbortController()
         expect(
             await getInlineCompletions({
                 ...params('const x = █', [completion`├1337\nconsole.log('what?');┤`], {
                     async onNetworkRequest(_params, onPartialResponse) {
                         onPartialResponse?.(completion`├13┤`)
-                        await nextTick()
-                        expect(abortController.signal.aborted).toBe(false)
                         onPartialResponse?.(completion`├1337\n┤`)
-                        await nextTick()
-                        expect(abortController.signal.aborted).toBe(true)
                     },
                 }),
-                abortSignal: abortController.signal,
             })
         ).toEqual<V>({
             items: [{ insertText: '1337' }],
@@ -49,7 +39,6 @@ describe('[getInlineCompletions] streaming', () => {
     })
 
     it('uses the multi-line truncation logic to terminate early for multi-line completions', async () => {
-        const abortController = new AbortController()
         const result = await getInlineCompletions({
             ...params(
                 dedent`
@@ -71,20 +60,15 @@ describe('[getInlineCompletions] streaming', () => {
                                         ├console.log('what?')┤
                                     ┴┴┴┴
                                 `)
-                        await nextTick()
-                        expect(abortController.signal.aborted).toBe(false)
                         onPartialResponse?.(completion`
                                         ├console.log('what?')
                                     }
 
                                     function never(){}┤
                                 `)
-                        await nextTick()
-                        expect(abortController.signal.aborted).toBe(true)
                     },
                 }
             ),
-            abortSignal: abortController.signal,
         })
 
         expect(result?.items.map(item => item.insertText)).toEqual(["console.log('what?')"])
@@ -92,7 +76,6 @@ describe('[getInlineCompletions] streaming', () => {
     })
 
     it('uses the next non-empty line comparison logic to terminate early for multi-line completions', async () => {
-        const abortController = new AbortController()
         expect(
             await getInlineCompletions({
                 ...params(
@@ -116,19 +99,14 @@ describe('[getInlineCompletions] streaming', () => {
                                         console.log('oh no')┤
                                     ┴┴┴┴
                                 `)
-                            await nextTick()
-                            expect(abortController.signal.aborted).toBe(false)
                             onPartialResponse?.(completion`
                                         ├const a = new Array()
                                         console.log('oh no')
                                     ┤
                                 `)
-                            await nextTick()
-                            expect(abortController.signal.aborted).toBe(true)
                         },
                     }
                 ),
-                abortSignal: abortController.signal,
             })
         ).toEqual<V>({
             items: [{ insertText: 'const a = new Array()' }],
@@ -137,8 +115,6 @@ describe('[getInlineCompletions] streaming', () => {
     })
 
     it('uses the multi-line truncation logic to terminate early for multi-line completions with leading new line', async () => {
-        const abortController = new AbortController()
-
         const result = await getInlineCompletions({
             ...params(
                 dedent`
@@ -154,17 +130,12 @@ describe('[getInlineCompletions] streaming', () => {
                         onPartialResponse?.(
                             completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (`
                         )
-                        await nextTick()
-                        expect(abortController.signal.aborted).toBe(false)
                         onPartialResponse?.(
                             completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (true) {}\n  }\n}\nconsole.log()\n`
                         )
-                        await nextTick()
-                        expect(abortController.signal.aborted).toBe(true)
                     },
                 }
             ),
-            abortSignal: abortController.signal,
         })
 
         expect(result?.items[0].insertText).toMatchInlineSnapshot(`
@@ -177,9 +148,7 @@ describe('[getInlineCompletions] streaming', () => {
         expect(result?.source).toBe(InlineCompletionsResultSource.Network)
     })
 
-    it.skip('cuts-off multlineline compeltions with inconsistent indentation correctly', async () => {
-        const abortController = new AbortController()
-
+    it('cuts-off multlineline compeltions with inconsistent indentation correctly', async () => {
         const result = await getInlineCompletions({
             ...params(
                 dedent`
@@ -191,12 +160,9 @@ describe('[getInlineCompletions] streaming', () => {
                 {
                     async onNetworkRequest(_params, onPartialResponse) {
                         onPartialResponse?.(completion`// Bubble sort algorithm\nconst numbers = [5, 3, 6, 2, 10];\n`)
-                        await nextTick()
-                        expect(abortController.signal.aborted).toBe(false)
                     },
                 }
             ),
-            abortSignal: abortController.signal,
         })
 
         expect(result?.items[0].insertText).toMatchInlineSnapshot('"// Bubble sort algorithm"')


### PR DESCRIPTION
## Context

- I've been refactoring the autocomplete streaming logic and bumped into these tests. By accident, I discovered a couple of things:
    1. The `expect` check for abort signal being aborted in `onNetworkRequest` callbacks is not applicable anymore. If you `console.log(abortController.signal.aborted)`, it's always `false`, which makes sense logic-wise. We do not cancel the top-level signal; we only cancel individual requests using the forked signal.
    2. These `expect` statements are not taken into account (were never taken into account?) by `vitest`. That's why they all pass even though the values do not match with expects.
- In my other branch, I made these expects reachable and spent an hour trying to understand why it does not work as expected. Then, I finally went to debug how it works on main and discovered the above 😛.
- This PR also enables one of the tests that was skipped previously. 

## Test plan

CI
