### PR TITLE
Cleanup: Put "is enhanced context enabled" in one place instead of passing it around

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -66,7 +66,6 @@ interface ChatProps extends ChatClassNames {
     UserContextSelectorComponent?: React.FunctionComponent<UserContextSelectorProps>
     chatModels?: ChatModelProvider[]
     EnhancedContextSettings?: React.FunctionComponent<{ isOpen: boolean; setOpen: (open: boolean) => void }>
-    isEnhancedContextEnabled: boolean
     ChatModelDropdownMenu?: React.FunctionComponent<ChatModelDropdownMenuProps>
     onCurrentChatModelChange?: (model: ChatModelProvider) => void
     userInfo: UserAccountInfo
@@ -224,7 +223,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     chatModels,
     ChatModelDropdownMenu,
     EnhancedContextSettings,
-    isEnhancedContextEnabled,
     chatEnabled,
     onCurrentChatModelChange,
     userInfo,
@@ -583,7 +581,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     userInfo={userInfo}
                     postMessage={postMessage}
                     guardrails={guardrails}
-                    isEnhancedContextEnabled={isEnhancedContextEnabled}
                 />
             )}
 

--- a/lib/ui/src/chat/BlinkingCursor.tsx
+++ b/lib/ui/src/chat/BlinkingCursor.tsx
@@ -1,17 +1,20 @@
 import React from 'react'
 
+import { useEnhancedContextEnabled } from './components/EnhancedContext'
+
 import styles from './BlinkingCursor.module.css'
 
 export const BlinkingCursor: React.FunctionComponent = () => <span className={styles.cursor} />
 
-export const LoadingContext: React.FunctionComponent<{ isEnhancedContextEnabled: boolean }> = ({
-    isEnhancedContextEnabled,
-}) => (
-    <div className={styles.loadingContainer}>
-        {isEnhancedContextEnabled ? '✨' : ''}
-        <LoadingDots />
-    </div>
-)
+export const LoadingContext: React.FunctionComponent<{}> = () => {
+    const isEnhancedContextEnabled = useEnhancedContextEnabled()
+    return (
+        <div className={styles.loadingContainer}>
+            {isEnhancedContextEnabled ? '✨' : ''}
+            <LoadingDots />
+        </div>
+    )
+}
 
 const LoadingDots: React.FunctionComponent = () => (
     <div className={styles.dotsHolder}>

--- a/lib/ui/src/chat/Transcript.tsx
+++ b/lib/ui/src/chat/Transcript.tsx
@@ -47,7 +47,6 @@ export const Transcript: React.FunctionComponent<
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails
-        isEnhancedContextEnabled: boolean
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptContent({
     transcript,
@@ -80,7 +79,6 @@ export const Transcript: React.FunctionComponent<
     userInfo,
     postMessage,
     guardrails,
-    isEnhancedContextEnabled,
 }) {
     // Scroll the last human message to the top whenever a new human message is received as input.
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
@@ -187,7 +185,6 @@ export const Transcript: React.FunctionComponent<
                     userInfo={userInfo}
                     postMessage={postMessage}
                     guardrails={guardrails}
-                    isEnhancedContextEnabled={isEnhancedContextEnabled}
                 />
             )
         }
@@ -232,7 +229,6 @@ export const Transcript: React.FunctionComponent<
                         ChatButtonComponent={ChatButtonComponent}
                         postMessage={postMessage}
                         userInfo={userInfo}
-                        isEnhancedContextEnabled={isEnhancedContextEnabled}
                     />
                 )}
                 {messageInProgress && messageInProgress.speaker === 'assistant' && (

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -63,7 +63,6 @@ export const TranscriptItem: React.FunctionComponent<
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails
-        isEnhancedContextEnabled: boolean
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptItemContent({
     message,
@@ -93,7 +92,6 @@ export const TranscriptItem: React.FunctionComponent<
     userInfo,
     postMessage,
     guardrails,
-    isEnhancedContextEnabled,
 }) {
     const [formInput, setFormInput] = useState<string>(message.displayText ?? '')
     const EditTextArea =
@@ -208,7 +206,7 @@ export const TranscriptItem: React.FunctionComponent<
                             className={transcriptActionClassName}
                         />
                     ) : (
-                        inProgress && <LoadingContext isEnhancedContextEnabled={isEnhancedContextEnabled} />
+                        inProgress && <LoadingContext />
                     )}
                 </div>
             )}

