### PR TITLE
test: move fixup logging to manager and provider

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -193,7 +193,7 @@ const register = async (
         commandsController
     )
 
-    disposables.push(new EditManager({ chat: chatClient, editor, contextProvider }))
+    disposables.push(new EditManager({ chat: chatClient, editor, contextProvider, authProvider }))
     disposables.push(new CodeActionProvider({ contextProvider }))
 
     let oldConfig = JSON.stringify(initialConfig)

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -733,17 +733,6 @@ export class FixupController
         if (state === 'complete') {
             task.inProgressReplacement = undefined
             task.replacement = replacementText
-            telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', {
-                ...countCode(replacementText),
-                source: task.source,
-                hasV2Event: true,
-            })
-            telemetryRecorder.recordEvent('cody.fixup.response', 'hasCode', {
-                metadata: countCode(replacementText),
-                privateMetadata: {
-                    source: task.source,
-                },
-            })
             return this.streamTask(task, state)
         }
 
@@ -776,17 +765,6 @@ export class FixupController
                 task.inProgressReplacement = undefined
                 task.replacement = text
                 this.setTaskState(task, CodyTaskState.applying)
-                telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', {
-                    ...countCode(text),
-                    source: task.source,
-                    hasV2Event: true,
-                })
-                telemetryRecorder.recordEvent('cody.fixup.response', 'hasCode', {
-                    metadata: countCode(text),
-                    privateMetadata: {
-                        source: task.source,
-                    },
-                })
                 break
         }
         this.textDidChange(task)


### PR DESCRIPTION
Currently not logging prompt text and llm responses for /edit command since we have moved it out of messageProvider. This PR:
- Move the telemetry logging for /edit command input text and responses to manager and provider file
- Log prompt text and llm responses for dot com users

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Run edit commands to see if prompt text and llm responses are logged correct for dot com users.
- log into enterprise instances to confirm they are not being logged when running the edit command