### PR TITLE
Symf: move term expansion to separate file

### DIFF
--- a/vscode/src/local-context/symf.test.ts
+++ b/vscode/src/local-context/symf.test.ts
@@ -5,7 +5,7 @@ import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/s
 
 import { startPollyRecording } from '../testutils/polly'
 
-import { expandQuery } from './symf'
+import { symfExpandQuery } from './symfExpandQuery'
 
 describe('symf', () => {
     const client = new SourcegraphNodeCompletionsClient({
@@ -23,7 +23,7 @@ describe('symf', () => {
 
         function check(query: string, expectedHandler: (expandedTerm: string) => void): void {
             it(query, async () => {
-                expectedHandler(await expandQuery(client, query))
+                expectedHandler(await symfExpandQuery(client, query))
             })
         }
 

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -5,7 +5,6 @@ import path from 'node:path'
 import { promisify } from 'node:util'
 
 import { Mutex } from 'async-mutex'
-import { XMLParser } from 'fast-xml-parser'
 import { mkdirp } from 'mkdirp'
 import * as vscode from 'vscode'
 
@@ -16,6 +15,7 @@ import { type SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/
 import { logDebug } from '../log'
 
 import { getSymfPath } from './download-symf'
+import { symfExpandQuery } from './symfExpandQuery'
 
 const execFile = promisify(_execFile)
 
@@ -70,7 +70,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
     }
 
     public getResults(userQuery: string, scopeDirs: string[]): Promise<Promise<Result[]>[]> {
-        const expandedQuery = expandQuery(this.completionsClient, userQuery)
+        const expandedQuery = symfExpandQuery(this.completionsClient, userQuery)
         return Promise.resolve(scopeDirs.map(scopeDir => this.getResultsForScopeDir(expandedQuery, scopeDir)))
     }
 
@@ -500,59 +500,4 @@ function toSymfError(error: unknown): Error {
         errorMessage = `symf index creation failed: ${error}`
     }
     return new EvalError(errorMessage)
-}
-
-export function expandQuery(completionsClient: SourcegraphCompletionsClient, query: string): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-        const streamingText: string[] = []
-        completionsClient.stream(
-            {
-                messages: [
-                    {
-                        speaker: 'human',
-                        text: `You are helping the user search over a codebase. List some filename fragments that would match files relevant to read to answer the user's query. Present your results in an XML list in the following format: <keywords><keyword><value>a single keyword</value><variants>a space separated list of synonyms and variants of the keyword, including acronyms, abbreviations, and expansions</variants><weight>a numerical weight between 0.0 and 1.0 that indicates the importance of the keyword</weight></keyword></keywords>. Here is the user query: <userQuery>${query}</userQuery>`,
-                    },
-                    { speaker: 'assistant' },
-                ],
-                maxTokensToSample: 400,
-                temperature: 0,
-                topK: 1,
-                fast: true,
-            },
-            {
-                onChange(text) {
-                    streamingText.push(text)
-                },
-                onComplete() {
-                    const text = streamingText.at(-1) ?? ''
-                    try {
-                        const parser = new XMLParser()
-                        const document = parser.parse(text)
-                        const keywords: { value?: string; variants?: string; weight?: number }[] =
-                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                            document?.keywords?.keyword ?? []
-                        const result = new Set<string>()
-                        for (const { value, variants } of keywords) {
-                            if (typeof value === 'string' && value) {
-                                result.add(value)
-                            }
-                            if (typeof variants === 'string') {
-                                for (const variant of variants.split(' ')) {
-                                    if (variant) {
-                                        result.add(variant)
-                                    }
-                                }
-                            }
-                        }
-                        resolve([...result].sort().join(' '))
-                    } catch (error) {
-                        reject(error)
-                    }
-                },
-                onError(error) {
-                    reject(error)
-                },
-            }
-        )
-    })
 }

--- a/vscode/src/local-context/symfExpandQuery.ts
+++ b/vscode/src/local-context/symfExpandQuery.ts
@@ -1,0 +1,58 @@
+import { XMLParser } from 'fast-xml-parser'
+
+import { type SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
+
+export function symfExpandQuery(completionsClient: SourcegraphCompletionsClient, query: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+        const streamingText: string[] = []
+        completionsClient.stream(
+            {
+                messages: [
+                    {
+                        speaker: 'human',
+                        text: `You are helping the user search over a codebase. List some filename fragments that would match files relevant to read to answer the user's query. Present your results in an XML list in the following format: <keywords><keyword><value>a single keyword</value><variants>a space separated list of synonyms and variants of the keyword, including acronyms, abbreviations, and expansions</variants><weight>a numerical weight between 0.0 and 1.0 that indicates the importance of the keyword</weight></keyword></keywords>. Here is the user query: <userQuery>${query}</userQuery>`,
+                    },
+                    { speaker: 'assistant' },
+                ],
+                maxTokensToSample: 400,
+                temperature: 0,
+                topK: 1,
+                fast: true,
+            },
+            {
+                onChange(text) {
+                    streamingText.push(text)
+                },
+                onComplete() {
+                    const text = streamingText.at(-1) ?? ''
+                    try {
+                        const parser = new XMLParser()
+                        const document = parser.parse(text)
+                        const keywords: { value?: string; variants?: string; weight?: number }[] =
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                            document?.keywords?.keyword ?? []
+                        const result = new Set<string>()
+                        for (const { value, variants } of keywords) {
+                            if (typeof value === 'string' && value) {
+                                result.add(value)
+                            }
+                            if (typeof variants === 'string') {
+                                for (const variant of variants.split(' ')) {
+                                    if (variant) {
+                                        result.add(variant)
+                                    }
+                                }
+                            }
+                        }
+                        resolve([...result].sort().join(' '))
+                    } catch (error) {
+                        reject(error)
+                    }
+                },
+                onError(error) {
+                    reject(error)
+                },
+            }
+        )
+    })
+}


### PR DESCRIPTION
Previously, I was unable to run the symf tests locally because it reported an issue with `vscode` imports. This error was understandable because the `symf.ts` file imported from the `'vscode'` module. Moving the term expansion function to a separate file fixes the problem. However, I'm not sure how the tests passed in the first place unless something regressed recently.


## Test plan

Green CI
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
