### PR TITLE
fix cody-shared import from agent issue

### DIFF
--- a/agent/src/esbuild.mjs
+++ b/agent/src/esbuild.mjs
@@ -17,6 +17,13 @@ import { build } from 'esbuild'
         logLevel: 'error',
         alias: {
             vscode: path.resolve(process.cwd(), 'src', 'vscode-shim.ts'),
+
+            // Build from TypeScript sources so we don't need to run `tsc -b` in the background
+            // during dev.
+            '@sourcegraph/cody-shared': '@sourcegraph/cody-shared/src/index',
+            '@sourcegraph/cody-shared/src': '@sourcegraph/cody-shared/src',
+            '@sourcegraph/cody-ui': '@sourcegraph/cody-ui/src/index',
+            '@sourcegraph/cody-ui/src': '@sourcegraph/cody-ui/src',
         },
     }
     const res = await build(esbuildOptions)

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -7,16 +7,10 @@ export type { ChatButton, ChatError, ChatMessage } from './chat/transcript/messa
 export type { ContextFile, PreciseContext } from './codebase-context/messages'
 export type { CodyCommand } from './commands'
 export { basename, dedupeWith, isDefined, isErrorLike, pluralize } from './common'
+export { languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './common/languages'
 export { isWindows } from './common/platform'
 export type { ActiveTextEditorSelectionRange } from './editor'
-// TODO: figure out why the symbols from displayPath.ts can't be imported from
-// `@sourcegraph/cody-shared`. To reproduce the problem, tweak the user query in
-// one of the tests in agent/src/index.test.ts, run `pnpm update-agent-recordings`
-// and look for the error message "no environment info for displayPath function
-// (call setDisplayPathEnvInfo; see displayPath docstring for more info)". The
-// error is not reproducible when running in replay mode.
-// export { displayPath, setDisplayPathEnvInfo } from './editor/displayPath'
-export { languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './common/languages'
+export { displayPath, setDisplayPathEnvInfo } from './editor/displayPath'
 export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
 export type { Attribution, Guardrails } from './guardrails'
 export { ContextWindowLimitError, RateLimitError } from './sourcegraph-api/errors'

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import classNames from 'classnames'
 
 import {
+    displayPath,
     isDefined,
     type ChatButton,
     type ChatMessage,
@@ -11,8 +12,6 @@ import {
     type ContextFile,
     type Guardrails,
 } from '@sourcegraph/cody-shared'
-
-import { displayPath } from '../../shared/src/editor/displayPath'
 
 import { type CodeBlockMeta } from './chat/CodeBlocks'
 import { type FileLinkProps } from './chat/components/EnhancedContext'

--- a/vscode/src/commands/prompt/display-text.test.ts
+++ b/vscode/src/commands/prompt/display-text.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
-import { setDisplayPathEnvInfo, type DisplayPathEnvInfo } from '@sourcegraph/cody-shared/src/editor/displayPath'
+import { setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
+import { type DisplayPathEnvInfo } from '@sourcegraph/cody-shared/src/editor/displayPath'
 
 import { replaceFileNameWithMarkdownLink } from './display-text'
 

--- a/vscode/src/commands/prompt/display-text.ts
+++ b/vscode/src/commands/prompt/display-text.ts
@@ -1,9 +1,8 @@
 import * as vscode from 'vscode'
 
+import { displayPath } from '@sourcegraph/cody-shared'
 import { type ContextFile } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { type ActiveTextEditorSelection } from '@sourcegraph/cody-shared/src/editor'
-
-import { displayPath } from '../../../../lib/shared/src/editor/displayPath'
 
 import { trailingNonAlphaNumericRegex } from './utils'
 

--- a/vscode/src/editor/displayPathEnvInfo.ts
+++ b/vscode/src/editor/displayPathEnvInfo.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isWindows } from '@sourcegraph/cody-shared'
-
-import { setDisplayPathEnvInfo } from '../../../lib/shared/src/editor/displayPath'
+import { isWindows, setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
 
 /** Runs in the VS Code extension host. */
 export function manageDisplayPathEnvInfoForExtension(): vscode.Disposable {

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -4,7 +4,7 @@ import fuzzysort from 'fuzzysort'
 import { throttle } from 'lodash'
 import * as vscode from 'vscode'
 
-import { type ContextFile } from '@sourcegraph/cody-shared'
+import { displayPath, type ContextFile } from '@sourcegraph/cody-shared'
 import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
 import {
     type ContextFileFile,
@@ -13,8 +13,6 @@ import {
     type ContextFileType,
     type SymbolKind,
 } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-
-import { displayPath } from '../../../../lib/shared/src/editor/displayPath'
 
 import { getOpenTabsUris, getWorkspaceSymbols } from '.'
 

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -1,9 +1,8 @@
 import * as vscode from 'vscode'
 
-import { type ContextFile } from '@sourcegraph/cody-shared'
+import { displayPath, type ContextFile } from '@sourcegraph/cody-shared'
 import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
-import { displayPath } from '../../../lib/shared/src/editor/displayPath'
 import { EDIT_COMMAND, menu_buttons } from '../commands/utils/menu'
 import { type ExecuteEditArguments } from '../edit/execute'
 import { getEditor } from '../editor/active-editor'

--- a/vscode/src/testutils/testSetup.ts
+++ b/vscode/src/testutils/testSetup.ts
@@ -1,9 +1,7 @@
 import { beforeAll } from 'vitest'
 import { URI } from 'vscode-uri'
 
-import { isWindows } from '@sourcegraph/cody-shared'
-
-import { setDisplayPathEnvInfo } from '../../../lib/shared/src/editor/displayPath'
+import { isWindows, setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
 
 beforeAll(() => {
     const isWin = isWindows()

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
+import { displayPath } from '@sourcegraph/cody-shared'
 import { type FileLinkProps } from '@sourcegraph/cody-ui/src/chat/components/EnhancedContext'
 
-import { displayPath } from '../../../lib/shared/src/editor/displayPath'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
 
 import styles from './FileLink.module.css'

--- a/vscode/webviews/UserContextSelector.tsx
+++ b/vscode/webviews/UserContextSelector.tsx
@@ -2,9 +2,8 @@ import React, { useEffect, useRef } from 'react'
 
 import classNames from 'classnames'
 
+import { displayPath } from '@sourcegraph/cody-shared'
 import { type UserContextSelectorProps } from '@sourcegraph/cody-ui/src/Chat'
-
-import { displayPath } from '../../lib/shared/src/editor/displayPath'
 
 import styles from './UserContextSelector.module.css'
 

--- a/vscode/webviews/utils/displayPathEnvInfo.ts
+++ b/vscode/webviews/utils/displayPathEnvInfo.ts
@@ -1,8 +1,6 @@
 import { URI } from 'vscode-uri'
 
-import { isWindows } from '@sourcegraph/cody-shared'
-
-import { setDisplayPathEnvInfo } from '../../../lib/shared/src/editor/displayPath'
+import { isWindows, setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
 
 /** Runs in the VS Code webview. */
 export function updateDisplayPathEnvInfoForWebview(workspaceFolderUris: string[]): void {


### PR DESCRIPTION
Now, `esbuild` builds other projects from their TypeScript sources instead of from their intermediate build products in `dist`.

As a benefit, also makes it so you don't need to run `tsc -b` to produce the latest `dist` dirs during agent development.

The cause was likely that the `dist` dirs were out of date (because `tsc -b` was not running or got confused during a `git checkout`), or different import strategies were causing `@sourcegraph/cody-shared` to be imported multiple times.

Discussion: https://sourcegraph.slack.com/archives/C05AGQYD528/p1705319075562969

## Test plan

Run agent tests as described in the now-deleted `lib/shared/src/index.ts` comment and ensure they pass.