### PR TITLE
Autocomplete: use async generators for autocomplete tests

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -3,14 +3,14 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { resetParsersCache } from '../../tree-sitter/parser'
 import { InlineCompletionsResultSource } from '../get-inline-completions'
-import { completion, initTreeSitterParser, nextTick } from '../test-helpers'
+import { completion, initTreeSitterParser, sleep } from '../test-helpers'
 
 import { getInlineCompletions, params } from './helpers'
 
 describe('[getInlineCompletions] hot streak', () => {
     describe('static multiline', () => {
         it('caches hot streaks completions that are streamed in', async () => {
-            const firstParams = params(
+            const { completionResponseGeneratorPromise, ...firstParams } = params(
                 dedent`
                     function myFunction() {
                         console.log(1)
@@ -27,28 +27,36 @@ describe('[getInlineCompletions] hot streak', () => {
                 `,
                 ],
                 {
-                    onNetworkRequest(_params, onPartialResponse) {
-                        onPartialResponse?.(completion`
+                    async *completionResponseGenerator() {
+                        yield completion`
                             ├console.log(2)
-                        ┤`)
-                        onPartialResponse?.(completion`
+                        ┤`
+
+                        // Add paused between completion chunks to emulate
+                        // the production behaviour where packets come with a delay.
+                        await sleep(100)
+
+                        yield completion`
                             ├console.log(2)
                             console.log(3)
                             console.┤
-                        ┴┴┴┴`)
-                        onPartialResponse?.(completion`
+                        ┴┴┴┴`
+
+                        await sleep(100)
+
+                        yield completion`
                             ├console.log(2)
                             console.log(3)
                             console.log(4)┤
-                        ┴┴┴┴`)
+                        ┴┴┴┴`
                     },
                     hotStreak: true,
                 }
             )
             const firstRequest = await getInlineCompletions(firstParams)
-            // TODO(valery): expose a way to wait for a completions generator to finish in tests.
+
             // Wait for hot streak completions be yielded and cached.
-            await nextTick()
+            await completionResponseGeneratorPromise
 
             expect(firstRequest?.items[0]?.insertText).toEqual('console.log(2)')
 

--- a/vscode/src/completions/get-inline-completions-tests/languages.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/languages.test.ts
@@ -1,5 +1,5 @@
 import dedent from 'dedent'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { type CompletionParameters } from '@sourcegraph/cody-shared'
 
@@ -9,7 +9,7 @@ import { MULTILINE_STOP_SEQUENCE } from '../text-processing'
 import { getInlineCompletionsInsertText, params } from './helpers'
 
 describe('[getInlineCompletions] languages', () => {
-    test('works with python', async () => {
+    it('works with python', async () => {
         const requests: CompletionParameters[] = []
         const items = await getInlineCompletionsInsertText(
             params(
@@ -31,8 +31,8 @@ describe('[getInlineCompletions] languages', () => {
                 ],
                 {
                     languageId: 'python',
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 }
             )
@@ -48,7 +48,7 @@ describe('[getInlineCompletions] languages', () => {
         `)
     })
 
-    test('works with java', async () => {
+    it('works with java', async () => {
         const requests: CompletionParameters[] = []
         const items = await getInlineCompletionsInsertText(
             params(
@@ -73,8 +73,8 @@ describe('[getInlineCompletions] languages', () => {
                 ],
                 {
                     languageId: 'java',
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 }
             )
@@ -92,7 +92,7 @@ describe('[getInlineCompletions] languages', () => {
     })
 
     // TODO: Detect `}\nelse\n{` pattern for else skip logic
-    test('works with csharp', async () => {
+    it('works with csharp', async () => {
         const requests: CompletionParameters[] = []
         const items = await getInlineCompletionsInsertText(
             params(
@@ -124,8 +124,8 @@ describe('[getInlineCompletions] languages', () => {
                 ],
                 {
                     languageId: 'csharp',
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 }
             )
@@ -138,7 +138,7 @@ describe('[getInlineCompletions] languages', () => {
             `)
     })
 
-    test('works with c++', async () => {
+    it('works with c++', async () => {
         const requests: CompletionParameters[] = []
         const items = await getInlineCompletionsInsertText(
             params(
@@ -163,8 +163,8 @@ describe('[getInlineCompletions] languages', () => {
                 ],
                 {
                     languageId: 'cpp',
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 }
             )
@@ -181,7 +181,7 @@ describe('[getInlineCompletions] languages', () => {
         `)
     })
 
-    test('works with c', async () => {
+    it('works with c', async () => {
         const requests: CompletionParameters[] = []
         const items = await getInlineCompletionsInsertText(
             params(
@@ -206,8 +206,8 @@ describe('[getInlineCompletions] languages', () => {
                 ],
                 {
                     languageId: 'c',
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 }
             )
@@ -224,7 +224,7 @@ describe('[getInlineCompletions] languages', () => {
         `)
     })
 
-    test('works with php', async () => {
+    it('works with php', async () => {
         const requests: CompletionParameters[] = []
         const items = await getInlineCompletionsInsertText(
             params(
@@ -249,8 +249,8 @@ describe('[getInlineCompletions] languages', () => {
                 ],
                 {
                     languageId: 'c',
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 }
             )
@@ -268,7 +268,7 @@ describe('[getInlineCompletions] languages', () => {
         `)
     })
 
-    test('works with dart', async () => {
+    it('works with dart', async () => {
         const requests: CompletionParameters[] = []
         const items = await getInlineCompletionsInsertText(
             params(
@@ -293,8 +293,8 @@ describe('[getInlineCompletions] languages', () => {
                 ],
                 {
                     languageId: 'dart',
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 }
             )

--- a/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
@@ -684,17 +684,19 @@ cases.forEach(isTreeSitterEnabled => {
 
                 it('handles missing brackets gracefully to truncate the completion correctly', async () => {
                     const requestParams = params('console.log(1); const █', [completion``], {
-                        onNetworkRequest(_params, onPartialResponse) {
-                            onPartialResponse?.(completion`
+                        *completionResponseGenerator() {
+                            yield completion`
                                 ├MyCoolObject = {
-                                constructor() {`)
-                            onPartialResponse?.(completion`
+                                constructor() {`
+
+                            yield completion`
                                 ├MyCoolObject = {
                                 constructor() {
                                     console.log(1)
 
-                                    if (false`)
-                            onPartialResponse?.(completion`
+                                    if (false`
+
+                            yield completion`
                                 ├MyCoolObject = {
                                 constructor() {
                                     console.log(1)
@@ -704,8 +706,9 @@ cases.forEach(isTreeSitterEnabled => {
                                     }
 
                                     const result = {
-                                        value:`)
-                            onPartialResponse?.(completion`
+                                        value:`
+
+                            yield completion`
                                 ├MyCoolObject = {
                                 constructor() {
                                     console.log(1)
@@ -721,7 +724,7 @@ cases.forEach(isTreeSitterEnabled => {
                                     return result
                                 }
                             }
-                            console.log(5)┤`)
+                            console.log(5)┤`
                         },
                         dynamicMultilineCompletions: true,
                     })

--- a/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/streaming.test.ts
@@ -11,8 +11,8 @@ describe('[getInlineCompletions] streaming', () => {
         expect(
             await getInlineCompletions({
                 ...params('const x = █', [completion`├1337\nconsole.log('what?');┤`], {
-                    onNetworkRequest(_params, onPartialResponse) {
-                        onPartialResponse?.(completion`├1337\ncon┤`)
+                    *completionResponseGenerator() {
+                        yield completion`├1337\ncon┤`
                     },
                 }),
             })
@@ -26,9 +26,9 @@ describe('[getInlineCompletions] streaming', () => {
         expect(
             await getInlineCompletions({
                 ...params('const x = █', [completion`├1337\nconsole.log('what?');┤`], {
-                    onNetworkRequest(_params, onPartialResponse) {
-                        onPartialResponse?.(completion`├13┤`)
-                        onPartialResponse?.(completion`├1337\n┤`)
+                    *completionResponseGenerator() {
+                        yield completion`├13┤`
+                        yield completion`├1337\n┤`
                     },
                 }),
             })
@@ -55,17 +55,17 @@ describe('[getInlineCompletions] streaming', () => {
                             `,
                 ],
                 {
-                    onNetworkRequest(_params, onPartialResponse) {
-                        onPartialResponse?.(completion`
-                                        ├console.log('what?')┤
-                                    ┴┴┴┴
-                                `)
-                        onPartialResponse?.(completion`
-                                        ├console.log('what?')
-                                    }
+                    *completionResponseGenerator() {
+                        yield completion`
+                                ├console.log('what?')┤
+                            ┴┴┴┴
+                        `
+                        yield completion`
+                                ├console.log('what?')
+                            }
 
-                                    function never(){}┤
-                                `)
+                            function never(){}┤
+                        `
                     },
                 }
             ),
@@ -93,17 +93,17 @@ describe('[getInlineCompletions] streaming', () => {
                             `,
                     ],
                     {
-                        onNetworkRequest(_params, onPartialResponse) {
-                            onPartialResponse?.(completion`
-                                        ├const a = new Array()
-                                        console.log('oh no')┤
-                                    ┴┴┴┴
-                                `)
-                            onPartialResponse?.(completion`
-                                        ├const a = new Array()
-                                        console.log('oh no')
-                                    ┤
-                                `)
+                        *completionResponseGenerator() {
+                            yield completion`
+                                    ├const a = new Array()
+                                    console.log('oh no')┤
+                                ┴┴┴┴
+                            `
+                            yield completion`
+                                    ├const a = new Array()
+                                    console.log('oh no')
+                                ┤
+                            `
                         },
                     }
                 ),
@@ -126,13 +126,10 @@ describe('[getInlineCompletions] streaming', () => {
                     completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (true) {}\n  }\n}\nconsole.log()`,
                 ],
                 {
-                    onNetworkRequest(_params, onPartialResponse) {
-                        onPartialResponse?.(
-                            completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (`
-                        )
-                        onPartialResponse?.(
-                            completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (true) {}\n  }\n}\nconsole.log()\n`
-                        )
+                    *completionResponseGenerator() {
+                        yield completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (`
+
+                        yield completion`\nconst merge = (left, right) => {\n  let arr = [];\n  while (left.length && right.length) {\n    if (true) {}\n  }\n}\nconsole.log()\n`
                     },
                 }
             ),
@@ -158,8 +155,8 @@ describe('[getInlineCompletions] streaming', () => {
                 `,
                 [completion`// Bubble sort algorithm\nconst numbers = [5, 3, 6, 2, 10];\n`],
                 {
-                    onNetworkRequest(_params, onPartialResponse) {
-                        onPartialResponse?.(completion`// Bubble sort algorithm\nconst numbers = [5, 3, 6, 2, 10];\n`)
+                    *completionResponseGenerator() {
+                        yield completion`// Bubble sort algorithm\nconst numbers = [5, 3, 6, 2, 10];\n`
                     },
                 }
             ),

--- a/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
@@ -53,8 +53,8 @@ describe('[getInlineCompletions] triggers', () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('function bubbleSort() {\n  █', [], {
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 })
             )
@@ -65,8 +65,8 @@ describe('[getInlineCompletions] triggers', () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('bar(█)', [], {
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 })
             )
@@ -77,8 +77,8 @@ describe('[getInlineCompletions] triggers', () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('foo.bar(█)', [], {
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 })
             )
@@ -98,8 +98,8 @@ describe('[getInlineCompletions] triggers', () => {
                     `,
                         [],
                         {
-                            onNetworkRequest(request) {
-                                requests.push(request)
+                            onNetworkRequest(params) {
+                                requests.push(params)
                             },
                         }
                     )
@@ -120,8 +120,8 @@ describe('[getInlineCompletions] triggers', () => {
                     `,
                         [],
                         {
-                            onNetworkRequest(request) {
-                                requests.push(request)
+                            onNetworkRequest(params) {
+                                requests.push(params)
                             },
                         }
                     )
@@ -134,8 +134,8 @@ describe('[getInlineCompletions] triggers', () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('method.hello () {█', [], {
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 })
             )
@@ -147,8 +147,8 @@ describe('[getInlineCompletions] triggers', () => {
             await getInlineCompletions(
                 params('function looksLegit() {\n  █', [], {
                     languageId: 'elixir',
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 })
             )
@@ -159,8 +159,8 @@ describe('[getInlineCompletions] triggers', () => {
             const requests: CompletionParameters[] = []
             await getInlineCompletions(
                 params('function bubbleSort() {\n█', [], {
-                    onNetworkRequest(request) {
-                        requests.push(request)
+                    onNetworkRequest(params) {
+                        requests.push(params)
                     },
                 })
             )

--- a/vscode/src/completions/test-helpers.ts
+++ b/vscode/src/completions/test-helpers.ts
@@ -62,3 +62,7 @@ export function documentAndPosition(
 export async function nextTick(): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 0))
 }
+
+export async function sleep(ms: number): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
## Context

- Addresses @dominiccooney's [suggestion](https://github.com/sourcegraph/cody/pull/2731#issuecomment-1891703877) to improve autocomplete integration tests by adding a delay between streamed chunks.
- Refactors autocomplete partial-response-helpers to async generators.
- Built on top of https://github.com/sourcegraph/cody/pull/2747

## Test plan

CI
