### PR TITLE
[Cody] remove cody-pro feature flag dependency

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -28,8 +28,6 @@ export enum FeatureFlag {
     // if the first completion is accepted.
     CodyAutocompleteHotStreak = 'cody-autocomplete-hot-streak',
 
-    // Enable Cody PLG features
-    CodyPro = 'cody-pro',
     // Enable Cody PLG features on JetBrains
     CodyProJetBrains = 'cody-pro-jetbrains',
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -396,7 +396,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 await localStorage.set('model', message.model)
                 break
             case 'get-chat-models':
-                await this.postChatModels()
+                this.postChatModels()
                 break
             case 'getUserContext':
                 await this.handleContextFiles(message.query)
@@ -487,7 +487,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             chatID: this.sessionID,
         })
 
-        await this.postChatModels()
+        this.postChatModels()
         await this.saveSession()
         await this.postCodyCommands()
         this.initDoer.signalInitialized()
@@ -552,7 +552,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         }
     }
 
-    private async postChatModels(): Promise<void> {
+    private postChatModels(): void {
         const authStatus = this.authProvider.getAuthStatus()
         if (!authStatus?.isLoggedIn) {
             return

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -565,14 +565,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         if (authStatus?.configOverwrites?.chatModel) {
             ChatModelProvider.add(new ChatModelProvider(authStatus.configOverwrites.chatModel))
         }
-        // selection is available to pro only at Dec GA
-        const isCodyProFeatureFlagEnabled = await this.featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyPro)
-        const models = ChatModelProvider.get(authStatus.endpoint, this.chatModel.modelID)?.map(model => {
-            return {
-                ...model,
-                codyProOnly: isCodyProFeatureFlagEnabled ? model.codyProOnly : false,
-            }
-        })
+        const models = ChatModelProvider.get(authStatus.endpoint, this.chatModel.modelID)
 
         void this.postMessage({
             type: 'chatModels',

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -7,7 +7,6 @@ import {
     ChatModelProvider,
     ConfigFeaturesSingleton,
     ContextWindowLimitError,
-    FeatureFlag,
     hydrateAfterPostMessage,
     isCodyIgnoredFile,
     isDefined,
@@ -138,8 +137,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
     private contextFilesQueryCancellation?: vscode.CancellationTokenSource
 
-    private readonly featureFlagProvider: FeatureFlagProvider
-
     // HACK: for now, we awkwardly need to keep this in sync with chatModel.sessionID,
     // as it is necessary to satisfy the IChatPanelProvider interface.
     public sessionID: string
@@ -147,7 +144,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     constructor({
         config,
         extensionUri,
-        featureFlagProvider,
         authProvider,
         chatClient,
         embeddingsClient,
@@ -161,7 +157,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }: SimpleChatPanelProviderOptions) {
         this.config = config
         this.extensionUri = extensionUri
-        this.featureFlagProvider = featureFlagProvider
         this.authProvider = authProvider
         this.chatClient = chatClient
         this.embeddingsClient = embeddingsClient

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -179,11 +179,8 @@ export class AuthProvider {
             return
         }
 
-        const codyProEnabled = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyPro)
-        const detail = codyProEnabled ? `Plan: ${this.authStatus.userCanUpgrade ? 'Cody Free' : 'Cody Pro'}` : undefined
-        const options = codyProEnabled
-            ? ['Manage Account', 'Switch Account...', 'Sign Out']
-            : ['Switch Account...', 'Sign Out']
+        const detail = `Plan: ${this.authStatus.userCanUpgrade ? 'Cody Free' : 'Cody Pro'}`
+        const options = ['Manage Account', 'Switch Account...', 'Sign Out']
         const displayName = this.authStatus.displayName || this.authStatus.username
         const email = this.authStatus.primaryEmail || 'No Email'
         const option = await vscode.window.showInformationMessage(

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -2,8 +2,6 @@ import * as vscode from 'vscode'
 
 import {
     DOTCOM_URL,
-    FeatureFlag,
-    featureFlagProvider,
     isDotCom,
     isError,
     LOCAL_APP_URL,

--- a/vscode/src/services/TreeViewProvider.test.ts
+++ b/vscode/src/services/TreeViewProvider.test.ts
@@ -73,7 +73,7 @@ describe('TreeViewProvider', () => {
     }
 
     describe('Cody Pro Upgrade', () => {
-        it('is shown when GA + user can upgrade', async () => {
+        it('is shown when user can upgrade', async () => {
             tree = new TreeViewProvider('support', emptyMockFeatureFlagProvider)
             await updateTree({ upgradeAvailable: true, endpoint: DOTCOM_URL })
             expect(findTreeItem('Upgrade')).not.toBeUndefined()
@@ -82,12 +82,6 @@ describe('TreeViewProvider', () => {
         it('is not shown when user cannot upgrade', async () => {
             tree = new TreeViewProvider('support', emptyMockFeatureFlagProvider)
             await updateTree({ upgradeAvailable: false, endpoint: DOTCOM_URL })
-            expect(findTreeItem('Upgrade')).toBeUndefined()
-        })
-
-        it('is not shown when not GA', async () => {
-            tree = new TreeViewProvider('support', emptyMockFeatureFlagProvider)
-            await updateTree({ upgradeAvailable: true, endpoint: DOTCOM_URL })
             expect(findTreeItem('Upgrade')).toBeUndefined()
         })
 

--- a/vscode/src/services/TreeViewProvider.test.ts
+++ b/vscode/src/services/TreeViewProvider.test.ts
@@ -4,7 +4,7 @@ import type * as vscode from 'vscode'
 import { DOTCOM_URL, isDotCom } from '@sourcegraph/cody-shared'
 
 import { newAuthStatus } from '../chat/utils'
-import { decGaMockFeatureFlagProvider, emptyMockFeatureFlagProvider, vsCodeMocks } from '../testutils/mocks'
+import { emptyMockFeatureFlagProvider, vsCodeMocks } from '../testutils/mocks'
 
 import { TreeViewProvider } from './TreeViewProvider'
 
@@ -74,13 +74,13 @@ describe('TreeViewProvider', () => {
 
     describe('Cody Pro Upgrade', () => {
         it('is shown when GA + user can upgrade', async () => {
-            tree = new TreeViewProvider('support', decGaMockFeatureFlagProvider)
+            tree = new TreeViewProvider('support', emptyMockFeatureFlagProvider)
             await updateTree({ upgradeAvailable: true, endpoint: DOTCOM_URL })
             expect(findTreeItem('Upgrade')).not.toBeUndefined()
         })
 
         it('is not shown when user cannot upgrade', async () => {
-            tree = new TreeViewProvider('support', decGaMockFeatureFlagProvider)
+            tree = new TreeViewProvider('support', emptyMockFeatureFlagProvider)
             await updateTree({ upgradeAvailable: false, endpoint: DOTCOM_URL })
             expect(findTreeItem('Upgrade')).toBeUndefined()
         })
@@ -92,29 +92,9 @@ describe('TreeViewProvider', () => {
         })
 
         it('is not shown when not dotCom regardless of GA or upgrade flags', async () => {
-            tree = new TreeViewProvider('support', decGaMockFeatureFlagProvider)
+            tree = new TreeViewProvider('support', emptyMockFeatureFlagProvider)
             await updateTree({ upgradeAvailable: true, endpoint: new URL('https://example.org') })
             expect(findTreeItem('Upgrade')).toBeUndefined()
-        })
-    })
-
-    describe('Usage', () => {
-        it('is shown when GA', async () => {
-            tree = new TreeViewProvider('support', decGaMockFeatureFlagProvider)
-            await updateTree({ upgradeAvailable: true, endpoint: DOTCOM_URL })
-            expect(findTreeItem('Usage')).not.toBeUndefined()
-        })
-
-        it('is not shown when not GA', async () => {
-            tree = new TreeViewProvider('support', emptyMockFeatureFlagProvider)
-            await updateTree({ upgradeAvailable: true, endpoint: DOTCOM_URL })
-            expect(findTreeItem('Usage')).toBeUndefined()
-        })
-
-        it('is not shown when not dotCom regardless of GA or upgrade flags', async () => {
-            tree = new TreeViewProvider('support', decGaMockFeatureFlagProvider)
-            await updateTree({ upgradeAvailable: true, endpoint: new URL('https://example.org') })
-            expect(findTreeItem('Usage')).toBeUndefined()
         })
     })
 })

--- a/vscode/src/services/TreeViewProvider.ts
+++ b/vscode/src/services/TreeViewProvider.ts
@@ -73,11 +73,7 @@ export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem
                 continue
             }
 
-            if (
-                item.requireUpgradeAvailable &&
-                (await this.featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyPro)) &&
-                !(this.authStatus?.userCanUpgrade ?? false)
-            ) {
+            if (item.requireUpgradeAvailable && !(this.authStatus?.userCanUpgrade ?? false)) {
                 continue
             }
 

--- a/vscode/src/services/TreeViewProvider.ts
+++ b/vscode/src/services/TreeViewProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { FeatureFlag, isDotCom, type FeatureFlagProvider } from '@sourcegraph/cody-shared'
+import { isDotCom, type FeatureFlagProvider } from '@sourcegraph/cody-shared'
 
 import { type AuthStatus } from '../chat/protocol'
 import { getFullConfig } from '../configuration'

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -79,14 +79,12 @@ const supportItems: CodySidebarTreeItem[] = [
         command: { command: 'cody.show-page', args: ['upgrade'] },
         requireDotCom: true,
         requireUpgradeAvailable: true,
-        requireFeature: FeatureFlag.CodyPro,
     },
     {
         title: 'Usage',
         icon: 'pulse',
         command: { command: 'cody.show-page', args: ['usage'] },
         requireDotCom: true,
-        requireFeature: FeatureFlag.CodyPro,
     },
     {
         title: 'Settings',

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -1,6 +1,6 @@
 import { findLast } from 'lodash'
 
-import { FeatureFlag } from '@sourcegraph/cody-shared'
+import type { FeatureFlag } from '@sourcegraph/cody-shared'
 
 import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 import { CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL, type AuthStatus } from '../chat/protocol'

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -12,7 +12,7 @@ import type {
     Range as VSCodeRange,
 } from 'vscode'
 
-import { FeatureFlag, FeatureFlagProvider, type Configuration } from '@sourcegraph/cody-shared'
+import { FeatureFlagProvider, type Configuration, type FeatureFlag } from '@sourcegraph/cody-shared'
 
 import { AgentEventEmitter as EventEmitter } from './AgentEventEmitter'
 import { Disposable } from './Disposable'

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -741,7 +741,6 @@ export class MockFeatureFlagProvider extends FeatureFlagProvider {
 }
 
 export const emptyMockFeatureFlagProvider = new MockFeatureFlagProvider(new Set<FeatureFlag>())
-export const decGaMockFeatureFlagProvider = new MockFeatureFlagProvider(new Set<FeatureFlag>([FeatureFlag.CodyPro]))
 
 export const DEFAULT_VSCODE_SETTINGS = {
     proxy: null,


### PR DESCRIPTION
Similar to: https://github.com/sourcegraph/sourcegraph/pull/59660

Remove dependency on cody-pro feature flag which was added during Dec GA release. Things are now stable and it is a good time to cleanup.

## Test plan
- Connect to a local sourcegraph instance
- Visit `/site-admin/feature-flags` and remove the cody-pro feature flag.
- Visit `/cody/manage` and make sure you are on a free plan.
- Check in IDE that Upgrade buttons are showing up.