### PR TITLE
Proto - attribution can be enabled via site config in VSCODE

### DIFF
--- a/lib/shared/src/guardrails/client.ts
+++ b/lib/shared/src/guardrails/client.ts
@@ -1,4 +1,5 @@
 import { type SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql'
+import { ConfigFeaturesSingleton } from '../sourcegraph-api/graphql/client'
 import { isError } from '../utils'
 
 import { type Attribution, type Guardrails } from '.'
@@ -7,6 +8,11 @@ export class SourcegraphGuardrailsClient implements Guardrails {
     constructor(private client: SourcegraphGraphQLAPIClient) {}
 
     public async searchAttribution(snippet: string): Promise<Attribution | Error> {
+        // Short-circuit attribution search if turned off in site config.
+        const configFeatures = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
+        if (!configFeatures.attribution) {
+            return new Error('Attribution search is turned off.')
+        }
         const result = await this.client.searchAttribution(snippet)
 
         if (isError(result)) {

--- a/lib/shared/src/guardrails/index.ts
+++ b/lib/shared/src/guardrails/index.ts
@@ -1,4 +1,5 @@
 import { pluralize } from '../common'
+import { ConfigFeaturesSingleton } from '../sourcegraph-api/graphql/client'
 import { isError } from '../utils'
 
 export interface Attribution {
@@ -22,7 +23,7 @@ export class GuardrailsPost implements Guardrails {
     private currentRequests: Map<string, AttributionSearchSync> = new Map()
     constructor(private postSnippet: (txt: string) => void) {}
 
-    public searchAttribution(snippet: string): Promise<Attribution> {
+    public async searchAttribution(snippet: string): Promise<Attribution> {
         let request = this.currentRequests.get(snippet)
         if (request === undefined) {
             request = new AttributionSearchSync()

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -81,6 +81,7 @@ interface CodyConfigFeatures {
     chat: boolean
     autoComplete: boolean
     commands: boolean
+    attribution: boolean
 }
 
 interface CodyConfigFeaturesResponse {
@@ -339,20 +340,18 @@ export class SourcegraphGraphQLAPIClient {
     /**
      * Fetches the Site Admin enabled/disable Cody config features for the current instance.
      */
-    public async getCodyConfigFeatures(): Promise<
-        | {
-              chat: boolean
-              autoComplete: boolean
-              commands: boolean
-          }
-        | Error
-    > {
-        return this.fetchSourcegraphAPI<APIResponse<CodyConfigFeaturesResponse>>(
+    public async getCodyConfigFeatures(): Promise<CodyConfigFeatures | Error> {
+        const response = await this.fetchSourcegraphAPI<APIResponse<CodyConfigFeaturesResponse>>(
             CURRENT_SITE_CODY_CONFIG_FEATURES,
             {}
-        ).then(response =>
-            extractDataOrError(response, data => data.site?.codyConfigFeatures ?? new Error('cody config not found'))
         )
+        console.log('CONFIG FEATURES', response)
+        const result = extractDataOrError(
+            response,
+            data => data.site?.codyConfigFeatures ?? new Error('cody config not found')
+        )
+        console.log('RESULT', result)
+        return result
     }
 
     public async getCodyLLMConfiguration(): Promise<undefined | CodyLLMSiteConfiguration | Error> {
@@ -636,6 +635,7 @@ export class SourcegraphGraphQLAPIClient {
         const queryName = query.match(QUERY_TO_NAME_REGEXP)?.[1]
 
         const url = buildGraphQLUrl({ request: query, baseUrl: this.config.serverEndpoint })
+        console.log('GRAPHQL SERVER ENDPOINT', url)
         return wrapInActiveSpan(`graphql.fetch${queryName ? `.${queryName}` : ''}`, () =>
             fetch(url, {
                 method: 'POST',
@@ -702,11 +702,7 @@ export const graphqlClient = new SourcegraphGraphQLAPIClient()
  */
 export class ConfigFeaturesSingleton {
     private static instance: ConfigFeaturesSingleton
-    private configFeatures: Promise<{
-        chat: boolean
-        autoComplete: boolean
-        commands: boolean
-    }>
+    private configFeatures: Promise<CodyConfigFeatures>
 
     // Constructor is private to prevent creating new instances outside of the class
     private constructor() {
@@ -715,6 +711,7 @@ export class ConfigFeaturesSingleton {
             chat: true,
             autoComplete: true,
             commands: true,
+            attribution: false,
         })
         // Initiate the first fetch and set up a recurring fetch every 30 seconds
         this.refreshConfigFeatures()
@@ -745,22 +742,15 @@ export class ConfigFeaturesSingleton {
         })
     }
 
-    public getConfigFeatures(): Promise<{
-        chat: boolean
-        autoComplete: boolean
-        commands: boolean
-    }> {
+    public getConfigFeatures(): Promise<CodyConfigFeatures> {
         return this.configFeatures
     }
 
     // Fetches the config features from the server and handles errors
-    private async fetchConfigFeatures(): Promise<{
-        chat: boolean
-        autoComplete: boolean
-        commands: boolean
-    }> {
+    private async fetchConfigFeatures(): Promise<CodyConfigFeatures> {
         // Execute the GraphQL query to fetch the configuration features
         const features = await graphqlClient.getCodyConfigFeatures()
+        console.log('FEATURES', features)
         if (features instanceof Error) {
             // If there's an error, throw it to be caught in refreshConfigFeatures
             throw features

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -65,7 +65,8 @@ query CodyConfigFeaturesResponse {
             chat
             autoComplete
             commands
-          }
+            attribution
+        }
     }
 }`
 

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -216,7 +216,12 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(f
                             attributionContainer.title = 'Attribution not found.'
                         })
                         .catch(error => {
-                            console.error('promise failed', error)
+                            attributionContainer.classList.add(styles.attributionIconUnavailable)
+                            if (isError(error)) {
+                                attributionContainer.title = error.message
+                            } else {
+                                attributionContainer.title = 'Attribution unavailable.'
+                            }
                         })
                 }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -314,8 +314,11 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
         const configFeatures = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
         void this.postMessage({
-            type: 'setChatEnabledConfigFeature',
-            data: configFeatures.chat,
+            type: 'setConfigFeatures',
+            configFeatures: {
+                chat: configFeatures.chat,
+                attribution: configFeatures.attribution,
+            },
         })
 
         return panel

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -119,7 +119,13 @@ export type ExtensionMessage =
     | { type: 'index-updated'; scopeDir: string }
     | { type: 'enhanced-context'; context: EnhancedContextContextT }
     | ({ type: 'attribution' } & ExtensionAttributionMessage)
-    | { type: 'setChatEnabledConfigFeature'; data: boolean }
+    | {
+          type: 'setConfigFeatures'
+          configFeatures: {
+              chat: boolean
+              attribution: boolean
+          }
+      }
 
 interface ExtensionAttributionMessage {
     snippet: string

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -62,6 +62,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [chatModels, setChatModels] = useState<ChatModelProvider[]>()
 
     const [chatEnabled, setChatEnabled] = useState<boolean>(true)
+    const [attributionEnabled, setAttributionEnabled] = useState<boolean>(false)
 
     const [enhancedContextEnabled, setEnhancedContextEnabled] = useState<boolean>(true)
     const [enhancedContextStatus, setEnhancedContextStatus] = useState<EnhancedContextContextT>({
@@ -116,8 +117,9 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                             vscodeAPI.postMessage({ command: 'get-chat-models' })
                         }
                         break
-                    case 'setChatEnabledConfigFeature':
-                        setChatEnabled(message.data)
+                    case 'setConfigFeatures':
+                        setChatEnabled(message.configFeatures.chat)
+                        setAttributionEnabled(message.configFeatures.attribution)
                         break
                     case 'history':
                         setInputHistory(message.messages?.input ?? [])
@@ -296,7 +298,9 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                                         enableNewChatUI={true}
                                         setChatModels={setChatModels}
                                         welcomeMessage={getWelcomeMessageByOS(config?.os)}
-                                        guardrails={config.experimentalGuardrails ? guardrails : undefined}
+                                        guardrails={
+                                            config.experimentalGuardrails && attributionEnabled ? guardrails : undefined
+                                        }
                                     />
                                 </EnhancedContextEnabled.Provider>
                             </EnhancedContextContext.Provider>


### PR DESCRIPTION
## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
