### PR TITLE
Agent: fix critical bugs related to document synchronization

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -8971,6 +8971,3255 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 3d36b66c2a788899508109f4d7129ef7
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1768
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Only show the code, no explanation needed.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 5776
+        content:
+          mimeType: text/event-stream
+          size: 5776
+          text: >+
+            event: completion
+
+            data: {"completion":" ```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Wo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\";","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isMammal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isMammal = true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isMammal = true;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isMammal = true;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isMammal = true;\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Woof!\"; \n  }\n  \n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 15:16:03 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T15:16:00.495Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 94accb8dce18933da394cb5a165f6f1e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 880
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is Squirrel?
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 18869
+        content:
+          mimeType: text/event-stream
+          size: 18869
+          text: >+
+            event: completion
+
+            data: {"completion":" Based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.ts file","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.ts file.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.ts file.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 15:16:06 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T15:16:04.372Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 7ddd992011e5e73bc5749687d94a8219
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 800
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            fast: true
+            maxTokensToSample: 400
+            messages:
+              - speaker: human
+                text: "You are helping the user search over a codebase. List some filename
+                  fragments that would match files relevant to read to answer
+                  the user's query. Present your results in an XML list in the
+                  following format: <keywords><keyword><value>a single
+                  keyword</value><variants>a space separated list of synonyms
+                  and variants of the keyword, including acronyms,
+                  abbreviations, and expansions</variants><weight>a numerical
+                  weight between 0.0 and 1.0 that indicates the importance of
+                  the keyword</weight></keyword></keywords>. Here is the user
+                  query: <userQuery>What is the name of the function that I have
+                  selected? Only answer with the name of the function, nothing
+                  else</userQuery>"
+              - speaker: assistant
+            temperature: 0
+            topK: 1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 118053
+        content:
+          mimeType: text/event-stream
+          size: 118053
+          text: >+
+            event: completion
+
+            data: {"completion":" ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eget","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003eget","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc get","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eget","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003eget","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc get","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetSelectedFunction\u003c/value\u003e\n    \u003cvariants\u003egetSelectedFunc getSelectedFn\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselectedFunction\u003c/value\u003e\n    \u003cvariants\u003eselectedFunc selectedFn\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003egetFunction\u003c/value\u003e\n    \u003cvariants\u003egetFunc getFn\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003efunction\u003c/value\u003e\n    \u003cvariants\u003efunc fn\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eselection\u003c/value\u003e\n    \u003cvariants\u003eselect\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 15:16:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T15:16:10.339Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 6967fe233fb31836d4a6c81d6f217fe6
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1532
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+
+                  function anotherFunction() {}
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 237
+        content:
+          mimeType: text/event-stream
+          size: 237
+          text: |+
+            event: completion
+            data: {"completion":"","stopReason":""}
+
+            event: completion
+            data: {"completion":"`anotherFunction`","stopReason":""}
+
+            event: completion
+            data: {"completion":"`anotherFunction`","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 15:16:13 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T15:16:12.386Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 2a1d9ceb28b08d9cd6029b713b25535d
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1537
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+                      return function inner() {}
+
+                      
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 217
+        content:
+          mimeType: text/event-stream
+          size: 217
+          text: |+
+            event: completion
+            data: {"completion":"","stopReason":""}
+
+            event: completion
+            data: {"completion":"`inner`","stopReason":""}
+
+            event: completion
+            data: {"completion":"`inner`","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 15:16:16 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T15:16:15.551Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 9b24c7a3ebd266ad97fc47ef12b7bf75
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1712
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: "Explain what the selected code does in simple terms. Assume the audience
+                  is a beginner programmer who has just learned the language
+                  features and basic syntax. Focus on explaining: 1) The purpose
+                  of the code 2) What input(s) it takes 3) What output(s) it
+                  produces 4) How it achieves its purpose through the logic and
+                  algorithm. 5) Any important logic flows or data
+                  transformations happening. Use simple language a beginner
+                  could understand. Include enough detail to give a full picture
+                  of what the code aims to accomplish without getting too
+                  technical. Format the explanation in coherent paragraphs,
+                  using proper punctuation and grammar. Write the explanation
+                  assuming no prior context about the code is known. Do not make
+                  assumptions about variables or functions not shown in the
+                  shared code. Start the answer with the name of the code that
+                  is being explained."
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 94533
+        content:
+          mimeType: text/event-stream
+          size: 94533
+          text: >+
+            event: completion
+
+            data: {"completion":"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn'","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutput","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achie","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMamm","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Trans","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method. By using the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method. By using the Animal interface to build classes or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method. By using the Animal interface to build classes or objects, developers can ensure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method. By using the Animal interface to build classes or objects, developers can ensure consistency in their code and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method. By using the Animal interface to build classes or objects, developers can ensure consistency in their code and provide structure for interacting","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method. By using the Animal interface to build classes or objects, developers can ensure consistency in their code and provide structure for interacting with and defining animals.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"The Selected Code: Animal Interface in TypeScript\n\nPurpose:\nThe selected code defines an interface called \"Animal\" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an \"Animal.\"\n\nInputs:\nThe Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.\n\nOutputs:\nThe Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.\n\nHow it achieves its purpose:\nThe Animal interface defines three required elements or members:\n\n1. name (property): This is a string type that stores the animal's name.\n2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.\n3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.\n\nWhen you create an object or class implementing this interface, you must include these three members in the implementing entity.\n\nImportant Logic Flows or Data Transformations:\nThe Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.\n\nSummary:\nIn summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method. By using the Animal interface to build classes or objects, developers can ensure consistency in their code and provide structure for interacting with and defining animals.","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 15:16:17 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T15:16:16.249Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: f2171348c93c7661cc3cbf8b178fb197
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2294
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Review the shared code context and configurations to identify the test
+                  framework and libraries in use. Then, generate a suite of
+                  multiple unit tests for the functions in <selected> using the
+                  detected test framework and libraries. Be sure to import the
+                  function being tested. Follow the same patterns as any shared
+                  context. Only add packages, imports, dependencies, and
+                  assertions if they are used in the shared code. Pay attention
+                  to the file path of each shared context to see if test for
+                  <selected> already exists. If one exists, focus on generating
+                  new unit tests for uncovered cases. If none are detected,
+                  import common unit test libraries for {languageName}. Focus on
+                  validating key functionality with simple and complete
+                  assertions. Only include mocks if one is detected in the
+                  shared code. Before writing the tests, identify which test
+                  libraries and frameworks to import, e.g. 'No new imports
+                  needed - using existing libs' or 'Importing test framework
+                  that matches shared context usage' or 'Importing the defined
+                  framework', etc. Then briefly summarize test coverage and any
+                  limitations. At the end, enclose the full completed code for
+                  the new unit tests, including all necessary imports, in a
+                  single markdown codeblock. No fragments or TODO. The new tests
+                  should validate expected functionality and cover edge cases
+                  for <selected> with all required imports, including importing
+                  the function being tested. Do not repeat existing tests.
+            model: fireworks/accounts/fireworks/models/mixtral-8x7b-instruct
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 41813
+        content:
+          mimeType: text/event-stream
+          size: 41813
+          text: >+
+            event: completion
+
+            data: {"completion":"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndesc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\",","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n       ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n           ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if the animal name is correctly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if the animal name is correctly set\", () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if the animal name is correctly set\", () =\u003e {\n        expect(an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if the animal name is correctly set\", () =\u003e {\n        expect(animal.name).toBe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if the animal name is correctly set\", () =\u003e {\n        expect(animal.name).toBe(\"Test Animal\");\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if the animal name is correctly set\", () =\u003e {\n        expect(animal.name).toBe(\"Test Animal\");\n    });\n});\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if the animal name is correctly set\", () =\u003e {\n        expect(animal.name).toBe(\"Test Animal\");\n    });\n});\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"No new imports needed - using existing libs.\n\nTest coverage includes:\n\n1. Check if the animal sound is correctly returned\n2. Check if the animal is a mammal\n3. Check if the animal name is correctly set\n\nTest limitations:\n\n1. Assumes that the `makeAnimalSound()` method returns consistent values for the same animal\n2. Assumes that the `isMammal` property does not change\n\nHere is the completed unit test code:\n\n```typescript\nimport { Animal } from \"../src/animal\";\n\ndescribe(\"Animal\", () =\u003e {\n    let animal: Animal;\n\n    beforeEach(() =\u003e {\n        animal = {\n            name: \"Test Animal\",\n            makeAnimalSound: () =\u003e \"Test Sound\",\n            isMammal: true\n        };\n    });\n\n    it(\"checks if the animal sound is correctly returned\", () =\u003e {\n        expect(animal.makeAnimalSound()).toBe(\"Test Sound\");\n    });\n\n    it(\"checks if the animal is a mammal\", () =\u003e {\n        expect(animal.isMammal).toBeTrue();\n    });\n\n    it(\"checks if the animal name is correctly set\", () =\u003e {\n        expect(animal.name).toBe(\"Test Animal\");\n    });\n});\n```","stopReason":"stop"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 15:16:22 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T15:16:21.288Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 0af734d27e9cdbb178bf5ef98f44b717
       _order: 0
       cache: {}

--- a/agent/src/AgentTextDocument.ts
+++ b/agent/src/AgentTextDocument.ts
@@ -14,7 +14,7 @@ import * as vscode_shim from './vscode-shim'
 // all references have a consistent view on a document. Use AgentWorkspaceDocuments
 // to get a reference to a new or existing instance.
 export class AgentTextDocument implements vscode.TextDocument {
-    constructor(public readonly textDocument: TextDocumentWithUri) {
+    constructor(public textDocument: TextDocumentWithUri) {
         this.content = textDocument.content ?? ''
         this.uri = textDocument.uri
         this.fileName = textDocument.uri.fsPath
@@ -22,10 +22,12 @@ export class AgentTextDocument implements vscode.TextDocument {
         this.languageId = getLanguageForFileName(this.fileName)
         this.offsets = new DocumentOffsets(textDocument.underlying)
         this.lineCount = this.offsets.lineCount()
-        this.underlying = textDocument
     }
 
-    public underlying: TextDocumentWithUri
+    public get underlying(): TextDocumentWithUri {
+        return this.textDocument
+    }
+
     private content: string
     private offsets: DocumentOffsets
     public uri: vscode.Uri
@@ -56,7 +58,7 @@ export class AgentTextDocument implements vscode.TextDocument {
         this.languageId = getLanguageForFileName(this.fileName)
         this.offsets = new DocumentOffsets(textDocument.underlying)
         this.lineCount = this.offsets.lineCount()
-        this.underlying = textDocument
+        this.textDocument = textDocument
         this.version++
     }
 

--- a/agent/src/AgentTextEditor.ts
+++ b/agent/src/AgentTextEditor.ts
@@ -3,16 +3,13 @@ import * as vscode from 'vscode'
 import { type AgentTextDocument } from './AgentTextDocument'
 
 export function newTextEditor(document: AgentTextDocument): vscode.TextEditor {
-    const selection: vscode.Selection = document.textDocument.selection
+    const selection: vscode.Selection = document.underlying.selection
         ? new vscode.Selection(
               new vscode.Position(
-                  document.textDocument.selection.start.line,
-                  document.textDocument.selection.start.character
+                  document.underlying.selection.start.line,
+                  document.underlying.selection.start.character
               ),
-              new vscode.Position(
-                  document.textDocument.selection.end.line,
-                  document.textDocument.selection.end.character
-              )
+              new vscode.Position(document.underlying.selection.end.line, document.underlying.selection.end.character)
           )
         : new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
 

--- a/agent/src/__tests__/example-ts/src/multiple-selections.ts
+++ b/agent/src/__tests__/example-ts/src/multiple-selections.ts
@@ -1,0 +1,9 @@
+function outer() {
+    /* SELECTION_START */
+    return function inner() {}
+    /* SELECTION_END */
+}
+
+/* SELECTION_2_START */
+function anotherFunction() {}
+/* SELECTION_2_END */

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1310,7 +1310,21 @@ class ContextProvider implements IContextProvider {
             })
             return (await Promise.all(items)).flat()
         })
-        return (await Promise.all(r0)).flat()
+        const allResults = (await Promise.all(r0)).flat()
+
+        // Sort results for deterministic ordering for stable tests. Ideally, we
+        // could sort by some numerical score from symf based on how relevant
+        // the matches are for the query.
+        // Feel free to change this behavior to only sort while running tests.
+        allResults.sort((a, b) => {
+            const byUri = a.uri.fsPath.localeCompare(b.uri.fsPath)
+            if (byUri !== 0) {
+                return byUri
+            }
+            return a.text.localeCompare(b.text)
+        })
+
+        return allResults
     }
 
     private async searchEmbeddingsLocal(text: string): Promise<ContextItem[]> {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -155,7 +155,7 @@ export type Notifications = {
     'textDocument/didChange': [TextDocument]
     // The user focused on a document without changing the document's content.
     // Only the 'uri' property is required, other properties are ignored.
-    'textDocument/didFocus': [TextDocument]
+    'textDocument/didFocus': [{ uri: string }]
     // The user closed the editor tab for the given document.
     // Only the 'uri' property is required, other properties are ignored.
     'textDocument/didClose': [TextDocument]

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -95,6 +95,13 @@ export class ThemeIcon {
     ) {}
 }
 
+export enum ColorThemeKind {
+    Light = 1,
+    Dark = 2,
+    HighContrast = 3,
+    HighContrastLight = 4,
+}
+
 export class MarkdownString implements vscode_types.MarkdownString {
     constructor(public readonly value: string) {}
     isTrusted?: boolean | { readonly enabledCommands: readonly string[] } | undefined


### PR DESCRIPTION
This PR fixes two critical bugs that prevented enhanced context from working as expected:

- Changes to the user's selection were not respected. The agent only kept the first selection. This might be a regression from https://github.com/sourcegraph/cody/pull/2048
- Symf results were ignored if they came from files that the user hadn't explicitly opened. Now, the agent reads files from disk on `vscode.workspace.openTextDocument`.


Massive kudos to @pkukielka for spotting the bug related to selections and coming up with a reliable minimized reproduction in his PR #2803.

## Test plan

See updated tests. 
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
