### PR TITLE
Wire chat guardrails with snippet attribution search on enterprise instance

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -17,6 +17,8 @@ export type { ActiveTextEditorSelectionRange } from './editor'
 // error is not reproducible when running in replay mode.
 // export { displayPath, setDisplayPathEnvInfo } from './editor/displayPath'
 export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
-export type { Attribution, Guardrails } from './guardrails'
+// eslint-disable-next-line @typescript-eslint/consistent-type-exports
+export { Attribution } from './guardrails'
+export type { Guardrails } from './guardrails'
 export { ContextWindowLimitError, RateLimitError } from './sourcegraph-api/errors'
 export { testFileUri } from './test/path-helpers'

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -17,8 +17,6 @@ export type { ActiveTextEditorSelectionRange } from './editor'
 // error is not reproducible when running in replay mode.
 // export { displayPath, setDisplayPathEnvInfo } from './editor/displayPath'
 export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
-// eslint-disable-next-line @typescript-eslint/consistent-type-exports
-export { Attribution } from './guardrails'
-export type { Guardrails } from './guardrails'
+export type { Attribution, Guardrails } from './guardrails'
 export { ContextWindowLimitError, RateLimitError } from './sourcegraph-api/errors'
 export { testFileUri } from './test/path-helpers'

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -1,7 +1,7 @@
 import { debounce } from 'lodash'
 import * as vscode from 'vscode'
 
-import { ChatModelProvider, type CodyCommand } from '@sourcegraph/cody-shared'
+import { ChatModelProvider, type CodyCommand, type Guardrails } from '@sourcegraph/cody-shared'
 import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { type ChatEventSource } from '@sourcegraph/cody-shared/src/chat/transcript/messages'
 
@@ -41,7 +41,8 @@ export class ChatManager implements vscode.Disposable {
         private chatClient: ChatClient,
         private embeddingsClient: CachedRemoteEmbeddingsClient,
         private localEmbeddings: LocalEmbeddingsController | null,
-        private symf: SymfRunner | null
+        private symf: SymfRunner | null,
+        private guardrails: Guardrails
     ) {
         logDebug(
             'ChatManager:constructor',
@@ -57,7 +58,8 @@ export class ChatManager implements vscode.Disposable {
             this.chatClient,
             this.embeddingsClient,
             this.localEmbeddings,
-            this.symf
+            this.symf,
+            this.guardrails
         )
 
         // Register Commands

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { ChatModelProvider } from '@sourcegraph/cody-shared'
+import { ChatModelProvider, type Guardrails } from '@sourcegraph/cody-shared'
 import { type ChatClient } from '@sourcegraph/cody-shared/src/chat/chat'
 import { type ConfigurationWithAccessToken } from '@sourcegraph/cody-shared/src/configuration'
 import {
@@ -59,7 +59,8 @@ export class ChatPanelsManager implements vscode.Disposable {
         private chatClient: ChatClient,
         private readonly embeddingsClient: CachedRemoteEmbeddingsClient,
         private readonly localEmbeddings: LocalEmbeddingsController | null,
-        private readonly symf: SymfRunner | null
+        private readonly symf: SymfRunner | null,
+        private readonly guardrails: Guardrails
     ) {
         logDebug('ChatPanelsManager:constructor', 'init')
         this.options = { treeView: this.treeViewProvider, extensionUri, featureFlagProvider, ...options }
@@ -194,6 +195,7 @@ export class ChatPanelsManager implements vscode.Disposable {
             localEmbeddings: this.localEmbeddings,
             symf: this.symf,
             models,
+            guardrails: this.guardrails,
         })
     }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -189,7 +189,8 @@ const register = async (
         chatClient,
         embeddingsClient,
         localEmbeddings || null,
-        symfRunner || null
+        symfRunner || null,
+        guardrails,
     )
 
     disposables.push(new EditManager({ chat: chatClient, editor, contextProvider }))

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -190,7 +190,7 @@ const register = async (
         embeddingsClient,
         localEmbeddings || null,
         symfRunner || null,
-        guardrails,
+        guardrails
     )
 
     disposables.push(new EditManager({ chat: chatClient, editor, contextProvider }))


### PR DESCRIPTION
Closes [59261](https://github.com/sourcegraph/sourcegraph/issues/59261)

This pull request wires editor process attribution command and response extension message with a guardrails back-end on the enterprise instance (done in https://github.com/sourcegraph/sourcegraph/pull/59513).

## Test plan

Manual check

Found:
<img width="583" alt="Screenshot 2024-01-16 at 10 43 04 AM" src="https://github.com/sourcegraph/cody/assets/153410/1dab3821-ddf6-4766-9eca-fabc6527e240">

(note this is too short of a snippet for attribution search to run at all, but that's not implemented yet)

Not found:
<img width="532" alt="Screenshot 2024-01-16 at 10 43 16 AM" src="https://github.com/sourcegraph/cody/assets/153410/7e9eb88c-21cf-4cb7-9f94-cf3d1c90cb4d">


