### PR TITLE
refactor: chat action command

### DIFF
--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -1,7 +1,14 @@
 import { debounce } from 'lodash'
+import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
-import { ChatModelProvider, type ChatClient, type CodyCommand, type Guardrails } from '@sourcegraph/cody-shared'
+import {
+    ChatModelProvider,
+    type ChatClient,
+    type ChatEventSource,
+    type CodyCommand,
+    type Guardrails,
+} from '@sourcegraph/cody-shared'
 
 import { type View } from '../../../webviews/NavBar'
 import { type CodyCommandArgs } from '../../commands'
@@ -64,6 +71,7 @@ export class ChatManager implements vscode.Disposable {
 
         // Register Commands
         this.disposables.push(
+            vscode.commands.registerCommand('cody.action.chat', (input, args) => this.executeChat(input, args)),
             vscode.commands.registerCommand('cody.chat.history.export', async () => this.exportHistory()),
             vscode.commands.registerCommand('cody.chat.history.clear', async () => this.clearHistory()),
             vscode.commands.registerCommand('cody.chat.history.delete', async item => this.clearHistory(item)),
@@ -92,6 +100,16 @@ export class ChatManager implements vscode.Disposable {
         const chatProvider = await this.getChatProvider()
         await chatProvider?.setWebviewView(view)
     }
+
+    // Execute a chat request in a new chat panel
+    public async executeChat(question: string, args?: { source?: ChatEventSource }): Promise<void> {
+        const requestID = uuid.v4()
+        telemetryService.log('CodyVSCodeExtension:chat-question:submitted', { requestID, ...args })
+        const chatProvider = await this.getChatProvider()
+        await chatProvider.handleHumanMessageSubmitted(requestID, question, 'user', [], false)
+    }
+
+    // Execute a command request in a new chat panel
 
     public async executeCommand(
         command: CodyCommand,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -300,7 +300,7 @@ const register = async (
         vscode.commands.registerCommand('cody.auth.account', () => authProvider.accountMenu()),
         vscode.commands.registerCommand('cody.auth.support', () => showFeedbackSupportQuickPick()),
         vscode.commands.registerCommand('cody.auth.status', () => authProvider.getAuthStatus()), // Used by the agent
-        // Commands
+        // Chat
         vscode.commands.registerCommand('cody.chat.restart', async () => {
             const confirmation = await vscode.window.showWarningMessage(
                 'Restart Chat Session',
@@ -321,10 +321,7 @@ const register = async (
         vscode.commands.registerCommand('cody.settings.extension.chat', () =>
             vscode.commands.executeCommand('workbench.action.openSettings', { query: '@ext:sourcegraph.cody-ai chat' })
         ),
-        // Recipes
-        vscode.commands.registerCommand('cody.action.chat', async (input, args) =>
-            executeCommand(`/ask ${input}`, args)
-        ),
+        // Cody Commands
         vscode.commands.registerCommand('cody.action.commands.menu', async () => {
             await commandsController?.menu('default')
         }),


### PR DESCRIPTION
The `cody.action.chat` command has been using `executeCommand` for chat questions that turns the question into Chat before it can be processed by the Simple Chat Panel as a question.

This PR adds a new `executeChat` method in ChatManager to handle chat questions directly to simplify the process.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

The `cody.action.chat` is being used by `Ask Cody to Explain` in CodeAction, so you can invoke that to make sure it works to confirm the changes in this PR.

https://github.com/sourcegraph/cody/assets/68532117/548be375-6351-45b3-9e1d-4aa9e69f1cac


