### PR TITLE
never use remote embeddings for dotcom/PLG users

### DIFF
--- a/lib/shared/src/codebase-context/index.ts
+++ b/lib/shared/src/codebase-context/index.ts
@@ -85,12 +85,13 @@ export class CodebaseContext {
         query: string,
         options: ContextSearchOptions
     ): Promise<EmbeddingsSearchResult[]> {
-        if (isDotCom(this.getServerEndpoint()) && this.localEmbeddings) {
-            // TODO(dpc): Check whether the local embeddings index exists for
-            // this repo before relying on it.
-            // TODO(dpc): Fetch code and text results.
-            return this.localEmbeddings.getContext(query, options.numCodeResults)
+        // For dotcom users, only use local embeddings. The remote embeddings impl remains for
+        // enterprise users below until it can be replaced by context search, but not for dotcom
+        // users as they have a better replacement already (local embeddings).
+        if (isDotCom(this.getServerEndpoint())) {
+            return this.localEmbeddings?.getContext(query, options.numCodeResults) ?? []
         }
+
         if (this.embeddings) {
             const embeddingsSearchResults = await this.embeddings.search(
                 query,


### PR DESCRIPTION
This makes the current state match the Feb 15 state more closely, so we can dogfood it better and our non-enterprise users experience the Feb 15 experience (symf + local embeddings, no remote embeddings) sooner. Enterprise users still get remote embeddings when available.



## Test plan

CI