### PR TITLE
fix testing vscode.Uri.joinPath(/* vscode-uri.URI */, ...)

### DIFF
--- a/vscode/src/testutils/uri.ts
+++ b/vscode/src/testutils/uri.ts
@@ -36,7 +36,7 @@ export class Uri {
     }
 
     public static joinPath(base: Uri, ...pathSegments: string[]): Uri {
-        return new Uri(Utils.joinPath(base.uri, ...pathSegments))
+        return new Uri(Utils.joinPath(base.uri ?? new Uri(base), ...pathSegments))
     }
 
     public static from(components: {


### PR DESCRIPTION
If the first arg was a `vscode-uri.URI` type, then it lacks a `.uri` property, and this would fail.



## Test plan

CI