--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -6,6 +6,12 @@ import { type ActiveTextEditorSelectionRange, type ContextFile } from '@sourcegr
 
 import { TranscriptAction } from '../actions/TranscriptAction'
 
+export const EnhancedContextEnabled: React.Context<boolean> = React.createContext(true)
+
+export function useEnhancedContextEnabled(): boolean {
+    return React.useContext(EnhancedContextEnabled)
+}
+
 export interface FileLinkProps {
     uri: URI
     repoName?: string

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -13,16 +13,13 @@ import {
     type EnhancedContextContextT,
 } from '@sourcegraph/cody-shared'
 import { type UserAccountInfo } from '@sourcegraph/cody-ui/src/Chat'
+import { EnhancedContextEnabled } from '@sourcegraph/cody-ui/src/chat/components/EnhancedContext'
 
 import { type AuthMethod, type AuthStatus, type LocalEnv } from '../src/chat/protocol'
 import { trailingNonAlphaNumericRegex } from '../src/commands/prompt/utils'
 
 import { Chat } from './Chat'
-import {
-    EnhancedContextContext,
-    EnhancedContextEnabled,
-    EnhancedContextEventHandlers,
-} from './Components/EnhancedContextSettings'
+import { EnhancedContextContext, EnhancedContextEventHandlers } from './Components/EnhancedContextSettings'
 import { LoadingPage } from './LoadingPage'
 import { type View } from './NavBar'
 import { Notices } from './Notices'

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -23,12 +23,13 @@ import {
     type UserAccountInfo,
 } from '@sourcegraph/cody-ui/src/Chat'
 import { type CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
+import { useEnhancedContextEnabled } from '@sourcegraph/cody-ui/src/chat/components/EnhancedContext'
 
 import { CODY_FEEDBACK_URL } from '../src/chat/protocol'
 
 import { ChatCommandsComponent } from './ChatCommands'
 import { ChatModelDropdownMenu } from './Components/ChatModelDropdownMenu'
-import { EnhancedContextSettings, useEnhancedContextEnabled } from './Components/EnhancedContextSettings'
+import { EnhancedContextSettings } from './Components/EnhancedContextSettings'
 import { FileLink } from './Components/FileLink'
 import { SymbolLink } from './SymbolLink'
 import { UserContextSelectorComponent } from './UserContextSelector'
@@ -231,7 +232,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             userInfo={userInfo}
             chatEnabled={chatEnabled}
             EnhancedContextSettings={enableNewChatUI ? EnhancedContextSettings : undefined}
-            isEnhancedContextEnabled={addEnhancedContext}
             postMessage={msg => vscodeAPI.postMessage(msg)}
             guardrails={guardrails}
         />

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -10,6 +10,7 @@ import {
     type LocalEmbeddingsProvider,
     type SearchProvider,
 } from '@sourcegraph/cody-shared'
+import { useEnhancedContextEnabled } from '@sourcegraph/cody-ui/src/chat/components/EnhancedContext'
 
 import { PopupFrame } from '../Popups/Popup'
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -32,8 +33,6 @@ export const EnhancedContextContext: React.Context<EnhancedContextContextT> = Re
     defaultEnhancedContextContext()
 )
 
-export const EnhancedContextEnabled: React.Context<boolean> = React.createContext(true)
-
 export const EnhancedContextEventHandlers: React.Context<EnhancedContextEventHandlersT> = React.createContext({
     onConsentToEmbeddings: (_): void => {},
     onEnabledChange: (_): void => {},
@@ -48,10 +47,6 @@ export interface EnhancedContextEventHandlersT {
 
 function useEnhancedContextContext(): EnhancedContextContextT {
     return React.useContext(EnhancedContextContext)
-}
-
-export function useEnhancedContextEnabled(): boolean {
-    return React.useContext(EnhancedContextEnabled)
 }
 
 function useEnhancedContextEventHandlers(): EnhancedContextEventHandlersT {


### PR DESCRIPTION
We're using React context for enhanced context settings instead of passing it around. This is more succinct and obviously consistent because the context is provided in far fewer places (specifically, one place) than it would be if it were passed around.

Moves the definition of the context into lib/ui so it is accessible from the lib/ui loading indicator, and cleans up passing the value around in some places and using context in others.

## Test plan

CI, this is not a functional change.