### PR TITLE
update google auth workflow step to unblock external contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,12 +129,6 @@ jobs:
         with:
           node-version-file: .tool-versions
       - uses: pnpm/action-setup@v2
-      - id: auth
-        uses: google-github-actions/auth@v0
-        with:
-          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
-          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
-      - uses: google-github-actions/setup-gcloud@v0
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
       - uses: pnpm/action-setup@v2
       - id: auth
         uses: google-github-actions/auth@v0
+        # Skip auth if PR is from a fork
+        if: !github.event.pull_request.head.repo.fork
         with:
           workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
           service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
@@ -129,6 +131,14 @@ jobs:
         with:
           node-version-file: .tool-versions
       - uses: pnpm/action-setup@v2
+      - id: auth
+        uses: google-github-actions/auth@v0
+        # Skip auth if PR is from a fork
+        if: !github.event.pull_request.head.repo.fork
+        with:
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v0
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v0
         # Skip auth if PR is from a fork
-        if: !github.event.pull_request.head.repo.fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
           service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
@@ -134,7 +134,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v0
         # Skip auth if PR is from a fork
-        if: !github.event.pull_request.head.repo.fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
           service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}


### PR DESCRIPTION
PR to update/remove GoogleAuth step to unblock external contributors.

[Slack thread](https://sourcegraph.slack.com/archives/C04MYFW01NV/p1705336704859289) for more information on this request.

## Test plan
test that CI is working as expected and events are still able to get logged from e2e tests
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
