### PR TITLE
Make new chats the default and limited context window allocated to enhanced context to preserve context window

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -175,7 +175,7 @@ export class TestClient extends MessageHandler {
                 message: {
                     command: 'submit',
                     text,
-                    submitType: 'user',
+                    submitType: 'user-followup',
                     addEnhancedContext: params?.addEnhancedContext ?? false,
                     contextFiles: params?.contextFiles,
                 },
@@ -513,7 +513,7 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'My name is Lars Monsen',
-                        submitType: 'user',
+                        submitType: 'user-followup',
                         addEnhancedContext: false,
                     },
                 })
@@ -536,7 +536,7 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'What is my name?',
-                        submitType: 'user',
+                        submitType: 'user-followup',
                         addEnhancedContext: false,
                     },
                 })

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -175,7 +175,7 @@ export class TestClient extends MessageHandler {
                 message: {
                     command: 'submit',
                     text,
-                    submitType: 'user-followup',
+                    submitType: 'user',
                     addEnhancedContext: params?.addEnhancedContext ?? false,
                     contextFiles: params?.contextFiles,
                 },
@@ -513,7 +513,7 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'My name is Lars Monsen',
-                        submitType: 'user-followup',
+                        submitType: 'user',
                         addEnhancedContext: false,
                     },
                 })
@@ -536,7 +536,7 @@ describe('Agent', () => {
                     message: {
                         command: 'submit',
                         text: 'What is my name?',
-                        submitType: 'user-followup',
+                        submitType: 'user',
                         addEnhancedContext: false,
                     },
                 })

--- a/lib/ui/src/Chat.module.css
+++ b/lib/ui/src/Chat.module.css
@@ -35,6 +35,11 @@
     resize: none;
 }
 
+.chat-input-bottom-text {
+    padding-left: 0.25rem;
+    color: var(--vscode-tab-inactiveForeground);
+}
+
 .submit-button {
     border: none;
     cursor: pointer;

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -156,7 +156,7 @@ export interface UserContextSelectorProps {
     setSelectedChatContext: (arg: number) => void
 }
 
-export type ChatSubmitType = 'user' | 'suggestion' | 'example' | 'user-followup'
+export type ChatSubmitType = 'user' | 'suggestion' | 'example' | 'user-newchat'
 
 export interface ChatModelDropdownMenuProps {
     models: ChatModelProvider[]
@@ -350,7 +350,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             // Submit chat only when input is not empty and not in progress
             if (formInput.trim() && !messageInProgress) {
                 setInputRows(1)
-                submitInput(formInput, isFollowUp ? 'user-followup' : 'user')
+                submitInput(formInput, isFollowUp ? 'user' : 'user-newchat')
                 setFormInput('')
             }
         },

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -66,6 +66,7 @@ interface ChatProps extends ChatClassNames {
     UserContextSelectorComponent?: React.FunctionComponent<UserContextSelectorProps>
     chatModels?: ChatModelProvider[]
     EnhancedContextSettings?: React.FunctionComponent<{ isOpen: boolean; setOpen: (open: boolean) => void }>
+    isEnhancedContextEnabled: boolean
     ChatModelDropdownMenu?: React.FunctionComponent<ChatModelDropdownMenuProps>
     onCurrentChatModelChange?: (model: ChatModelProvider) => void
     userInfo: UserAccountInfo
@@ -221,6 +222,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     chatModels,
     ChatModelDropdownMenu,
     EnhancedContextSettings,
+    isEnhancedContextEnabled,
     chatEnabled,
     onCurrentChatModelChange,
     userInfo,
@@ -569,6 +571,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     userInfo={userInfo}
                     postMessage={postMessage}
                     guardrails={guardrails}
+                    isEnhancedContextEnabled={isEnhancedContextEnabled}
                 />
             )}
 

--- a/lib/ui/src/chat/BlinkingCursor.tsx
+++ b/lib/ui/src/chat/BlinkingCursor.tsx
@@ -4,9 +4,12 @@ import styles from './BlinkingCursor.module.css'
 
 export const BlinkingCursor: React.FunctionComponent = () => <span className={styles.cursor} />
 
