### PR TITLE
feat: add support for custom edit commands in chat

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Commands: Custom edit commands are now executable from the Chat panel. [pull/2789](https://github.com/sourcegraph/cody/pull/2789)
 - [Internal] Edit/Chat: Added "ghost" text alongside code to showcase Edit and Chat commands. [pull/2611](https://github.com/sourcegraph/cody/pull/2611)
 - [Internal] Edit/Chat: Added Cmd/Ctrl+K and Cmd/Ctrl+L commands to trigger Edit and Chat [pull/2611](https://github.com/sourcegraph/cody/pull/2611)
 - Added support for the new `fireworks/starcoder` virtual model name when used in combination with an Enterprise instance. [pull/2714](https://github.com/sourcegraph/cody/pull/2714)
@@ -14,6 +15,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Edit: Fixed an issue where concurrent applying edits could result in the incorrect insertion point for a new edit. [pull/2707](https://github.com/sourcegraph/cody/pull/2707)
 - Edit: Fixed an issue where the file/symbol hint would remain even after the file/symbol prefix had been deleted. [pull/2712](https://github.com/sourcegraph/cody/pull/2712)
+- Commands: Fixed an issue where Cody failed to register additional instructions followed by the command key when submitted from the command menu. [pull/2789](https://github.com/sourcegraph/cody/pull/2789)
 
 ### Changed
 

--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -36,10 +36,7 @@ export class CommandRunner implements vscode.Disposable {
     constructor(
         private readonly vscodeEditor: VSCodeEditor,
         public readonly command: CodyCommand,
-        private readonly args: CodyCommandArgs,
-        // instruction that goes after the command key
-        // e.g. 'in Japanese' from '/explain in Japanese'
-        public instruction?: string
+        private readonly args: CodyCommandArgs
     ) {
         logDebug('CommandRunner:constructor', command.slashCommand, { verbose: { command, args } })
         // use commandKey to identify default command in telemetry
@@ -51,16 +48,16 @@ export class CommandRunner implements vscode.Disposable {
         if (commandKey === '/ask') {
             command.prompt = command.prompt.replace('/ask', '')
         }
-
+        // Set commmand mode - default mode to 'ask' if not specified
         if (args.runInChatMode) {
             command.mode = 'ask'
         } else {
-            const isEditPrompt = promptStatsWithEdit(command, instruction)
-            // Default mode to 'ask' if not specified
+            const isEditPrompt = promptStatsWithEdit(command.prompt)
             command.mode = isEditPrompt ? 'edit' : command.mode || 'ask'
         }
 
-        command.additionalInput = instruction
+        // update prompt with additional input added at the end
+        command.prompt = [this.command.prompt, this.command.additionalInput].join(' ')
         this.isFixupRequest = command.mode !== 'ask'
         this.command = command
 
@@ -235,6 +232,6 @@ function getDocCommandRange(
     return new vscode.Selection(adjustedStartPosition, selection.end)
 }
 
-function promptStatsWithEdit(command: CodyCommand, instruction?: string): boolean {
-    return command.prompt.startsWith('/edit ') || instruction?.startsWith('/edit ') || false
+function promptStatsWithEdit(prompt: string): boolean {
+    return prompt.startsWith('/edit ')
 }

--- a/vscode/src/commands/CommandRunner.ts
+++ b/vscode/src/commands/CommandRunner.ts
@@ -57,7 +57,7 @@ export class CommandRunner implements vscode.Disposable {
         }
 
         // update prompt with additional input added at the end
-        command.prompt = [this.command.prompt, this.command.additionalInput].join(' ')
+        command.prompt = [this.command.prompt, this.command.additionalInput].join(' ')?.trim()
         this.isFixupRequest = command.mode !== 'ask'
         this.command = command
 

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -96,7 +96,7 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
 
         // Start the command runner
         const runner = new CommandRunner(this.editor, command, args)
-        if (!runner?.command) {
+        if (!runner) {
             return null
         }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -279,7 +279,7 @@ const register = async (
         args?: Partial<CodyCommandArgs>
     ): Promise<ChatSession | undefined> => {
         const commandArgs = newCodyCommandArgs(args)
-        const command = await commandsController?.findCommand(commandKey, commandArgs)
+        const command = await commandsController?.startCommand(commandKey, commandArgs)
         if (!command) {
             return
         }


### PR DESCRIPTION
Previously the custom edit commands are filtered from the chat command list because it wasn't supported. Since we have implemented handleCommand in a previous PR, this PR remove the filter added for excluding custom edit commands from chat view

- Add support for custom edit commands in chat
- Display custom edit commands in chat
- Improve command handling by updating the findCommand method to startCommand in the SimpleChatPanelProvider and CommandsController classes.
- Fix a bug where additional instruction followed by command key submitted in menu were removed incorrectly.
- Remove unused variables, e.g. commandRunners map

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->


https://github.com/sourcegraph/cody/assets/68532117/79b87c00-9726-4dfe-9ce4-3da72481a78a


