### PR TITLE
Edit: Stop auto selecting code when opening diff

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -922,7 +922,6 @@ export class FixupController
             {
                 preview: true,
                 preserveFocus: false,
-                selection: task.selectionRange,
                 label: 'Cody Edit Diff View',
                 description: 'Cody Edit Diff View: ' + task.fixupFile.uri.fsPath,
             }


### PR DESCRIPTION
## Description

We can already see the changes because we have diff highlighting in VS Code

Selecting the code as well just makes it harder to read.

## Test plan

1. Create an edit
2. Click "Show diff"

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