-export const LoadingContext: React.FunctionComponent = () => (
+export const LoadingContext: React.FunctionComponent<{ isEnhancedContextEnabled: boolean }> = ({
+    isEnhancedContextEnabled,
+}) => (
     <div className={styles.loadingContainer}>
-        ✨ <LoadingDots />
+        {isEnhancedContextEnabled ? '✨' : ''}
+        <LoadingDots />
     </div>
 )
 

--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -47,6 +47,7 @@ export const Transcript: React.FunctionComponent<
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails
+        isEnhancedContextEnabled: boolean
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptContent({
     transcript,
@@ -79,6 +80,7 @@ export const Transcript: React.FunctionComponent<
     userInfo,
     postMessage,
     guardrails,
+    isEnhancedContextEnabled,
 }) {
     // Scroll the last human message to the top whenever a new human message is received as input.
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
@@ -185,6 +187,7 @@ export const Transcript: React.FunctionComponent<
                     userInfo={userInfo}
                     postMessage={postMessage}
                     guardrails={guardrails}
+                    isEnhancedContextEnabled={isEnhancedContextEnabled}
                 />
             )
         }
@@ -229,6 +232,7 @@ export const Transcript: React.FunctionComponent<
                         ChatButtonComponent={ChatButtonComponent}
                         postMessage={postMessage}
                         userInfo={userInfo}
