### PR TITLE
Fix failing Windows integration test

### DIFF
--- a/vscode/test/integration/api.test.ts
+++ b/vscode/test/integration/api.test.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert'
-import path from 'path'
 
 import * as vscode from 'vscode'
 
@@ -35,8 +34,8 @@ suite('API tests', () => {
             },
         })
         assert.deepStrictEqual(
-            h.lastN(20).map(h => h.document.uri.fsPath),
-            [path.sep + 'foo.ts', path.sep + 'bar.ts']
+            h.lastN(20).map(h => h.document.uri.toString()),
+            [testFileUri('foo.ts').toString(), testFileUri('bar.ts').toString()]
         )
     })
 })


### PR DESCRIPTION
This test is failing on `main` on the Windows bots because the way the expected string is built is not correct for Windows (the path will have a drive letter).

This changes it to just compare the string URIs instead.

## Test plan

CI
