### PR TITLE
Agent: re-enable tree-sitter parsing tests

### DIFF
--- a/agent/src/cli/evaluate-autocomplete/testParse.test.ts
+++ b/agent/src/cli/evaluate-autocomplete/testParse.test.ts
@@ -1,63 +1,61 @@
-import { describe } from 'node:test'
-import { it } from 'vitest'
+import path from 'path'
 
-// TODO(olaf): tests disabled due to encountering the same issue as the one flagged for Cpp
+import { describe, expect, it } from 'vitest'
 
-// import { SupportedLanguage } from '../../../../vscode/src/tree-sitter/grammars'
+import { SupportedLanguage } from '../../../../vscode/src/tree-sitter/grammars'
+import { createParser } from '../../../../vscode/src/tree-sitter/parser'
 
-// const tests: { language: SupportedLanguage; okText: string; errorText: string }[] = [
-//     {
-//         language: SupportedLanguage.TypeScript,
-//         okText: 'const x = 42\n',
-//         errorText: 'const x =\n',
-//     },
-//     {
-//         language: SupportedLanguage.Go,
-//         okText: 'type Person struct {\n\tName string\n}\n',
-//         errorText: 'type Person struct {\n',
-//     },
-//     {
-//         language: SupportedLanguage.Java,
-//         okText: 'class Foo {}\n',
-//         errorText: 'class Foo {\n',
-//     },
-//     {
-//         language: SupportedLanguage.Python,
-//         okText: 'def foo():\n    pass\n',
-//         errorText: 'def foo(\n',
-//     },
-//     // Cpp is commented out because it fails in CI with the error
-//     //    FAIL  |agent| src/cli/evaluate-autocomplete/testParse.test.ts > testParse > works for 'cpp'
-//     //   CompileError: WebAssembly.instantiate(): section (code 11, "Data") extends past end of the module (length 1618416, remaining bytes 1322339) @+119449
-//     // {
-//     //     language: SupportedLanguage.Cpp,
-//     //     okText: 'int main() {\n\treturn 0;\n}\n',
-//     //     errorText: 'int main() {\n',
-//     // },
-//     {
-//         language: SupportedLanguage.CSharp,
-//         okText: 'class Foo {\n\tpublic void Bar() {}\n}\n',
-//         errorText: 'class Foo {\n',
-//     },
-//     {
-//         language: SupportedLanguage.Php,
-//         okText: '<?php\nfunction foo() {\n\treturn 0;\n}\n',
-//         errorText: '<?php\nfunction foo() {\n',
-//     },
-// ]
+import { testParses } from './testParse'
 
-// describe('testParse', () => {
-//     it.each(tests)('works for $language', async ({ language, okText, errorText }) => {
-//         const parser = await createParser({
-//             language,
-//             grammarDirectory: path.resolve(__dirname, '../../../../vscode/dist'),
-//         })
-//         const originalTree = parser.parse(okText)
-//         expect(originalTree.rootNode.hasError()).toBe(false)
-//         expect(testParses(errorText, parser)).toBe(false)
-//     })
-// })
+const tests: { language: SupportedLanguage; okText: string; errorText: string }[] = [
+    {
+        language: SupportedLanguage.TypeScript,
+        okText: 'const x = 42\n',
+        errorText: 'const x =\n',
+    },
+    {
+        language: SupportedLanguage.Go,
+        okText: 'type Person struct {\n\tName string\n}\n',
+        errorText: 'type Person struct {\n',
+    },
+    {
+        language: SupportedLanguage.Java,
+        okText: 'class Foo {}\n',
+        errorText: 'class Foo {\n',
+    },
+    {
+        language: SupportedLanguage.Python,
+        okText: 'def foo():\n    pass\n',
+        errorText: 'def foo(\n',
+    },
+    {
+        language: SupportedLanguage.Cpp,
+        okText: 'int main() {\n\treturn 0;\n}\n',
+        errorText: 'int main() {\n',
+    },
+    {
+        language: SupportedLanguage.CSharp,
+        okText: 'class Foo {\n\tpublic void Bar() {}\n}\n',
+        errorText: 'class Foo {\n',
+    },
+    {
+        language: SupportedLanguage.Php,
+        okText: '<?php\nfunction foo() {\n\treturn 0;\n}\n',
+        errorText: '<?php\nfunction foo() {\n',
+    },
+]
 
 describe('testParse', () => {
-    it('placeholder for flakey tests', () => {})
+    it.each(tests)('works for $language', async ({ language, okText, errorText }) => {
+        const parser = await createParser({
+            language,
+            grammarDirectory: path.resolve(__dirname, '../../../../vscode/dist'),
+        })
+        if (!parser) {
+            throw new TypeError(`parser is undefined for language ${language}`)
+        }
+        const originalTree = parser.parse(okText)
+        expect(originalTree.rootNode.hasError()).toBe(false)
+        expect(testParses(errorText, parser)).toBe(false)
+    })
 })


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody/issues/2088 Now that this PR here https://github.com/sourcegraph/cody/pull/2690 has been merged, we should no longer have flaky tree-sitter loading.


## Test plan
Green CI, no flaky failures!

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