+                        isEnhancedContextEnabled={isEnhancedContextEnabled}
                     />
                 )}
                 {messageInProgress && messageInProgress.speaker === 'assistant' && (

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -126,6 +126,7 @@ export const TranscriptItem: React.FunctionComponent<
                 />
                 <SubmitButton
                     className={styles.submitButton}
+                    isFollowUp={false}
                     onClick={() => {
                         setBeingEdited(false)
                         editButtonOnSubmit(formInput)

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -63,6 +63,7 @@ export const TranscriptItem: React.FunctionComponent<
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails
+        isEnhancedContextEnabled: boolean
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptItemContent({
     message,
@@ -92,6 +93,7 @@ export const TranscriptItem: React.FunctionComponent<
     userInfo,
     postMessage,
     guardrails,
+    isEnhancedContextEnabled,
 }) {
     const [formInput, setFormInput] = useState<string>(message.displayText ?? '')
     const EditTextArea =
@@ -205,7 +207,7 @@ export const TranscriptItem: React.FunctionComponent<
                             className={transcriptActionClassName}
                         />
                     ) : (
-                        inProgress && <LoadingContext />
+                        inProgress && <LoadingContext isEnhancedContextEnabled={isEnhancedContextEnabled} />
                     )}
                 </div>
             )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,8 +433,8 @@ importers:
         specifier: ^1.9.7
         version: 1.9.7
       '@vscode/test-electron':
-        specifier: ^2.3.2
-        version: 2.3.2
+        specifier: ^2.3.8
+        version: 2.3.8
       '@vscode/test-web':
         specifier: ^0.0.47
         version: 0.0.47
@@ -6814,8 +6814,8 @@ packages:
     resolution: {integrity: sha512-7iiKdA5wHVYSbO7/Mm0hiHD3i4h+9hKUe1O4hISAe/nHhagMwb2ZbFC8jU6d7Cw+JNT2dWXN2j+WHbkhT5/l2w==}
     dev: false
 
-  /@vscode/test-electron@2.3.2:
-    resolution: {integrity: sha512-CRfQIs5Wi5Ok5SUCC3PTvRRXa74LD43cSXHC8EuNlmHHEPaJa/AGrv76brcA1hVSxrdja9tiYwp95Lq8kwY0tw==}
+  /@vscode/test-electron@2.3.8:
+    resolution: {integrity: sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==}
     engines: {node: '>=16'}
     dependencies:
       http-proxy-agent: 4.0.1

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -23,6 +23,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Removed recipes, which were replaced by commands in November 2023 (version 0.18.0).
 - Edit: Updated the codelens display to be more descriptive. [pull/2710](https://github.com/sourcegraph/cody/pull/2710)
 - [Internal] New generate unit test available behind `cody.internal.unstable`. [pull/2646](https://github.com/sourcegraph/cody/pull/2646)
+- New chats are now the default when the user submits a new quesetion. Previously, follow-up questions were the default, but this frequently led to exceeding the LLM context window, which users interpreted as an error state. Follow-up questions are still accessible via ⌘-Enter or Ctrl-Enter.
+- We now allocate no more than 60% of the overall LLM context window for enhanced context. This preserves more room for follow-up questions and context.
 
 ## [1.1.3]
 
@@ -834,7 +836,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
-- New chats are now the default when the user submits a new quesetion. Previously, follow-up questions were the default, but this frequently led to exceeding the LLM context window, which users interpreted as an error state. Follow-up questions are still accessible via ⌘-Enter or Ctrl-Enter.
 - Removed the experimental hallucination detection that highlighted nonexistent file paths.
 - Hide the feedback button in case of error assistant response. [pull/448](https://github.com/sourcegraph/cody/pull/448)
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -834,6 +834,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- New chats are now the default when the user submits a new quesetion. Previously, follow-up questions were the default, but this frequently led to exceeding the LLM context window, which users interpreted as an error state. Follow-up questions are still accessible via ⌘-Enter or Ctrl-Enter.
 - Removed the experimental hallucination detection that highlighted nonexistent file paths.
 - Hide the feedback button in case of error assistant response. [pull/448](https://github.com/sourcegraph/cody/pull/448)
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1087,7 +1087,7 @@
     "@types/uuid": "^9.0.2",
     "@types/vscode": "^1.79.0",
     "@types/yaml": "^1.9.7",
-    "@vscode/test-electron": "^2.3.2",
+    "@vscode/test-electron": "^2.3.8",
     "@vscode/test-web": "^0.0.47",
     "@vscode/vsce": "^2.22.0",
     "blueimp-md5": "^2.19.0",

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -44,7 +44,7 @@ interface ChatPanelProviderOptions extends MessageProviderOptions {
 export class ChatPanelsManager implements vscode.Disposable {
     // Chat views in editor panels
     private activePanelProvider: SimpleChatPanelProvider | undefined = undefined
-    private panelProvidersMap: Map<ChatID, SimpleChatPanelProvider> = new Map()
+    private panelProviders: SimpleChatPanelProvider[] = []
 
     private options: ChatPanelProviderOptions
 
@@ -124,8 +124,8 @@ export class ChatPanelsManager implements vscode.Disposable {
         chatQuestion?: string,
         panel?: vscode.WebviewPanel
     ): Promise<SimpleChatPanelProvider> {
-        if (chatID && this.panelProvidersMap.has(chatID)) {
-            const provider = this.panelProvidersMap.get(chatID)
+        if (chatID && this.panelProviders.map(p => p.sessionID).includes(chatID)) {
+            const provider = this.panelProviders.find(p => p.sessionID === chatID)
             if (provider?.webviewPanel) {
                 provider.webviewPanel?.reveal()
                 this.activePanelProvider = provider
@@ -135,10 +135,10 @@ export class ChatPanelsManager implements vscode.Disposable {
         }
 
         // Reuse existing "New Chat" panel if there is an empty one
-        const emptyNewChatProvider = Array.from(this.panelProvidersMap.values()).find(
+        const emptyNewChatProvider = Array.from(this.panelProviders.values()).find(
             p => p.webviewPanel?.title === 'New Chat'
         )
-        if (!chatID && !panel && this.panelProvidersMap.size && emptyNewChatProvider) {
+        if (!chatID && !panel && this.panelProviders.length && emptyNewChatProvider) {
             emptyNewChatProvider.webviewPanel?.reveal()
             this.activePanelProvider = emptyNewChatProvider
             this.options.contextProvider.webview = emptyNewChatProvider.webview
@@ -146,7 +146,7 @@ export class ChatPanelsManager implements vscode.Disposable {
             return emptyNewChatProvider
         }
 
-        logDebug('ChatPanelsManager:createWebviewPanel', this.panelProvidersMap.size.toString())
+        logDebug('ChatPanelsManager:createWebviewPanel', this.panelProviders.length.toString())
 
         // Get the view column of the current active chat panel so that we can open a new one on top of it
         const activePanelViewColumn = this.activePanelProvider?.webviewPanel?.viewColumn
@@ -177,7 +177,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         })
 
         this.activePanelProvider = provider
-        this.panelProvidersMap.set(sessionID, provider)
+        this.panelProviders.push(provider)
 
         // Selects the corresponding tree view item.
         this.selectTreeItem(sessionID)
@@ -243,7 +243,9 @@ export class ChatPanelsManager implements vscode.Disposable {
                     await chatHistory.saveChat(authStatus, history)
                     await this.updateTreeViewHistory()
                     const chatIDUTC = new Date(chatID).toUTCString()
-                    const provider = this.panelProvidersMap.get(chatID) || this.panelProvidersMap.get(chatIDUTC)
+                    const provider =
+                        this.panelProviders.find(p => p.sessionID === chatID) ||
+                        this.panelProviders.find(p => p.sessionID === chatIDUTC)
                     provider?.handleChatTitle(title)
                 }
             })
@@ -282,10 +284,12 @@ export class ChatPanelsManager implements vscode.Disposable {
         try {
             logDebug('ChatPanelsManager', 'restorePanel')
             // Panel already exists, just reveal it
-            const provider = this.panelProvidersMap.get(chatID)
+            const provider = this.panelProviders.find(p => p.sessionID === chatID)
             if (provider) {
-                provider.webviewPanel?.reveal()
-                return provider
+                if (provider.sessionID === chatID) {
+                    provider.webviewPanel?.reveal()
+                    return provider
+                }
             }
             return await this.createWebviewPanel(chatID, chatQuestion)
         } catch (error) {
@@ -299,11 +303,11 @@ export class ChatPanelsManager implements vscode.Disposable {
             this.activePanelProvider = undefined
         }
 
-        const provider = this.panelProvidersMap.get(chatID)
-        if (provider) {
-            this.panelProvidersMap.delete(chatID)
-            provider.webviewPanel?.dispose()
-            provider.dispose()
+        const providerIndex = this.panelProviders.findIndex(p => p.sessionID === chatID)
+        if (providerIndex !== -1) {
+            const removedProvider = this.panelProviders.splice(providerIndex, 1)[0]
+            removedProvider.webviewPanel?.dispose()
+            removedProvider.dispose()
         }
     }
 
@@ -315,12 +319,12 @@ export class ChatPanelsManager implements vscode.Disposable {
             this.disposeProvider(activePanelID)
         }
         // loop through the panel provider map
-        const panelsProvider = Array.from(this.panelProvidersMap.values())
+        const panelsProvider = Array.from(this.panelProviders.values())
         for (const provider of panelsProvider) {
             provider.webviewPanel?.dispose()
             provider.dispose()
         }
-        this.panelProvidersMap.clear()
+        this.panelProviders = []
         void this.updateTreeViewHistory()
     }
 

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -135,9 +135,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         }
 
         // Reuse existing "New Chat" panel if there is an empty one
-        const emptyNewChatProvider = Array.from(this.panelProviders.values()).find(
-            p => p.webviewPanel?.title === 'New Chat'
-        )
+        const emptyNewChatProvider = this.panelProviders.find(p => p.webviewPanel?.title === 'New Chat')
         if (!chatID && !panel && this.panelProviders.length && emptyNewChatProvider) {
             emptyNewChatProvider.webviewPanel?.reveal()
             this.activePanelProvider = emptyNewChatProvider
@@ -285,11 +283,9 @@ export class ChatPanelsManager implements vscode.Disposable {
             logDebug('ChatPanelsManager', 'restorePanel')
             // Panel already exists, just reveal it
             const provider = this.panelProviders.find(p => p.sessionID === chatID)
-            if (provider) {
-                if (provider.sessionID === chatID) {
-                    provider.webviewPanel?.reveal()
-                    return provider
-                }
+            if (provider?.sessionID === chatID) {
+                provider.webviewPanel?.reveal()
+                return provider
             }
             return await this.createWebviewPanel(chatID, chatQuestion)
         } catch (error) {
@@ -319,12 +315,12 @@ export class ChatPanelsManager implements vscode.Disposable {
             this.disposeProvider(activePanelID)
         }
         // loop through the panel provider map
-        const panelsProvider = Array.from(this.panelProviders.values())
-        for (const provider of panelsProvider) {
+        const oldPanelProviders = this.panelProviders
+        this.panelProviders = []
+        for (const provider of oldPanelProviders) {
             provider.webviewPanel?.dispose()
             provider.dispose()
         }
-        this.panelProviders = []
         void this.updateTreeViewHistory()
     }
 

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -107,7 +107,7 @@ export class SimpleChatModel {
         return findLast(this.messagesWithContext, message => message.message.speaker === 'human')
     }
 
-    public updateLastHumanMessage(message: Omit<Message, 'speaker'>): void {
+    public updateLastHumanMessage(message: Omit<Message, 'speaker'>, displayText?: string): void {
         const lastMessage = this.messagesWithContext.at(-1)
         if (!lastMessage) {
             return
@@ -117,7 +117,7 @@ export class SimpleChatModel {
         } else if (lastMessage.message.speaker === 'assistant') {
             this.messagesWithContext.splice(-2, 2)
         }
-        this.addHumanMessage(message)
+        this.addHumanMessage(message, displayText)
     }
 
     public getMessagesWithContext(): MessageWithContext[] {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -574,7 +574,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     public async handleHumanMessageSubmitted(
         requestID: string,
         text: string,
-        submitType: 'user' | 'user-followup' | 'suggestion' | 'example',
+        submitType: 'user' | 'user-newchat' | 'suggestion' | 'example',
         userContextFiles: ContextFile[],
         addEnhancedContext: boolean
     ): Promise<void> {
@@ -602,7 +602,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         }
 
         // HACK
-        if (submitType === 'user' && !this.chatModel.isEmpty()) {
+        if (submitType === 'user-newchat' && !this.chatModel.isEmpty()) {
             await this.clearAndRestartSession()
         }
 
@@ -645,7 +645,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private async handleChatRequest(
         requestID: string,
         inputText: string,
-        submitType: 'user' | 'suggestion' | 'example' | 'user-followup',
+        submitType: 'user' | 'suggestion' | 'example' | 'user-newchat',
         userContextFiles: ContextFile[],
         addEnhancedContext: boolean,
         command?: CodyCommand
@@ -671,7 +671,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             userContextFiles,
             addEnhancedContext,
             contextSummary => {
-                if (submitType !== 'user') {
+                if (submitType !== 'user' && submitType !== 'user-newchat') {
                     return
                 }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -577,7 +577,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     public async handleHumanMessageSubmitted(
         requestID: string,
         text: string,
-        submitType: 'user' | 'suggestion' | 'example',
+        submitType: 'user' | 'user-followup' | 'suggestion' | 'example',
         userContextFiles: ContextFile[],
         addEnhancedContext: boolean
     ): Promise<void> {
@@ -643,7 +643,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private async handleChatRequest(
         requestID: string,
         inputText: string,
-        submitType: 'user' | 'suggestion' | 'example',
+        submitType: 'user' | 'suggestion' | 'example' | 'user-followup',
         userContextFiles: ContextFile[],
         addEnhancedContext: boolean,
         command?: CodyCommand
@@ -659,7 +659,12 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             : inputText
         // The text we will use to send to LLM
         const promptText = command ? command.prompt : inputText
-        this.chatModel.addHumanMessage({ text: promptText }, displayText)
+        if (submitType === 'user-followup' || this.chatModel.isEmpty()) {
+            this.chatModel.addHumanMessage({ text: promptText }, displayText)
+        } else {
+            this.chatModel = new SimpleChatModel(this.chatModel.modelID)
+            this.chatModel.addHumanMessage({ text: promptText }, displayText)
+        }
 
         await this.saveSession(inputText)
         // trigger the context progress indicator

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -83,7 +83,7 @@ test('@-file empty state', async ({ page, sidebar }) => {
     )
 
     // Send the message and check it was included
-    await chatInput.press('Enter')
+    await chatInput.press('Meta+Enter')
     await expect(chatInput).toBeEmpty()
     await expect(
         chatPanelFrame.getByText(

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -23,7 +23,6 @@ import {
     type UserAccountInfo,
 } from '@sourcegraph/cody-ui/src/Chat'
 import { type CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
-import { SubmitSvg } from '@sourcegraph/cody-ui/src/utils/icons'
 
 import { CODY_FEEDBACK_URL } from '../src/chat/protocol'
 
@@ -254,6 +253,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
     required,
     onInput,
     onKeyDown,
+    onKeyUp,
     onFocus,
     chatModels,
 }) => {
@@ -288,6 +288,13 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
         },
         [inputRef, onKeyDown]
     )
+    const onTextAreaKeyUp = useCallback(
+        (event: React.KeyboardEvent<HTMLElement>): void => {
+            onKeyUp?.(event, inputRef.current?.selectionStart ?? null)
+        },
+        [inputRef, onKeyUp]
+    )
+
     const actualPlaceholder = chatEnabled ? placeholder : disabledPlaceHolder
     const isDisabled = !chatEnabled
 
@@ -309,6 +316,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
                 required={required}
                 onInput={onInput}
                 onKeyDown={onTextAreaKeyDown}
+                onKeyUp={onTextAreaKeyUp}
                 onFocus={onFocus}
                 placeholder={actualPlaceholder}
                 aria-label="Chat message"
@@ -323,6 +331,7 @@ const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({
     className,
     disabled,
     onClick,
+    isFollowUp,
     onAbortMessageInProgress,
 }) => (
     <VSCodeButton
@@ -332,7 +341,13 @@ const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({
         onClick={onAbortMessageInProgress ?? onClick}
         title={onAbortMessageInProgress ? 'Stop Generating' : disabled ? '' : 'Send Message'}
     >
-        {onAbortMessageInProgress ? <i className="codicon codicon-debug-stop" /> : <SubmitSvg />}
+        {onAbortMessageInProgress ? (
+            <i className="codicon codicon-debug-stop" />
+        ) : isFollowUp ? (
+            <i className="codicon codicon-comment-discussion" />
+        ) : (
+            <i className="codicon codicon-comment" />
+        )}
     </VSCodeButton>
 )
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -232,6 +232,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             userInfo={userInfo}
             chatEnabled={chatEnabled}
             EnhancedContextSettings={enableNewChatUI ? EnhancedContextSettings : undefined}
+            isEnhancedContextEnabled={addEnhancedContext}
             postMessage={msg => vscodeAPI.postMessage(msg)}
             guardrails={guardrails}
         />


### PR DESCRIPTION
From the `vscode/CHANGELOG.md`:
- New chats are now the default when the user submits a new quesetion. Previously, follow-up questions were the default, but this frequently led to exceeding the LLM context window, which users interpreted as an error state. Follow-up questions are still accessible via ⌘-Enter or Ctrl-Enter.
- We now allocate no more than 60% of the overall LLM context window for enhanced context. This preserves more room for follow-up questions and context.

![image](https://github.com/sourcegraph/cody/assets/1646931/75b2b59b-2522-4ba4-a20b-ed32af8068c1)


## Test plan

- [ ] Check out branch locally
- [ ] Verify new chat is the default behavior
- [ ] Check cmd-enter and ctrl-enter to see that this results in asking a follow-up question