### PR TITLE
encapsulate @sourcegraph/cody-shared, restrict subpath imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,19 @@ const config = {
         disallowTypeAnnotations: false,
       },
     ],
+
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['@sourcegraph/cody-shared/*'],
+            message:
+              'Please import from @sourcegraph/cody-shared instead of subpaths. If you need to use something that is not exported by @sourcegraph/cody-shared, just update lib/shared/src/index.ts to export the thing you need. Reasons for this restriction: (1) enforce a clean boundary between the internal and external API of the shared lib, (2) avoid accidentally bundling multiple copies of the shared lib.',
+          },
+        ],
+      },
+    ],
   },
   overrides: [
     {

--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode'
 
-import type { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import type { Configuration } from '@sourcegraph/cody-shared'
 
 import { defaultConfigurationValue } from '../../vscode/src/configuration-keys'
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -6,14 +6,21 @@ import { type Polly } from '@pollyjs/core'
 import envPaths from 'env-paths'
 import * as vscode from 'vscode'
 
-import { createClient, type Client } from '@sourcegraph/cody-shared/src/chat/client'
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import {
+    convertGitCloneURLToCodebaseName,
+    createClient,
+    FeatureFlag,
+    featureFlagProvider,
+    isRateLimitError,
+    NoOpTelemetryRecorderProvider,
+    setUserAgent,
+    type BillingCategory,
+    type BillingProduct,
+    type Client,
+    type LogEventMode,
+} from '@sourcegraph/cody-shared'
+// eslint-disable-next-line no-restricted-imports
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
-import { isRateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { setUserAgent, type LogEventMode } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import { type BillingCategory, type BillingProduct } from '@sourcegraph/cody-shared/src/telemetry-v2'
-import { NoOpTelemetryRecorderProvider } from '@sourcegraph/cody-shared/src/telemetry-v2/TelemetryRecorderProvider'
-import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared/src/utils'
 import { type TelemetryEventParameters } from '@sourcegraph/telemetry'
 
 import { chatHistory } from '../../vscode/src/chat/chat-view/ChatHistoryManager'

--- a/agent/src/editor.ts
+++ b/agent/src/editor.ts
@@ -1,15 +1,15 @@
 import type * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
 import {
+    isCodyIgnoredFile,
     type ActiveTextEditor,
     type ActiveTextEditorDiagnostic,
     type ActiveTextEditorSelection,
     type ActiveTextEditorViewControllers,
     type ActiveTextEditorVisibleContent,
     type Editor,
-} from '@sourcegraph/cody-shared/src/editor'
+} from '@sourcegraph/cody-shared'
 
 import { type TextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
 

--- a/agent/src/telemetry/index.ts
+++ b/agent/src/telemetry/index.ts
@@ -1,6 +1,9 @@
-import { type SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
-import { GraphQLTelemetryExporter } from '@sourcegraph/cody-shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter'
-import { type BillingCategory, type BillingProduct } from '@sourcegraph/cody-shared/src/telemetry-v2'
+import {
+    GraphQLTelemetryExporter,
+    type BillingCategory,
+    type BillingProduct,
+    type SourcegraphGraphQLAPIClient,
+} from '@sourcegraph/cody-shared'
 import {
     defaultEventRecordingOptions,
     MarketingTrackingTelemetryProcessor,

--- a/e2e/src/run.ts
+++ b/e2e/src/run.ts
@@ -2,9 +2,8 @@ import fs from 'fs/promises'
 
 import chalk from 'chalk'
 
-import { type ChatMessage } from '@sourcegraph/cody-shared'
-import { createClient, Transcript } from '@sourcegraph/cody-shared/src/chat/client'
-import { NoopEditor } from '@sourcegraph/cody-shared/src/editor'
+import { createClient, NoopEditor, Transcript, type ChatMessage } from '@sourcegraph/cody-shared'
+// eslint-disable-next-line no-restricted-imports
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
 import { program, type CLIOptions } from '.'

--- a/e2e/src/test-cases/index.ts
+++ b/e2e/src/test-cases/index.ts
@@ -1,4 +1,4 @@
-import { type ConfigurationUseContext } from '@sourcegraph/cody-shared/src/configuration'
+import { type ConfigurationUseContext } from '@sourcegraph/cody-shared'
 
 export interface Fact {
     type: 'literal' | 'regex'

--- a/e2e/src/test-results.ts
+++ b/e2e/src/test-results.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 
-import { type ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { type ContextMessage } from '@sourcegraph/cody-shared'
 
 import { type FactCheck } from './fact-check'
 import { type LLMJudgement } from './llm-judge'

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -1,18 +1,152 @@
-// Add anything else here that needs to be used outside of this repository.
+// Add anything else here that needs to be used outside of this library.
 
 export { ChatModelProvider } from './chat-models'
+export { BotResponseMultiplexer } from './chat/bot-response-multiplexer'
+export { ChatClient } from './chat/chat'
+export { createClient, type Client } from './chat/client'
 export type { ChatContextStatus } from './chat/context'
+export { ignores, isCodyIgnoredFile } from './chat/context-filter'
+export { CODY_IGNORE_FILENAME_POSIX_GLOB } from './chat/ignore-helper'
 export { renderCodyMarkdown } from './chat/markdown'
-export type { ChatButton, ChatError, ChatMessage } from './chat/transcript/messages'
-export type { ContextFile, PreciseContext } from './codebase-context/messages'
-export type { CodyCommand } from './commands'
+export { getSimplePreamble } from './chat/preamble'
+export { Transcript } from './chat/transcript'
+export type { TranscriptJSON } from './chat/transcript'
+export { Interaction } from './chat/transcript/interaction'
+export type { InteractionJSON } from './chat/transcript/interaction'
+export { errorToChatError } from './chat/transcript/messages'
+export type {
+    ChatButton,
+    ChatError,
+    ChatEventSource,
+    ChatHistory,
+    ChatMessage,
+    InteractionMessage,
+    UserLocalHistory,
+} from './chat/transcript/messages'
+export { Typewriter } from './chat/typewriter'
+export { reformatBotMessageForChat } from './chat/viewHelpers'
+export { CodebaseContext } from './codebase-context'
+export type {
+    ContextGroup,
+    ContextProvider,
+    ContextStatusProvider,
+    Disposable,
+    EnhancedContextContextT,
+    LocalEmbeddingsProvider,
+    SearchProvider,
+} from './codebase-context/context-status'
+export { createContextMessageByFile, getContextMessageWithResponse } from './codebase-context/messages'
+export type {
+    ContextFile,
+    ContextFileFile,
+    ContextFileSource,
+    ContextFileSymbol,
+    ContextFileType,
+    ContextMessage,
+    HoverContext,
+    PreciseContext,
+    SymbolKind,
+} from './codebase-context/messages'
+export { defaultCodyCommandContext } from './commands'
+export type { CodyCommand, CodyCommandContext, CustomCommandType } from './commands'
 export { basename, dedupeWith, isDefined, isErrorLike, pluralize } from './common'
-export { languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './common/languages'
+export { ProgrammingLanguage, languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './common/languages'
+export { renderMarkdown } from './common/markdown'
 export { isWindows } from './common/platform'
-export type { ActiveTextEditorSelectionRange } from './editor'
-export { displayPath, setDisplayPathEnvInfo } from './editor/displayPath'
+export type {
+    AutocompleteTimeouts,
+    Configuration,
+    ConfigurationUseContext,
+    ConfigurationWithAccessToken,
+    OllamaGenerateParameters,
+    OllamaOptions,
+} from './configuration'
+export { NoopEditor } from './editor'
+export type {
+    ActiveTextEditor,
+    ActiveTextEditorDiagnostic,
+    ActiveTextEditorDiagnosticType,
+    ActiveTextEditorSelection,
+    ActiveTextEditorSelectionRange,
+    ActiveTextEditorViewControllers,
+    ActiveTextEditorVisibleContent,
+    Editor,
+    VsCodeCommandsController,
+} from './editor'
+export { displayPath, setDisplayPathEnvInfo, type DisplayPathEnvInfo } from './editor/displayPath'
 export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
+export { EmbeddingsDetector } from './embeddings/EmbeddingsDetector'
+export { SourcegraphEmbeddingsSearchClient } from './embeddings/client'
+export { FeatureFlag, FeatureFlagProvider, featureFlagProvider } from './experimentation/FeatureFlagProvider'
+export type { GraphContextFetcher } from './graph-context'
+export { GuardrailsPost, summariseAttribution } from './guardrails'
 export type { Attribution, Guardrails } from './guardrails'
-export { ContextWindowLimitError, RateLimitError } from './sourcegraph-api/errors'
+export { SourcegraphGuardrailsClient } from './guardrails/client'
+export type { IntentClassificationOption, IntentDetector } from './intent-detector'
+export { SourcegraphIntentDetectorClient } from './intent-detector/client'
+export type {
+    ContextResult,
+    FilenameContextFetcher,
+    IndexedKeywordContextFetcher,
+    LocalEmbeddingsFetcher,
+    Result,
+    SearchPanelFile,
+    SearchPanelSnippet,
+} from './local-context'
+export {
+    MAX_BYTES_PER_FILE,
+    MAX_CURRENT_FILE_TOKENS,
+    MAX_HUMAN_INPUT_TOKENS,
+    NUM_CODE_RESULTS,
+    NUM_TEXT_RESULTS,
+    SURROUNDING_LINES,
+    tokensToChars,
+} from './prompt/constants'
+export { PromptMixin, newPromptMixin } from './prompt/prompt-mixin'
+export * from './prompt/templates'
+export { truncateText, truncateTextNearestLine, truncateTextStart } from './prompt/truncation'
+export type { Message } from './sourcegraph-api'
+export { SourcegraphBrowserCompletionsClient } from './sourcegraph-api/completions/browserClient'
+export { SourcegraphCompletionsClient } from './sourcegraph-api/completions/client'
+export type { CompletionLogger, CompletionsClientConfig } from './sourcegraph-api/completions/client'
+export type { CompletionParameters, CompletionResponse, Event } from './sourcegraph-api/completions/types'
+export { DOTCOM_URL, LOCAL_APP_URL, isDotCom } from './sourcegraph-api/environments'
+export {
+    AbortError,
+    ContextWindowLimitError,
+    NetworkError,
+    RateLimitError,
+    TimeoutError,
+    TracedError,
+    isAbortError,
+    isAuthError,
+    isNetworkError,
+    isRateLimitError,
+} from './sourcegraph-api/errors'
+export { SourcegraphGraphQLAPIClient, graphqlClient, type EmbeddingsSearchResults } from './sourcegraph-api/graphql'
+export {
+    ConfigFeaturesSingleton,
+    addCustomUserAgent,
+    customUserAgent,
+    isNodeResponse,
+    setUserAgent,
+    type BrowserOrNodeResponse,
+    type GraphQLAPIClientConfig,
+    type LogEventMode,
+} from './sourcegraph-api/graphql/client'
+export type { CodyLLMSiteConfiguration, EmbeddingsSearchResult, event } from './sourcegraph-api/graphql/client'
+export { GraphQLTelemetryExporter } from './sourcegraph-api/telemetry/GraphQLTelemetryExporter'
+export { NOOP_TELEMETRY_SERVICE } from './telemetry'
+export type { TelemetryEventProperties, TelemetryService } from './telemetry'
+export { type BillingCategory, type BillingProduct } from './telemetry-v2'
+export {
+    MockServerTelemetryRecorderProvider,
+    NoOpTelemetryRecorderProvider,
+    TelemetryRecorderProvider,
+} from './telemetry-v2/TelemetryRecorderProvider'
+export type { TelemetryRecorder } from './telemetry-v2/TelemetryRecorderProvider'
+export { EventLogger } from './telemetry/EventLogger'
+export type { ExtensionDetails } from './telemetry/EventLogger'
 export { testFileUri } from './test/path-helpers'
-export { isError } from './utils'
+export { addTraceparent, getActiveTraceAndSpanId, wrapInActiveSpan } from './tracing'
+export { convertGitCloneURLToCodebaseName, isError } from './utils'

--- a/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
+++ b/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
@@ -1,8 +1,8 @@
 import {
     SourcegraphGraphQLAPIClient,
     type EmbeddingsSearchResults,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
-import { type GraphQLAPIClientConfig } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+    type GraphQLAPIClientConfig,
+} from '@sourcegraph/cody-shared'
 
 export class CachedRemoteEmbeddingsClient {
     private client: SourcegraphGraphQLAPIClient

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -1,18 +1,18 @@
 import * as vscode from 'vscode'
 
-import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
-import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import {
+    CodebaseContext,
+    EmbeddingsDetector,
+    isError,
+    SourcegraphGraphQLAPIClient,
+    type ChatClient,
+    type ConfigurationWithAccessToken,
     type ContextGroup,
     type ContextStatusProvider,
-} from '@sourcegraph/cody-shared/src/codebase-context/context-status'
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { type Editor } from '@sourcegraph/cody-shared/src/editor'
-import { EmbeddingsDetector } from '@sourcegraph/cody-shared/src/embeddings/EmbeddingsDetector'
-import { type IndexedKeywordContextFetcher } from '@sourcegraph/cody-shared/src/local-context'
-import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
-import { type GraphQLAPIClientConfig } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import { isError } from '@sourcegraph/cody-shared/src/utils'
+    type Editor,
+    type GraphQLAPIClientConfig,
+    type IndexedKeywordContextFetcher,
+} from '@sourcegraph/cody-shared'
 
 import { getFullConfig } from '../configuration'
 import { getEditor } from '../editor/active-editor'

--- a/vscode/src/chat/GraphContextProvider.ts
+++ b/vscode/src/chat/GraphContextProvider.ts
@@ -2,10 +2,10 @@ import {
     type ContextGroup,
     type ContextStatusProvider,
     type Disposable,
-} from '@sourcegraph/cody-shared/src/codebase-context/context-status'
-import { type PreciseContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { type Editor } from '@sourcegraph/cody-shared/src/editor'
-import { type GraphContextFetcher } from '@sourcegraph/cody-shared/src/graph-context'
+    type Editor,
+    type GraphContextFetcher,
+    type PreciseContext,
+} from '@sourcegraph/cody-shared'
 
 import { getGraphContextFromEditor } from '../graph/lsp/graph'
 

--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -1,6 +1,4 @@
-import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
-import { type Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
-import { type IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
+import { type ChatClient, type Guardrails, type IntentDetector } from '@sourcegraph/cody-shared'
 
 import { type VSCodeEditor } from '../editor/vscode-editor'
 import { type AuthProvider } from '../services/AuthProvider'

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -1,5 +1,4 @@
-import { type TranscriptJSON } from '@sourcegraph/cody-shared/src/chat/transcript'
-import { type UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { type TranscriptJSON, type UserLocalHistory } from '@sourcegraph/cody-shared'
 
 import { localStorage } from '../../services/LocalStorageProvider'
 import { type AuthStatus } from '../protocol'

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -1,9 +1,13 @@
 import { debounce } from 'lodash'
 import * as vscode from 'vscode'
 
-import { ChatModelProvider, type CodyCommand, type Guardrails } from '@sourcegraph/cody-shared'
-import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import {
+    ChatModelProvider,
+    type ChatClient,
+    type ChatEventSource,
+    type CodyCommand,
+    type Guardrails,
+} from '@sourcegraph/cody-shared'
 
 import { type View } from '../../../webviews/NavBar'
 import { type CommandsController } from '../../commands/CommandsController'

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode'
 
-import { ChatModelProvider, type Guardrails } from '@sourcegraph/cody-shared'
-import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import {
+    ChatModelProvider,
     featureFlagProvider,
+    type ChatClient,
+    type ConfigurationWithAccessToken,
     type FeatureFlagProvider,
-} from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+    type Guardrails,
+} from '@sourcegraph/cody-shared'
 
 import { type CommandsController } from '../../commands/CommandsController'
 import { type LocalEmbeddingsController } from '../../local-context/local-embeddings'

--- a/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
+++ b/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
@@ -2,14 +2,14 @@ import { isEqual } from 'lodash'
 import * as vscode from 'vscode'
 
 import {
+    isDotCom,
+    isError,
     type ContextGroup,
     type ContextProvider,
     type ContextStatusProvider,
     type Disposable,
-} from '@sourcegraph/cody-shared/src/codebase-context/context-status'
-import { type Editor } from '@sourcegraph/cody-shared/src/editor'
-import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
-import { isError } from '@sourcegraph/cody-shared/src/utils'
+    type Editor,
+} from '@sourcegraph/cody-shared'
 
 import { getConfiguration } from '../../configuration'
 import { getEditor } from '../../editor/active-editor'

--- a/vscode/src/chat/chat-view/SidebarViewController.ts
+++ b/vscode/src/chat/chat-view/SidebarViewController.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { DOTCOM_URL } from '@sourcegraph/cody-shared'
 
 import { type View } from '../../../webviews/NavBar'
 import { logDebug } from '../../log'

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -1,13 +1,17 @@
 import { findLast } from 'lodash'
 import type * as vscode from 'vscode'
 
-import { type ChatError, type ChatMessage } from '@sourcegraph/cody-shared'
-import { type TranscriptJSON } from '@sourcegraph/cody-shared/src/chat/transcript'
-import { type InteractionJSON } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
-import { errorToChatError, type InteractionMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { reformatBotMessageForChat } from '@sourcegraph/cody-shared/src/chat/viewHelpers'
-import { type ContextFileSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { type Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
+import {
+    errorToChatError,
+    reformatBotMessageForChat,
+    type ChatError,
+    type ChatMessage,
+    type ContextFileSource,
+    type InteractionJSON,
+    type InteractionMessage,
+    type Message,
+    type TranscriptJSON,
+} from '@sourcegraph/cody-shared'
 
 import { contextItemsToContextFiles } from './chat-helpers'
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.test.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { URI } from 'vscode-uri'
 
-import { type Editor } from '@sourcegraph/cody-shared/src/editor'
+import { type Editor } from '@sourcegraph/cody-shared'
 
 import { type ContextItem } from './SimpleChatModel'
 import { contextFilesToContextItems } from './SimpleChatPanelProvider'

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -4,34 +4,38 @@ import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
 import {
+    ChatModelProvider,
+    ConfigFeaturesSingleton,
+    ContextWindowLimitError,
+    FeatureFlag,
     hydrateAfterPostMessage,
+    isCodyIgnoredFile,
     isDefined,
+    isDotCom,
+    isError,
+    isRateLimitError,
+    MAX_BYTES_PER_FILE,
+    NUM_CODE_RESULTS,
+    NUM_TEXT_RESULTS,
+    reformatBotMessageForChat,
+    truncateTextNearestLine,
+    Typewriter,
     type ActiveTextEditorSelectionRange,
+    type ChatClient,
+    type ChatEventSource,
     type ChatMessage,
     type CodyCommand,
     type ContextFile,
+    type ContextMessage,
+    type CustomCommandType,
+    type Editor,
+    type FeatureFlagProvider,
     type Guardrails,
+    type InteractionJSON,
+    type Message,
+    type Result,
+    type TranscriptJSON,
 } from '@sourcegraph/cody-shared'
-import { ChatModelProvider } from '@sourcegraph/cody-shared/src/chat-models'
-import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
-import { type TranscriptJSON } from '@sourcegraph/cody-shared/src/chat/transcript'
-import { type InteractionJSON } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { Typewriter } from '@sourcegraph/cody-shared/src/chat/typewriter'
-import { reformatBotMessageForChat } from '@sourcegraph/cody-shared/src/chat/viewHelpers'
-import { type ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { type CustomCommandType } from '@sourcegraph/cody-shared/src/commands'
-import { type Editor } from '@sourcegraph/cody-shared/src/editor'
-import { FeatureFlag, type FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
-import { type Result } from '@sourcegraph/cody-shared/src/local-context'
-import { MAX_BYTES_PER_FILE, NUM_CODE_RESULTS, NUM_TEXT_RESULTS } from '@sourcegraph/cody-shared/src/prompt/constants'
-import { truncateTextNearestLine } from '@sourcegraph/cody-shared/src/prompt/truncation'
-import { type Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
-import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
-import { ContextWindowLimitError, isRateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { ConfigFeaturesSingleton } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import { isError } from '@sourcegraph/cody-shared/src/utils'
 
 import { type View } from '../../../webviews/NavBar'
 import { type CommandsController } from '../../commands/CommandsController'

--- a/vscode/src/chat/chat-view/chat-helpers.test.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from 'vitest'
 
-import { testFileUri, type ContextFile } from '@sourcegraph/cody-shared'
-import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import {
+    CodebaseContext,
     populateCurrentEditorSelectedContextTemplate,
     populateCurrentSelectedCodeContextTemplate,
-} from '@sourcegraph/cody-shared/src/prompt/templates'
+    testFileUri,
+    type ContextFile,
+} from '@sourcegraph/cody-shared'
 
 import * as vscode from '../../testutils/mocks'
 

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type ActiveTextEditorSelectionRange } from '@sourcegraph/cody-shared'
-import { type ContextFile, type ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { type ActiveTextEditorSelectionRange, type ContextFile, type ContextMessage } from '@sourcegraph/cody-shared'
 
 import { type ContextItem } from './SimpleChatModel'
 

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -1,17 +1,17 @@
 import * as vscode from 'vscode'
 
-import { languageFromFilename } from '@sourcegraph/cody-shared'
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
-import { getSimplePreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
-import { type CodyCommand } from '@sourcegraph/cody-shared/src/commands'
-import { ProgrammingLanguage } from '@sourcegraph/cody-shared/src/common/languages'
 import {
+    getSimplePreamble,
+    isCodyIgnoredFile,
+    languageFromFilename,
     populateCodeContextTemplate,
     populateContextTemplateFromText,
     populateCurrentSelectedCodeContextTemplate,
     populateMarkdownContextTemplate,
-} from '@sourcegraph/cody-shared/src/prompt/templates'
-import { type Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
+    ProgrammingLanguage,
+    type CodyCommand,
+    type Message,
+} from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../../log'
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -1,14 +1,20 @@
 import { type URI } from 'vscode-uri'
 
-import { type ActiveTextEditorSelectionRange, type ChatModelProvider, type ContextFile } from '@sourcegraph/cody-shared'
-import { type ChatMessage, type UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { type EnhancedContextContextT } from '@sourcegraph/cody-shared/src/codebase-context/context-status'
-import { type ContextFileType } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { type CodyCommand, type CustomCommandType } from '@sourcegraph/cody-shared/src/commands'
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { type SearchPanelFile } from '@sourcegraph/cody-shared/src/local-context'
-import { type CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import type { TelemetryEventProperties } from '@sourcegraph/cody-shared/src/telemetry'
+import {
+    type ActiveTextEditorSelectionRange,
+    type ChatMessage,
+    type ChatModelProvider,
+    type CodyCommand,
+    type CodyLLMSiteConfiguration,
+    type ConfigurationWithAccessToken,
+    type ContextFile,
+    type ContextFileType,
+    type CustomCommandType,
+    type EnhancedContextContextT,
+    type SearchPanelFile,
+    type TelemetryEventProperties,
+    type UserLocalHistory,
+} from '@sourcegraph/cody-shared'
 import { type ChatSubmitType } from '@sourcegraph/cody-ui/src/Chat'
 import { type CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
 

--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type CodyCommand } from '@sourcegraph/cody-shared'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { ConfigFeaturesSingleton } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import { ConfigFeaturesSingleton, type ChatEventSource, type CodyCommand } from '@sourcegraph/cody-shared'
 
 import { executeEdit, type ExecuteEditArguments } from '../edit/execute'
 import { type EditIntent, type EditMode } from '../edit/types'

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type CodyCommand, type CustomCommandType } from '@sourcegraph/cody-shared/src/commands'
-import { type VsCodeCommandsController } from '@sourcegraph/cody-shared/src/editor'
+import { type CodyCommand, type CustomCommandType, type VsCodeCommandsController } from '@sourcegraph/cody-shared'
 
 import { getFullConfig } from '../configuration'
 import { executeEdit } from '../edit/execute'

--- a/vscode/src/commands/CustomPromptsStore.ts
+++ b/vscode/src/commands/CustomPromptsStore.ts
@@ -1,7 +1,7 @@
 import { omit } from 'lodash'
 import * as vscode from 'vscode'
 
-import { type CodyCommand, type CustomCommandType } from '@sourcegraph/cody-shared/src/commands'
+import { type CodyCommand, type CustomCommandType } from '@sourcegraph/cody-shared'
 
 import { logDebug, logError } from '../log'
 

--- a/vscode/src/commands/PromptsProvider.ts
+++ b/vscode/src/commands/PromptsProvider.ts
@@ -1,4 +1,4 @@
-import { type CodyCommand } from '@sourcegraph/cody-shared/src/commands'
+import { type CodyCommand } from '@sourcegraph/cody-shared'
 
 import { getDefaultCommandsMap } from '.'
 import { ASK_QUESTION_COMMAND, EDIT_COMMAND } from './utils/menu'

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -1,4 +1,4 @@
-import { type CodyCommand } from '@sourcegraph/cody-shared/src/commands'
+import { type CodyCommand } from '@sourcegraph/cody-shared'
 
 import * as defaultCommands from './prompt/cody.json'
 import { toSlashCommand } from './prompt/utils'

--- a/vscode/src/commands/menus/CustomCommandBuilderMenu.ts
+++ b/vscode/src/commands/menus/CustomCommandBuilderMenu.ts
@@ -1,7 +1,6 @@
 import { window, type QuickPickItem } from 'vscode'
 
-import { type CodyCommand } from '@sourcegraph/cody-shared'
-import { defaultCodyCommandContext, type CustomCommandType } from '@sourcegraph/cody-shared/src/commands'
+import { defaultCodyCommandContext, type CodyCommand, type CustomCommandType } from '@sourcegraph/cody-shared'
 
 import { toSlashCommand } from '../prompt/utils'
 import { customPromptsContextOptions } from '../utils/menu'

--- a/vscode/src/commands/prompt/display-text.test.ts
+++ b/vscode/src/commands/prompt/display-text.test.ts
@@ -2,8 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
-import { setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
-import { type DisplayPathEnvInfo } from '@sourcegraph/cody-shared/src/editor/displayPath'
+import { setDisplayPathEnvInfo, type DisplayPathEnvInfo } from '@sourcegraph/cody-shared'
 
 import { replaceFileNameWithMarkdownLink } from './display-text'
 

--- a/vscode/src/commands/prompt/display-text.ts
+++ b/vscode/src/commands/prompt/display-text.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode'
 
-import { displayPath } from '@sourcegraph/cody-shared'
-import { type ContextFile } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { type ActiveTextEditorSelection } from '@sourcegraph/cody-shared/src/editor'
+import { displayPath, type ActiveTextEditorSelection, type ContextFile } from '@sourcegraph/cody-shared'
 
 import { trailingNonAlphaNumericRegex } from './utils'
 

--- a/vscode/src/commands/utils/get-context.ts
+++ b/vscode/src/commands/utils/get-context.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { type CodyCommand } from '@sourcegraph/cody-shared/src/commands'
+import { type CodyCommand, type ContextMessage } from '@sourcegraph/cody-shared'
 
 import { VSCodeEditorContext } from '../../editor-context/VSCodeEditorContext'
 import { type VSCodeEditor } from '../../editor/vscode-editor'

--- a/vscode/src/commands/utils/index.ts
+++ b/vscode/src/commands/utils/index.ts
@@ -1,6 +1,6 @@
 import { type QuickPickItem } from 'vscode'
 
-import { type CustomCommandType } from '@sourcegraph/cody-shared/src/commands'
+import { type CustomCommandType } from '@sourcegraph/cody-shared'
 
 type CustomCommandMenuAction = 'add' | 'file' | 'delete' | 'list' | 'open' | 'cancel' | 'docs' | 'back'
 

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -1,22 +1,21 @@
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
-import type {
-    CompletionLogger,
-    CompletionsClientConfig,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
-import type {
-    CompletionParameters,
-    CompletionResponse,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
 import {
+    addTraceparent,
+    FeatureFlag,
+    featureFlagProvider,
+    getActiveTraceAndSpanId,
     isAbortError,
+    isNodeResponse,
     isRateLimitError,
     NetworkError,
     RateLimitError,
     TimeoutError,
     TracedError,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { isNodeResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import { addTraceparent, getActiveTraceAndSpanId, wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
+    wrapInActiveSpan,
+    type CompletionLogger,
+    type CompletionParameters,
+    type CompletionResponse,
+    type CompletionsClientConfig,
+} from '@sourcegraph/cody-shared'
 
 import { fetch } from '../fetch'
 

--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode'
 
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
+import { wrapInActiveSpan } from '@sourcegraph/cody-shared'
 
 import { type DocumentContext } from '../get-current-doc-context'
 import { type ContextSnippet } from '../types'

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import * as vscode from 'vscode'
 import { type URI } from 'vscode-uri'
 
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
+import { isCodyIgnoredFile } from '@sourcegraph/cody-shared'
 
 import { type ContextRetriever, type ContextRetrieverOptions, type ContextSnippet } from '../../../types'
 import { baseLanguageId } from '../../utils'

--- a/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.ts
+++ b/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.ts
@@ -5,8 +5,7 @@ import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
-import { type HoverContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { dedupeWith } from '@sourcegraph/cody-shared/src/common'
+import { dedupeWith, type HoverContext } from '@sourcegraph/cody-shared'
 
 import { getGraphContextFromRange as defaultGetGraphContextFromRange } from '../../../../graph/lsp/graph'
 import {

--- a/vscode/src/completions/context/retrievers/new-jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/new-jaccard-similarity/jaccard-similarity-retriever.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import * as vscode from 'vscode'
 import { type URI } from 'vscode-uri'
 
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
+import { isCodyIgnoredFile } from '@sourcegraph/cody-shared'
 
 import { getContextRange } from '../../../doc-context-getters'
 import { type ContextRetriever, type ContextRetrieverOptions } from '../../../types'

--- a/vscode/src/completions/context/retrievers/section-history/section-history-retriever.ts
+++ b/vscode/src/completions/context/retrievers/section-history/section-history-retriever.ts
@@ -4,7 +4,7 @@ import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 import { type URI } from 'vscode-uri'
 
-import { isDefined } from '@sourcegraph/cody-shared/src/common'
+import { isDefined } from '@sourcegraph/cody-shared'
 
 import { locationKeyFn } from '../../../../graph/lsp/graph'
 import {

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
-import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { FeatureFlag, featureFlagProvider, isDotCom, type Configuration } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 import type { AuthProvider } from '../services/AuthProvider'

--- a/vscode/src/completions/get-inline-completions-tests/common.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/common.test.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent'
 import { describe, expect, test } from 'vitest'
 
-import { type CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { type CompletionParameters } from '@sourcegraph/cody-shared'
 
 import { vsCodeMocks } from '../../testutils/mocks'
 import { InlineCompletionsResultSource } from '../get-inline-completions'

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -1,11 +1,7 @@
 import { isEqual } from 'lodash'
 import { expect } from 'vitest'
 
-import { testFileUri } from '@sourcegraph/cody-shared'
-import {
-    type CompletionParameters,
-    type CompletionResponse,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { testFileUri, type CompletionParameters, type CompletionResponse } from '@sourcegraph/cody-shared'
 
 import { type SupportedLanguage } from '../../tree-sitter/grammars'
 import { updateParseTreeCache } from '../../tree-sitter/parse-tree-cache'

--- a/vscode/src/completions/get-inline-completions-tests/languages.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/languages.test.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent'
 import { describe, expect, test } from 'vitest'
 
-import { type CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { type CompletionParameters } from '@sourcegraph/cody-shared'
 
 import { completion } from '../test-helpers'
 import { MULTILINE_STOP_SEQUENCE } from '../text-processing'

--- a/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/no-request-when-accepting.test.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
-import { type CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { type CompletionResponse } from '@sourcegraph/cody-shared'
 
 import { TriggerKind } from '../get-inline-completions'
 import { completion } from '../test-helpers'

--- a/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
@@ -1,7 +1,7 @@
 import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 
-import { type CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { type CompletionParameters } from '@sourcegraph/cody-shared'
 
 import { range } from '../../testutils/textDocument'
 import { InlineCompletionsResultSource } from '../get-inline-completions'

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -1,8 +1,7 @@
 import type * as vscode from 'vscode'
 import { type URI } from 'vscode-uri'
 
-import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { getActiveTraceAndSpanId, wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
+import { getActiveTraceAndSpanId, isAbortError, wrapInActiveSpan } from '@sourcegraph/cody-shared'
 
 import { logError } from '../log'
 import { type CompletionIntent } from '../tree-sitter/query-sdk'

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -2,9 +2,7 @@ import dedent from 'dedent'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as vscode from 'vscode'
 
-import { RateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
-import { type GraphQLAPIClientConfig } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import { graphqlClient, RateLimitError, type GraphQLAPIClientConfig } from '@sourcegraph/cody-shared'
 
 import { type AuthStatus } from '../chat/protocol'
 import { localStorage } from '../services/LocalStorageProvider'

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -1,10 +1,13 @@
 import * as vscode from 'vscode'
 
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
-import { RateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { ConfigFeaturesSingleton } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
+import {
+    ConfigFeaturesSingleton,
+    FeatureFlag,
+    featureFlagProvider,
+    isCodyIgnoredFile,
+    RateLimitError,
+    wrapInActiveSpan,
+} from '@sourcegraph/cody-shared'
 
 import { type AuthStatus } from '../chat/protocol'
 import { logDebug } from '../log'

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -2,8 +2,7 @@ import { LRUCache } from 'lru-cache'
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
-import { isNetworkError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { type BillingCategory, type BillingProduct } from '@sourcegraph/cody-shared/src/telemetry-v2'
+import { isNetworkError, type BillingCategory, type BillingProduct } from '@sourcegraph/cody-shared'
 import { type KnownString, type TelemetryEventParameters } from '@sourcegraph/telemetry'
 
 import { getConfiguration } from '../configuration'

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -1,8 +1,7 @@
 import * as anthropic from '@anthropic-ai/sdk'
 import * as vscode from 'vscode'
 
-import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
-import { type Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
+import { tokensToChars, type Message } from '@sourcegraph/cody-shared'
 
 import { type CodeCompletionsClient, type CodeCompletionsParams } from '../client'
 import { type DocumentContext } from '../get-current-doc-context'

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { type Configuration } from '@sourcegraph/cody-shared/src/configuration'
 import {
     graphqlClient,
     type CodyLLMSiteConfiguration,
+    type Configuration,
     type GraphQLAPIClientConfig,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+} from '@sourcegraph/cody-shared'
 
 import { DEFAULT_VSCODE_SETTINGS } from '../../testutils/mocks'
 import { type CodeCompletionsClient } from '../client'

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -1,6 +1,9 @@
-import { type Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
-import { type CodyLLMSiteConfiguration } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import {
+    FeatureFlag,
+    featureFlagProvider,
+    type CodyLLMSiteConfiguration,
+    type Configuration,
+} from '@sourcegraph/cody-shared'
 
 import { logError } from '../../log'
 import { type CodeCompletionsClient } from '../client'

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -1,4 +1,4 @@
-import { type CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { type CompletionResponse } from '@sourcegraph/cody-shared'
 
 import { addAutocompleteDebugEvent } from '../../services/open-telemetry/debug-utils'
 import { canUsePartialCompletion } from '../can-use-partial-completion'

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type AutocompleteTimeouts } from '@sourcegraph/cody-shared/src/configuration'
-import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
+import { tokensToChars, type AutocompleteTimeouts } from '@sourcegraph/cody-shared'
 
 import { getLanguageConfig } from '../../tree-sitter/language'
 import { type CodeCompletionsClient, type CodeCompletionsParams } from '../client'

--- a/vscode/src/completions/providers/generate-completions.ts
+++ b/vscode/src/completions/providers/generate-completions.ts
@@ -1,4 +1,4 @@
-import { type AutocompleteTimeouts } from '@sourcegraph/cody-shared/src/configuration'
+import { type AutocompleteTimeouts } from '@sourcegraph/cody-shared'
 
 import { type CodeCompletionsClient, type CodeCompletionsParams } from '../client'
 import { type DocumentContext } from '../get-current-doc-context'

--- a/vscode/src/completions/providers/ollama-client.ts
+++ b/vscode/src/completions/providers/ollama-client.ts
@@ -1,10 +1,14 @@
-import { isDefined } from '@sourcegraph/cody-shared'
-import type { OllamaGenerateParameters, OllamaOptions } from '@sourcegraph/cody-shared/src/configuration'
-import type { CompletionLogger } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
-import type { CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
-import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
-import { isNodeResponse, type BrowserOrNodeResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import { isError } from '@sourcegraph/cody-shared/src/utils'
+import {
+    isAbortError,
+    isDefined,
+    isError,
+    isNodeResponse,
+    type BrowserOrNodeResponse,
+    type CompletionLogger,
+    type CompletionResponse,
+    type OllamaGenerateParameters,
+    type OllamaOptions,
+} from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../../log'
 import { createTimeout, type CodeCompletionsClient } from '../client'

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -1,7 +1,6 @@
 import { type Position, type TextDocument } from 'vscode'
 
-import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
-import { type CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { tokensToChars, type CompletionParameters } from '@sourcegraph/cody-shared'
 
 import { type DocumentContext } from '../get-current-doc-context'
 import { type InlineCompletionItemWithAnalytics } from '../text-processing/process-inline-completions'

--- a/vscode/src/completions/providers/unstable-ollama.ts
+++ b/vscode/src/completions/providers/unstable-ollama.ts
@@ -1,4 +1,4 @@
-import type { OllamaOptions } from '@sourcegraph/cody-shared/src/configuration'
+import type { OllamaOptions } from '@sourcegraph/cody-shared'
 
 import { logger } from '../../log'
 import { getLanguageConfig } from '../../tree-sitter/language'

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { tokensToChars } from '@sourcegraph/cody-shared/src/prompt/constants'
+import { tokensToChars } from '@sourcegraph/cody-shared'
 
 import { type CodeCompletionsClient, type CodeCompletionsParams } from '../client'
 import { type DocumentContext } from '../get-current-doc-context'

--- a/vscode/src/completions/request-manager.ts
+++ b/vscode/src/completions/request-manager.ts
@@ -1,7 +1,7 @@
 import { LRUCache } from 'lru-cache'
 import type * as vscode from 'vscode'
 
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
+import { wrapInActiveSpan } from '@sourcegraph/cody-shared'
 
 import { type DocumentContext } from './get-current-doc-context'
 import { InlineCompletionsResultSource, type LastInlineCompletionCandidate } from './get-inline-completions'

--- a/vscode/src/completions/reuse-last-candidate.ts
+++ b/vscode/src/completions/reuse-last-candidate.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isDefined } from '@sourcegraph/cody-shared/src/common'
+import { isDefined } from '@sourcegraph/cody-shared'
 
 import { getCurrentLinePrefixWithoutInjectedPrefix } from './doc-context-getters'
 import { type DocumentContext } from './get-current-doc-context'

--- a/vscode/src/completions/test-helpers.ts
+++ b/vscode/src/completions/test-helpers.ts
@@ -2,8 +2,7 @@ import dedent from 'dedent'
 import type { Position as VSCodePosition, TextDocument as VSCodeTextDocument } from 'vscode'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
-import { testFileUri } from '@sourcegraph/cody-shared'
-import { type CompletionResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { testFileUri, type CompletionResponse } from '@sourcegraph/cody-shared'
 
 import { wrapVSCodeTextDocument } from '../testutils/textDocument'
 

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -1,7 +1,7 @@
 import { Range, type Position, type TextDocument } from 'vscode'
 import { type Tree } from 'web-tree-sitter'
 
-import { dedupeWith } from '@sourcegraph/cody-shared/src/common'
+import { dedupeWith } from '@sourcegraph/cody-shared'
 
 import { addAutocompleteDebugEvent } from '../../services/open-telemetry/debug-utils'
 import { getNodeAtCursorAndParents } from '../../tree-sitter/ast-getters'

--- a/vscode/src/completions/tracer/index.ts
+++ b/vscode/src/completions/tracer/index.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode'
 
-import { type CompletionParameters } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import { type CompletionParameters } from '@sourcegraph/cody-shared'
 
 import { type GetContextResult } from '../context/context-mixer'
 import { type InlineCompletionsResult, type TriggerKind } from '../get-inline-completions'

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isDefined } from '@sourcegraph/cody-shared'
-import { renderMarkdown } from '@sourcegraph/cody-shared/src/common/markdown'
+import { isDefined, renderMarkdown } from '@sourcegraph/cody-shared'
 
 import {
     registerDebugListener as registerSectionObserverDebugListener,

--- a/vscode/src/completions/utils.ts
+++ b/vscode/src/completions/utils.ts
@@ -1,6 +1,6 @@
 import * as anthropic from '@anthropic-ai/sdk'
 
-import { type Message } from '@sourcegraph/cody-shared/src/sourcegraph-api'
+import { type Message } from '@sourcegraph/cody-shared'
 
 export function messagesToText(messages: Message[]): string {
     return messages

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type * as vscode from 'vscode'
 
-import { type Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import { type Configuration } from '@sourcegraph/cody-shared'
 
 import { getConfiguration } from './configuration'
 import { DEFAULT_VSCODE_SETTINGS } from './testutils/mocks'

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode'
 
-import type {
-    Configuration,
-    ConfigurationUseContext,
-    ConfigurationWithAccessToken,
-} from '@sourcegraph/cody-shared/src/configuration'
-import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import {
+    DOTCOM_URL,
+    type Configuration,
+    type ConfigurationUseContext,
+    type ConfigurationWithAccessToken,
+} from '@sourcegraph/cody-shared'
 
 import { CONFIG_KEY, getConfigEnumValues, type ConfigKeys, type ConfigurationKeysMap } from './configuration-keys'
 import { localStorage } from './services/LocalStorageProvider'

--- a/vscode/src/edit/execute.ts
+++ b/vscode/src/edit/execute.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type ContextFile } from '@sourcegraph/cody-shared'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { type ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { type ChatEventSource, type ContextFile, type ContextMessage } from '@sourcegraph/cody-shared'
 
 import { type EditIntent, type EditMode } from './types'
 

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { ConfigFeaturesSingleton } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import { ConfigFeaturesSingleton, type ChatClient, type ChatEventSource } from '@sourcegraph/cody-shared'
 
 import { type ContextProvider } from '../chat/ContextProvider'
 import { getEditor } from '../editor/active-editor'

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -1,20 +1,19 @@
 import type * as vscode from 'vscode'
 
-import { type CodyCommand } from '@sourcegraph/cody-shared'
-import { type CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
 import {
     createContextMessageByFile,
     getContextMessageWithResponse,
-    type ContextFile,
-    type ContextMessage,
-} from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { MAX_CURRENT_FILE_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
-import {
+    MAX_CURRENT_FILE_TOKENS,
     populateCodeContextTemplate,
     populateCodeGenerationContextTemplate,
     populateCurrentEditorDiagnosticsTemplate,
-} from '@sourcegraph/cody-shared/src/prompt/templates'
-import { truncateText, truncateTextStart } from '@sourcegraph/cody-shared/src/prompt/truncation'
+    truncateText,
+    truncateTextStart,
+    type CodebaseContext,
+    type CodyCommand,
+    type ContextFile,
+    type ContextMessage,
+} from '@sourcegraph/cody-shared'
 
 import { type VSCodeEditor } from '../../editor/vscode-editor'
 import { type EditIntent } from '../types'

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -1,13 +1,16 @@
 import * as vscode from 'vscode'
 
-import { BotResponseMultiplexer } from '@sourcegraph/cody-shared/src/chat/bot-response-multiplexer'
-import { getSimplePreamble } from '@sourcegraph/cody-shared/src/chat/preamble'
-import { Transcript } from '@sourcegraph/cody-shared/src/chat/transcript'
-import { Interaction } from '@sourcegraph/cody-shared/src/chat/transcript/interaction'
-import { type CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
-import { MAX_CURRENT_FILE_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
-import { truncateText } from '@sourcegraph/cody-shared/src/prompt/truncation'
-import { type CompletionParameters, type Message } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+import {
+    BotResponseMultiplexer,
+    getSimplePreamble,
+    Interaction,
+    MAX_CURRENT_FILE_TOKENS,
+    Transcript,
+    truncateText,
+    type CodebaseContext,
+    type CompletionParameters,
+    type Message,
+} from '@sourcegraph/cody-shared'
 
 import { type VSCodeEditor } from '../../editor/vscode-editor'
 import { type FixupTask } from '../../non-stop/FixupTask'

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -2,9 +2,7 @@ import path from 'path'
 
 import { URI } from 'vscode-uri'
 
-import { BotResponseMultiplexer } from '@sourcegraph/cody-shared/src/chat/bot-response-multiplexer'
-import { Typewriter } from '@sourcegraph/cody-shared/src/chat/typewriter'
-import { isAbortError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { BotResponseMultiplexer, isAbortError, Typewriter } from '@sourcegraph/cody-shared'
 
 import { convertFsPathToTestFile } from '../commands/utils/new-test-file'
 import { doesFileExist } from '../editor-context/helpers'

--- a/vscode/src/editor-context/VSCodeEditorContext.ts
+++ b/vscode/src/editor-context/VSCodeEditorContext.ts
@@ -3,23 +3,21 @@ import { dirname } from 'path'
 import * as vscode from 'vscode'
 import { type URI } from 'vscode-uri'
 
-import { languageFromFilename } from '@sourcegraph/cody-shared'
 import {
     getContextMessageWithResponse,
-    type ContextMessage,
-} from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { ProgrammingLanguage } from '@sourcegraph/cody-shared/src/common/languages'
-import { type ActiveTextEditorSelection } from '@sourcegraph/cody-shared/src/editor'
-import { MAX_CURRENT_FILE_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
-import {
+    languageFromFilename,
+    MAX_CURRENT_FILE_TOKENS,
     populateContextTemplateFromText,
     populateCurrentEditorContextTemplate,
     populateCurrentEditorSelectedContextTemplate,
     populateImportListContextTemplate,
     populateListOfFilesContextTemplate,
     populateTerminalOutputContextTemplate,
-} from '@sourcegraph/cody-shared/src/prompt/templates'
-import { truncateText } from '@sourcegraph/cody-shared/src/prompt/truncation'
+    ProgrammingLanguage,
+    truncateText,
+    type ActiveTextEditorSelection,
+    type ContextMessage,
+} from '@sourcegraph/cody-shared'
 
 import { answers } from '../commands/prompt/templates'
 import { type VSCodeEditor } from '../editor/vscode-editor'

--- a/vscode/src/editor-context/helpers.ts
+++ b/vscode/src/editor-context/helpers.ts
@@ -6,14 +6,12 @@ import { type URI } from 'vscode-uri'
 
 import {
     getContextMessageWithResponse,
-    type ContextMessage,
-} from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { MAX_CURRENT_FILE_TOKENS } from '@sourcegraph/cody-shared/src/prompt/constants'
-import {
+    MAX_CURRENT_FILE_TOKENS,
     populateCodeContextTemplate,
     populateContextTemplateFromText,
-} from '@sourcegraph/cody-shared/src/prompt/templates'
-import { truncateText } from '@sourcegraph/cody-shared/src/prompt/truncation'
+    truncateText,
+    type ContextMessage,
+} from '@sourcegraph/cody-shared'
 
 import { isValidTestFileName } from '../commands/prompt/utils'
 

--- a/vscode/src/editor/active-editor.ts
+++ b/vscode/src/editor/active-editor.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
+import { isCodyIgnoredFile } from '@sourcegraph/cody-shared'
 
 /**
  * Interface for tracking the last active text editor that is not a webview panel for

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -3,8 +3,7 @@ import { basename } from 'path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as vscode from 'vscode'
 
-import { testFileUri } from '@sourcegraph/cody-shared'
-import { ignores } from '@sourcegraph/cody-shared/src/chat/context-filter'
+import { ignores, testFileUri } from '@sourcegraph/cody-shared'
 
 import { getFileContextFiles } from './editor-context'
 

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -4,15 +4,16 @@ import fuzzysort from 'fuzzysort'
 import throttle from 'lodash/throttle'
 import * as vscode from 'vscode'
 
-import { displayPath, type ContextFile } from '@sourcegraph/cody-shared'
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
 import {
+    displayPath,
+    isCodyIgnoredFile,
+    type ContextFile,
     type ContextFileFile,
     type ContextFileSource,
     type ContextFileSymbol,
     type ContextFileType,
     type SymbolKind,
-} from '@sourcegraph/cody-shared/src/codebase-context/messages'
+} from '@sourcegraph/cody-shared'
 
 import { getOpenTabsUris, getWorkspaceSymbols } from '.'
 

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -1,16 +1,16 @@
 import * as vscode from 'vscode'
 
-import { isCodyIgnoredFile } from '@sourcegraph/cody-shared/src/chat/context-filter'
-import type {
-    ActiveTextEditor,
-    ActiveTextEditorDiagnostic,
-    ActiveTextEditorDiagnosticType,
-    ActiveTextEditorSelection,
-    ActiveTextEditorSelectionRange,
-    ActiveTextEditorVisibleContent,
-    Editor,
-} from '@sourcegraph/cody-shared/src/editor'
-import { SURROUNDING_LINES } from '@sourcegraph/cody-shared/src/prompt/constants'
+import {
+    isCodyIgnoredFile,
+    SURROUNDING_LINES,
+    type ActiveTextEditor,
+    type ActiveTextEditorDiagnostic,
+    type ActiveTextEditorDiagnosticType,
+    type ActiveTextEditorSelection,
+    type ActiveTextEditorSelectionRange,
+    type ActiveTextEditorVisibleContent,
+    type Editor,
+} from '@sourcegraph/cody-shared'
 
 import { getEditor } from './active-editor'
 import { EditorCodeLenses } from './EditorCodeLenses'

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -1,7 +1,11 @@
 import * as vscode from 'vscode'
 
-import { type Configuration, type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import type { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/browserClient'
+import {
+    type Configuration,
+    type ConfigurationWithAccessToken,
+    type SourcegraphBrowserCompletionsClient,
+} from '@sourcegraph/cody-shared'
+// eslint-disable-next-line no-restricted-imports
 import type { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
 import { type CommandsController } from './commands/CommandsController'

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -1,5 +1,6 @@
 import type * as vscode from 'vscode'
 
+// eslint-disable-next-line no-restricted-imports
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
 import { CommandsController } from './commands/CommandsController'

--- a/vscode/src/extension.web.ts
+++ b/vscode/src/extension.web.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode'
 
-import { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/browserClient'
+import { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared'
 
 import { type ExtensionApi } from './extension-api'
 import { activate as activateCommon } from './extension.common'

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -1,16 +1,18 @@
 import type * as vscode from 'vscode'
 
-import { ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
-import { CodebaseContext } from '@sourcegraph/cody-shared/src/codebase-context'
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { type Editor } from '@sourcegraph/cody-shared/src/editor'
-import { SourcegraphEmbeddingsSearchClient } from '@sourcegraph/cody-shared/src/embeddings/client'
-import { type Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
-import { SourcegraphGuardrailsClient } from '@sourcegraph/cody-shared/src/guardrails/client'
-import { type IntentDetector } from '@sourcegraph/cody-shared/src/intent-detector'
-import { SourcegraphIntentDetectorClient } from '@sourcegraph/cody-shared/src/intent-detector/client'
-import { graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
-import { isError } from '@sourcegraph/cody-shared/src/utils'
+import {
+    ChatClient,
+    CodebaseContext,
+    graphqlClient,
+    isError,
+    SourcegraphEmbeddingsSearchClient,
+    SourcegraphGuardrailsClient,
+    SourcegraphIntentDetectorClient,
+    type ConfigurationWithAccessToken,
+    type Editor,
+    type Guardrails,
+    type IntentDetector,
+} from '@sourcegraph/cody-shared'
 
 import { createClient as createCodeCompletionsClint, type CodeCompletionsClient } from './completions/client'
 import { type PlatformContext } from './extension.common'

--- a/vscode/src/fetch.node.ts
+++ b/vscode/src/fetch.node.ts
@@ -6,7 +6,7 @@ import https from 'https'
 
 import { SocksProxyAgent } from 'socks-proxy-agent'
 
-import { type Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import { type Configuration } from '@sourcegraph/cody-shared'
 
 import { getConfiguration } from './configuration'
 import { agent } from './fetch'

--- a/vscode/src/fetch.ts
+++ b/vscode/src/fetch.ts
@@ -6,11 +6,7 @@ import type { Agent } from 'http'
  */
 import isomorphicFetch from 'isomorphic-fetch'
 
-import {
-    addCustomUserAgent,
-    customUserAgent,
-    type BrowserOrNodeResponse,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import { addCustomUserAgent, customUserAgent, type BrowserOrNodeResponse } from '@sourcegraph/cody-shared'
 
 /**
  * In node environments, it might be necessary to set up a custom agent to control the network

--- a/vscode/src/graph/lsp/graph.ts
+++ b/vscode/src/graph/lsp/graph.ts
@@ -1,9 +1,14 @@
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
-import { type HoverContext, type PreciseContext } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { dedupeWith, isDefined } from '@sourcegraph/cody-shared/src/common'
-import { type ActiveTextEditorSelectionRange, type Editor } from '@sourcegraph/cody-shared/src/editor'
+import {
+    dedupeWith,
+    isDefined,
+    type ActiveTextEditorSelectionRange,
+    type Editor,
+    type HoverContext,
+    type PreciseContext,
+} from '@sourcegraph/cody-shared'
 
 import { type CustomAbortSignal } from '../../completions/context/utils'
 import { logDebug } from '../../log'

--- a/vscode/src/graph/lsp/limiter.test.ts
+++ b/vscode/src/graph/lsp/limiter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { AbortError, TimeoutError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { AbortError, TimeoutError } from '@sourcegraph/cody-shared'
 
 import { createLimiter, type Limiter } from './limiter'
 

--- a/vscode/src/graph/lsp/limiter.ts
+++ b/vscode/src/graph/lsp/limiter.ts
@@ -1,4 +1,4 @@
-import { AbortError, TimeoutError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { AbortError, TimeoutError } from '@sourcegraph/cody-shared'
 
 import { type CustomAbortSignal } from '../../completions/context/utils'
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -1,9 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 
-import { type ChatModelProvider } from '@sourcegraph/cody-shared'
-import type { ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import type { event } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import type { BillingCategory, BillingProduct } from '@sourcegraph/cody-shared/src/telemetry-v2'
+import type { BillingCategory, BillingProduct, ChatMessage, ChatModelProvider, event } from '@sourcegraph/cody-shared'
 import type {
     KnownKeys,
     KnownString,

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -6,7 +6,7 @@ import { Readable, Writable } from 'stream'
 
 import * as vscode from 'vscode'
 
-import { isRateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { isRateLimitError } from '@sourcegraph/cody-shared'
 
 import type * as agent from './agent-protocol'
 import type * as bfg from './bfg-protocol'

--- a/vscode/src/local-context/enhanced-context-status.test.ts
+++ b/vscode/src/local-context/enhanced-context-status.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 
-import type * as status from '@sourcegraph/cody-shared/src/codebase-context/context-status'
+import type * as status from '@sourcegraph/cody-shared'
 
 import { ContextStatusAggregator } from './enhanced-context-status'
 

--- a/vscode/src/local-context/enhanced-context-status.ts
+++ b/vscode/src/local-context/enhanced-context-status.ts
@@ -1,9 +1,6 @@
 import * as vscode from 'vscode'
 
-import {
-    type ContextGroup,
-    type ContextStatusProvider,
-} from '@sourcegraph/cody-shared/src/codebase-context/context-status'
+import { type ContextGroup, type ContextStatusProvider } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 

--- a/vscode/src/local-context/filename-context-fetcher.ts
+++ b/vscode/src/local-context/filename-context-fetcher.ts
@@ -4,13 +4,14 @@ import * as path from 'path'
 import { uniq } from 'lodash'
 import * as vscode from 'vscode'
 
-import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
-import { type ContextFileSource, type ContextFileType } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { type Editor } from '@sourcegraph/cody-shared/src/editor'
 import {
+    type ChatClient,
+    type ContextFileSource,
+    type ContextFileType,
     type ContextResult,
+    type Editor,
     type FilenameContextFetcher as IFilenameContextFetcher,
-} from '@sourcegraph/cody-shared/src/local-context'
+} from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -2,14 +2,14 @@ import { type GetFieldType } from 'lodash'
 import * as vscode from 'vscode'
 
 import {
+    isDotCom,
+    type ConfigurationWithAccessToken,
     type ContextGroup,
     type ContextStatusProvider,
+    type EmbeddingsSearchResult,
+    type LocalEmbeddingsFetcher,
     type LocalEmbeddingsProvider,
-} from '@sourcegraph/cody-shared/src/codebase-context/context-status'
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { type LocalEmbeddingsFetcher } from '@sourcegraph/cody-shared/src/local-context'
-import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
-import { type EmbeddingsSearchResult } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+} from '@sourcegraph/cody-shared'
 
 import { spawnBfg } from '../graph/bfg/spawn-bfg'
 import { type IndexHealthResultFound, type IndexRequest, type QueryResultSet } from '../jsonrpc/embeddings-protocol'

--- a/vscode/src/local-context/symf.test.ts
+++ b/vscode/src/local-context/symf.test.ts
@@ -1,6 +1,7 @@
 import { type Polly } from '@pollyjs/core'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
+// eslint-disable-next-line no-restricted-imports
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 
 import { startPollyRecording } from '../testutils/polly'

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -8,9 +8,12 @@ import { Mutex } from 'async-mutex'
 import { mkdirp } from 'mkdirp'
 import * as vscode from 'vscode'
 
-import { isWindows } from '@sourcegraph/cody-shared'
-import { type IndexedKeywordContextFetcher, type Result } from '@sourcegraph/cody-shared/src/local-context'
-import { type SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
+import {
+    isWindows,
+    type IndexedKeywordContextFetcher,
+    type Result,
+    type SourcegraphCompletionsClient,
+} from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 

--- a/vscode/src/local-context/symfExpandQuery.ts
+++ b/vscode/src/local-context/symfExpandQuery.ts
@@ -1,6 +1,6 @@
 import { XMLParser } from 'fast-xml-parser'
 
-import { type SourcegraphCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
+import { type SourcegraphCompletionsClient } from '@sourcegraph/cody-shared'
 
 export function symfExpandQuery(completionsClient: SourcegraphCompletionsClient, query: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {

--- a/vscode/src/log.ts
+++ b/vscode/src/log.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode'
 
-import { type CompletionLogger } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/client'
 import {
+    type CompletionLogger,
     type CompletionParameters,
     type CompletionResponse,
     type Event,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/types'
+} from '@sourcegraph/cody-shared'
 
 import { getConfiguration } from './configuration'
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -1,11 +1,16 @@
 import * as vscode from 'vscode'
 
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
-import { newPromptMixin, PromptMixin } from '@sourcegraph/cody-shared/src/prompt/prompt-mixin'
-import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
-import { ConfigFeaturesSingleton, graphqlClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
+import {
+    ConfigFeaturesSingleton,
+    FeatureFlag,
+    featureFlagProvider,
+    graphqlClient,
+    isDotCom,
+    newPromptMixin,
+    PromptMixin,
+    type ChatEventSource,
+    type ConfigurationWithAccessToken,
+} from '@sourcegraph/cody-shared'
 
 import { CachedRemoteEmbeddingsClient } from './chat/CachedRemoteEmbeddingsClient'
 import { ChatManager, CodyChatPanelViewType } from './chat/chat-view/ChatManager'

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type ContextFile } from '@sourcegraph/cody-shared'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { type ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { type ChatEventSource, type ContextFile, type ContextMessage } from '@sourcegraph/cody-shared'
 
 import { type ExecuteEditArguments } from '../edit/execute'
 import { type EditIntent, type EditMode } from '../edit/types'

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -1,8 +1,6 @@
 import type * as vscode from 'vscode'
 
-import { type ContextFile } from '@sourcegraph/cody-shared'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { type ContextMessage } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { type ChatEventSource, type ContextFile, type ContextMessage } from '@sourcegraph/cody-shared'
 
 import { type EditIntent, type EditMode } from '../edit/types'
 

--- a/vscode/src/non-stop/FixupTypingUI.ts
+++ b/vscode/src/non-stop/FixupTypingUI.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
-import { displayPath, type ContextFile } from '@sourcegraph/cody-shared'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { displayPath, type ChatEventSource, type ContextFile } from '@sourcegraph/cody-shared'
 
 import { EDIT_COMMAND, menu_buttons } from '../commands/utils/menu'
 import { type ExecuteEditArguments } from '../edit/execute'

--- a/vscode/src/non-stop/codelenses.ts
+++ b/vscode/src/non-stop/codelenses.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isRateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { isRateLimitError } from '@sourcegraph/cody-shared'
 
 import { getSingleLineRange } from '../services/InlineAssist'
 

--- a/vscode/src/non-stop/roles.ts
+++ b/vscode/src/non-stop/roles.ts
@@ -1,7 +1,6 @@
 import type * as vscode from 'vscode'
 
-import { type ContextFile } from '@sourcegraph/cody-shared'
-import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { type ChatEventSource, type ContextFile } from '@sourcegraph/cody-shared'
 
 import { type EditIntent, type EditMode } from '../edit/types'
 

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
+import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared'
 
 import { localStorage } from '../services/LocalStorageProvider'
 

--- a/vscode/src/repository/repositoryHelpers.ts
+++ b/vscode/src/repository/repositoryHelpers.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared/src/utils'
+import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 import { setUpCodyIgnore } from '../services/context-filter'

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -3,8 +3,12 @@ import * as path from 'path'
 
 import * as vscode from 'vscode'
 
-import { hydrateAfterPostMessage } from '@sourcegraph/cody-shared'
-import { type Result, type SearchPanelFile, type SearchPanelSnippet } from '@sourcegraph/cody-shared/src/local-context'
+import {
+    hydrateAfterPostMessage,
+    type Result,
+    type SearchPanelFile,
+    type SearchPanelSnippet,
+} from '@sourcegraph/cody-shared'
 
 import { type WebviewMessage } from '../chat/protocol'
 import { getEditor } from '../editor/active-editor'

--- a/vscode/src/services/AuthMenus.ts
+++ b/vscode/src/services/AuthMenus.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isDotCom, LOCAL_APP_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { isDotCom, LOCAL_APP_URL } from '@sourcegraph/cody-shared'
 
 interface LoginMenuItem {
     id: string

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -1,10 +1,15 @@
 import * as vscode from 'vscode'
 
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
-import { DOTCOM_URL, isDotCom, LOCAL_APP_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
-import { SourcegraphGraphQLAPIClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql'
-import { isError } from '@sourcegraph/cody-shared/src/utils'
+import {
+    DOTCOM_URL,
+    FeatureFlag,
+    featureFlagProvider,
+    isDotCom,
+    isError,
+    LOCAL_APP_URL,
+    SourcegraphGraphQLAPIClient,
+    type ConfigurationWithAccessToken,
+} from '@sourcegraph/cody-shared'
 
 import { CodyChatPanelViewType } from '../chat/chat-view/ChatManager'
 import {

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { DOTCOM_URL } from '@sourcegraph/cody-shared'
 
 import { type AuthMethod } from '../chat/protocol'
 

--- a/vscode/src/services/GuardrailsProvider.ts
+++ b/vscode/src/services/GuardrailsProvider.ts
@@ -1,5 +1,4 @@
-import { type Editor } from '@sourcegraph/cody-shared/src/editor'
-import { summariseAttribution, type Guardrails } from '@sourcegraph/cody-shared/src/guardrails'
+import { summariseAttribution, type Editor, type Guardrails } from '@sourcegraph/cody-shared'
 
 export class GuardrailsProvider {
     // TODO(keegancsmith) this provider should create the client since the guardrails client requires a dotcom graphql connection.

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -1,7 +1,7 @@
 import * as uuid from 'uuid'
 import { type Memento } from 'vscode'
 
-import { type ChatHistory, type UserLocalHistory } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { type ChatHistory, type UserLocalHistory } from '@sourcegraph/cody-shared'
 
 import { type AuthStatus } from '../chat/protocol'
 

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import type { Configuration } from '@sourcegraph/cody-shared/src/configuration'
+import type { Configuration } from '@sourcegraph/cody-shared'
 
 import { getConfiguration } from '../configuration'
 

--- a/vscode/src/services/TreeViewProvider.test.ts
+++ b/vscode/src/services/TreeViewProvider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type * as vscode from 'vscode'
 
-import { DOTCOM_URL, isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { DOTCOM_URL, isDotCom } from '@sourcegraph/cody-shared'
 
 import { newAuthStatus } from '../chat/utils'
 import { decGaMockFeatureFlagProvider, emptyMockFeatureFlagProvider, vsCodeMocks } from '../testutils/mocks'

--- a/vscode/src/services/TreeViewProvider.ts
+++ b/vscode/src/services/TreeViewProvider.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode'
 
-import { FeatureFlag, type FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
-import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { FeatureFlag, isDotCom, type FeatureFlagProvider } from '@sourcegraph/cody-shared'
 
 import { type AuthStatus } from '../chat/protocol'
 import { getFullConfig } from '../configuration'

--- a/vscode/src/services/context-filter.ts
+++ b/vscode/src/services/context-filter.ts
@@ -2,8 +2,7 @@ import { dirname } from 'path'
 
 import * as vscode from 'vscode'
 
-import { ignores } from '@sourcegraph/cody-shared/src/chat/context-filter'
-import { CODY_IGNORE_FILENAME_POSIX_GLOB } from '@sourcegraph/cody-shared/src/chat/ignore-helper'
+import { CODY_IGNORE_FILENAME_POSIX_GLOB, ignores } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 import { getCodebaseFromWorkspaceUri } from '../repository/repositoryHelpers'

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -6,8 +6,7 @@ import { NodeSDK } from '@opentelemetry/sdk-node'
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag, featureFlagProvider, type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared'
 
 import { version } from '../../version'
 

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -1,14 +1,14 @@
 import type { init as browserInit } from '@sentry/browser'
 import type { init as nodeInit } from '@sentry/node'
 
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { isDotCom } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
 import {
     isAbortError,
     isAuthError,
+    isDotCom,
     isRateLimitError,
     NetworkError,
-} from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+    type ConfigurationWithAccessToken,
+} from '@sourcegraph/cody-shared'
 
 import { version } from '../../version'
 

--- a/vscode/src/services/telemetry-v2.test.ts
+++ b/vscode/src/services/telemetry-v2.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { NoOpTelemetryRecorderProvider } from '@sourcegraph/cody-shared/src/telemetry-v2/TelemetryRecorderProvider'
+import { NoOpTelemetryRecorderProvider } from '@sourcegraph/cody-shared'
 import { type TelemetryEventInput } from '@sourcegraph/telemetry'
 
 import { splitSafeMetadata } from './telemetry-v2'

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -1,11 +1,11 @@
-import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { type LogEventMode } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 import {
     MockServerTelemetryRecorderProvider,
     NoOpTelemetryRecorderProvider,
     TelemetryRecorderProvider,
+    type ConfigurationWithAccessToken,
+    type LogEventMode,
     type TelemetryRecorder,
-} from '@sourcegraph/cody-shared/src/telemetry-v2/TelemetryRecorderProvider'
+} from '@sourcegraph/cody-shared'
 import { CallbackTelemetryProcessor, TimestampTelemetryProcessor } from '@sourcegraph/telemetry'
 
 import { logDebug } from '../log'

--- a/vscode/src/services/telemetry.ts
+++ b/vscode/src/services/telemetry.ts
@@ -1,8 +1,13 @@
 import * as vscode from 'vscode'
 
-import { type Configuration, type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
-import { type TelemetryEventProperties, type TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
-import { EventLogger, type ExtensionDetails } from '@sourcegraph/cody-shared/src/telemetry/EventLogger'
+import {
+    EventLogger,
+    type Configuration,
+    type ConfigurationWithAccessToken,
+    type ExtensionDetails,
+    type TelemetryEventProperties,
+    type TelemetryService,
+} from '@sourcegraph/cody-shared'
 
 import { getConfiguration } from '../configuration'
 import { logDebug } from '../log'

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -1,6 +1,6 @@
 import { findLast } from 'lodash'
 
-import { FeatureFlag } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag } from '@sourcegraph/cody-shared'
 
 import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 import { CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL, type AuthStatus } from '../chat/protocol'

--- a/vscode/src/test-support.ts
+++ b/vscode/src/test-support.ts
@@ -1,4 +1,4 @@
-import { type ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { type ChatMessage } from '@sourcegraph/cody-shared'
 
 import { type SimpleChatPanelProvider } from './chat/chat-view/SimpleChatPanelProvider'
 

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -13,8 +13,7 @@ import type {
     Range as VSCodeRange,
 } from 'vscode'
 
-import { type Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { FeatureFlag, FeatureFlagProvider } from '@sourcegraph/cody-shared/src/experimentation/FeatureFlagProvider'
+import { FeatureFlag, FeatureFlagProvider, type Configuration } from '@sourcegraph/cody-shared'
 
 import { Uri } from './uri'
 

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -59,8 +59,7 @@ export async function run<T>(around: () => Promise<T>): Promise<T> {
         res.status(200)
     })
 
-    // matches @sourcegraph/cody-shared/src/sourcegraph-api/telemetry/MockServerTelemetryExporter
-    // importing const doesn't work, so hardcode it here.
+    // matches @sourcegraph/cody-shared't work, so hardcode it here.
     app.post('/.api/mockEventRecording', (req, res) => {
         const events = req.body as TelemetryEventInput[]
         events.forEach(event => {

--- a/vscode/test/integration/helpers.ts
+++ b/vscode/test/integration/helpers.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 
 import * as vscode from 'vscode'
 
-import { type ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
+import { type ChatMessage } from '@sourcegraph/cody-shared'
 
 import { type ExtensionApi } from '../../src/extension-api'
 import * as mockServer from '../fixtures/mock-server'

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -2,12 +2,16 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import './App.css'
 
-import { type ChatModelProvider, type ContextFile } from '@sourcegraph/cody-shared'
-import { type ChatHistory, type ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { type EnhancedContextContextT } from '@sourcegraph/cody-shared/src/codebase-context/context-status'
-import { type CodyCommand } from '@sourcegraph/cody-shared/src/commands'
-import { type Configuration } from '@sourcegraph/cody-shared/src/configuration'
-import { GuardrailsPost } from '@sourcegraph/cody-shared/src/guardrails'
+import {
+    GuardrailsPost,
+    type ChatHistory,
+    type ChatMessage,
+    type ChatModelProvider,
+    type CodyCommand,
+    type Configuration,
+    type ContextFile,
+    type EnhancedContextContextT,
+} from '@sourcegraph/cody-shared'
 import { type UserAccountInfo } from '@sourcegraph/cody-ui/src/Chat'
 
 import { type AuthMethod, type AuthStatus, type LocalEnv } from '../src/chat/protocol'

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -3,10 +3,14 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
-import { type ChatModelProvider, type ContextFile, type Guardrails } from '@sourcegraph/cody-shared'
-import { type ChatMessage } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
-import { type CodyCommand } from '@sourcegraph/cody-shared/src/commands'
-import { type TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
+import {
+    type ChatMessage,
+    type ChatModelProvider,
+    type CodyCommand,
+    type ContextFile,
+    type Guardrails,
+    type TelemetryService,
+} from '@sourcegraph/cody-shared'
 import {
     Chat as ChatUI,
     type ChatButtonProps,

--- a/vscode/webviews/ChatErrorNotice.story.tsx
+++ b/vscode/webviews/ChatErrorNotice.story.tsx
@@ -2,7 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react'
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
-import { RateLimitError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
+import { RateLimitError } from '@sourcegraph/cody-shared'
 import { type ChatButtonProps } from '@sourcegraph/cody-ui/src/Chat'
 import { ErrorItem } from '@sourcegraph/cody-ui/src/chat/ErrorItem'
 

--- a/vscode/webviews/Components/ChatModelDropdownMenu.story.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.story.tsx
@@ -1,7 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import { ChatModelProvider } from '@sourcegraph/cody-shared/src/chat-models'
-import { DOTCOM_URL } from '@sourcegraph/cody-shared/src/sourcegraph-api/environments'
+import { ChatModelProvider, DOTCOM_URL } from '@sourcegraph/cody-shared'
 
 import { VSCodeStoryDecorator } from '../storybook/VSCodeStoryDecorator'
 

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -1,11 +1,7 @@
 import { useArgs, useState } from '@storybook/preview-api'
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import {
-    type ContextProvider,
-    type LocalEmbeddingsProvider,
-    type SearchProvider,
-} from '@sourcegraph/cody-shared/src/codebase-context/context-status'
+import { type ContextProvider, type LocalEmbeddingsProvider, type SearchProvider } from '@sourcegraph/cody-shared'
 
 import { VSCodeStoryDecorator } from '../storybook/VSCodeStoryDecorator'
 

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -9,7 +9,7 @@ import {
     type EnhancedContextContextT,
     type LocalEmbeddingsProvider,
     type SearchProvider,
-} from '@sourcegraph/cody-shared/src/codebase-context/context-status'
+} from '@sourcegraph/cody-shared'
 
 import { PopupFrame } from '../Popups/Popup'
 import { getVSCodeAPI } from '../utils/VSCodeApi'

--- a/vscode/webviews/OnboardingExperiment.story.tsx
+++ b/vscode/webviews/OnboardingExperiment.story.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react'
 
-import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared/src/telemetry'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared'
 
 import { LoginSimplified } from './OnboardingExperiment'
 import { VSCodeStoryDecorator } from './storybook/VSCodeStoryDecorator'

--- a/vscode/webviews/OnboardingExperiment.tsx
+++ b/vscode/webviews/OnboardingExperiment.tsx
@@ -1,6 +1,6 @@
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
-import { type TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
+import { type TelemetryService } from '@sourcegraph/cody-shared'
 
 import { type AuthMethod } from '../src/chat/protocol'
 

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useMemo, useRef } from 'react'
 import { debounce } from 'lodash'
 import { LRUCache } from 'lru-cache'
 
-import { type SearchPanelFile } from '@sourcegraph/cody-shared/src/local-context'
+import { type SearchPanelFile } from '@sourcegraph/cody-shared'
 
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 

--- a/vscode/webviews/utils/telemetry.ts
+++ b/vscode/webviews/utils/telemetry.ts
@@ -1,4 +1,4 @@
-import { type TelemetryService } from '@sourcegraph/cody-shared/src/telemetry'
+import { type TelemetryService } from '@sourcegraph/cody-shared'
 
 import { type VSCodeWrapper } from './VSCodeApi'
 


### PR DESCRIPTION
You should only import from `@sourcegraph/cody-shared` and not `@sourcegraph/cody-shared/{dist,src}/...`. This is to (1) enforce a clean boundary between the internal and external API of the shared lib, (2) avoid accidentally bundling multiple copies of the shared lib.

We may still remove the shared lib. In that case, this PR will still be a cleanup and footgun-avoider in the interim, and it will help us create a simpler API for clients even in a possible monolib. It also makes it easier to move stuff around in the shared lib for simplification in the interim.

No behavior changes.

## Test plan

CI