### PR TITLE
Agent: support `new vscode.Selection(number,number,number,number)`

### DIFF
--- a/vscode/src/testutils/mocks.test.ts
+++ b/vscode/src/testutils/mocks.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { Position, Range, Selection } from './mocks'
+
+describe('VS Code Mocks', () => {
+    describe('Range', () => {
+        it('constructor(Position,Position)', () => {
+            const start = new Position(1, 2)
+            const end = new Position(2, 3)
+            const selection = new Range(start, end)
+            expect(selection.start).toStrictEqual(start)
+            expect(selection.end).toStrictEqual(end)
+        })
+
+        it('constructor(number,number)', () => {
+            const selection = new Selection(1, 2, 3, 4)
+            expect(selection.start.line).toStrictEqual(1)
+            expect(selection.start.character).toStrictEqual(2)
+            expect(selection.end.line).toStrictEqual(3)
+            expect(selection.end.character).toStrictEqual(4)
+        })
+    })
+    describe('Selection', () => {
+        it('constructor(Position,Position)', () => {
+            const anchor = new Position(1, 2)
+            const active = new Position(2, 3)
+            const selection = new Selection(anchor, active)
+            expect(selection.anchor).toStrictEqual(anchor)
+            expect(selection.start).toStrictEqual(selection.anchor)
+            expect(selection.active).toStrictEqual(active)
+            expect(selection.end).toStrictEqual(selection.active)
+        })
+        it('constructor(number,number)', () => {
+            const selection = new Selection(1, 2, 3, 4)
+            expect(selection.start.line).toStrictEqual(1)
+            expect(selection.start.character).toStrictEqual(2)
+            expect(selection.end.line).toStrictEqual(3)
+            expect(selection.end.character).toStrictEqual(4)
+        })
+    })
+})

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -368,11 +368,28 @@ export class Range implements VSCodeRange {
 }
 
 export class Selection extends Range {
+    public readonly anchor: Position
+    public readonly active: Position
     constructor(
-        public readonly anchor: Position,
-        public readonly active: Position
+        anchorLine: number | Position,
+        anchorCharacter: number | Position,
+        activeLine?: number,
+        activeCharacter?: number
     ) {
-        super(anchor, active)
+        if (
+            typeof anchorLine === 'number' &&
+            typeof anchorCharacter === 'number' &&
+            typeof activeLine === 'number' &&
+            typeof activeCharacter === 'number'
+        ) {
+            super(anchorLine, anchorCharacter, activeLine, activeCharacter)
+        } else if (typeof anchorLine === 'object' && typeof anchorCharacter === 'object') {
+            super(anchorLine, anchorCharacter)
+        } else {
+            throw new TypeError('this version of the constructor is not implemented')
+        }
+        this.anchor = this.start
+        this.active = this.end
     }
 
     /**


### PR DESCRIPTION
Previously, local embeddings were enabled for agent clients. We had disabled local embeddings in the tests through an environment variable because they were causing stability issues, but clients like the JetBrains plugin were not setting this environment variable. This PR fixes the problem so that local embeddings are always disabled for all agent clients.


## Test plan
See new tests
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
