### PR TITLE
Fix Ctrl+Enter for follow-on chat on Windows

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -395,7 +395,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             // Handles keyboard shortcuts with Ctrl key.
             // Checks if the Ctrl key is pressed with a key not in the allow list
             // to avoid triggering default browser shortcuts and bubbling the event.
-            const ctrlKeysAllowList = new Set(['a', 'c', 'v', 'x', 'y', 'z'])
+            const ctrlKeysAllowList = new Set(['a', 'c', 'v', 'x', 'y', 'z', 'Enter' /* follow-up */])
             if (event.ctrlKey && !ctrlKeysAllowList.has(event.key)) {
                 event.preventDefault()
                 return

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Edit: Fixed an issue where the file/symbol hint would remain even after the file/symbol prefix had been deleted. [pull/2712](https://github.com/sourcegraph/cody/pull/2712)
 - Commands: Fixed an issue where Cody failed to register additional instructions followed by the command key when submitted from the command menu. [pull/2789](https://github.com/sourcegraph/cody/pull/2789)
 - Chat: The title for the chat panel is now reset correctly on "Restart Chat Session"/"New Chat Session" button click. [pull/2786](https://github.com/sourcegraph/cody/pull/2786)
+- Chat: Fixed an issue where Ctrl+Enter on Windows would not work (did not send a follow-on chat). [pull/2823](https://github.com/sourcegraph/cody/pull/2823)
 
 ### Changed
 

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -9,6 +9,9 @@ import { test } from './helpers'
 
 // Creating new chats is slow, and setup is slow, so we collapse all these into one test
 
+const followUpChatSubmitKey = isWindows() ? 'Control+Enter' : 'Meta+Enter'
+const newChatSubmitKey = 'Enter'
+
 test('@-file empty state', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
 
@@ -64,26 +67,26 @@ test('@-file empty state', async ({ page, sidebar }) => {
     await chatInput.fill('Explain @mj')
     await chatPanelFrame.getByRole('button', { name: 'Main.java' }).click()
     await expect(chatInput).toHaveValue('Explain @Main.java ')
-    await chatInput.press('Enter')
+    await chatInput.press(newChatSubmitKey)
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java')).toBeVisible()
 
     // Keyboard nav
     await chatInput.type('Explain @vgo', { delay: 50 }) // without this delay the following Enter submits the form instead of selecting
-    await chatInput.press('Enter')
+    await chatInput.press(newChatSubmitKey)
     await expect(chatInput).toHaveValue(withPlatformSlashes('Explain @lib/batches/env/var.go '))
     await chatInput.type('and @vgo', { delay: 50 }) // without this delay the following Enter submits the form instead of selecting
     await chatInput.press('ArrowDown') // second item (visualize.go)
     await chatInput.press('ArrowDown') // third item (.vscode/settings.json)
     await chatInput.press('ArrowDown') // wraps back to first item
     await chatInput.press('ArrowDown') // second item again
-    await chatInput.press('Enter')
+    await chatInput.press(newChatSubmitKey)
     await expect(chatInput).toHaveValue(
         withPlatformSlashes('Explain @lib/batches/env/var.go and @lib/codeintel/tools/lsif-visualize/visualize.go ')
     )
 
     // Send the message and check it was included
-    await chatInput.press('Meta+Enter')
+    await chatInput.press(followUpChatSubmitKey)
     await expect(chatInput).toBeEmpty()
     await expect(
         chatPanelFrame.getByText(

--- a/vscode/test/e2e/at-file-context-selecting.test.ts
+++ b/vscode/test/e2e/at-file-context-selecting.test.ts
@@ -10,7 +10,6 @@ import { test } from './helpers'
 // Creating new chats is slow, and setup is slow, so we collapse all these into one test
 
 const followUpChatSubmitKey = isWindows() ? 'Control+Enter' : 'Meta+Enter'
-const newChatSubmitKey = 'Enter'
 
 test('@-file empty state', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
@@ -67,20 +66,20 @@ test('@-file empty state', async ({ page, sidebar }) => {
     await chatInput.fill('Explain @mj')
     await chatPanelFrame.getByRole('button', { name: 'Main.java' }).click()
     await expect(chatInput).toHaveValue('Explain @Main.java ')
-    await chatInput.press(newChatSubmitKey)
+    await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java')).toBeVisible()
 
     // Keyboard nav
     await chatInput.type('Explain @vgo', { delay: 50 }) // without this delay the following Enter submits the form instead of selecting
-    await chatInput.press(newChatSubmitKey)
+    await chatInput.press('Enter')
     await expect(chatInput).toHaveValue(withPlatformSlashes('Explain @lib/batches/env/var.go '))
     await chatInput.type('and @vgo', { delay: 50 }) // without this delay the following Enter submits the form instead of selecting
     await chatInput.press('ArrowDown') // second item (visualize.go)
     await chatInput.press('ArrowDown') // third item (.vscode/settings.json)
     await chatInput.press('ArrowDown') // wraps back to first item
     await chatInput.press('ArrowDown') // second item again
-    await chatInput.press(newChatSubmitKey)
+    await chatInput.press('Enter')
     await expect(chatInput).toHaveValue(
         withPlatformSlashes('Explain @lib/batches/env/var.go and @lib/codeintel/tools/lsif-visualize/visualize.go ')
     )


### PR DESCRIPTION
We have some code that `return`s if you press certain `Ctrl+` combinations. Since we're using `Ctrl+Enter` for follow-on chat on Windows, we need to not exit out here.

## Test plan

- Run `pnpm test:e2e` to run the updated test, or
- Run the extension on Windows
- Send a chat
- Send a second chat with `<enter>` and ensure it's a new chat (replaces the first message)
- Type a third chat and press `<ctrl+enter>` and ensure it's a follow-on chat (appended after the previous message)
