### PR TITLE
Agent: always disable local embeddings

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -256,7 +256,6 @@ export class TestClient extends MessageHandler {
             env: {
                 CODY_SHIM_TESTING: 'true',
                 CODY_TEMPERATURE_ZERO: 'true',
-                CODY_LOCAL_EMBEDDINGS_DISABLED: 'true',
                 CODY_RECORDING_MODE: 'replay', // can be overwritten with process.env.CODY_RECORDING_MODE
                 CODY_RECORDING_DIRECTORY: recordingDirectory,
                 CODY_RECORDING_NAME: this.name,

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -1,4 +1,4 @@
-import type * as vscode from 'vscode'
+import * as vscode from 'vscode'
 
 // eslint-disable-next-line no-restricted-imports
 import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
@@ -26,14 +26,12 @@ import { NodeSentryService } from './services/sentry/sentry.node'
 export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi> {
     initializeNetworkAgent()
 
-    // NOTE: local embeddings were causing flaky test failures in CI due to
-    // failures around downloading the cody-engine binary. The root problem
-    // seems caused by the fact that we don't handle the error case when failing
-    // to download the binary, which caused the entire agent Node process to
-    // exit and fail the tests. For now, we have disabled local embeddings like
-    // this to unblock further progress. Tracked here
-    // https://github.com/sourcegraph/jetbrains/issues/270
-    const isLocalEmbeddingsDisabled = process.env.CODY_LOCAL_EMBEDDINGS_DISABLED === 'true'
+    // NOTE: local embeddings are only going to be supported in VSC for now.
+    // Until we revisit this decision, we disable local embeddings for all agent
+    // clients like the JetBrains plugin.
+    const isLocalEmbeddingsDisabled = vscode.workspace
+        .getConfiguration()
+        .get<boolean>('cody.advanced.agent.running', false)
 
     return activateCommon(context, {
         getRgPath,


### PR DESCRIPTION
Previously, local embeddings were enabled for agent clients. We had disabled local embeddings in the tests through an environment variable because they were causing stability issues, but clients like the JetBrains plugin were not setting this environment variable. This PR fixes the problem so that local embeddings are always disabled for all agent clients.


## Test plan

Our tests are already running in this environment.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
