### PR TITLE
fix: remove context limit warnings from UI

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -6,7 +6,6 @@ import * as vscode from 'vscode'
 import {
     ChatModelProvider,
     ConfigFeaturesSingleton,
-    ContextWindowLimitError,
     FeatureFlag,
     hydrateAfterPostMessage,
     isCodyIgnoredFile,
@@ -762,7 +761,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 const warningMsg = contextLimitWarnings
                     .map(w => (w.trim().endsWith('.') ? w.trim() : w.trim() + '.'))
                     .join(' ')
-                this.postError(new ContextWindowLimitError(warningMsg), 'transcript')
+                logDebug('SimpleChatPanelProvider', 'generateAssistantResponse > contextLimitWarnings', warningMsg)
             }
 
             if (sendTelemetry) {


### PR DESCRIPTION


The ContextWindowLimitError banner was being displayed in the Chat UI when context limit warnings occurred, causing confusion to users. The PR updates to log the context limit warning message instead to provide useful debugging info, instead of sending it to the webview to display as an error, which will then be rendered as the ContextWindowLimitError banner.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Ask Cody multiple questions to confirm no ContextWindowLimitError banner was displayed in the Chat UI.
