### PR TITLE
improve usage of URIs and FS paths for multi-root support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 // @ts-check
 
+const RESTRICT_PATH_IMPORT_MESSAGE =
+  "Use URIs instead of file system paths, and use the following helpers from @sourcegraph/cody-shared: (1) for displaying paths to the user: displayPath, displayPathDirname, displayPathBasename; (2) for manipulating URI paths: uriDirname, uriBasename, uriExtname. If you are writing code that ONLY runs in Node, import from 'node:path'."
+
 /** @type {import('eslint').Linter.Config} */
 const config = {
   extends: ['@sourcegraph/eslint-config', 'plugin:storybook/recommended'],
@@ -72,6 +75,23 @@ const config = {
     ],
   },
   overrides: [
+    {
+      // Apply this rule to a subset of files so we can gradually roll it out.
+      files: ['shared/**/*.ts', 'vscode/src/**/*.ts'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            paths: [
+              { name: 'path', message: RESTRICT_PATH_IMPORT_MESSAGE },
+              { name: 'path/posix', message: RESTRICT_PATH_IMPORT_MESSAGE },
+              { name: 'path/win32', message: RESTRICT_PATH_IMPORT_MESSAGE },
+              { name: 'path-browserify', message: RESTRICT_PATH_IMPORT_MESSAGE },
+            ],
+          },
+        ],
+      },
+    },
     {
       files: ['*.d.ts'],
       rules: {

--- a/lib/shared/src/chat/ignore-helper.test.ts
+++ b/lib/shared/src/chat/ignore-helper.test.ts
@@ -1,38 +1,34 @@
-import path from 'path'
-
-import { beforeEach, describe, expect, it } from 'vitest'
-// TODO(dantup): Determine whether we should be using vscode-uri URI here, or vscode.URI/shim
-//  (or if we should be testing both).
+import { beforeEach, describe, expect, it, test } from 'vitest'
 import { URI, Utils } from 'vscode-uri'
 
 import { testFileUri } from '../test/path-helpers'
 
-import { CODY_IGNORE_FILENAME, IgnoreHelper } from './ignore-helper'
+import { CODY_IGNORE_URI_PATH, ignoreFileEffectiveDirectory, IgnoreHelper } from './ignore-helper'
 
 describe('IgnoreHelper', () => {
     let ignore: IgnoreHelper
     const workspace1Root = testFileUri('foo/workspace1')
     const workspace2Root = testFileUri('foo/workspace2')
 
-    function setIgnores(workspaceRoot: string, ignoreFolder: string, rules: string[]) {
+    function setIgnores(workspaceRoot: URI, ignoreFolder: string, rules: string[]) {
         ignore.setIgnoreFiles(workspaceRoot, [
             {
-                filePath: path.join(ignoreFolder, CODY_IGNORE_FILENAME),
+                uri: Utils.joinPath(workspaceRoot, ignoreFolder, CODY_IGNORE_URI_PATH),
                 content: rules.join('\n'),
             },
         ])
     }
 
     function setWorkspace1Ignores(rules: string[]) {
-        setIgnores(workspace1Root.fsPath, workspace1Root.fsPath, rules)
+        setIgnores(workspace1Root, '.', rules)
     }
 
     function setWorkspace2Ignores(rules: string[]) {
-        setIgnores(workspace2Root.fsPath, workspace2Root.fsPath, rules)
+        setIgnores(workspace2Root, '.', rules)
     }
 
     function setWorkspace1NestedIgnores(folder: string, rules: string[]) {
-        setIgnores(workspace1Root.fsPath, path.join(workspace1Root.fsPath, folder), rules)
+        setIgnores(workspace1Root, folder, rules)
     }
 
     beforeEach(() => {
@@ -196,5 +192,11 @@ describe('IgnoreHelper', () => {
         ])('returns false for file not in ignore list %s', (filePath: string) => {
             expect(ignore.isIgnored(Utils.joinPath(workspace1Root, filePath))).toBe(false)
         })
+    })
+})
+
+describe('ignoreFileEffectiveDirectory', () => {
+    test('', () => {
+        expect(ignoreFileEffectiveDirectory(URI.parse('file:///a/b/.cody/ignore')).toString()).toBe('file:///a/b')
     })
 })

--- a/lib/shared/src/codebase-context/context-status.ts
+++ b/lib/shared/src/codebase-context/context-status.ts
@@ -1,3 +1,5 @@
+import { type URI } from 'vscode-uri'
+
 // This should remain compatible with vscode.Disposable.
 export interface Disposable {
     dispose(): void
@@ -53,7 +55,17 @@ interface GraphProvider {
 }
 
 export interface ContextGroup {
-    name: string
+    /** The directory that this context group represents. */
+    dir?: URI
+
+    /**
+     * Usually `basename(dir)`.
+     *
+     * TODO(sqs): when old remote embeddings code is removed, remove this field and compute it as
+     * late as possible for presentation only.
+     */
+    displayName: string
+
     providers: ContextProvider[]
 }
 

--- a/lib/shared/src/codebase-context/index.ts
+++ b/lib/shared/src/codebase-context/index.ts
@@ -190,10 +190,9 @@ function groupResultsByFile(
 ): { file: ContextFile & Required<Pick<ContextFile, 'uri'>>; results: string[] }[] {
     const originalFileOrder: (ContextFile & Required<Pick<ContextFile, 'uri'>>)[] = []
     for (const result of results) {
-        const resultUri = URI.file(result.fileName)
-        if (!originalFileOrder.find((ogFile: ContextFile) => ogFile.uri.toString() === resultUri.toString())) {
+        if (!originalFileOrder.find((ogFile: ContextFile) => ogFile.uri.toString() === result.uri.toString())) {
             originalFileOrder.push({
-                uri: resultUri,
+                uri: result.uri,
                 repoName: result.repoName,
                 revision: result.revision,
                 range: createContextFileRange(result),
@@ -205,12 +204,11 @@ function groupResultsByFile(
 
     const resultsGroupedByFile = new Map<string /* resultUri.toString() */, EmbeddingsSearchResult[]>()
     for (const result of results) {
-        const resultUri = URI.file(result.fileName)
-        const results = resultsGroupedByFile.get(resultUri.toString())
+        const results = resultsGroupedByFile.get(result.uri.toString())
         if (results === undefined) {
-            resultsGroupedByFile.set(resultUri.toString(), [result])
+            resultsGroupedByFile.set(result.uri.toString(), [result])
         } else {
-            resultsGroupedByFile.set(resultUri.toString(), results.concat([result]))
+            resultsGroupedByFile.set(result.uri.toString(), results.concat([result]))
         }
     }
 
@@ -239,8 +237,8 @@ function mergeConsecutiveResults(results: EmbeddingsSearchResult[]): string[] {
 }
 
 function resultsToMessages(results: ContextResult[]): ContextMessage[] {
-    return results.flatMap(({ content, fileName, uri, repoName, revision }) => {
-        const messageText = populateCodeContextTemplate(content, uri ?? URI.file(fileName), repoName)
+    return results.flatMap(({ content, uri, repoName, revision }) => {
+        const messageText = populateCodeContextTemplate(content, uri, repoName)
         return getContextMessageWithResponse(messageText, { type: 'file', uri, repoName, revision })
     })
 }

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -1,6 +1,7 @@
 import { type URI } from 'vscode-uri'
 
 import { type ActiveTextEditorSelectionRange } from '../editor'
+import { displayPath } from '../editor/displayPath'
 import { type Message } from '../sourcegraph-api'
 
 // tracked for telemetry purposes. Which context source provided this context file.
@@ -110,7 +111,7 @@ export function createContextMessageByFile(file: ContextFile, content: string): 
             text:
                 file.type === 'file'
                     ? `Context from file path @${file.uri?.path}:\n${code}`
-                    : `$${file.symbolName} is a ${file.kind} symbol from file path @${file.uri?.fsPath}:\n${code}`,
+                    : `$${file.symbolName} is a ${file.kind} symbol from file path @${displayPath(file.uri)}:\n${code}`,
             file,
         },
         { speaker: 'assistant', text: 'OK.' },

--- a/lib/shared/src/common/index.ts
+++ b/lib/shared/src/common/index.ts
@@ -13,13 +13,6 @@ export const isErrorLike = (value: unknown): value is ErrorLike =>
  */
 export const isDefined = <T>(value: T): value is NonNullable<T> => value !== undefined && value !== null
 
-/**
- * Returns the last element of path, or "." if path is empty.
- */
-export function basename(path: string): string {
-    return path.split('/').at(-1) || '.'
-}
-
 export function pluralize(string: string, count: number | bigint, plural = string + 's'): string {
     return count === 1 || count === 1n ? string : plural
 }

--- a/lib/shared/src/common/languages.test.ts
+++ b/lib/shared/src/common/languages.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from 'vitest'
+import { URI } from 'vscode-uri'
 
-import { languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './languages'
+import { languageFromFilename as _languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './languages'
 
 describe('languageFromFilename', () => {
+    function languageFromFilename(name: string): ReturnType<typeof _languageFromFilename> {
+        return _languageFromFilename(URI.parse(`file:///${name}`))
+    }
+
     test('', () => {
         expect(languageFromFilename('foo.java')).toBe('Java')
         expect(languageFromFilename('foo.go')).toBe('Go')
@@ -22,12 +27,12 @@ describe('languageFromFilename', () => {
 
 describe('markdownCodeBlockLanguageIDForFilename', () => {
     test('simple', () => {
-        expect(markdownCodeBlockLanguageIDForFilename('foo.java')).toBe('java')
-        expect(markdownCodeBlockLanguageIDForFilename('foo.go')).toBe('go')
+        expect(markdownCodeBlockLanguageIDForFilename(URI.parse('file:///foo.java'))).toBe('java')
+        expect(markdownCodeBlockLanguageIDForFilename(URI.parse('file:///foo.go'))).toBe('go')
     })
     test('complex', () => {
-        expect(markdownCodeBlockLanguageIDForFilename('foo.js')).toBe('javascript')
-        expect(markdownCodeBlockLanguageIDForFilename('foo.ts')).toBe('typescript')
-        expect(markdownCodeBlockLanguageIDForFilename('foo.tsx')).toBe('typescript')
+        expect(markdownCodeBlockLanguageIDForFilename(URI.parse('file:///foo.js'))).toBe('javascript')
+        expect(markdownCodeBlockLanguageIDForFilename(URI.parse('file:///foo.ts'))).toBe('typescript')
+        expect(markdownCodeBlockLanguageIDForFilename(URI.parse('file:///foo.tsx'))).toBe('typescript')
     })
 })

--- a/lib/shared/src/common/languages.ts
+++ b/lib/shared/src/common/languages.ts
@@ -1,6 +1,6 @@
-import path from 'path'
-
 import { type URI } from 'vscode-uri'
+
+import { uriExtname } from './uri'
 
 /**
  * Programming languages that we treat specially. Add to this (and {@link languageFromFilename} as
@@ -51,8 +51,8 @@ const EXTENSION_TO_LANGUAGE: { [key: string]: string } = {
  * For languages that we want to programmatically treat specially, check the return value against
  * the {@link ProgrammingLanguage} enum instead of strings like 'java'.
  */
-export function languageFromFilename(file: URI | string): string /* | ProgrammingLanguage */ {
-    const extWithoutDot = path.extname(typeof file === 'string' ? file : file.path).slice(1)
+export function languageFromFilename(file: URI): string /* | ProgrammingLanguage */ {
+    const extWithoutDot = uriExtname(file).slice(1)
     return EXTENSION_TO_LANGUAGE[extWithoutDot] ?? extWithoutDot
 }
 
@@ -69,6 +69,6 @@ export function languageFromFilename(file: URI | string): string /* | Programmin
  *
  * There is no standard ID convention for Markdown code blocks, so we have to do some guesswork.
  */
-export function markdownCodeBlockLanguageIDForFilename(file: URI | string): string {
+export function markdownCodeBlockLanguageIDForFilename(file: URI): string {
     return languageFromFilename(file).toLowerCase()
 }

--- a/lib/shared/src/common/path.test.ts
+++ b/lib/shared/src/common/path.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest'
+import { URI } from 'vscode-uri'
+
+import { pathFunctionsForURI, posixAndURIPaths } from './path'
+
+describe('pathFunctions', () => {
+    describe('nonWindows', () => {
+        const nonWindowsFSPath = pathFunctionsForURI(URI.file(''), false)
+        test('dirname', () => {
+            expect(nonWindowsFSPath.dirname('/a/b/c')).toBe('/a/b')
+            expect(nonWindowsFSPath.dirname('/a/b')).toBe('/a')
+            expect(nonWindowsFSPath.dirname('/a/b/')).toBe('/a')
+            expect(nonWindowsFSPath.dirname('/a')).toBe('/')
+            expect(nonWindowsFSPath.dirname('/a/')).toBe('/')
+            expect(nonWindowsFSPath.dirname('/')).toBe('/')
+            expect(nonWindowsFSPath.dirname('')).toBe('.')
+            expect(nonWindowsFSPath.dirname('a')).toBe('.')
+        })
+        test('basename', () => {
+            expect(nonWindowsFSPath.basename('/a/b/c')).toBe('c')
+            expect(nonWindowsFSPath.basename('/a/b')).toBe('b')
+            expect(nonWindowsFSPath.basename('/a/b/')).toBe('b')
+            expect(nonWindowsFSPath.basename('/a')).toBe('a')
+            expect(nonWindowsFSPath.basename('/a/')).toBe('a')
+            expect(nonWindowsFSPath.basename('/')).toBe('')
+            expect(nonWindowsFSPath.basename('')).toBe('')
+            expect(nonWindowsFSPath.basename('a')).toBe('a')
+        })
+        test('relative', () => {
+            expect(posixAndURIPaths.relative('/a/b', '/a/b/c')).toBe('c')
+            expect(posixAndURIPaths.relative('/a/b/', '/a/b/c')).toBe('c')
+            expect(posixAndURIPaths.relative('/a', '/a/b/c')).toBe('b/c')
+            expect(posixAndURIPaths.relative('/a', '/a')).toBe('')
+            expect(posixAndURIPaths.relative('/a/', '/a')).toBe('')
+            expect(posixAndURIPaths.relative('/a', '/a/')).toBe('')
+            expect(posixAndURIPaths.relative('/a/', '/a/')).toBe('')
+            expect(posixAndURIPaths.relative('/', '/a/b/c')).toBe('a/b/c')
+            expect(posixAndURIPaths.relative('/a/b', '/a')).toBe('..')
+            expect(posixAndURIPaths.relative('/a/b', '/a/')).toBe('..')
+            expect(posixAndURIPaths.relative('/a/b/', '/a/')).toBe('..')
+            expect(posixAndURIPaths.relative('/a/b', '/a/')).toBe('..')
+            expect(posixAndURIPaths.relative('/a/b/c/d', '/a/b/c')).toBe('..')
+            expect(posixAndURIPaths.relative('/a/b/c/d', '/a')).toBe('../../..')
+            expect(posixAndURIPaths.relative('a', '/a')).toBe('/a')
+            expect(posixAndURIPaths.relative('a/b', '/a')).toBe('/a')
+            expect(posixAndURIPaths.relative('a', '/c')).toBe('/c')
+            expect(posixAndURIPaths.relative('a/b', '/c')).toBe('/c')
+        })
+    })
+
+    describe('windows', () => {
+        const windowsFSPath = pathFunctionsForURI(URI.file(''), true)
+        test('dirname', () => {
+            expect(windowsFSPath.dirname('C:\\a\\b\\c')).toBe('C:\\a\\b')
+            expect(windowsFSPath.dirname('C:\\a\\b')).toBe('C:\\a')
+            expect(windowsFSPath.dirname('C:\\a')).toBe('C:\\')
+            expect(windowsFSPath.dirname('C:\\a\\')).toBe('C:\\')
+            expect(windowsFSPath.dirname('C:\\')).toBe('C:\\')
+            expect(windowsFSPath.dirname('C:')).toBe('C:')
+            expect(windowsFSPath.dirname('a\\b')).toBe('a')
+            expect(windowsFSPath.dirname('\\a\\b')).toBe('\\a')
+            expect(windowsFSPath.dirname('a')).toBe('.')
+            expect(windowsFSPath.dirname('\\a')).toBe('\\')
+        })
+        test('basename', () => {
+            expect(windowsFSPath.basename('C:\\a\\b\\c')).toBe('c')
+            expect(windowsFSPath.basename('C:\\a\\b')).toBe('b')
+            expect(windowsFSPath.basename('C:\\a')).toBe('a')
+            expect(windowsFSPath.basename('C:\\a\\')).toBe('a')
+            expect(windowsFSPath.basename('C:\\')).toBe('')
+            expect(windowsFSPath.basename('C:')).toBe('')
+            expect(windowsFSPath.basename('')).toBe('')
+            expect(windowsFSPath.basename('a\\b')).toBe('b')
+            expect(windowsFSPath.basename('\\a\\b')).toBe('b')
+            expect(windowsFSPath.basename('a')).toBe('a')
+            expect(windowsFSPath.basename('\\a')).toBe('a')
+        })
+    })
+
+    test('extname', () => {
+        // extname does not differ in behavior on Windows vs. non-Windows, so we don't need to test
+        // it for both platforms.
+        const extname = pathFunctionsForURI(URI.file(''), false).extname
+        expect(extname('/a/b/c.ts')).toBe('.ts')
+        expect(extname('/a/b.XX')).toBe('.XX')
+        expect(extname('/a/.a')).toBe('')
+        expect(extname('/a/.index.md')).toBe('.md')
+        expect(extname('c.test.ts')).toBe('.ts')
+        expect(extname('a')).toBe('')
+        expect(extname('a.')).toBe('.')
+    })
+})

--- a/lib/shared/src/common/path.ts
+++ b/lib/shared/src/common/path.ts
@@ -1,0 +1,164 @@
+import { type URI } from 'vscode-uri'
+
+import { isWindows as _isWindows } from './platform'
+
+export interface PathFunctions {
+    /**
+     * All but the last element of path, or "." if that would be the empty path.
+     */
+    dirname: (path: string) => string
+
+    /**
+     * The last element of path, or "" if path is empty.
+     * @param path the path to operate on
+     * @param suffix optional suffix to remove
+     */
+    basename: (path: string, suffix?: string) => string
+
+    /** The extension of path, including the last '.'. */
+    extname: (path: string) => string
+
+    /** Path separator. */
+    separator: string
+}
+
+/** For file system paths on Windows ('\' separators and drive letters). */
+export const windowsFilePaths: PathFunctions = pathFunctions(true)
+
+/**
+ * For POSIX and URI paths ('/' separators).
+ */
+export const posixAndURIPaths: PathFunctions & {
+    /**
+     * The relative path from {@link from} to {@link to}.
+     *
+     * Only implemented for POSIX and URI paths because there are currently no callers that need
+     * this for Windows paths.
+     */
+    relative: (from: string, to: string) => string
+} = { ...pathFunctions(false), relative: posixAndURIPathsRelative }
+
+/**
+ * Get the {@link PathFunctions} to use for the given URI's path.
+ */
+export function pathFunctionsForURI(uri: URI, isWindows = _isWindows()): PathFunctions {
+    return uri.scheme === 'file' && isWindows ? windowsFilePaths : posixAndURIPaths
+}
+
+// I don't like reimplementing this here, but it's the best option because: (1) using Node's `path`
+// module requires us to configure the bundler right or risk a subtle bug (and path-browserify
+// doesn't have `path/win32` support, so we'd need multiple underlying packages); and (2)
+// `vscode-uri` is hard to test because it has a global constant for the current platform set at
+// init time.
+function pathFunctions(isWindows: boolean): PathFunctions {
+    const sep = isWindows ? '\\' : '/'
+    const f: PathFunctions = {
+        dirname(path: string): string {
+            if (path === '') {
+                return '.'
+            }
+            if (isWindows && isDriveLetter(path)) {
+                return path
+            }
+            if (path.endsWith(sep)) {
+                path = path.slice(0, -1)
+            }
+            if (isWindows && isDriveLetter(path)) {
+                return path + sep
+            }
+            if (path === '') {
+                return sep
+            }
+            const i = path.lastIndexOf(sep)
+            if (i === -1) {
+                return '.'
+            }
+            if (i === 0) {
+                return sep
+            }
+            path = path.slice(0, i)
+            if (isWindows && isDriveLetter(path)) {
+                return path + sep
+            }
+            return path
+        },
+        basename(path: string, suffix?: string): string {
+            if (path.endsWith(sep)) {
+                path = path.slice(0, -1)
+            }
+            if (isWindows && isDriveLetter(path)) {
+                return ''
+            }
+            path = path.split(sep).at(-1) ?? ''
+            if (suffix && path.endsWith(suffix)) {
+                path = path.slice(0, -suffix.length)
+            }
+            return path
+        },
+        extname(path: string): string {
+            const basename = f.basename(path)
+            const i = basename.lastIndexOf('.')
+            if (i === 0 || i === -1) {
+                return ''
+            }
+            return basename.slice(i)
+        },
+        separator: sep,
+    }
+    return f
+}
+
+function isDriveLetter(path: string): boolean {
+    return /^[A-Za-z]:$/.test(path)
+}
+
+/** The relative path from {@link from} to {@link to}. */
+function posixAndURIPathsRelative(from: string, to: string): string {
+    // Normalize slashes.
+    from = from.replaceAll(/\/{2,}/g, '/')
+    to = to.replaceAll(/\/{2,}/g, '/')
+
+    // Trim trailing slashes.
+    if (from !== '/' && from.endsWith('/')) {
+        from = from.slice(0, -1)
+    }
+    if (to !== '/' && to.endsWith('/')) {
+        to = to.slice(0, -1)
+    }
+
+    if (from === to) {
+        return ''
+    }
+
+    // From a relative to an absolute path, the absolute path dominates.
+    if (!from.startsWith('/') && to.startsWith('/')) {
+        return to
+    }
+
+    const fromParts = from === '/' ? [''] : from.split('/')
+    const toParts = to === '/' ? [''] : to.split('/')
+
+    // Find the common root.
+    let commonLength = 0
+    while (
+        commonLength < fromParts.length &&
+        commonLength < toParts.length &&
+        fromParts[commonLength] === toParts[commonLength]
+    ) {
+        commonLength++
+    }
+
+    // Calculate the number of directory traversals needed.
+    const traversals = fromParts.length - commonLength
+
+    // Build the relative path.
+    const relativePath: string[] = []
+    for (let i = 0; i < traversals; i++) {
+        relativePath.push('..')
+    }
+
+    // Add the non-common path parts from the 'to' path.
+    relativePath.push(...toParts.slice(commonLength))
+
+    return relativePath.join('/')
+}

--- a/lib/shared/src/common/uri.test.ts
+++ b/lib/shared/src/common/uri.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest'
+import { URI } from 'vscode-uri'
+
+import { uriBasename, uriDirname, uriExtname, uriParseNameAndExtension } from './uri'
+
+describe('uriDirname', () => {
+    test('', () => {
+        expect(uriDirname(URI.parse('file:///a/b/c')).toString()).toBe('file:///a/b')
+        expect(uriDirname(URI.parse('https://example.com/a/b')).toString()).toBe('https://example.com/a')
+        expect(uriDirname(URI.parse('https://example.com/a/')).toString()).toBe('https://example.com/')
+        expect(uriDirname(URI.parse('https://example.com/')).toString()).toBe('https://example.com/')
+    })
+})
+
+describe('uriBasename', () => {
+    test('', () => {
+        expect(uriBasename(URI.parse('file:///a/b/c')).toString()).toBe('c')
+        expect(uriBasename(URI.parse('https://example.com/a/b')).toString()).toBe('b')
+        expect(uriBasename(URI.parse('file:///c:/a/b')).toString()).toBe('b')
+        expect(uriBasename(URI.parse('file:///c:/')).toString()).toBe('c:')
+        expect(uriBasename(URI.parse('file:///c:')).toString()).toBe('c:')
+        expect(uriBasename(URI.parse('file:///c%3A')).toString()).toBe('c:')
+        expect(uriBasename(URI.parse('file:///a/b%20c')).toString()).toBe('b c')
+    })
+})
+
+describe('uriExtname', () => {
+    test('', () => {
+        expect(uriExtname(URI.parse('file:///a/b.txt')).toString()).toBe('.txt')
+        expect(uriExtname(URI.parse('https://example.com/a/b.test.rb')).toString()).toBe('.rb')
+        expect(uriExtname(URI.parse('file:///c:/a/.foo.js')).toString()).toBe('.js')
+        expect(uriExtname(URI.parse('file:///a/b')).toString()).toBe('')
+    })
+})
+
+describe('uriParseNameAndExtension', () => {
+    test('', () => {
+        expect(uriParseNameAndExtension(URI.parse('file:///a/b.txt'))).toEqual<
+            ReturnType<typeof uriParseNameAndExtension>
+        >({ name: 'b', ext: '.txt' })
+    })
+})

--- a/lib/shared/src/common/uri.ts
+++ b/lib/shared/src/common/uri.ts
@@ -1,0 +1,82 @@
+import { type URI } from 'vscode-uri'
+
+import { posixAndURIPaths } from './path'
+
+/**
+ * dirname, but operates on a {@link URI}.
+ *
+ * Use this instead of Node's `path` module because on Windows, Node `path` uses '\' as path
+ * separators, which will break because URI paths are always separated with '/'.
+ */
+export function uriDirname(uri: URI): URI {
+    return uri.with({ path: posixAndURIPaths.dirname(uri.path) })
+}
+
+/**
+ * basename, but operates on a {@link URI}'s path.
+ *
+ * See {@link uriDirname} for why we use this instead of Node's `path` module.
+ */
+export function uriBasename(uri: URI, suffix?: string): string {
+    return posixAndURIPaths.basename(uri.path, suffix)
+}
+
+/**
+ * extname, but operates on a {@link URI}'s path.
+ *
+ * See {@link uriDirname} for why we use this instead of Node's `path` module.
+ */
+export function uriExtname(uri: URI): string {
+    return posixAndURIPaths.extname(uri.path)
+}
+
+/**
+ * parse, but operates on a {@link URI}'s path.
+ *
+ * See {@link uriDirname} for why we use this instead of Node's `path` module.
+ */
+export function uriParseNameAndExtension(uri: URI): { name: string; ext: string } {
+    const ext = uriExtname(uri)
+    const name = uriBasename(uri, ext)
+    return { ext, name }
+}
+
+/**
+ * A file URI.
+ *
+ * It is helpful to use the {@link FileURI} type instead of just {@link URI} or {@link vscode.Uri}
+ * when the URI is known to be `file`-scheme-only.
+ */
+export type FileURI = Omit<URI, 'fsPath'> & {
+    scheme: 'file'
+
+    // Re-declare this here so it doesn't pick up the @deprecated tag on URI.fsPath.
+    /**
+     * The platform-specific file system path. Thank you for only using `.fsPath` on {@link FileURI}
+     * types (and not vscode.Uri or URI types)! :-)
+     */
+    fsPath: string
+}
+
+export function isFileURI(uri: URI): uri is FileURI {
+    return uri.scheme === 'file'
+}
+
+export function assertFileURI(uri: URI): FileURI {
+    if (!isFileURI(uri)) {
+        throw new TypeError(`assertFileURI failed on ${uri.toString()}`)
+    }
+    return uri
+}
+
+declare module 'vscode-uri' {
+    export class URI {
+        public static file(fsPath: string): FileURI
+
+        /**
+         * @deprecated Only call `.fsPath` on {@link FileURI}, which you can create with `URI.file`
+         * or with the {@link isFileURI} and {@link assertFileURI} helpers.
+         */
+        public fsPath: string
+    }
+}

--- a/lib/shared/src/editor/displayPath.ts
+++ b/lib/shared/src/editor/displayPath.ts
@@ -1,11 +1,11 @@
 import { URI } from 'vscode-uri'
 
-import { basename } from '../common'
+import { pathFunctionsForURI, posixAndURIPaths } from '../common/path'
 
 /**
- * Convert an absolute URI or file path to a (possibly shorter) path to display to the user. The
- * display path is always a path (not a full URI string) and is typically is relative to the nearest
- * workspace root. The path uses OS-native path separators ('/' on macOS/Linux, '\' on Windows).
+ * Convert an absolute URI to a (possibly shorter) path to display to the user. The display path is
+ * always a path (not a full URI string) and is typically is relative to the nearest workspace root.
+ * The path uses OS-native path separators ('/' on macOS/Linux, '\' on Windows).
  *
  * The returned path string MUST ONLY be used for display purposes. It MUST NOT be used to identify
  * or locate files.
@@ -20,34 +20,93 @@ import { basename } from '../common'
  * - `vscode.workspace.asRelativePath`: because it's not available in webviews, and it does not
  *   handle custom URI schemes (such as if we want to represent remote files that exist on the
  *   Sourcegraph instance).
- * @param location The absolute URI or file path to convert to a display path.
+ * @param location The absolute URI to convert to a display path.
  */
-export function displayPath(location: URI | string): string {
+export function displayPath(location: URI): string {
+    const result = _displayPath(location, checkEnvInfo())
+    return typeof result === 'string' ? result : result.toString()
+}
+
+/**
+ * Dirname of the location's display path, to display to the user. Similar to
+ * `dirname(displayPath(location))`, but it uses the right path separators in `dirname` ('\' for
+ * file URIs on Windows, '/' otherwise).
+ *
+ * The returned path string MUST ONLY be used for display purposes. It MUST NOT be used to identify
+ * or locate files.
+ *
+ * Use this instead of other seemingly simpler techniques to avoid a few subtle
+ * bugs/inconsistencies:
+ *
+ * - On Windows, Node's `dirname(uri.fsPath)` breaks on a non-`file` URI on Windows because
+ *   `dirname` would use '\' path separators but the URI would have '/' path separators.
+ * - In a single-root workspace, Node's `dirname(uri.fsPath)` would return the root directory name,
+ *   which is usually superfluous for display purposes. For example, if VS Code is open to a
+ *   directory named `myproject` and there is a list of 2 search results, one `file1.txt` (at the
+ *   root) and `dir/file2.txt`, then the VS Code-idiomatic way to present the results is as
+ *   `file1.txt` and `file2.txt <dir>` (try it in the search sidebar to see).
+ */
+export function displayPathDirname(location: URI): string {
+    const envInfo = checkEnvInfo()
+    const result = _displayPath(location, envInfo)
+
+    const dirname = pathFunctionsForURI(location, envInfo.isWindows).dirname
+    if (typeof result === 'string') {
+        return dirname(result)
+    }
+    return result.with({ path: dirname(result.path) }).toString()
+}
+
+/**
+ * Similar to `basename(displayPath(location))`, but it uses the right path separators in `basename`
+ * ('\' for file URIs on Windows, '/' otherwise).
+ */
+export function displayPathBasename(location: URI): string {
+    const envInfo = checkEnvInfo()
+    const displayPath = _displayPath(location, envInfo)
+    return pathFunctionsForURI(location, envInfo.isWindows).basename(
+        typeof displayPath === 'string' ? displayPath : displayPath.path
+    )
+}
+
+/**
+ * Like {@link displayPath}, but does not show `<WORKSPACE-FOLDER-BASENAME>/` as a prefix if the
+ * location is in a workspace folder and there are 2 or more workspace folders.
+ */
+export function displayPathWithoutWorkspaceFolderPrefix(location: URI): string {
+    const result = _displayPath(location, checkEnvInfo(), false)
+    return typeof result === 'string' ? result : result.toString()
+}
+
+function checkEnvInfo(): DisplayPathEnvInfo {
     if (!envInfo) {
         throw new Error(
             'no environment info for displayPath function (call setDisplayPathEnvInfo; see displayPath docstring for more info)'
         )
     }
-    return _displayPath(location, envInfo)
+    return envInfo
 }
 
-function _displayPath(location: URI | string, { workspaceFolders, isWindows }: DisplayPathEnvInfo): string {
+function _displayPath(
+    location: URI,
+    { workspaceFolders, isWindows }: DisplayPathEnvInfo,
+    includeWorkspaceFolderWhenMultiple = true
+): string | URI {
     const uri = typeof location === 'string' ? URI.parse(location) : URI.from(location)
 
-    // URIs always use forward slashes, but the "display path" should be an OS-native path, which
-    // means backslashes for Windows file paths.
-    const filePathSep = isWindows ? '\\' : '/'
-
-    // Non-file URIs use '/' in paths on all platforms (even Windows).
-    const pathSep = uri.scheme === 'file' ? filePathSep : '/'
-
     // Mimic the behavior of vscode.workspace.asRelativePath.
-    const includeWorkspaceFolder = workspaceFolders.length >= 2
+    const includeWorkspaceFolder = includeWorkspaceFolderWhenMultiple && workspaceFolders.length >= 2
     for (const folder of workspaceFolders) {
         if (uriHasPrefix(uri, folder, isWindows)) {
-            const folderPath = folder.path.endsWith('/') ? folder.path.slice(0, -1) : folder.path
-            const workspaceFolderPrefix = includeWorkspaceFolder ? basename(folderPath) + pathSep : ''
-            return fixPathSep(workspaceFolderPrefix + uri.path.slice(folderPath.length + 1), isWindows, uri.scheme)
+            const workspacePrefix = folder.path.endsWith('/') ? folder.path.slice(0, -1) : folder.path
+            const workspaceDisplayPrefix = includeWorkspaceFolder
+                ? posixAndURIPaths.basename(folder.path) + pathFunctionsForURI(folder).separator
+                : ''
+            return fixPathSep(
+                workspaceDisplayPrefix + uri.path.slice(workspacePrefix.length + 1),
+                isWindows,
+                uri.scheme
+            )
         }
     }
 
@@ -57,7 +116,7 @@ function _displayPath(location: URI | string, { workspaceFolders, isWindows }: D
     }
 
     // Show the full URI for anything else.
-    return uri.toString()
+    return uri
 }
 
 /**
@@ -80,7 +139,7 @@ export function uriHasPrefix(uri: URI, prefix: URI, isWindows: boolean): boolean
             : prefix.path
     return (
         uri.scheme === prefix.scheme &&
-        (uri.authority || '') === (prefix.authority || '') && // different URI impls treat empty different
+        (uri.authority ?? '') === (prefix.authority ?? '') && // different URI impls treat empty different
         (uriPath === prefixPath ||
             uriPath.startsWith(prefixPath.endsWith('/') ? prefixPath : prefixPath + '/') ||
             (prefixPath.endsWith('/') && uriPath === prefixPath.slice(0, -1)))

--- a/lib/shared/src/embeddings/client.ts
+++ b/lib/shared/src/embeddings/client.ts
@@ -36,7 +36,7 @@ export class SourcegraphEmbeddingsSearchClient implements EmbeddingsSearch {
     public get status(): status.ContextGroup[] {
         return [
             {
-                name: this.codebaseLocalName || this.repoName,
+                displayName: this.codebaseLocalName || this.repoName,
                 providers: [
                     {
                         kind: 'embeddings',

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -6,7 +6,7 @@ export { ChatClient } from './chat/chat'
 export { createClient, type Client } from './chat/client'
 export type { ChatContextStatus } from './chat/context'
 export { ignores, isCodyIgnoredFile } from './chat/context-filter'
-export { CODY_IGNORE_FILENAME_POSIX_GLOB, type IgnoreFileContent } from './chat/ignore-helper'
+export { CODY_IGNORE_POSIX_GLOB, type IgnoreFileContent } from './chat/ignore-helper'
 export { renderCodyMarkdown } from './chat/markdown'
 export { getSimplePreamble } from './chat/preamble'
 export { Transcript } from './chat/transcript'
@@ -49,10 +49,20 @@ export type {
 } from './codebase-context/messages'
 export { defaultCodyCommandContext } from './commands'
 export type { CodyCommand, CodyCommandContext, CustomCommandType } from './commands'
-export { basename, dedupeWith, isDefined, isErrorLike, pluralize } from './common'
+export { dedupeWith, isDefined, isErrorLike, pluralize } from './common'
 export { ProgrammingLanguage, languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './common/languages'
 export { renderMarkdown } from './common/markdown'
+export { posixAndURIPaths } from './common/path'
 export { isWindows } from './common/platform'
+export {
+    assertFileURI,
+    isFileURI,
+    uriBasename,
+    uriDirname,
+    uriExtname,
+    uriParseNameAndExtension,
+    type FileURI,
+} from './common/uri'
 export type {
     AutocompleteTimeouts,
     Configuration,
@@ -73,7 +83,14 @@ export type {
     Editor,
     VsCodeCommandsController,
 } from './editor'
-export { displayPath, setDisplayPathEnvInfo, type DisplayPathEnvInfo } from './editor/displayPath'
+export {
+    displayPath,
+    displayPathBasename,
+    displayPathDirname,
+    displayPathWithoutWorkspaceFolderPrefix,
+    setDisplayPathEnvInfo,
+    type DisplayPathEnvInfo,
+} from './editor/displayPath'
 export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
 export { EmbeddingsDetector } from './embeddings/EmbeddingsDetector'
 export { SourcegraphEmbeddingsSearchClient } from './embeddings/client'
@@ -93,6 +110,7 @@ export type {
     SearchPanelFile,
     SearchPanelSnippet,
 } from './local-context'
+export { logDebug, logError, setLogger } from './logger'
 export {
     MAX_BYTES_PER_FILE,
     MAX_CURRENT_FILE_TOKENS,
@@ -150,4 +168,3 @@ export type { ExtensionDetails } from './telemetry/EventLogger'
 export { testFileUri } from './test/path-helpers'
 export { addTraceparent, getActiveTraceAndSpanId, wrapInActiveSpan } from './tracing'
 export { convertGitCloneURLToCodebaseName, isError } from './utils'
-export { logDebug, logError, setLogger } from './logger'

--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -6,7 +6,6 @@ import { type EmbeddingsSearchResult } from '../sourcegraph-api/graphql/client'
 export type ContextResult = ContextFile & {
     repoName?: string
     revision?: string
-    fileName: string
     content: string
 }
 
@@ -37,13 +36,13 @@ export interface Result {
     doc: string
     exported: boolean
     lang: string
-    file: string
+    file: URI
     range: Range
     summary: string
 }
 
 export interface IndexedKeywordContextFetcher {
-    getResults(query: string, scopeDirs: string[]): Promise<Promise<Result[]>[]>
+    getResults(query: string, scopeDirs: URI[]): Promise<Promise<Result[]>[]>
 }
 
 /**
@@ -51,9 +50,6 @@ export interface IndexedKeywordContextFetcher {
  */
 export interface SearchPanelFile {
     uri: URI
-    basename: string
-    dirname: string
-    wsname?: string
     snippets: SearchPanelSnippet[]
 }
 

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1,5 +1,6 @@
 import fetch from 'isomorphic-fetch'
 import type { Response as NodeResponse } from 'node-fetch'
+import { type URI } from 'vscode-uri'
 
 import { type TelemetryEventInput } from '@sourcegraph/telemetry'
 
@@ -129,7 +130,7 @@ interface LogEventResponse {}
 export interface EmbeddingsSearchResult {
     repoName?: string
     revision?: string
-    fileName: string
+    uri: URI
     startLine: number
     endLine: number
     content: string

--- a/lib/shared/src/test/path-helpers.ts
+++ b/lib/shared/src/test/path-helpers.ts
@@ -11,5 +11,5 @@ import { isWindows } from '../common/platform'
  * @param relativePath The name/relative path of the file (with forward slashes).
  */
 export function testFileUri(relativePath: string): URI {
-    return URI.file(isWindows() ? `C:\\${relativePath.replaceAll('/', '\\')}` : `/${relativePath}`)
+    return URI.file(isWindows() ? `c:\\${relativePath.replaceAll('/', '\\')}` : `/${relativePath}`)
 }

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -65,7 +65,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
     public configurationChangeEvent = new vscode.EventEmitter<void>()
 
     // Codebase-context-related state
-    public currentWorkspaceRoot: string
+    public currentWorkspaceRoot: vscode.Uri | undefined
 
     protected disposables: vscode.Disposable[] = []
 
@@ -85,7 +85,6 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
     ) {
         this.disposables.push(this.configurationChangeEvent)
 
-        this.currentWorkspaceRoot = ''
         this.disposables.push(
             vscode.window.onDidChangeActiveTextEditor(async () => {
                 await this.updateCodebaseContext()
@@ -141,7 +140,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
     }
 
     public async forceUpdateCodebaseContext(): Promise<void> {
-        this.currentWorkspaceRoot = ''
+        this.currentWorkspaceRoot = undefined
         return this.syncAuthStatus()
     }
 
@@ -150,8 +149,8 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
             // these are ephemeral
             return
         }
-        const workspaceRoot = this.editor.getWorkspaceRootUri()?.fsPath
-        if (!workspaceRoot || workspaceRoot === '' || workspaceRoot === this.currentWorkspaceRoot) {
+        const workspaceRoot = this.editor.getWorkspaceRootUri()
+        if (!workspaceRoot || workspaceRoot.toString() === this.currentWorkspaceRoot?.toString()) {
             return
         }
         this.currentWorkspaceRoot = workspaceRoot
@@ -170,8 +169,8 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
         if (!codebaseContext) {
             return
         }
-        // after await, check we're still hitting the same workspace root
-        if (this.currentWorkspaceRoot !== workspaceRoot) {
+        // After await, check we're still hitting the same workspace root.
+        if (this.currentWorkspaceRoot && this.currentWorkspaceRoot.toString() !== workspaceRoot.toString()) {
             return
         }
 

--- a/vscode/src/commands/prompt/utils.ts
+++ b/vscode/src/commands/prompt/utils.ts
@@ -1,6 +1,6 @@
-import path from 'path'
-
 import { type URI } from 'vscode-uri'
+
+import { uriBasename, uriExtname } from '@sourcegraph/cody-shared'
 
 /**
  * Extracts the test type from the given text.
@@ -40,7 +40,7 @@ export function toSlashCommand(command: string): string {
  * Also returns false for any files in node_modules directory.
  */
 export function isValidTestFile(uri: URI): boolean {
-    const fileNameWithoutExt = path.posix.basename(uri.path, path.posix.extname(uri.path))
+    const fileNameWithoutExt = uriBasename(uri, uriExtname(uri))
 
     const suffixTest = /([._-](test|spec))|Test|Spec$/
 

--- a/vscode/src/commands/utils/get-context.ts
+++ b/vscode/src/commands/utils/get-context.ts
@@ -39,7 +39,10 @@ export const getContextForCommand = async (editor: VSCodeEditor, command: CodyCo
     }
     if (contextConfig.directoryPath) {
         contextMessages.push(
-            ...(await editorContext.getEditorDirContext(contextConfig.directoryPath, selection?.fileUri))
+            ...(await editorContext.getEditorDirContext(
+                vscode.Uri.file(contextConfig.directoryPath),
+                selection?.fileUri
+            ))
         )
     }
     if (contextConfig.currentDir) {

--- a/vscode/src/commands/utils/new-test-file.ts
+++ b/vscode/src/commands/utils/new-test-file.ts
@@ -1,6 +1,6 @@
-import { posix } from 'path'
-
 import { Utils, type URI } from 'vscode-uri'
+
+import { uriBasename, uriExtname, uriParseNameAndExtension } from '@sourcegraph/cody-shared'
 
 import { isValidTestFile } from '../prompt/utils'
 
@@ -25,9 +25,9 @@ export function createDefaultTestFile(file: URI): URI {
         return file
     }
 
-    // remove the first dot from ext
-    const ext = posix.extname(file.path).slice(1)
-    const fileName = posix.parse(file.path).name
+    const extWithDot = uriExtname(file)
+    const fileName = uriBasename(file, extWithDot)
+    const ext = extWithDot.slice(1)
 
     let testFileName = `${fileName}Test.${ext}`
     if (TEST_FILE_DOT_SUFFIX_EXTENSIONS.has(ext)) {
@@ -62,8 +62,8 @@ export function convertFileUriToTestFileUri(currentFile: URI, testFile?: URI): U
 
     // If there is an existing test file, create the test file following its naming convention
     if (testFile?.path && isValidTestFile(testFile)) {
-        const parsedCurrentFile = posix.parse(currentFile.path)
-        const parsedTestFile = posix.parse(testFile.path)
+        const parsedCurrentFile = uriParseNameAndExtension(currentFile)
+        const parsedTestFile = uriParseNameAndExtension(testFile)
         if (parsedCurrentFile.ext === parsedTestFile.ext) {
             const testFileName = parsedTestFile.name
             const index = testFileName.lastIndexOf('test') || testFileName.lastIndexOf('spec')

--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -106,7 +106,7 @@ export class ContextMixer implements vscode.Disposable {
         const resultsByDocument = new Map<string, { [identifier: string]: ContextSnippet[] }>()
         for (const { identifier, snippets } of results) {
             for (const snippet of snippets) {
-                const documentId = snippet.fileName
+                const documentId = snippet.uri.toString()
 
                 let document = resultsByDocument.get(documentId)
                 if (!document) {
@@ -128,7 +128,7 @@ export class ContextMixer implements vscode.Disposable {
         const fusedDocumentScores: Map<string, number> = new Map()
         for (const { identifier, snippets } of results) {
             snippets.forEach((snippet, rank) => {
-                const documentId = snippet.fileName
+                const documentId = snippet.uri.toString()
 
                 // Since every retriever can return many snippets for a given document, we need to
                 // only consider the best rank for each document.

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts
@@ -1,5 +1,3 @@
-import path from 'path'
-
 import * as vscode from 'vscode'
 import { type URI } from 'vscode-uri'
 
@@ -39,13 +37,7 @@ export class JaccardSimilarityRetriever implements ContextRetriever {
                 continue
             }
 
-            matches.push({
-                // Use relative path to remove redundant information from the prompts and
-                // keep in sync with embeddings search results which use relative to repo root paths
-                fileName: path.normalize(vscode.workspace.asRelativePath(uri.fsPath)),
-                ...match,
-                uri,
-            })
+            matches.push({ ...match, uri })
         }
 
         matches.sort((a, b) => b.score - a.score)
@@ -63,7 +55,6 @@ export class JaccardSimilarityRetriever implements ContextRetriever {
 }
 
 interface JaccardMatchWithFilename extends JaccardMatch {
-    fileName: string
     uri: URI
 }
 

--- a/vscode/src/completions/context/retrievers/new-jaccard-similarity/jaccard-similarity-retriever.ts
+++ b/vscode/src/completions/context/retrievers/new-jaccard-similarity/jaccard-similarity-retriever.ts
@@ -1,5 +1,3 @@
-import path from 'path'
-
 import * as vscode from 'vscode'
 import { type URI } from 'vscode-uri'
 
@@ -60,10 +58,6 @@ export class JaccardSimilarityRetriever implements ContextRetriever {
             const lines = contents.split('\n')
             const fileMatches = bestJaccardMatches(targetText, contents, this.snippetWindowSize, this.maxMatchesPerFile)
 
-            // Use relative path to remove redundant information from the prompts and
-            // keep in sync with embeddings search results which use relative to repo root paths
-            const readableFileName = path.normalize(vscode.workspace.asRelativePath(uri.fsPath))
-
             // Ignore matches with 0 overlap to our source file
             const relatedMatches = fileMatches.filter(match => match.score > 0)
 
@@ -87,11 +81,7 @@ export class JaccardSimilarityRetriever implements ContextRetriever {
                     continue
                 }
 
-                matches.push({
-                    fileName: readableFileName,
-                    ...match,
-                    uri,
-                })
+                matches.push({ ...match, uri })
             }
         }
 
@@ -110,7 +100,6 @@ export class JaccardSimilarityRetriever implements ContextRetriever {
 }
 
 interface JaccardMatchWithFilename extends JaccardMatch {
-    fileName: string
     uri: URI
 }
 

--- a/vscode/src/completions/context/retrievers/section-history/section-history-retriever.test.ts
+++ b/vscode/src/completions/context/retrievers/section-history/section-history-retriever.test.ts
@@ -95,7 +95,7 @@ describe('GraphSectionObserver', () => {
 
     it('loads visible documents when it loads', () => {
         expect(withPosixPathsInString(sectionObserver.debugPrint())).toMatchInlineSnapshot(`
-          "file:/document1.ts
+          "file:///document1.ts
             ├─ foo
             └─ bar"
         `)
@@ -109,10 +109,10 @@ describe('GraphSectionObserver', () => {
         await onDidChangeVisibleTextEditors()
 
         expect(withPosixPathsInString(sectionObserver.debugPrint())).toMatchInlineSnapshot(`
-          "file:/document2.ts
+          "file:///document2.ts
             ├─ baz
             └─ qux
-          file:/document1.ts
+          file:///document1.ts
             ├─ foo
             └─ bar"
         `)
@@ -123,10 +123,10 @@ describe('GraphSectionObserver', () => {
         await onDidChangeVisibleTextEditors()
 
         expect(withPosixPathsInString(sectionObserver.debugPrint())).toMatchInlineSnapshot(`
-          "file:/document2.ts
+          "file:///document2.ts
             ├─ baz
             └─ qux
-          file:/document1.ts
+          file:///document1.ts
             ├─ foo
             └─ bar"
         `)
@@ -144,7 +144,7 @@ describe('GraphSectionObserver', () => {
         })
 
         expect(withPosixPathsInString(sectionObserver.debugPrint())).toMatchInlineSnapshot(`
-          "file:/document1.ts
+          "file:///document1.ts
             ├─ foo
             └─ baz"
         `)
@@ -156,12 +156,12 @@ describe('GraphSectionObserver', () => {
             selections: [{ active: { line: 1, character: 0 } }],
         })
         expect(withPosixPathsInString(sectionObserver.debugPrint())).toMatchInlineSnapshot(`
-          "file:/document1.ts
+          "file:///document1.ts
             ├─ foo
             └─ bar
 
           Last visited sections:
-            └ file:/document1.ts foo"
+            └ file:///document1.ts foo"
         `)
 
         testDocuments.document1.lineCount = 10
@@ -174,11 +174,11 @@ describe('GraphSectionObserver', () => {
         })
 
         expect(withPosixPathsInString(sectionObserver.debugPrint())).toMatchInlineSnapshot(`
-          "file:/document1.ts
+          "file:///document1.ts
             └─ baz
 
           Last visited sections:
-            └ file:/document1.ts baz"
+            └ file:///document1.ts baz"
         `)
     })
 
@@ -205,16 +205,16 @@ describe('GraphSectionObserver', () => {
 
             // We opened and preloaded the first section of both documents and have visited them
             expect(withPosixPathsInString(sectionObserver.debugPrint())).toMatchInlineSnapshot(`
-              "file:/document1.ts
+              "file:///document1.ts
                 ├─ foo
                 └─ bar
-              file:/document2.ts
+              file:///document2.ts
                 ├─ baz
                 └─ qux
 
               Last visited sections:
-                ├ file:/document1.ts foo
-                └ file:/document2.ts baz"
+                ├ file:///document1.ts foo
+                └ file:///document2.ts baz"
             `)
 
             const context = await sectionObserver.retrieve({
@@ -228,8 +228,7 @@ describe('GraphSectionObserver', () => {
 
             expect(context[0]).toEqual({
                 content: 'foo\nbar\nfoo',
-                fileName: document2Uri.fsPath,
-                fileUri: document2Uri,
+                uri: document2Uri,
             })
         })
 
@@ -245,13 +244,13 @@ describe('GraphSectionObserver', () => {
             })
 
             expect(withPosixPathsInString(sectionObserver.debugPrint())).toMatchInlineSnapshot(`
-              "file:/document1.ts
+              "file:///document1.ts
                 ├─ foo
                 └─ bar
 
               Last visited sections:
-                ├ file:/document1.ts bar
-                └ file:/document1.ts foo"
+                ├ file:///document1.ts bar
+                └ file:///document1.ts foo"
             `)
 
             const context = await sectionObserver.retrieve({

--- a/vscode/src/completions/context/retrievers/section-history/section-history-retriever.ts
+++ b/vscode/src/completions/context/retrievers/section-history/section-history-retriever.ts
@@ -1,5 +1,3 @@
-import path from 'path'
-
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 import { type URI } from 'vscode-uri'
@@ -133,9 +131,8 @@ export class SectionHistoryRetriever implements ContextRetriever {
                         try {
                             const uri = section.location.uri
                             const textDocument = await vscode.workspace.openTextDocument(uri)
-                            const fileName = path.normalize(vscode.workspace.asRelativePath(uri.fsPath))
                             const content = textDocument.getText(section.location.range)
-                            return { fileUri: uri, fileName, content }
+                            return { uri, content }
                         } catch (error) {
                             // Ignore errors opening the text file. This can happen when the file was deleted
                             console.error(error)
@@ -158,14 +155,11 @@ export class SectionHistoryRetriever implements ContextRetriever {
 
     /**
      * A pretty way to print the current state of all cached sections
-     *
-     * Printed paths are always in posix format (forwards slashes) even on windows
-     * for consistency.
      */
     public debugPrint(selectedDocument?: vscode.TextDocument, selections?: readonly vscode.Selection[]): string {
         const lines: string[] = []
         this.activeDocuments.forEach(document => {
-            lines.push(path.posix.normalize(vscode.workspace.asRelativePath(document.uri)))
+            lines.push(vscode.workspace.asRelativePath(document.uri))
             for (const section of document.sections) {
                 const isSelected =
                     selectedDocument?.uri.toString() === document.uri.toString() &&
@@ -185,7 +179,7 @@ export class SectionHistoryRetriever implements ContextRetriever {
             for (let i = 0; i < lastSections.length; i++) {
                 const section = lastSections[i]
                 const isLast = i === lastSections.length - 1
-                const filePath = path.posix.normalize(vscode.workspace.asRelativePath(section.location.uri))
+                const filePath = vscode.workspace.asRelativePath(section.location.uri)
 
                 lines.push(`  ${isLast ? '└' : '├'} ${filePath} ${section.fuzzyName ?? 'unknown'}`)
             }

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -1,7 +1,7 @@
 import * as anthropic from '@anthropic-ai/sdk'
 import * as vscode from 'vscode'
 
-import { tokensToChars, type Message } from '@sourcegraph/cody-shared'
+import { displayPath, tokensToChars, type Message } from '@sourcegraph/cody-shared'
 
 import { type CodeCompletionsClient, type CodeCompletionsParams } from '../client'
 import {
@@ -120,7 +120,9 @@ class AnthropicProvider extends Provider {
                     text:
                         'symbol' in snippet && snippet.symbol !== ''
                             ? `Additional documentation for \`${snippet.symbol}\`: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`
-                            : `Codebase context from file path '${snippet.fileName}': ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`,
+                            : `Codebase context from file path '${displayPath(snippet.uri)}': ${OPENING_CODE_TAG}${
+                                  snippet.content
+                              }${CLOSING_CODE_TAG}`,
                 },
                 {
                     speaker: 'assistant',

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { tokensToChars, type AutocompleteTimeouts } from '@sourcegraph/cody-shared'
+import { displayPath, tokensToChars, type AutocompleteTimeouts } from '@sourcegraph/cody-shared'
 
 import { getLanguageConfig } from '../../tree-sitter/language'
 import { type CodeCompletionsClient, type CodeCompletionsParams } from '../client'
@@ -113,7 +113,9 @@ class FireworksProvider extends Provider {
                 if ('symbol' in snippet && snippet.symbol !== '') {
                     intro.push(`Additional documentation for \`${snippet.symbol}\`:\n\n${snippet.content}`)
                 } else {
-                    intro.push(`Here is a reference snippet of code from ${snippet.fileName}:\n\n${snippet.content}`)
+                    intro.push(
+                        `Here is a reference snippet of code from ${displayPath(snippet.uri)}:\n\n${snippet.content}`
+                    )
                 }
             }
 

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { tokensToChars } from '@sourcegraph/cody-shared'
+import { displayPath, tokensToChars } from '@sourcegraph/cody-shared'
 
 import { type CodeCompletionsClient, type CodeCompletionsParams } from '../client'
 import {
@@ -92,7 +92,9 @@ ${OPENING_CODE_TAG}${infillBlock}`
             const snippetMessages: string[] = [
                 'symbol' in snippet && snippet.symbol !== ''
                     ? `Additional documentation for \`${snippet.symbol}\`: ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`
-                    : `Codebase context from file path '${snippet.fileName}': ${OPENING_CODE_TAG}${snippet.content}${CLOSING_CODE_TAG}`,
+                    : `Codebase context from file path '${displayPath(snippet.uri)}': ${OPENING_CODE_TAG}${
+                          snippet.content
+                      }${CLOSING_CODE_TAG}`,
             ]
             const numSnippetChars = snippetMessages.join('\n\n').length + 1
             if (numSnippetChars > remainingChars) {

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { isDefined, renderMarkdown } from '@sourcegraph/cody-shared'
+import { displayPath, isDefined, renderMarkdown } from '@sourcegraph/cody-shared'
 
 import {
     registerDebugListener as registerSectionObserverDebugListener,
@@ -132,9 +132,9 @@ ${
         : data.context.context
               .map(contextSnippet =>
                   codeDetailsWithSummary(
-                      `${contextSnippet.fileName}${'symbol' in contextSnippet ? `#${contextSnippet.symbol}` : ''} (${
-                          contextSnippet.content.length
-                      } chars)`,
+                      `${displayPath(contextSnippet.uri)}${
+                          'symbol' in contextSnippet ? `#${contextSnippet.symbol}` : ''
+                      } (${contextSnippet.content.length} chars)`,
                       contextSnippet.content,
                       'start'
                   )
@@ -331,8 +331,10 @@ function jsonForDataset(data: ProvideInlineCompletionsItemTraceData | undefined)
     }
 
     return `{
-        context: ${JSON.stringify(data?.context?.context.map(c => ({ fileName: c.fileName, content: c.content })))},
-        fileName: ${JSON.stringify(vscode.workspace.asRelativePath(completer.document.fileName))},
+        context: ${JSON.stringify(
+            data?.context?.context.map(c => ({ fileUri: c.uri.toString(), content: c.content }))
+        )},
+        uri: ${JSON.stringify(completer.document.uri.toString())},
         languageId: ${JSON.stringify(completer.document.languageId)},
         content: \`${completer.docContext.prefix}$\{CURSOR}${completer.docContext.suffix}\`,
     }`

--- a/vscode/src/completions/types.ts
+++ b/vscode/src/completions/types.ts
@@ -21,13 +21,11 @@ export interface InlineCompletionItem {
  * Keep property names in sync with the `EmbeddingsSearchResult` type.
  */
 export interface FileContextSnippet {
-    fileName: string
-    fileUri?: URI
+    uri: URI
     content: string
 }
 export interface SymbolContextSnippet {
-    fileName: string
-    fileUri?: URI
+    uri: URI
     symbol: string
     content: string
 }

--- a/vscode/src/edit/prompt/claude.ts
+++ b/vscode/src/edit/prompt/claude.ts
@@ -1,3 +1,5 @@
+import { displayPath } from '@sourcegraph/cody-shared'
+
 import { PROMPT_TOPICS } from './constants'
 import { type EditLLMInteraction } from './type'
 
@@ -12,7 +14,7 @@ const EDIT_PROMPT = `
 - Only enclose your response in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags. Do use any other XML tags unless they are part of the generated code.
 - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
 
-This is part of the file: {fileName}
+This is part of the file: {filePath}
 
 The user has the following code in their selection:
 <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
@@ -34,7 +36,7 @@ const ADD_PROMPT = `
 - Only enclose your response in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags. Do use any other XML tags unless they are part of the generated code.
 - Do not provide any additional commentary about the code you added. Only respond with the generated code.
 
-The user is currently in the file: {fileName}
+The user is currently in the file: {filePath}
 
 Provide your generated code using the following instructions:
 <${PROMPT_TOPICS.INSTRUCTIONS}>
@@ -53,7 +55,7 @@ const FIX_PROMPT = `
 - Only enclose your response in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags. Do use any other XML tags unless they are part of the generated code.
 - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
 
-This is part of the file: {fileName}
+This is part of the file: {filePath}
 
 The user has the following code in their selection:
 <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
@@ -76,7 +78,7 @@ const NEW_FILE_PROMPT = `
 - Only enclose generated code in <${PROMPT_TOPICS.OUTPUT}></${PROMPT_TOPICS.OUTPUT}> XML tags, with the file name for the generated code enclosed between the <${PROMPT_TOPICS.FILENAME}></${PROMPT_TOPICS.FILENAME}> tags.
 - Exclude any additional comment from the generated code.
 
-This is part of the file: {fileName}
+This is part of the file: {filePath}
 
 The user has the following code in their selection:
 <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
@@ -96,32 +98,32 @@ const SHARED_PARAMETERS = {
 }
 
 export const claude: EditLLMInteraction = {
-    getEdit({ instruction, selectedText, fileName }) {
+    getEdit({ instruction, selectedText, uri }) {
         return {
             ...SHARED_PARAMETERS,
             prompt: EDIT_PROMPT.replace('{instruction}', instruction)
                 .replace('{selectedText}', selectedText)
-                .replace('{fileName}', fileName),
+                .replace('{filePath}', displayPath(uri)),
         }
     },
-    getDoc({ instruction, selectedText, fileName }) {
+    getDoc({ instruction, selectedText, uri }) {
         return {
             ...SHARED_PARAMETERS,
             // TODO: Consider using a different prompt for the `doc` intent
             prompt: EDIT_PROMPT.replace('{instruction}', instruction)
                 .replace('{selectedText}', selectedText)
-                .replace('{fileName}', fileName),
+                .replace('{filePath}', displayPath(uri)),
         }
     },
-    getFix({ instruction, selectedText, fileName }) {
+    getFix({ instruction, selectedText, uri }) {
         return {
             ...SHARED_PARAMETERS,
             prompt: FIX_PROMPT.replace('{instruction}', instruction)
                 .replace('{selectedText}', selectedText)
-                .replace('{fileName}', fileName),
+                .replace('{filePath}', displayPath(uri)),
         }
     },
-    getAdd({ instruction, precedingText, fileName }) {
+    getAdd({ instruction, precedingText, uri }) {
         let assistantPreamble = ''
 
         if (precedingText) {
@@ -130,17 +132,17 @@ export const claude: EditLLMInteraction = {
 
         return {
             ...SHARED_PARAMETERS,
-            prompt: ADD_PROMPT.replace('{instruction}', instruction).replace('{fileName}', fileName),
+            prompt: ADD_PROMPT.replace('{instruction}', instruction).replace('{filePath}', displayPath(uri)),
             assistantText: `${assistantPreamble}${RESPONSE_PREFIX}`,
         }
     },
-    getNew({ instruction, selectedText, fileName }) {
+    getNew({ instruction, selectedText, uri }) {
         // NOTE: Works better with the prompt for "Edit" than "Add"
         return {
             ...SHARED_PARAMETERS,
             prompt: NEW_FILE_PROMPT.replace('{instruction}', instruction)
                 .replace('{selectedText}', selectedText)
-                .replace('{fileName}', fileName),
+                .replace('{filePath}', displayPath(uri)),
         }
     },
 }

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -87,7 +87,7 @@ export const buildInteraction = async ({
         task.intent,
         model,
         {
-            fileName: task.fixupFile.uri.fsPath,
+            uri: task.fixupFile.uri,
             followingText,
             precedingText,
             selectedText,

--- a/vscode/src/edit/prompt/prompt.test.ts
+++ b/vscode/src/edit/prompt/prompt.test.ts
@@ -1,36 +1,42 @@
 import { describe, expect, it } from 'vitest'
 
+import { isWindows, testFileUri } from '@sourcegraph/cody-shared'
+
 import { claude } from './claude'
 import { type GetLLMInteractionOptions } from './type'
 
 describe('Edit Prompts', () => {
     const fixupTask: GetLLMInteractionOptions = {
-        fileName: 'src/file/index.ts',
+        uri: testFileUri('src/file/index.ts'),
         followingText: "const text = 'Hello, world!'\n",
         selectedText: 'return text',
         precedingText: '\n}',
         instruction: 'Console log text',
     }
 
+    function normalize(text: string): string {
+        return isWindows() ? text.replaceAll('src\\file\\index.ts', 'src/file/index.ts') : text
+    }
+
     describe('Claude', () => {
         it('builds prompt correctly for edits', () => {
             const { prompt } = claude.getEdit(fixupTask)
-            expect(prompt).toMatchSnapshot()
+            expect(normalize(prompt)).toMatchSnapshot()
         })
 
         it('builds prompt correctly for doc', () => {
             const { prompt } = claude.getDoc(fixupTask)
-            expect(prompt).toMatchSnapshot()
+            expect(normalize(prompt)).toMatchSnapshot()
         })
 
         it('builds prompt correctly for adding', () => {
             const { prompt } = claude.getAdd(fixupTask)
-            expect(prompt).toMatchSnapshot()
+            expect(normalize(prompt)).toMatchSnapshot()
         })
 
         it('builds prompt correctly for fixing', () => {
             const { prompt } = claude.getFix(fixupTask)
-            expect(prompt).toMatchSnapshot()
+            expect(normalize(prompt)).toMatchSnapshot()
         })
     })
 })

--- a/vscode/src/edit/prompt/type.ts
+++ b/vscode/src/edit/prompt/type.ts
@@ -1,3 +1,5 @@
+import type * as vscode from 'vscode'
+
 export interface LLMInteraction {
     prompt: string
     stopSequences?: string[]
@@ -11,7 +13,7 @@ export interface GetLLMInteractionOptions {
     precedingText: string
     selectedText: string
     followingText: string
-    fileName: string
+    uri: vscode.Uri
 }
 
 type LLMInteractionBuilder = (options: GetLLMInteractionOptions) => LLMInteraction

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -1,9 +1,7 @@
-import { basename } from 'path'
-
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as vscode from 'vscode'
 
-import { ignores, testFileUri } from '@sourcegraph/cody-shared'
+import { ignores, testFileUri, uriBasename } from '@sourcegraph/cody-shared'
 
 import { getFileContextFiles } from './editor-context'
 
@@ -21,7 +19,7 @@ describe('getFileContextFiles', () => {
     async function runSearch(query: string, maxResults: number): Promise<(string | undefined)[]> {
         const results = await getFileContextFiles(query, maxResults, new vscode.CancellationTokenSource().token)
 
-        return results.map(f => basename(f.uri.fsPath))
+        return results.map(f => uriBasename(f.uri))
     }
 
     it('fuzzy filters results', async () => {
@@ -65,9 +63,7 @@ describe('getFileContextFiles', () => {
 
     it('filters out ignored files', async () => {
         ignores.setActiveState(true)
-        ignores.setIgnoreFiles(testFileUri('').fsPath, [
-            { filePath: testFileUri('.cody/ignore').fsPath, content: '*.ignore' },
-        ])
+        ignores.setIgnoreFiles(testFileUri(''), [{ uri: testFileUri('.cody/ignore'), content: '*.ignore' }])
         setFiles(['foo.txt', 'foo.ignore'])
 
         // Match the .txt but not the .ignore

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode'
 import {
     displayPath,
     isCodyIgnoredFile,
+    isWindows,
     type ContextFile,
     type ContextFileFile,
     type ContextFileSource,
@@ -59,9 +60,11 @@ export async function getFileContextFiles(
         return []
     }
 
-    // On Windows, if the user has typed forward slashes, map them to backslashes before
-    // running the search so they match the real paths.
-    query = query.replaceAll(path.posix.sep, path.sep)
+    if (isWindows()) {
+        // On Windows, if the user has typed forward slashes, map them to backslashes before
+        // running the search so they match the real paths.
+        query = query.replaceAll('/', '\\')
+    }
 
     // Add on the relative URIs for search, so we only search the visible part
     // of the path and not the full FS path.

--- a/vscode/src/fileUri.d.ts
+++ b/vscode/src/fileUri.d.ts
@@ -1,0 +1,9 @@
+declare module 'vscode' {
+    export interface Uri {
+        /**
+         * @deprecated Only call `.fsPath` on {@link FileURI}, which you can create with `URI.file`
+         * or with the {@link isFileURI} and {@link assertFileURI} helpers.
+         */
+        fsPath: string
+    }
+}

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -1,8 +1,8 @@
-import assert from 'assert'
-import { type ChildProcessWithoutNullStreams } from 'child_process'
-import { appendFileSync, existsSync, mkdirSync, rmSync } from 'fs'
-import { dirname } from 'path'
-import { Readable, Writable } from 'stream'
+import assert from 'node:assert'
+import { type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { appendFileSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { Readable, Writable } from 'node:stream'
 
 import * as vscode from 'vscode'
 

--- a/vscode/src/local-context/enhanced-context-status.test.ts
+++ b/vscode/src/local-context/enhanced-context-status.test.ts
@@ -18,7 +18,7 @@ class TestProvider implements status.ContextStatusProvider {
         return (
             this.status_ || [
                 {
-                    name: 'github.com/foo/bar',
+                    displayName: 'github.com/foo/bar',
                     providers: [
                         {
                             kind: 'embeddings',
@@ -38,13 +38,13 @@ class TestProvider implements status.ContextStatusProvider {
 describe('ContextStatusAggregator', () => {
     it('should fire status changed when providers are added and pass through simple status', async () => {
         const aggregator = new ContextStatusAggregator()
-        const promise = new Promise(resolve => {
+        const promise = new Promise<status.ContextGroup[]>(resolve => {
             aggregator.onDidChangeStatus(provider => resolve(provider.status))
         })
         aggregator.addProvider(new TestProvider())
-        expect(await promise).toEqual([
+        expect(await promise).toEqual<status.ContextGroup[]>([
             {
-                name: 'github.com/foo/bar',
+                displayName: 'github.com/foo/bar',
                 providers: [
                     {
                         kind: 'embeddings',
@@ -59,7 +59,7 @@ describe('ContextStatusAggregator', () => {
     it('should fire aggregate status from multiple providers', async () => {
         const aggregator = new ContextStatusAggregator()
         let callbackCount = 0
-        const promise = new Promise(resolve => {
+        const promise = new Promise<status.ContextGroup[]>(resolve => {
             aggregator.onDidChangeStatus(provider => {
                 callbackCount++
                 resolve(provider.status)
@@ -69,11 +69,11 @@ describe('ContextStatusAggregator', () => {
         aggregator.addProvider(
             new TestProvider([
                 {
-                    name: 'host.example/foo',
+                    displayName: 'host.example/foo',
                     providers: [{ kind: 'graph', state: 'ready' }],
                 },
                 {
-                    name: 'github.com/foo/bar',
+                    displayName: 'github.com/foo/bar',
                     providers: [
                         {
                             kind: 'embeddings',
@@ -86,9 +86,9 @@ describe('ContextStatusAggregator', () => {
                 },
             ])
         )
-        expect(await promise).toEqual([
+        expect(await promise).toEqual<status.ContextGroup[]>([
             {
-                name: 'github.com/foo/bar',
+                displayName: 'github.com/foo/bar',
                 providers: [
                     {
                         kind: 'embeddings',
@@ -105,7 +105,7 @@ describe('ContextStatusAggregator', () => {
                 ],
             },
             {
-                name: 'host.example/foo',
+                displayName: 'host.example/foo',
                 providers: [{ kind: 'graph', state: 'ready' }],
             },
         ])
@@ -120,18 +120,18 @@ describe('ContextStatusAggregator', () => {
         // Skip the first update event.
         await Promise.resolve()
         let callbackCount = 0
-        const promise = new Promise(resolve => {
+        const promise = new Promise<status.ContextGroup[]>(resolve => {
             aggregator.onDidChangeStatus(provider => {
                 callbackCount++
                 resolve(provider.status)
             })
         })
-        provider.status = [{ name: 'github.com/foo/bar', providers: [{ kind: 'graph', state: 'indexing' }] }]
+        provider.status = [{ displayName: 'github.com/foo/bar', providers: [{ kind: 'graph', state: 'indexing' }] }]
         provider.emitter.fire(provider)
 
-        expect(await promise).toEqual([
+        expect(await promise).toEqual<status.ContextGroup[]>([
             {
-                name: 'github.com/foo/bar',
+                displayName: 'github.com/foo/bar',
                 providers: [
                     {
                         kind: 'graph',

--- a/vscode/src/local-context/enhanced-context-status.ts
+++ b/vscode/src/local-context/enhanced-context-status.ts
@@ -122,13 +122,13 @@ export class ContextStatusAggregator implements vscode.Disposable, ContextStatus
 
             // Collect context groups by name
             for (const group of status) {
-                if (group.name in groupBy) {
+                if (group.displayName in groupBy) {
                     // Merge the items in the group.
-                    groupBy[group.name].providers.push(...group.providers)
+                    groupBy[group.displayName].providers.push(...group.providers)
                 } else {
                     // Create a new group for the merged result.
-                    groupBy[group.name] = {
-                        name: group.name,
+                    groupBy[group.displayName] = {
+                        displayName: group.displayName,
                         providers: [...group.providers],
                     }
                 }

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -1,7 +1,6 @@
 import { execFile as _execFile, spawn } from 'node:child_process'
 import fs, { access, rename, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
-import path from 'node:path'
 import { promisify } from 'node:util'
 
 import { Mutex } from 'async-mutex'
@@ -9,7 +8,12 @@ import { mkdirp } from 'mkdirp'
 import * as vscode from 'vscode'
 
 import {
+    assertFileURI,
+    isFileURI,
     isWindows,
+    uriBasename,
+    uriDirname,
+    type FileURI,
     type IndexedKeywordContextFetcher,
     type Result,
     type SourcegraphCompletionsClient,
@@ -24,7 +28,7 @@ const execFile = promisify(_execFile)
 
 export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposable {
     // The root of all symf index directories
-    private indexRoot: string
+    private indexRoot: FileURI
     private indexLocks: Map<string, RWLock> = new Map()
 
     private status: IndexStatus = new IndexStatus()
@@ -35,7 +39,15 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         private authToken: string | null,
         private completionsClient: SourcegraphCompletionsClient
     ) {
-        const indexRoot = path.join(context.globalStorageUri.fsPath, 'symf', 'indexroot')
+        const indexRoot = vscode.Uri.joinPath(context.globalStorageUri, 'symf', 'indexroot').with(
+            // On VS Code Desktop, this is a `vscode-userdata:` URI that actually just refers to
+            // file system paths.
+            vscode.env.uiKind === vscode.UIKind.Desktop ? { scheme: 'file' } : {}
+        )
+
+        if (!isFileURI(indexRoot)) {
+            throw new Error('symf only supports running on the file system')
+        }
         this.indexRoot = indexRoot
     }
 
@@ -72,9 +84,11 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         return { accessToken, serverEndpoint, symfPath }
     }
 
-    public getResults(userQuery: string, scopeDirs: string[]): Promise<Promise<Result[]>[]> {
+    public getResults(userQuery: string, scopeDirs: vscode.Uri[]): Promise<Promise<Result[]>[]> {
         const expandedQuery = symfExpandQuery(this.completionsClient, userQuery)
-        return Promise.resolve(scopeDirs.map(scopeDir => this.getResultsForScopeDir(expandedQuery, scopeDir)))
+        return Promise.resolve(
+            scopeDirs.filter(isFileURI).map(scopeDir => this.getResultsForScopeDir(expandedQuery, scopeDir))
+        )
     }
 
     /**
@@ -82,7 +96,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
      * @param keywordQuery is a promise, because query expansion might be an expensive
      * operation that is best done concurrently with querying and (re)building the index.
      */
-    private async getResultsForScopeDir(keywordQuery: Promise<string>, scopeDir: string): Promise<Result[]> {
+    private async getResultsForScopeDir(keywordQuery: Promise<string>, scopeDir: FileURI): Promise<Result[]> {
         const maxRetries = 10
 
         // Run in a loop in case the index is deleted before we can query it
@@ -109,13 +123,13 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         throw new Error(`failed to find index after ${maxRetries} tries for directory ${scopeDir}`)
     }
 
-    public async deleteIndex(scopeDir: string): Promise<void> {
+    public async deleteIndex(scopeDir: FileURI): Promise<void> {
         await this.getIndexLock(scopeDir).withWrite(async () => {
             await this.unsafeDeleteIndex(scopeDir)
         })
     }
 
-    public async getIndexStatus(scopeDir: string): Promise<'unindexed' | 'indexing' | 'ready' | 'failed'> {
+    public async getIndexStatus(scopeDir: FileURI): Promise<'unindexed' | 'indexing' | 'ready' | 'failed'> {
         if (this.status.isInProgress(scopeDir)) {
             // Check this before waiting on the lock
             return 'indexing'
@@ -132,30 +146,30 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         return 'unindexed'
     }
 
-    public async ensureIndex(scopeDir: string, options: { hard: boolean } = { hard: false }): Promise<void> {
+    public async ensureIndex(scopeDir: FileURI, options: { hard: boolean } = { hard: false }): Promise<void> {
         await this.getIndexLock(scopeDir).withWrite(async () => {
             await this.unsafeEnsureIndex(scopeDir, options)
         })
     }
 
-    private getIndexLock(scopeDir: string): RWLock {
+    private getIndexLock(scopeDir: FileURI): RWLock {
         const { indexDir } = this.getIndexDir(scopeDir)
-        let lock = this.indexLocks.get(indexDir)
+        let lock = this.indexLocks.get(indexDir.toString())
         if (lock) {
             return lock
         }
         lock = new RWLock()
-        this.indexLocks.set(indexDir, lock)
+        this.indexLocks.set(indexDir.toString(), lock)
         return lock
     }
 
-    private async unsafeRunQuery(keywordQuery: string, scopeDir: string): Promise<string> {
+    private async unsafeRunQuery(keywordQuery: string, scopeDir: FileURI): Promise<string> {
         const { indexDir } = this.getIndexDir(scopeDir)
         const { accessToken, symfPath, serverEndpoint } = await this.getSymfInfo()
         try {
             const { stdout } = await execFile(
                 symfPath,
-                ['--index-root', indexDir, 'query', '--scopes', scopeDir, '--fmt', 'json', keywordQuery],
+                ['--index-root', indexDir.fsPath, 'query', '--scopes', scopeDir.fsPath, '--fmt', 'json', keywordQuery],
                 {
                     env: {
                         SOURCEGRAPH_TOKEN: accessToken,
@@ -172,9 +186,9 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         }
     }
 
-    private async unsafeDeleteIndex(scopeDir: string): Promise<void> {
-        const trashRootDir = path.join(this.indexRoot, '.trash')
-        await mkdirp(trashRootDir)
+    private async unsafeDeleteIndex(scopeDir: FileURI): Promise<void> {
+        const trashRootDir = vscode.Uri.joinPath(this.indexRoot, '.trash')
+        await mkdirp(trashRootDir.fsPath)
         const { indexDir } = this.getIndexDir(scopeDir)
 
         if (!(await fileExists(indexDir))) {
@@ -183,22 +197,22 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         }
 
         // Unique name for trash directory
-        const trashDir = path.join(trashRootDir, `${path.basename(indexDir)}-${Date.now()}`)
+        const trashDir = vscode.Uri.joinPath(trashRootDir, `${uriBasename(indexDir)}-${Date.now()}`)
         if (await fileExists(trashDir)) {
             // if trashDir already exists, error
             throw new Error(`could not delete index ${indexDir}: target trash directory ${trashDir} already exists`)
         }
 
-        await rename(indexDir, trashDir)
-        void rm(trashDir, { recursive: true, force: true }) // delete in background
+        await rename(indexDir.fsPath, trashDir.fsPath)
+        void rm(trashDir.fsPath, { recursive: true, force: true }) // delete in background
     }
 
-    private async unsafeIndexExists(scopeDir: string): Promise<boolean> {
+    private async unsafeIndexExists(scopeDir: FileURI): Promise<boolean> {
         const { indexDir } = this.getIndexDir(scopeDir)
-        return fileExists(path.join(indexDir, 'index.json'))
+        return fileExists(vscode.Uri.joinPath(indexDir, 'index.json'))
     }
 
-    private async unsafeEnsureIndex(scopeDir: string, options: { hard: boolean } = { hard: false }): Promise<void> {
+    private async unsafeEnsureIndex(scopeDir: FileURI, options: { hard: boolean } = { hard: false }): Promise<void> {
         const indexExists = await this.unsafeIndexExists(scopeDir)
         if (indexExists) {
             return
@@ -221,21 +235,26 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         await this.clearIndexFailure(scopeDir)
     }
 
-    private getIndexDir(scopeDir: string): { indexDir: string; tmpDir: string } {
-        let absIndexedDir = path.resolve(scopeDir)
-        // On Windows, we can't use an absolute path with a dirve letter inside another path
-        // so we remove the colon, so `C:\foo\bar` just becomes `C\foo\bar` which is a valid
-        // sub-path in the index.
-        if (isWindows() && absIndexedDir[1] === ':') {
-            absIndexedDir = absIndexedDir[0] + absIndexedDir.slice(2)
+    private getIndexDir(scopeDir: FileURI): { indexDir: FileURI; tmpDir: FileURI } {
+        let indexSubdir = scopeDir.path
+
+        // On Windows, we can't use an absolute path with a drive letter inside another path
+        // so we remove the colon, so `/c:/foo/` becomes `/c/foo` and `/c%3A/foo` becomes `/c/foo`.
+        if (isWindows()) {
+            if (indexSubdir[2] === ':') {
+                indexSubdir = indexSubdir.slice(0, 2) + indexSubdir.slice(3)
+            } else if (indexSubdir.slice(2, 5) === '%3A') {
+                indexSubdir = indexSubdir.slice(0, 2) + indexSubdir.slice(5)
+            }
         }
+
         return {
-            indexDir: path.join(this.indexRoot, absIndexedDir),
-            tmpDir: path.join(this.indexRoot, '.tmp', absIndexedDir),
+            indexDir: assertFileURI(vscode.Uri.joinPath(this.indexRoot, indexSubdir)),
+            tmpDir: assertFileURI(vscode.Uri.joinPath(this.indexRoot, '.tmp', indexSubdir)),
         }
     }
 
-    private unsafeUpsertIndex(indexDir: string, tmpIndexDir: string, scopeDir: string): Promise<void> {
+    private unsafeUpsertIndex(indexDir: FileURI, tmpIndexDir: FileURI, scopeDir: FileURI): Promise<void> {
         const cancellation = new vscode.CancellationTokenSource()
         const upsert = this._unsafeUpsertIndex(indexDir, tmpIndexDir, scopeDir, cancellation.token)
         this.status.didStart({ scopeDir, done: upsert, cancel: () => cancellation.cancel() })
@@ -247,9 +266,9 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
     }
 
     private async _unsafeUpsertIndex(
-        indexDir: string,
-        tmpIndexDir: string,
-        scopeDir: string,
+        indexDir: FileURI,
+        tmpIndexDir: FileURI,
+        scopeDir: FileURI,
         cancellationToken: vscode.CancellationToken
     ): Promise<void> {
         const symfPath = await getSymfPath(this.context)
@@ -257,8 +276,8 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
             return
         }
         await Promise.all([
-            rm(indexDir, { recursive: true }).catch(() => undefined),
-            rm(tmpIndexDir, { recursive: true }).catch(() => undefined),
+            rm(indexDir.fsPath, { recursive: true }).catch(() => undefined),
+            rm(tmpIndexDir.fsPath, { recursive: true }).catch(() => undefined),
         ])
 
         logDebug('symf', 'creating index', indexDir)
@@ -275,7 +294,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         let wasCancelled = false
         let onExit: (() => void) | undefined
         try {
-            const proc = spawn(symfPath, ['--index-root', tmpIndexDir, 'add', scopeDir], {
+            const proc = spawn(symfPath, ['--index-root', tmpIndexDir.fsPath, 'add', scopeDir.fsPath], {
                 env: {
                     ...process.env,
                     GOMAXPROCS: `${maxCPUs}`, // use at most one cpu for indexing
@@ -311,8 +330,8 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
                     }
                 })
             })
-            await mkdirp(path.dirname(indexDir))
-            await rename(tmpIndexDir, indexDir)
+            await mkdirp(uriDirname(indexDir).fsPath)
+            await rename(tmpIndexDir.fsPath, indexDir.fsPath)
         } catch (error) {
             if (wasCancelled) {
                 throw new vscode.CancellationError()
@@ -323,7 +342,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
                 process.removeListener('exit', onExit)
             }
             disposeOnFinish.forEach(d => d.dispose())
-            await rm(tmpIndexDir, { recursive: true, force: true })
+            await rm(tmpIndexDir.fsPath, { recursive: true, force: true })
         }
     }
 
@@ -331,45 +350,40 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
      * Helpers for tracking index failure
      */
 
-    private async markIndexFailed(scopeDir: string): Promise<void> {
-        const failureRoot = path.join(this.indexRoot, '.failed')
-        await mkdirp(failureRoot)
-
-        const absIndexedDir = path.resolve(scopeDir)
-        const failureSentinelFile = path.join(failureRoot, absIndexedDir.replaceAll(path.sep, '__'))
-
-        await writeFile(failureSentinelFile, '')
+    private async markIndexFailed(scopeDir: FileURI): Promise<void> {
+        const failureRoot = vscode.Uri.joinPath(this.indexRoot, '.failed')
+        await mkdirp(failureRoot.fsPath)
+        const failureSentinelFile = vscode.Uri.joinPath(failureRoot, scopeDir.path.replaceAll('/', '__'))
+        await writeFile(failureSentinelFile.fsPath, '')
     }
 
-    private async didIndexFail(scopeDir: string): Promise<boolean> {
-        const failureRoot = path.join(this.indexRoot, '.failed')
-        const absIndexedDir = path.resolve(scopeDir)
-        const failureSentinelFile = path.join(failureRoot, absIndexedDir.replaceAll(path.sep, '__'))
+    private async didIndexFail(scopeDir: FileURI): Promise<boolean> {
+        const failureRoot = vscode.Uri.joinPath(this.indexRoot, '.failed')
+        const failureSentinelFile = vscode.Uri.joinPath(failureRoot, scopeDir.path.replaceAll('/', '__'))
         return fileExists(failureSentinelFile)
     }
 
-    private async clearIndexFailure(scopeDir: string): Promise<void> {
-        const failureRoot = path.join(this.indexRoot, '.failed')
-        const absIndexedDir = path.resolve(scopeDir)
-        const failureSentinelFile = path.join(failureRoot, absIndexedDir.replaceAll(path.sep, '__'))
-        await rm(failureSentinelFile, { force: true })
+    private async clearIndexFailure(scopeDir: FileURI): Promise<void> {
+        const failureRoot = vscode.Uri.joinPath(this.indexRoot, '.failed')
+        const failureSentinelFile = vscode.Uri.joinPath(failureRoot, scopeDir.path.replaceAll('/', '__'))
+        await rm(failureSentinelFile.fsPath, { force: true })
     }
 }
 
 export interface IndexStartEvent {
-    scopeDir: string
+    scopeDir: FileURI
     cancel: () => void
     done: Promise<void>
 }
 
 interface IndexEndEvent {
-    scopeDir: string
+    scopeDir: FileURI
 }
 
 class IndexStatus implements vscode.Disposable {
     private startEmitter = new vscode.EventEmitter<IndexStartEvent>()
     private stopEmitter = new vscode.EventEmitter<IndexEndEvent>()
-    private inProgressDirs = new Set<string>()
+    private inProgressDirs = new Set<string /* uri.toString() */>()
 
     public dispose(): void {
         this.startEmitter.dispose()
@@ -377,12 +391,12 @@ class IndexStatus implements vscode.Disposable {
     }
 
     public didStart(event: IndexStartEvent): void {
-        this.inProgressDirs.add(event.scopeDir)
+        this.inProgressDirs.add(event.scopeDir.toString())
         this.startEmitter.fire(event)
     }
 
     public didEnd(event: IndexEndEvent): void {
-        this.inProgressDirs.delete(event.scopeDir)
+        this.inProgressDirs.delete(event.scopeDir.toString())
         this.stopEmitter.fire(event)
     }
 
@@ -394,14 +408,17 @@ class IndexStatus implements vscode.Disposable {
         return this.stopEmitter.event(cb)
     }
 
-    public isInProgress(scopeDir: string): boolean {
-        return this.inProgressDirs.has(scopeDir)
+    public isInProgress(scopeDir: FileURI): boolean {
+        return this.inProgressDirs.has(scopeDir.toString())
     }
 }
 
-async function fileExists(filePath: string): Promise<boolean> {
+async function fileExists(file: vscode.Uri): Promise<boolean> {
+    if (!isFileURI(file)) {
+        throw new Error('only file URIs are supported')
+    }
     try {
-        await access(filePath, fs.constants.F_OK)
+        await access(file.fsPath, fs.constants.F_OK)
         return true
     } catch {
         return false
@@ -409,9 +426,12 @@ async function fileExists(filePath: string): Promise<boolean> {
 }
 
 function parseSymfStdout(stdout: string): Result[] {
-    const results: Result[] = JSON.parse(stdout) as Result[]
+    interface RawSymfResult extends Omit<Result, 'file'> {
+        file: string
+    }
+    const results = JSON.parse(stdout) as RawSymfResult[]
     return results.map(result => {
-        const { fqname, name, type, doc, exported, lang, file, range, summary } = result
+        const { fqname, name, type, doc, exported, lang, file: fsPath, range, summary } = result
 
         const { row: startRow, col: startColumn } = range.startPoint
         const { row: endRow, col: endColumn } = range.endPoint
@@ -426,7 +446,7 @@ function parseSymfStdout(stdout: string): Result[] {
             doc,
             exported,
             lang,
-            file,
+            file: vscode.Uri.file(fsPath),
             summary,
             range: {
                 startByte,
@@ -440,7 +460,7 @@ function parseSymfStdout(stdout: string): Result[] {
                     col: endColumn,
                 },
             },
-        }
+        } satisfies Result
     })
 }
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1,6 +1,12 @@
 import * as vscode from 'vscode'
 
-import { type ChatEventSource, type ContextFile, type ContextMessage } from '@sourcegraph/cody-shared'
+import {
+    displayPath,
+    displayPathBasename,
+    type ChatEventSource,
+    type ContextFile,
+    type ContextMessage,
+} from '@sourcegraph/cody-shared'
 
 import { type ExecuteEditArguments } from '../edit/execute'
 import { type EditIntent, type EditMode } from '../edit/types'
@@ -546,7 +552,7 @@ export class FixupController
         }
         const showChangesButton = 'Show Changes'
         const result = await vscode.window.showInformationMessage(
-            `Edit applied to ${task.fixupFile.fileName}`,
+            `Edit applied to ${displayPathBasename(task.fixupFile.uri)}`,
             showChangesButton
         )
         if (result === showChangesButton) {
@@ -942,7 +948,7 @@ export class FixupController
 
         // Prompt the user for a new instruction, and create a new fixup
         const input = await this.typingUI.getInputFromQuickPick({
-            filePath: task.fixupFile.filePath,
+            filePath: displayPath(task.fixupFile.uri),
             range: previousRange,
             initialValue: previousInstruction,
             initialSelectedContextFiles: previousUserContextFiles,

--- a/vscode/src/non-stop/FixupFile.ts
+++ b/vscode/src/non-stop/FixupFile.ts
@@ -1,9 +1,7 @@
-import path from 'path'
-
 import type * as vscode from 'vscode'
 
 /**
- * A handle to a fixup file. FixupFileWatcher is the factory for these; do not
+ * A handle to a fixup file. FixupFileObserver is the factory for these; do not
  * construct them directly.
  */
 export class FixupFile {
@@ -20,14 +18,6 @@ export class FixupFile {
 
     public get uri(): vscode.Uri {
         return this.uri_
-    }
-
-    public get fileName(): string {
-        return path.basename(this.uri_.fsPath)
-    }
-
-    public get filePath(): string {
-        return this.uri_.fsPath
     }
 
     public toString(): string {

--- a/vscode/src/rg.ts
+++ b/vscode/src/rg.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises'
-import path from 'path'
+import path from 'node:path'
 
 import * as vscode from 'vscode'
 

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -1,10 +1,11 @@
-import * as os from 'os'
-import * as path from 'path'
-
 import * as vscode from 'vscode'
 
 import {
+    displayPath,
     hydrateAfterPostMessage,
+    isDefined,
+    isFileURI,
+    type FileURI,
     type Result,
     type SearchPanelFile,
     type SearchPanelSnippet,
@@ -42,8 +43,8 @@ class CancellationManager implements vscode.Disposable {
 }
 
 class IndexManager implements vscode.Disposable {
-    private currentlyRefreshing = new Map<string, Promise<void>>()
-    private scopeDirIndexInProgress: Map<string, Promise<void>> = new Map()
+    private currentlyRefreshing = new Map<string /* uri.toString() */, Promise<void>>()
+    private scopeDirIndexInProgress: Map<string /* uri.toString() */, Promise<void>> = new Map()
     private disposables: vscode.Disposable[] = []
 
     constructor(private symf: SymfRunner) {
@@ -59,37 +60,33 @@ class IndexManager implements vscode.Disposable {
      * This is needed, because the user may have dismissed previous indexing progress
      * messages.
      */
-    public showMessageIfIndexingInProgress = (scopeDirs: string[]): void => {
-        const indexingScopeDirs: string[] = []
+    public showMessageIfIndexingInProgress(scopeDirs: vscode.Uri[]): void {
+        const indexingScopeDirs: vscode.Uri[] = []
         for (const scopeDir of scopeDirs) {
-            if (this.scopeDirIndexInProgress.has(scopeDir)) {
-                const { base, dir, wsName } = getRenderableComponents(scopeDir)
-                const prettyScopeDir = wsName ? path.join(wsName, dir, base) : path.join(dir, base)
-                indexingScopeDirs.push(prettyScopeDir)
+            if (this.scopeDirIndexInProgress.has(scopeDir.toString())) {
+                indexingScopeDirs.push(scopeDir)
             }
         }
         if (indexingScopeDirs.length === 0) {
             return
         }
-        void vscode.window.showWarningMessage(`Still indexing: ${indexingScopeDirs.join(', ')}`)
+        void vscode.window.showWarningMessage(`Still indexing: ${indexingScopeDirs.map(displayPath).join(', ')}`)
     }
 
     public showIndexProgress({ scopeDir, cancel, done }: IndexStartEvent): void {
-        const { base, dir, wsName } = getRenderableComponents(scopeDir)
-        const prettyScopeDir = wsName ? path.join(wsName, dir, base) : path.join(dir, base)
-        if (this.scopeDirIndexInProgress.has(scopeDir)) {
-            void vscode.window.showWarningMessage(`Duplicate index request for ${prettyScopeDir}`)
+        if (this.scopeDirIndexInProgress.has(scopeDir.toString())) {
+            void vscode.window.showWarningMessage(`Duplicate index request for ${displayPath(scopeDir)}`)
             return
         }
-        this.scopeDirIndexInProgress.set(scopeDir, done)
+        this.scopeDirIndexInProgress.set(scopeDir.toString(), done)
         void done.finally(() => {
-            this.scopeDirIndexInProgress.delete(scopeDir)
+            this.scopeDirIndexInProgress.delete(scopeDir.toString())
         })
 
         void vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: `Building Cody search index for ${prettyScopeDir}`,
+                title: `Building Cody search index for ${displayPath(scopeDir)}`,
                 cancellable: true,
             },
             async (_progress, token) => {
@@ -103,26 +100,28 @@ class IndexManager implements vscode.Disposable {
         )
     }
 
-    public refreshIndex(scopeDir: string): Promise<void> {
-        const fromCache = this.currentlyRefreshing.get(scopeDir)
+    public refreshIndex(scopeDir: FileURI): Promise<void> {
+        const fromCache = this.currentlyRefreshing.get(scopeDir.toString())
         if (fromCache) {
             return fromCache
         }
         const result = this.forceRefreshIndex(scopeDir)
-        this.currentlyRefreshing.set(scopeDir, result)
+        this.currentlyRefreshing.set(scopeDir.toString(), result)
         return result
     }
 
-    private async forceRefreshIndex(scopeDir: string): Promise<void> {
+    private async forceRefreshIndex(scopeDir: FileURI): Promise<void> {
         try {
             await this.symf.deleteIndex(scopeDir)
             await this.symf.ensureIndex(scopeDir, { hard: true })
         } catch (error) {
             if (!(error instanceof vscode.CancellationError)) {
-                void vscode.window.showErrorMessage(`Error refreshing search index for ${scopeDir}: ${error}`)
+                void vscode.window.showErrorMessage(
+                    `Error refreshing search index for ${displayPath(scopeDir)}: ${error}`
+                )
             }
         } finally {
-            this.currentlyRefreshing.delete(scopeDir)
+            this.currentlyRefreshing.delete(scopeDir.toString())
         }
     }
 }
@@ -160,26 +159,30 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
                 await this.indexManager.refreshIndex(scopeDirs[0])
             }),
             vscode.commands.registerCommand('cody.search.index-update-all', async () => {
-                const folders = vscode.workspace.workspaceFolders
+                const folders = vscode.workspace.workspaceFolders?.map(folder => folder.uri).filter(isFileURI)
                 if (!folders) {
                     void vscode.window.showWarningMessage('Open a workspace folder to index')
                     return
                 }
                 for (const folder of folders) {
-                    await this.indexManager.refreshIndex(folder.uri.fsPath)
+                    await this.indexManager.refreshIndex(folder)
                 }
             })
         )
         // Kick off search index creation for all workspace folders
         vscode.workspace.workspaceFolders?.forEach(folder => {
-            void this.symfRunner.ensureIndex(folder.uri.fsPath, { hard: false })
+            if (isFileURI(folder.uri)) {
+                void this.symfRunner.ensureIndex(folder.uri, { hard: false })
+            }
         })
         this.disposables.push(
             vscode.workspace.onDidChangeWorkspaceFolders(event => {
                 event.added.forEach(folder => {
-                    void this.symfRunner.ensureIndex(folder.uri.fsPath, {
-                        hard: false,
-                    })
+                    if (isFileURI(folder.uri)) {
+                        void this.symfRunner.ensureIndex(folder.uri, {
+                            hard: false,
+                        })
+                    }
                 })
             })
         )
@@ -302,59 +305,34 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
     }
 }
 
-function getRenderableComponents(filename: string): { base: string; dir: string; wsName?: string } {
-    // get workspace folders
-    const wsFolders = vscode.workspace.workspaceFolders
-    const home = os.homedir()
-
-    const base = path.basename(filename)
-    const absdir = path.dirname(filename)
-
-    if (wsFolders) {
-        for (const wsFolder of wsFolders) {
-            const reldir = path.relative(wsFolder.uri.fsPath, absdir)
-            if (!reldir.startsWith('..')) {
-                return { base, dir: reldir, wsName: wsFolders.length > 1 ? wsFolder.name : undefined }
-            }
-        }
-    }
-
-    // No matches in workspace folders, check home directory
-    const reldir = path.relative(home, absdir)
-    if (!reldir.startsWith('..')) {
-        return { base, dir: reldir }
-    }
-    return { base, dir: absdir }
-}
-
 /**
  * @returns the list of workspace folders to search. The first folder is the active file's folder.
  */
-function getScopeDirs(): string[] {
-    const folders = vscode.workspace.workspaceFolders
+function getScopeDirs(): FileURI[] {
+    const folders = vscode.workspace.workspaceFolders?.map(f => f.uri).filter(isFileURI)
     if (!folders) {
         return []
     }
     const uri = getEditor().active?.document.uri
     if (!uri) {
-        return folders.map(f => f.uri.fsPath)
+        return folders
     }
     const currentFolder = vscode.workspace.getWorkspaceFolder(uri)
     if (!currentFolder) {
-        return folders.map(f => f.uri.fsPath)
+        return folders
     }
 
     return [
-        currentFolder.uri.fsPath,
-        ...folders.filter(folder => folder.uri.toString() !== currentFolder.uri.toString()).map(f => f.uri.fsPath),
-    ]
+        isFileURI(currentFolder.uri) ? currentFolder.uri : undefined,
+        ...folders.filter(folder => folder.toString() !== currentFolder.uri.toString()),
+    ].filter(isDefined)
 }
 
-function groupByFile(results: Result[]): { file: string; results: Result[] }[] {
-    const groups: { file: string; results: Result[] }[] = []
+function groupByFile(results: Result[]): { file: vscode.Uri; results: Result[] }[] {
+    const groups: { file: vscode.Uri; results: Result[] }[] = []
 
     for (const result of results) {
-        const group = groups.find(g => g.file === result.file)
+        const group = groups.find(g => g.file.toString() === result.file.toString())
         if (group) {
             group.results.push(result)
         } else {
@@ -373,15 +351,10 @@ async function resultsToDisplayResults(results: Result[]): Promise<SearchPanelFi
     return (
         await Promise.all(
             groupedResults.map(async group => {
-                const uri = vscode.Uri.file(group.file)
                 try {
-                    const contents = await vscode.workspace.fs.readFile(uri)
-                    const { base, dir, wsName } = getRenderableComponents(group.file)
+                    const contents = await vscode.workspace.fs.readFile(group.file)
                     return {
-                        uri,
-                        basename: base,
-                        dirname: dir,
-                        wsname: wsName,
+                        uri: group.file,
                         snippets: group.results.map((result: Result): SearchPanelSnippet => {
                             return {
                                 contents: textDecoder.decode(
@@ -399,7 +372,7 @@ async function resultsToDisplayResults(results: Result[]): Promise<SearchPanelFi
                                 },
                             }
                         }),
-                    }
+                    } satisfies SearchPanelFile
                 } catch {
                     return null
                 }

--- a/vscode/src/testutils/textDocument.ts
+++ b/vscode/src/testutils/textDocument.ts
@@ -91,7 +91,7 @@ export function withPosixPaths<T extends object>(obj: T): T {
 }
 
 export function withPosixPathsInString(text: string): string {
-    return text.replaceAll('file:/c%3A%5C', 'file:/').replaceAll('file:/c%3A/', 'file:/')
+    return text.replaceAll('file:///c%3A%5C', 'file:///').replaceAll('file:///c%3A/', 'file:///').replaceAll('\\', '/')
 }
 
 function normalizeFilePathToPosix(filePath: string): string {

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -94,7 +94,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
                 value={{
                     groups: [
                         {
-                            name: args.name,
+                            displayName: args.name,
                             providers: [
                                 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
                                 {
@@ -133,7 +133,7 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                 value={{
                     groups: [
                         {
-                            name: '~/projects/foo',
+                            displayName: '~/projects/foo',
                             providers: [
                                 { kind: 'embeddings', type: 'local', state: 'unconsented' },
                                 { kind: 'graph', state: 'ready' },
@@ -141,7 +141,7 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                             ],
                         },
                         {
-                            name: 'gitlab.com/my/repo',
+                            displayName: 'gitlab.com/my/repo',
                             providers: [
                                 {
                                     kind: 'embeddings',
@@ -153,7 +153,7 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                             ],
                         },
                         {
-                            name: 'github.com/sourcegraph/bar',
+                            displayName: 'github.com/sourcegraph/bar',
                             providers: [
                                 {
                                     kind: 'embeddings',

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -60,15 +60,15 @@ const ContextGroupComponent: React.FunctionComponent<{ group: ContextGroup; allG
     // if there's a single group, we want the group name's basename
     let groupName
     if (allGroups.length === 1) {
-        const matches = group.name.match(/.+[/\\](.+?)$/)
-        groupName = matches ? matches[1] : group.name
+        const matches = group.displayName.match(/.+[/\\](.+?)$/)
+        groupName = matches ? matches[1] : group.displayName
     } else {
-        groupName = group.name
+        groupName = group.displayName
     }
 
     return (
         <>
-            <dt title={group.name} className={styles.lineBreakAll}>
+            <dt title={group.displayName} className={styles.lineBreakAll}>
                 <i className="codicon codicon-folder" /> {groupName}
             </dt>
             <dd>
@@ -299,7 +299,11 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                         </p>
                         <dl className={styles.foldersList}>
                             {context.groups.map(group => (
-                                <ContextGroupComponent key={group.name} group={group} allGroups={context.groups} />
+                                <ContextGroupComponent
+                                    key={group.displayName}
+                                    group={group}
+                                    allGroups={context.groups}
+                                />
                             ))}
                         </dl>
                     </div>

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useMemo, useRef } from 'react'
 import { debounce } from 'lodash'
 import { LRUCache } from 'lru-cache'
 
-import { type SearchPanelFile } from '@sourcegraph/cody-shared'
+import { displayPathBasename, displayPathDirname, type SearchPanelFile } from '@sourcegraph/cody-shared'
 
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
@@ -300,14 +300,13 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                                         <span className={styles.filematchIcon}>
                                             <i className="codicon codicon-file-code" />
                                         </span>
-                                        <span className={styles.filematchTitle} title={result.basename}>
-                                            {result.basename}
+                                        <span className={styles.filematchTitle} title={displayPathBasename(result.uri)}>
+                                            {displayPathBasename(result.uri)}
                                         </span>
                                         <span className={styles.filematchDescription}>
-                                            {result.wsname && (
-                                                <span title={result.wsname}>{result.wsname}&nbsp;&middot;&nbsp;</span>
-                                            )}
-                                            <span title={result.dirname}>{result.dirname}</span>
+                                            <span title={displayPathDirname(result.uri)}>
+                                                {displayPathDirname(result.uri)}
+                                            </span>
                                         </span>
                                     </div>
                                 </div>


### PR DESCRIPTION
Add displayPath{Dir,Base}name and uri{Dir,Base,Ext}name funcs. These helpers make it easier to write code that uses URIs and renders paths correctly across platforms and with multi-root workspaces.

- `displayPath{Dir,Base}name`: for showing the user a URI's dirname or basename
- `uri{Dir,Base,Ext}name`: for path manipulation of URIs that works on `vscode.Uri` and `URI` in VS Code, webviews, tests, agent, and any other environment (pure JS)
    
Then use these new APIs to clean up incorrect usage of `uri.fsPath`, `URI.file`, `vscode.Uri.file`, `dirname`, etc.
    
Also add a `FileURI` type for URIs that are known to be `file`-scheme.

Multi-root is not yet supported by local embeddings or symf because those have hard-coded assumptions of a single workspace root. This PR will make it easier to remove that assumption.

## Test plan

CI and e2e tests. Ensure that symf indexes can be created and queried, and same for local embeddings.