### PR TITLE
Fix Anthropic model ID overwrite for old instances

### DIFF
--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -189,7 +189,10 @@ class AnthropicProvider extends Provider {
                         //
                         // If it happens once, we disable the behavior where the client includes a
                         // `model` parameter.
-                        if (error.message.includes('Unsupported code completion model')) {
+                        if (
+                            error.message.includes('Unsupported code completion model') ||
+                            error.message.includes('Unsupported custom model')
+                        ) {
                             isOutdatedSourcegraphInstanceWithoutAnthropicAllowlist = true
                         }
                     }

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -15,7 +15,7 @@ import {
     type PrefixComponents,
 } from '../text-processing'
 import { type ContextSnippet } from '../types'
-import { forkSignal, generatorWithErrorObserver, generatorWithTimeout, messagesToText, zipGenerators } from '../utils'
+import { forkSignal, generatorWithErrorObserver, generatorWithTimeout, messagesToText } from '../utils'
 
 import { type FetchCompletionResult } from './fetch-and-process-completions'
 import { getCompletionParamsAndFetchImpl, getLineNumberDependentCompletionParams } from './get-completion-params'
@@ -191,6 +191,7 @@ class AnthropicProvider extends Provider {
                         // `model` parameter.
                         if (
                             error.message.includes('Unsupported code completion model') ||
+                            error.message.includes('Unsupported chat model') ||
                             error.message.includes('Unsupported custom model')
                         ) {
                             isOutdatedSourcegraphInstanceWithoutAnthropicAllowlist = true
@@ -206,8 +207,6 @@ class AnthropicProvider extends Provider {
                 providerOptions: this.options,
             })
         })
-
-        return zipGenerators(completionsGenerators)
     }
 
     private postProcess = (rawResponse: string): string => {

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -15,7 +15,7 @@ import {
     type PrefixComponents,
 } from '../text-processing'
 import { type ContextSnippet } from '../types'
-import { forkSignal, generatorWithErrorObserver, generatorWithTimeout, messagesToText } from '../utils'
+import { forkSignal, generatorWithErrorObserver, generatorWithTimeout, messagesToText, zipGenerators } from '../utils'
 
 import { type FetchCompletionResult } from './fetch-and-process-completions'
 import { getCompletionParamsAndFetchImpl, getLineNumberDependentCompletionParams } from './get-completion-params'
@@ -207,6 +207,8 @@ class AnthropicProvider extends Provider {
                 providerOptions: this.options,
             })
         })
+
+        return zipGenerators(completionsGenerators)
     }
 
     private postProcess = (rawResponse: string): string => {


### PR DESCRIPTION
Follow up to #2783

I tested the gracefull fallback in #2783 on the demo instance (demo.sourcegraph.com) and noticed that the error is a different string. Turns out the string was changed in the past and thus the fallback behavior was not working and the insider build broke completions for these instances 😬. 

So I did a git blame on the `codecompletion.go` file to find all variations of this string. Turns out there is a third one that was available too for some time:

- https://github.com/sourcegraph/sourcegraph/commit/f700d84cab215b84dfbc4ae63d9e6134a856b8be
- https://github.com/sourcegraph/sourcegraph/commit/3b53b4e623e978a559e8ae05d71e8550dded4886#diff-3b488ccb5c3c1aa6d139c640704ba6d118ba6737fda7bc4ac077242a188956baR30
- https://github.com/sourcegraph/sourcegraph/commit/5b95c4b98e2890b9dd7bfdce35977d223227259f#diff-3b488ccb5c3c1aa6d139c640704ba6d118ba6737fda7bc4ac077242a188956baL32

Makes me wonder if we should handle this a bit more gracefully? 🤔  Maybe _any_ upstream error should reset this field from being sent, just to be safe?   

## Test plan

- Connect to demo.sourcegraph.com
- Make code completions

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
