### PR TITLE
Revert "remove remote embeddings-related code (#2776)"

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -453,7 +453,15 @@ export class Agent extends MessageHandler {
             return null
         })
 
-        this.registerAuthenticatedRequest('graphql/getRepoId', async ({ repoName }) => {
+        this.registerRequest('graphql/getRepoIdIfEmbeddingExists', async ({ repoName }) => {
+            const result = await graphqlClient.getRepoIdIfEmbeddingExists(repoName)
+            if (result instanceof Error) {
+                console.error('getRepoIdIfEmbeddingExists', result)
+            }
+            return typeof result === 'string' ? result : null
+        })
+
+        this.registerRequest('graphql/getRepoId', async ({ repoName }) => {
             const result = await graphqlClient.getRepoId(repoName)
             if (result instanceof Error) {
                 console.error('getRepoId', result)

--- a/lib/shared/src/codebase-context/context-status.ts
+++ b/lib/shared/src/codebase-context/context-status.ts
@@ -14,12 +14,25 @@ export interface ContextStatusProvider {
 
 export type ContextProvider = EmbeddingsProvider | GraphProvider | SearchProvider
 
-type EmbeddingsProvider = IndeterminateEmbeddingsProvider | LocalEmbeddingsProvider
+type EmbeddingsProvider = IndeterminateEmbeddingsProvider | LocalEmbeddingsProvider | RemoteEmbeddingsProvider
 
 interface IndeterminateEmbeddingsProvider {
     kind: 'embeddings'
     type: 'indeterminate'
     state: 'indeterminate'
+}
+
+interface RemoteEmbeddingsProvider {
+    kind: 'embeddings'
+    type: 'remote'
+    state: 'ready' | 'no-match'
+    // The host name of the provider. This is displayed to the user *and*
+    // used to construct a URL to the settings page.
+    origin: string
+    // The name of the repository in the remote provider. For example the
+    // context group may be "~/projects/frobbler" but the remote name is
+    // "host.example/universal/frobbler".
+    remoteName: string
 }
 
 export interface LocalEmbeddingsProvider {

--- a/lib/shared/src/embeddings/EmbeddingsDetector.ts
+++ b/lib/shared/src/embeddings/EmbeddingsDetector.ts
@@ -1,0 +1,58 @@
+import { type SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql/client'
+
+import { SourcegraphEmbeddingsSearchClient } from './client'
+
+// A factory for SourcegraphEmbeddingsSearchClients. Queries the client
+// connection and app (if available) in parallel and returns the one with
+// embeddings available.
+export const EmbeddingsDetector = {
+    // Creates an embeddings search client with the first client in `clients`
+    // that has embeddings. If none have embeddings, returns undefined. If all
+    // fail, returns the first error.
+    async newEmbeddingsSearchClient(
+        clients: readonly SourcegraphGraphQLAPIClient[],
+        codebase: string,
+        codebaseLocalName: string
+    ): Promise<SourcegraphEmbeddingsSearchClient | Error | undefined> {
+        let firstError: Error | undefined
+        let allFailed = true
+        for (const promise of clients.map(client => this.detectEmbeddings(client, codebase, codebaseLocalName))) {
+            const result = await promise
+            const isError = result instanceof Error
+            allFailed &&= isError
+            if (isError) {
+                firstError ||= result
+                continue
+            }
+            if (result === undefined) {
+                continue
+            }
+            // We got a result, drop the rest of the promises on the floor.
+            return result()
+        }
+        if (allFailed) {
+            console.log('EmbeddingsDetector', `Error getting embeddings availability for ${codebase}`, firstError)
+            return firstError
+        }
+        return undefined
+    },
+
+    // Detects whether *one* client has embeddings for the specified codebase.
+    // Returns one of:
+    // - A thunk to construct an embeddings search client, if embeddings exist.
+    // - undefined, if the client doesn't have embeddings.
+    // - An error.
+    async detectEmbeddings(
+        client: SourcegraphGraphQLAPIClient,
+        codebase: string,
+        codebaseLocalName: string
+    ): Promise<(() => SourcegraphEmbeddingsSearchClient) | Error | undefined> {
+        const repoId = await client.getRepoIdIfEmbeddingExists(codebase)
+        if (repoId instanceof Error) {
+            return repoId
+        }
+        return repoId
+            ? () => new SourcegraphEmbeddingsSearchClient(client, codebase, repoId, codebaseLocalName)
+            : undefined
+    },
+}

--- a/lib/shared/src/embeddings/client.ts
+++ b/lib/shared/src/embeddings/client.ts
@@ -1,0 +1,52 @@
+import type * as status from '../codebase-context/context-status'
+import { type EmbeddingsSearchResults, type SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
+
+import { type EmbeddingsSearch } from '.'
+
+export class SourcegraphEmbeddingsSearchClient implements EmbeddingsSearch {
+    constructor(
+        private client: SourcegraphGraphQLAPIClient,
+        private repoName: string,
+        public readonly repoId: string,
+        private codebaseLocalName: string = '',
+        private web: boolean = false
+    ) {}
+
+    public get endpoint(): string {
+        return this.client.endpoint
+    }
+
+    public async search(
+        query: string,
+        codeResultsCount: number,
+        textResultsCount: number
+    ): Promise<EmbeddingsSearchResults | Error> {
+        if (this.web) {
+            return this.client.searchEmbeddings([this.repoId], query, codeResultsCount, textResultsCount)
+        }
+
+        return this.client.legacySearchEmbeddings(this.repoId, query, codeResultsCount, textResultsCount)
+    }
+
+    public onDidChangeStatus(callback: (provider: status.ContextStatusProvider) => void): status.Disposable {
+        // This does not change, so there is nothing to report.
+        return { dispose: () => {} }
+    }
+
+    public get status(): status.ContextGroup[] {
+        return [
+            {
+                name: this.codebaseLocalName || this.repoName,
+                providers: [
+                    {
+                        kind: 'embeddings',
+                        type: 'remote',
+                        state: 'ready',
+                        origin: this.endpoint,
+                        remoteName: this.repoName,
+                    },
+                ],
+            },
+        ]
+    }
+}

--- a/lib/shared/src/embeddings/index.ts
+++ b/lib/shared/src/embeddings/index.ts
@@ -1,0 +1,8 @@
+import type * as status from '../codebase-context/context-status'
+import { type EmbeddingsSearchResults } from '../sourcegraph-api/graphql/client'
+
+export interface EmbeddingsSearch extends status.ContextStatusProvider {
+    repoId: string
+    endpoint: string
+    search(query: string, codeResultsCount: number, textResultsCount: number): Promise<EmbeddingsSearchResults | Error>
+}

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -75,6 +75,8 @@ export type {
 } from './editor'
 export { displayPath, setDisplayPathEnvInfo, type DisplayPathEnvInfo } from './editor/displayPath'
 export { hydrateAfterPostMessage } from './editor/hydrateAfterPostMessage'
+export { EmbeddingsDetector } from './embeddings/EmbeddingsDetector'
+export { SourcegraphEmbeddingsSearchClient } from './embeddings/client'
 export { FeatureFlag, FeatureFlagProvider, featureFlagProvider } from './experimentation/FeatureFlagProvider'
 export type { GraphContextFetcher } from './graph-context'
 export { GuardrailsPost, summariseAttribution } from './guardrails'
@@ -121,7 +123,7 @@ export {
     isNetworkError,
     isRateLimitError,
 } from './sourcegraph-api/errors'
-export { SourcegraphGraphQLAPIClient, graphqlClient } from './sourcegraph-api/graphql'
+export { SourcegraphGraphQLAPIClient, graphqlClient, type EmbeddingsSearchResults } from './sourcegraph-api/graphql'
 export {
     ConfigFeaturesSingleton,
     addCustomUserAgent,

--- a/lib/shared/src/sourcegraph-api/graphql/index.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/index.ts
@@ -1,1 +1,2 @@
+export type { EmbeddingsSearchResults } from './client'
 export { SourcegraphGraphQLAPIClient, graphqlClient } from './client'

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -90,6 +90,54 @@ query Repository($name: String!) {
 	}
 }`
 
+export const REPOSITORY_EMBEDDING_EXISTS_QUERY = `
+query Repository($name: String!) {
+	repository(name: $name) {
+                id
+                embeddingExists
+	}
+}`
+
+export const SEARCH_EMBEDDINGS_QUERY = `
+query EmbeddingsSearch($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!) {
+	embeddingsMultiSearch(repos: $repos, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount) {
+		codeResults {
+                        repoName
+                        revision
+			fileName
+			startLine
+			endLine
+			content
+		}
+		textResults {
+                        repoName
+                        revision
+			fileName
+			startLine
+			endLine
+			content
+		}
+	}
+}`
+
+export const LEGACY_SEARCH_EMBEDDINGS_QUERY = `
+query LegacyEmbeddingsSearch($repo: ID!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!) {
+	embeddingsSearch(repo: $repo, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount) {
+		codeResults {
+			fileName
+			startLine
+			endLine
+			content
+		}
+		textResults {
+			fileName
+			startLine
+			endLine
+			content
+		}
+	}
+}`
+
 export const SEARCH_ATTRIBUTION_QUERY = `
 query SnippetAttribution($snippet: String!) {
     snippetAttribution(snippet: $snippet) {

--- a/lib/shared/src/test/mocks.ts
+++ b/lib/shared/src/test/mocks.ts
@@ -8,7 +8,39 @@ import {
     type ActiveTextEditorVisibleContent,
     type Editor,
 } from '../editor'
+import { type EmbeddingsSearch } from '../embeddings'
 import { type IntentClassificationOption, type IntentDetector } from '../intent-detector'
+import { type EmbeddingsSearchResults } from '../sourcegraph-api/graphql'
+
+export class MockEmbeddingsClient implements EmbeddingsSearch {
+    public readonly repoId = 'test-repo-id'
+
+    constructor(private mocks: Partial<EmbeddingsSearch> = {}) {}
+
+    public get endpoint(): string {
+        return this.mocks.endpoint || 'https://host.example:3000'
+    }
+
+    public search(
+        query: string,
+        codeResultsCount: number,
+        textResultsCount: number
+    ): Promise<EmbeddingsSearchResults | Error> {
+        return (
+            this.mocks.search?.(query, codeResultsCount, textResultsCount) ??
+            Promise.resolve({ codeResults: [], textResults: [] })
+        )
+    }
+
+    public onDidChangeStatus(): { dispose: () => void } {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        return { dispose() {} }
+    }
+
+    public get status(): never[] {
+        return []
+    }
+}
 
 export class MockIntentDetector implements IntentDetector {
     constructor(private mocks: Partial<IntentDetector> = {}) {}
@@ -74,6 +106,8 @@ export class MockEditor implements Editor {
         return this.mocks.getTextEditorContentForFile?.(uri, range) ?? Promise.resolve(undefined)
     }
 }
+
+export const defaultEmbeddingsClient = new MockEmbeddingsClient()
 
 export const defaultIntentDetector = new MockIntentDetector()
 

--- a/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
+++ b/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
@@ -1,0 +1,49 @@
+import {
+    SourcegraphGraphQLAPIClient,
+    type EmbeddingsSearchResults,
+    type GraphQLAPIClientConfig,
+} from '@sourcegraph/cody-shared'
+
+export class CachedRemoteEmbeddingsClient {
+    private client: SourcegraphGraphQLAPIClient
+    private repoIdCache: Map<string, string> = new Map()
+
+    constructor(private config: GraphQLAPIClientConfig) {
+        this.client = new SourcegraphGraphQLAPIClient(config)
+    }
+
+    public getEndpoint(): string {
+        return this.config.serverEndpoint
+    }
+
+    public updateConfiguration(newConfig: GraphQLAPIClientConfig): void {
+        this.config = newConfig
+        this.client = new SourcegraphGraphQLAPIClient(newConfig)
+        this.repoIdCache.clear()
+    }
+
+    public async getRepoIdIfEmbeddingExists(codebase: string): Promise<string | Error | null> {
+        const cachedRepoId = this.repoIdCache.get(codebase)
+        if (cachedRepoId) {
+            return cachedRepoId
+        }
+
+        const repoID = await this.client.getRepoIdIfEmbeddingExists(codebase)
+        if (!(repoID instanceof Error) && repoID) {
+            this.repoIdCache.set(codebase, repoID)
+        }
+        return repoID
+    }
+
+    public search(
+        repoIDs: string[],
+        query: string,
+        codeResultsCount: number,
+        textResultsCount: number
+    ): Promise<EmbeddingsSearchResults | Error> {
+        if (repoIDs.length !== 1) {
+            throw new Error('Only one repoID is supported for now')
+        }
+        return this.client.legacySearchEmbeddings(repoIDs[0], query, codeResultsCount, textResultsCount)
+    }
+}

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -21,6 +21,7 @@ import { logDebug, logError } from '../../log'
 import { localStorage } from '../../services/LocalStorageProvider'
 import { telemetryService } from '../../services/telemetry'
 import { telemetryRecorder } from '../../services/telemetry-v2'
+import { type CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 import { type AuthStatus } from '../protocol'
 
 import { ChatPanelsManager } from './ChatPanelsManager'
@@ -46,6 +47,7 @@ export class ChatManager implements vscode.Disposable {
     constructor(
         { extensionUri, ...options }: SidebarViewOptions,
         private chatClient: ChatClient,
+        private embeddingsClient: CachedRemoteEmbeddingsClient,
         private localEmbeddings: LocalEmbeddingsController | null,
         private symf: SymfRunner | null,
         private guardrails: Guardrails,
@@ -63,6 +65,7 @@ export class ChatManager implements vscode.Disposable {
         this.chatPanelsManager = new ChatPanelsManager(
             this.options,
             this.chatClient,
+            this.embeddingsClient,
             this.localEmbeddings,
             this.symf,
             this.guardrails,

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -15,6 +15,7 @@ import { type SymfRunner } from '../../local-context/symf'
 import { logDebug } from '../../log'
 import { createCodyChatTreeItems } from '../../services/treeViewItems'
 import { TreeViewProvider } from '../../services/TreeViewProvider'
+import { type CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 import { type MessageProviderOptions } from '../MessageProvider'
 import { type AuthStatus, type ExtensionMessage } from '../protocol'
 
@@ -62,6 +63,7 @@ export class ChatPanelsManager implements vscode.Disposable {
     constructor(
         { extensionUri, ...options }: SidebarViewOptions,
         private chatClient: ChatClient,
+        private readonly embeddingsClient: CachedRemoteEmbeddingsClient,
         private readonly localEmbeddings: LocalEmbeddingsController | null,
         private readonly symf: SymfRunner | null,
         private readonly guardrails: Guardrails,
@@ -198,6 +200,7 @@ export class ChatPanelsManager implements vscode.Disposable {
             ...this.options,
             config: this.options.contextProvider.config,
             chatClient: this.chatClient,
+            embeddingsClient: this.embeddingsClient,
             localEmbeddings: this.localEmbeddings,
             symf: this.symf,
             models,

--- a/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
+++ b/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
@@ -1,13 +1,21 @@
+import { isEqual } from 'lodash'
 import * as vscode from 'vscode'
 
 import {
+    isDotCom,
+    isError,
     type ContextGroup,
     type ContextProvider,
     type ContextStatusProvider,
     type Disposable,
+    type Editor,
 } from '@sourcegraph/cody-shared'
 
+import { getConfiguration } from '../../configuration'
+import { getEditor } from '../../editor/active-editor'
 import { type SymfRunner } from '../../local-context/symf'
+import { getCodebaseFromWorkspaceUri } from '../../repository/repositoryHelpers'
+import { type CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 
 interface CodebaseIdentifiers {
     local: string
@@ -30,7 +38,11 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
     // undefined means symf is not active or there is no current codebase
     private symfIndexStatus?: 'unindexed' | 'indexing' | 'ready' | 'failed'
 
-    constructor(private readonly symf: SymfRunner | null) {
+    constructor(
+        private readonly editor: Editor,
+        private readonly embeddingsClient: CachedRemoteEmbeddingsClient,
+        private readonly symf: SymfRunner | null
+    ) {
         this.disposables.push(
             vscode.window.onDidChangeActiveTextEditor(() => this.updateStatus()),
             vscode.workspace.onDidChangeWorkspaceFolders(() => this.updateStatus()),
@@ -77,6 +89,7 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
         }
 
         const providers: ContextProvider[] = []
+        providers.push(...this.getRemoteEmbeddingsStatus())
         providers.push(...this.getSymfIndexStatus())
 
         if (providers.length === 0) {
@@ -103,6 +116,38 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
         ]
     }
 
+    private getRemoteEmbeddingsStatus(): ContextProvider[] {
+        const codebase = this._currentCodebase
+        if (!codebase) {
+            return []
+        }
+        if (codebase?.remote && codebase?.remoteRepoId) {
+            return [
+                {
+                    kind: 'embeddings',
+                    type: 'remote',
+                    state: 'ready',
+                    origin: this.embeddingsClient.getEndpoint(),
+                    remoteName: codebase.remote,
+                },
+            ]
+        }
+        if (!codebase?.remote || isDotCom(this.embeddingsClient.getEndpoint())) {
+            // Dotcom users or no remote codebase name: remote embeddings omitted from context
+            return []
+        }
+        // Enterprise users where no repo ID is found for the desired remote codebase name: no-match context group
+        return [
+            {
+                kind: 'embeddings',
+                type: 'remote',
+                state: 'no-match',
+                origin: this.embeddingsClient.getEndpoint(),
+                remoteName: codebase.remote,
+            },
+        ]
+    }
+
     public async currentCodebase(): Promise<CodebaseIdentifiers | null> {
         if (this._currentCodebase === undefined) {
             // lazy initialization
@@ -112,10 +157,45 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
     }
 
     private async updateStatus(): Promise<void> {
+        const didCodebaseChange = await this._updateCodebase_NoFire()
         const didSymfStatusChange = await this._updateSymfStatus_NoFire()
-        if (didSymfStatusChange) {
+        if (didCodebaseChange || didSymfStatusChange) {
             this.eventEmitter.fire(this)
         }
+    }
+
+    private async _updateCodebase_NoFire(): Promise<boolean> {
+        const workspaceRoot = this.editor.getWorkspaceRootUri()
+        const config = getConfiguration()
+        if (
+            this._currentCodebase !== undefined &&
+            workspaceRoot?.fsPath === this._currentCodebase?.local &&
+            config.codebase === this._currentCodebase?.setting &&
+            this._currentCodebase?.remoteRepoId
+        ) {
+            // do nothing if local codebase identifier is unchanged and we have a remote repo ID
+            return false
+        }
+
+        let newCodebase: CodebaseIdentifiers | null = null
+        if (workspaceRoot) {
+            newCodebase = { local: workspaceRoot.fsPath, setting: config.codebase }
+            const currentFile = getEditor()?.active?.document?.uri
+            // Get codebase from config or fallback to getting codebase name from current file URL
+            // Always use the codebase from config as this is manually set by the user
+            newCodebase.remote =
+                config.codebase || (currentFile ? getCodebaseFromWorkspaceUri(currentFile) : config.codebase)
+            if (newCodebase.remote) {
+                const repoId = await this.embeddingsClient.getRepoIdIfEmbeddingExists(newCodebase.remote)
+                if (!isError(repoId)) {
+                    newCodebase.remoteRepoId = repoId ?? undefined
+                }
+            }
+        }
+
+        const didCodebaseChange = !isEqual(this._currentCodebase, newCodebase)
+        this._currentCodebase = newCodebase
+        return didCodebaseChange
     }
 
     private async _updateSymfStatus_NoFire(): Promise<boolean> {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -63,6 +63,7 @@ import {
 } from '../../services/utils/codeblock-action-tracker'
 import { openExternalLinks, openLocalFileWithRange } from '../../services/utils/workspace-action'
 import { TestSupport } from '../../test-support'
+import { type CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 import { type MessageErrorType } from '../MessageProvider'
 import {
     type AuthStatus,
@@ -87,6 +88,7 @@ interface SimpleChatPanelProviderOptions {
     extensionUri: vscode.Uri
     authProvider: AuthProvider
     chatClient: ChatClient
+    embeddingsClient: CachedRemoteEmbeddingsClient
     localEmbeddings: LocalEmbeddingsController | null
     symf: SymfRunner | null
     editor: VSCodeEditor
@@ -121,6 +123,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private config: Config
     private readonly authProvider: AuthProvider
     private readonly chatClient: ChatClient
+    private readonly embeddingsClient: CachedRemoteEmbeddingsClient
     private readonly codebaseStatusProvider: CodebaseStatusProvider
     private readonly localEmbeddings: LocalEmbeddingsController | null
     private readonly symf: SymfRunner | null
@@ -147,6 +150,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         featureFlagProvider,
         authProvider,
         chatClient,
+        embeddingsClient,
         localEmbeddings,
         symf,
         editor,
@@ -160,6 +164,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         this.featureFlagProvider = featureFlagProvider
         this.authProvider = authProvider
         this.chatClient = chatClient
+        this.embeddingsClient = embeddingsClient
         this.localEmbeddings = localEmbeddings
         this.symf = symf
         this.commandsController = commandsController
@@ -184,7 +189,11 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         if (this.localEmbeddings) {
             this.disposables.push(this.contextStatusAggregator.addProvider(this.localEmbeddings))
         }
-        this.codebaseStatusProvider = new CodebaseStatusProvider(this.config.experimentalSymfContext ? this.symf : null)
+        this.codebaseStatusProvider = new CodebaseStatusProvider(
+            this.editor,
+            embeddingsClient,
+            this.config.experimentalSymfContext ? this.symf : null
+        )
         this.disposables.push(this.contextStatusAggregator.addProvider(this.codebaseStatusProvider))
     }
 
@@ -740,8 +749,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             const contextProvider = new ContextProvider(
                 userContextItems,
                 this.editor,
+                this.embeddingsClient,
                 this.localEmbeddings,
-                this.config.experimentalSymfContext ? this.symf : null
+                this.config.experimentalSymfContext ? this.symf : null,
+                this.codebaseStatusProvider
             )
             const { prompt, contextLimitWarnings, newContextUsed } = await this.prompter.makePrompt(
                 this.chatModel,
@@ -1071,8 +1082,10 @@ class ContextProvider implements IContextProvider {
     constructor(
         private userContext: ContextItem[],
         private editor: VSCodeEditor,
+        private embeddingsClient: CachedRemoteEmbeddingsClient | null,
         private localEmbeddings: LocalEmbeddingsController | null,
-        private symf: SymfRunner | null
+        private symf: SymfRunner | null,
+        private codebaseStatusProvider: CodebaseStatusProvider
     ) {}
 
     public getExplicitContext(): ContextItem[] {
@@ -1170,12 +1183,20 @@ class ContextProvider implements IContextProvider {
         if (useContextConfig !== 'keyword') {
             logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (start)')
             const localEmbeddingsResults = this.searchEmbeddingsLocal(text)
+            const remoteEmbeddingsResults = this.searchEmbeddingsRemote(text)
             try {
                 const r = await localEmbeddingsResults
                 hasEmbeddingsContext = hasEmbeddingsContext || r.length > 0
                 searchContext.push(...r)
             } catch (error) {
                 logDebug('SimpleChatPanelProvider', 'getEnhancedContext > local embeddings', error)
+            }
+            try {
+                const r = await remoteEmbeddingsResults
+                hasEmbeddingsContext = hasEmbeddingsContext || r.length > 0
+                searchContext.push(...r)
+            } catch (error) {
+                logDebug('SimpleChatPanelProvider', 'getEnhancedContext > remote embeddings', error)
             }
             logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (end)')
         }
@@ -1329,6 +1350,72 @@ class ContextProvider implements IContextProvider {
                 })
             }
         }
+        return contextItems
+    }
+
+    // Note: does not throw error if remote embeddings are not available, just returns empty array
+    private async searchEmbeddingsRemote(text: string): Promise<ContextItem[]> {
+        if (!this.embeddingsClient) {
+            return []
+        }
+        const codebase = await this.codebaseStatusProvider?.currentCodebase()
+        if (!codebase?.remote) {
+            return []
+        }
+        const repoId = await this.embeddingsClient.getRepoIdIfEmbeddingExists(codebase.remote)
+        if (isError(repoId)) {
+            throw new Error(`Error retrieving repo ID: ${repoId}`)
+        } else if (!repoId) {
+            return []
+        }
+
+        const workspaceFolder = vscode.workspace.workspaceFolders?.at(0)
+        if (!workspaceFolder) {
+            return []
+        }
+
+        logDebug('SimpleChatPanelProvider', 'getEnhancedContext > searching remote embeddings')
+        const contextItems: ContextItem[] = []
+        const embeddings = await this.embeddingsClient.search([repoId], text, NUM_CODE_RESULTS, NUM_TEXT_RESULTS)
+        if (isError(embeddings)) {
+            throw new Error(`Error retrieving embeddings: ${embeddings}`)
+        }
+        for (const codeResult of embeddings.codeResults) {
+            // TODO(sqs): this is broken for multi-root workspaces because it assumes that the file
+            // exists in the first workspaceFolder and that the file still exists.
+            const uri = vscode.Uri.joinPath(workspaceFolder.uri, codeResult.fileName)
+            const range = new vscode.Range(
+                new vscode.Position(codeResult.startLine, 0),
+                new vscode.Position(codeResult.endLine, 0)
+            )
+            if (!isCodyIgnoredFile(uri)) {
+                contextItems.push({
+                    uri,
+                    range,
+                    text: codeResult.content,
+                    source: 'embeddings',
+                })
+            }
+        }
+
+        for (const textResult of embeddings.textResults) {
+            // TODO(sqs): this is broken for multi-root workspaces because it assumes that the file
+            // exists in the first workspaceFolder and that the file still exists.
+            const uri = vscode.Uri.joinPath(workspaceFolder.uri, textResult.fileName)
+            const range = new vscode.Range(
+                new vscode.Position(textResult.startLine, 0),
+                new vscode.Position(textResult.endLine, 0)
+            )
+            if (!isCodyIgnoredFile(uri)) {
+                contextItems.push({
+                    uri,
+                    range,
+                    text: textResult.content,
+                    source: 'embeddings',
+                })
+            }
+        }
+
         return contextItems
     }
 

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -5,6 +5,7 @@ import {
     CodebaseContext,
     graphqlClient,
     isError,
+    SourcegraphEmbeddingsSearchClient,
     SourcegraphGuardrailsClient,
     SourcegraphIntentDetectorClient,
     type ConfigurationWithAccessToken,
@@ -80,6 +81,10 @@ export async function configureExternalServices(
                 'Please check that the repository exists. You can override the repository with the "cody.codebase" setting.'
         )
     }
+    const embeddingsSearch =
+        repoId && !isError(repoId)
+            ? new SourcegraphEmbeddingsSearchClient(graphqlClient, initialConfig.codebase || repoId, repoId)
+            : null
 
     const localEmbeddings = platform.createLocalEmbeddingsController?.(initialConfig)
 
@@ -88,6 +93,7 @@ export async function configureExternalServices(
         initialConfig,
         initialConfig.codebase,
         () => initialConfig.serverEndpoint,
+        embeddingsSearch,
         rgPath ? platform.createFilenameContextFetcher?.(rgPath, editor, chatClient) ?? null : null,
         null,
         symfRunner,

--- a/vscode/src/local-context/enhanced-context-status.test.ts
+++ b/vscode/src/local-context/enhanced-context-status.test.ts
@@ -38,11 +38,11 @@ class TestProvider implements status.ContextStatusProvider {
 describe('ContextStatusAggregator', () => {
     it('should fire status changed when providers are added and pass through simple status', async () => {
         const aggregator = new ContextStatusAggregator()
-        const promise = new Promise<status.ContextGroup[]>(resolve => {
+        const promise = new Promise(resolve => {
             aggregator.onDidChangeStatus(provider => resolve(provider.status))
         })
         aggregator.addProvider(new TestProvider())
-        expect(await promise).toEqual<status.ContextGroup[]>([
+        expect(await promise).toEqual([
             {
                 name: 'github.com/foo/bar',
                 providers: [
@@ -59,7 +59,7 @@ describe('ContextStatusAggregator', () => {
     it('should fire aggregate status from multiple providers', async () => {
         const aggregator = new ContextStatusAggregator()
         let callbackCount = 0
-        const promise = new Promise<status.ContextGroup[]>(resolve => {
+        const promise = new Promise(resolve => {
             aggregator.onDidChangeStatus(provider => {
                 callbackCount++
                 resolve(provider.status)
@@ -77,14 +77,16 @@ describe('ContextStatusAggregator', () => {
                     providers: [
                         {
                             kind: 'embeddings',
-                            type: 'local',
+                            type: 'remote',
                             state: 'ready',
+                            origin: 'sourcegraph.com',
+                            remoteName: 'github.com/foo/bar',
                         },
                     ],
                 },
             ])
         )
-        expect(await promise).toEqual<status.ContextGroup[]>([
+        expect(await promise).toEqual([
             {
                 name: 'github.com/foo/bar',
                 providers: [
@@ -95,8 +97,10 @@ describe('ContextStatusAggregator', () => {
                     },
                     {
                         kind: 'embeddings',
-                        type: 'local',
+                        type: 'remote',
                         state: 'ready',
+                        origin: 'sourcegraph.com',
+                        remoteName: 'github.com/foo/bar',
                     },
                 ],
             },
@@ -116,7 +120,7 @@ describe('ContextStatusAggregator', () => {
         // Skip the first update event.
         await Promise.resolve()
         let callbackCount = 0
-        const promise = new Promise<status.ContextGroup[]>(resolve => {
+        const promise = new Promise(resolve => {
             aggregator.onDidChangeStatus(provider => {
                 callbackCount++
                 resolve(provider.status)
@@ -125,7 +129,7 @@ describe('ContextStatusAggregator', () => {
         provider.status = [{ name: 'github.com/foo/bar', providers: [{ kind: 'graph', state: 'indexing' }] }]
         provider.emitter.fire(provider)
 
-        expect(await promise).toEqual<status.ContextGroup[]>([
+        expect(await promise).toEqual([
             {
                 name: 'github.com/foo/bar',
                 providers: [

--- a/vscode/src/local-context/enhanced-context-status.ts
+++ b/vscode/src/local-context/enhanced-context-status.ts
@@ -145,6 +145,7 @@ export class ContextStatusAggregator implements vscode.Disposable, ContextStatus
 
     // TODO: Create a publisher to push into the webview
     // TODO: Hook in local embeddings
+    // TODO: Hook in cloud embeddings
     // TODO: Hook in symf
     // TODO: Hook in graph
     // TODO: Hook in the Cody: building code index ... notification pusher's

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -35,8 +35,10 @@ interface SingleTileArgs {
     isOpen: boolean
     name: string
     kind: 'embeddings' | 'graph' | 'search'
-    type: 'local'
+    type: 'local' | 'remote'
     state: 'indeterminate' | 'unconsented' | 'indexing' | 'ready' | 'no-match'
+    origin: string
+    remoteName: string
 }
 
 export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArgs> = {
@@ -44,8 +46,10 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
         isOpen: true,
         name: '~/sourcegraph',
         kind: 'embeddings',
-        type: 'local',
+        type: 'remote',
         state: 'ready',
+        origin: 'https://sourcegraph.com',
+        remoteName: 'github.com/sourcegraph/sourcegraph',
     },
     argTypes: {
         isOpen: { control: 'boolean' },
@@ -55,7 +59,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
             control: 'select',
         },
         type: {
-            options: ['local'],
+            options: ['local', 'remote'],
             control: 'select',
             if: {
                 arg: 'kind',
@@ -66,6 +70,8 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
             options: ['indeterminate', 'unconsented', 'indexing', 'ready', 'no-match'],
             control: 'select',
         },
+        origin: { control: 'text' },
+        remoteName: { control: 'text' },
     },
     render: function Render() {
         const [args, updateArgs] = useArgs<SingleTileArgs>()
@@ -95,6 +101,8 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
                                     kind: args.kind,
                                     type: args.type,
                                     state: args.state,
+                                    origin: args.origin,
+                                    remoteName: args.remoteName,
                                 } as ContextProvider,
                             ],
                         },
@@ -137,7 +145,9 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                             providers: [
                                 {
                                     kind: 'embeddings',
-                                    type: 'local',
+                                    type: 'remote',
+                                    remoteName: 'gitlab.com/my/repo',
+                                    origin: 'sourcegraph.com',
                                     state: 'ready',
                                 },
                             ],
@@ -147,7 +157,9 @@ export const Smorgasbord: StoryObj<typeof EnhancedContextSettings> = {
                             providers: [
                                 {
                                     kind: 'embeddings',
-                                    type: 'local',
+                                    type: 'remote',
+                                    remoteName: 'github.com/sourcegraph/bar',
+                                    origin: 'sourcegraph.sourcegraph.com',
                                     state: 'no-match',
                                 },
                             ],

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -150,6 +150,13 @@ function contextProviderState(provider: ContextProvider): React.ReactNode {
         case 'indeterminate':
             return <></>
         case 'ready':
+            if (provider.kind === 'embeddings' && provider.type === 'remote') {
+                return (
+                    <p className={classNames(styles.providerExplanatoryText, styles.lineBreakAll)}>
+                        Inherited {provider.remoteName}
+                    </p>
+                )
+            }
             return <span className={styles.providerInlineState}>&mdash; Indexed</span>
         case 'indexing':
             return <span className={styles.providerInlineState}>&mdash; Indexing&hellip;</span>
@@ -157,6 +164,13 @@ function contextProviderState(provider: ContextProvider): React.ReactNode {
             return <EmbeddingsConsentComponent provider={provider} />
         case 'no-match':
             if (provider.kind === 'embeddings') {
+                if (provider.type === 'remote') {
+                    return (
+                        <p className={styles.providerExplanatoryText}>
+                            No repository matching {provider.remoteName} on {provider.origin}
+                        </p>
+                    )
+                }
                 // Error messages for local embeddings missing.
                 switch (provider.errorReason) {
                     case 'not-a-git-repo':


### PR DESCRIPTION
This reverts commit 160553231db1da8e8a85d9841507d309cf96da2d.

This is so the product remains releasable for customers using remote embeddings until we get the new context sources implemented (https://docs.google.com/document/d/1t3-NrlgYd1tdgbabN3YoPpumuP0WpFeOTp_B1C14Rnw/edit#heading=h.9ebsu4sgujtv) for Feb 15.



## Test plan

CI