### PR TITLE
Agent: reset server environment between tests

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -11132,6 +11132,7 @@ log:
                       return function inner() {}
 
 
+
                       
                   </selected>
               - speaker: assistant
@@ -12831,6 +12832,7 @@ log:
                   <selected>
 
                       return function inner() {}
+
 
                       
                   </selected>
@@ -17407,6 +17409,334 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-01-19T20:01:47.549Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 9382ed8adf2739a451ff5c81ecc7eb67
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1519
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+
+                  function anotherFunction() {}
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 252
+        content:
+          mimeType: text/event-stream
+          size: 252
+          text: |+
+            event: completion
+            data: {"completion":" another","stopReason":""}
+
+            event: completion
+            data: {"completion":" anotherFunction","stopReason":""}
+
+            event: completion
+            data: {"completion":" anotherFunction","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 20:29:47 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T20:29:45.025Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 7bf613cad6709104ff3eef24e5810a47
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1524
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+                      return function inner() {}
+
+                      
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 165
+        content:
+          mimeType: text/event-stream
+          size: 165
+          text: |+
+            event: completion
+            data: {"completion":" inner","stopReason":""}
+
+            event: completion
+            data: {"completion":" inner","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 20:29:50 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T20:29:47.925Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -11131,6 +11131,7 @@ log:
 
                       return function inner() {}
 
+
                       
                   </selected>
               - speaker: assistant
@@ -12211,6 +12212,5201 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-01-19T15:16:21.288Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: cd36755a405ceea5415aecd70df24c18
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1768
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Only show the code, no explanation needed.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 5701
+        content:
+          mimeType: text/event-stream
+          size: 5701
+          text: >+
+            event: completion
+
+            data: {"completion":" ```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"B","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\";","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isMammal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isMammal = true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isMammal = true;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isMammal = true;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isMammal = true;\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound() {\n    return \"Bark!\"; \n  }\n\n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 20:01:04 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T20:01:01.631Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 1850cc9cc539c62e8539cd1e6c980b92
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1519
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+
+                  function anotherFunction() {}
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 252
+        content:
+          mimeType: text/event-stream
+          size: 252
+          text: |+
+            event: completion
+            data: {"completion":" another","stopReason":""}
+
+            event: completion
+            data: {"completion":" anotherFunction","stopReason":""}
+
+            event: completion
+            data: {"completion":" anotherFunction","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 20:01:07 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T20:01:05.713Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: be5524ecca9c7f96f0fb70cfd5e39012
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1524
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+                      return function inner() {}
+
+                      
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 165
+        content:
+          mimeType: text/event-stream
+          size: 165
+          text: |+
+            event: completion
+            data: {"completion":" inner","stopReason":""}
+
+            event: completion
+            data: {"completion":" inner","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 20:01:09 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T20:01:07.429Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: b09bbe8f7c1f8b956a8726958b39091f
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1699
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: "Explain what the selected code does in simple terms. Assume the audience
+                  is a beginner programmer who has just learned the language
+                  features and basic syntax. Focus on explaining: 1) The purpose
+                  of the code 2) What input(s) it takes 3) What output(s) it
+                  produces 4) How it achieves its purpose through the logic and
+                  algorithm. 5) Any important logic flows or data
+                  transformations happening. Use simple language a beginner
+                  could understand. Include enough detail to give a full picture
+                  of what the code aims to accomplish without getting too
+                  technical. Format the explanation in coherent paragraphs,
+                  using proper punctuation and grammar. Write the explanation
+                  assuming no prior context about the code is known. Do not make
+                  assumptions about variables or functions not shown in the
+                  shared code. Start the answer with the name of the code that
+                  is being explained."
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 174608
+        content:
+          mimeType: text/event-stream
+          size: 174608
+          text: >+
+            event: completion
+
+            data: {"completion":" The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Inter","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in a type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in a type-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in a type-safe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in a type-safe way","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in a type-safe way.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The Animal interface:\n\nThe Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have. \n\nThis interface has three properties:\n\n1. name - This will be a string property to represent the animal's name.\n\n2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.\n\n3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.\n\nThe interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.\n\nBy defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.\n\nInterfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in a type-safe way.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 20:01:12 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T20:01:09.624Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 157505891789c9b4d049c9206cff2bf8
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2281
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Review the shared code context and configurations to identify the test
+                  framework and libraries in use. Then, generate a suite of
+                  multiple unit tests for the functions in <selected> using the
+                  detected test framework and libraries. Be sure to import the
+                  function being tested. Follow the same patterns as any shared
+                  context. Only add packages, imports, dependencies, and
+                  assertions if they are used in the shared code. Pay attention
+                  to the file path of each shared context to see if test for
+                  <selected> already exists. If one exists, focus on generating
+                  new unit tests for uncovered cases. If none are detected,
+                  import common unit test libraries for {languageName}. Focus on
+                  validating key functionality with simple and complete
+                  assertions. Only include mocks if one is detected in the
+                  shared code. Before writing the tests, identify which test
+                  libraries and frameworks to import, e.g. 'No new imports
+                  needed - using existing libs' or 'Importing test framework
+                  that matches shared context usage' or 'Importing the defined
+                  framework', etc. Then briefly summarize test coverage and any
+                  limitations. At the end, enclose the full completed code for
+                  the new unit tests, including all necessary imports, in a
+                  single markdown codeblock. No fragments or TODO. The new tests
+                  should validate expected functionality and cover edge cases
+                  for <selected> with all required imports, including importing
+                  the function being tested. Do not repeat existing tests.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 197121
+        content:
+          mimeType: text/event-stream
+          size: 197121
+          text: >+
+            event: completion
+
+            data: {"completion":" Okay","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate J","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n//","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal';","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property',","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', ()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic J","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete valid","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported J","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand the tests","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand the tests in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand the tests in any","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand the tests in any way","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand the tests in any way.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:\n\n```ts\n// New imports needed\nimport { Animal } from './animal'; \n\ndescribe('Animal', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal = {} as Animal;\n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand the tests in any way.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 20:01:32 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T20:01:29.751Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: c6c1d95857652dde7518a089eddd4a81
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1257
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Please review and analyze the {languageName} code I have selected and
+                  identify potential areas for improvement related to code
+                  smells, readability, maintainability, performance, security,
+                  etc. Do not list issues already addressed in the given code.
+                  Focus on providing up to 5 constructive suggestions that could
+                  make the code more robust, efficient, or align with best
+                  practices. For each suggestion, provide a brief explanation of
+                  the potential benefits. After listing any recommendations,
+                  summarize if you found notable opportunities to enhance the
+                  code quality overall or if the code generally follows sound
+                  design principles. If no issues found, reply 'There are no
+                  errors.'
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 238145
+        content:
+          mimeType: text/event-stream
+          size: 238145
+          text: >+
+            event: completion
+
+            data: {"completion":" Here","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number):","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  //","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being re","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  //","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound():","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `get","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves read","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  //","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal():","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encaps","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Ext","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like Living","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface Living","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends Living","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  //","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintain","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encaps","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean get","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters. No","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters. No major","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters. No major issues","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters. No major issues were","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters. No major issues were found","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters. No major issues were found.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string\n  isMammal: boolean \n}\n```\n\nAdding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.\n\n2. Make name readonly:\n\n```\nexport interface Animal {\n  readonly name: string\n  // ...\n}\n```\n\nThis prevents the name from being reassigned after initialization, making the code more robust.\n\n3. Add alternate method name:\n\n```\nexport interface Animal {\n\n  // ...\n\n  getSound(): string\n}\n```\n\nAdding a method like `getSound()` as an alias for `makeAnimalSound()` improves readability.\n\n4. Use boolean getter instead of property for isMammal:\n\n```\nexport interface Animal {\n\n  // ...\n\n  get isMammal(): boolean\n}\n```\n\nThis allows encapsulation of the logic for determining if mammal.\n\n5. Extend a base interface like LivingThing:\n\n```\ninterface LivingThing {\n  name: string\n}\n\ninterface Animal extends LivingThing {\n  // ...\n}\n```\n\nThis improves maintainability by separating common properties into a base interface.\n\nOverall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters. No major issues were found.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 19 Jan 2024 20:01:49 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1289
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-19T20:01:47.549Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/AgentGlobalState.ts
+++ b/agent/src/AgentGlobalState.ts
@@ -19,6 +19,9 @@ export class AgentGlobalState implements vscode.Memento {
         // chat/new.
         this.globalStorage.set('completion.inline.hasAcceptedFirstCompletion', true)
     }
+    public reset(): void {
+        this.globalStorage.clear()
+    }
 
     public keys(): readonly string[] {
         return [localStorage.LAST_USED_ENDPOINT, localStorage.ANONYMOUS_USER_ID_KEY, ...this.globalStorage.keys()]

--- a/agent/src/AgentTabGroups.ts
+++ b/agent/src/AgentTabGroups.ts
@@ -10,4 +10,9 @@ export class AgentTabGroups implements vscode.TabGroups {
     public close(): Thenable<boolean> {
         throw new Error('Method not implemented.')
     }
+    public reset(): void {
+        while (this.all.length > 0) {
+            this.all.pop()
+        }
+    }
 }

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -37,6 +37,7 @@ import { AgentHandlerTelemetryRecorderProvider } from './telemetry'
 import * as vscode_shim from './vscode-shim'
 
 const inMemorySecretStorageMap = new Map<string, string>()
+const globalState = new AgentGlobalState()
 
 export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Promise<void> {
     const paths = envPaths('Cody')
@@ -59,7 +60,7 @@ export async function initializeVscodeExtension(workspaceRoot: vscode.Uri): Prom
         // types but don't have to point to a meaningful path/URI.
         extensionPath: paths.config,
         extensionUri: vscode.Uri.file(paths.config),
-        globalState: new AgentGlobalState(),
+        globalState,
         logUri: vscode.Uri.file(paths.log),
         logPath: paths.log,
         secrets: {
@@ -329,6 +330,12 @@ export class Agent extends MessageHandler {
                 }
             )
             return { result: message }
+        })
+
+        this.registerAuthenticatedRequest('testing/reset', async () => {
+            await this.workspace.reset()
+            globalState.reset()
+            return null
         })
 
         this.registerAuthenticatedRequest('command/execute', async params => {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -598,7 +598,7 @@ describe('Agent', () => {
                 name: string;
 
                 makeAnimalSound() {
-                  return "Bark!";
+                  return "Woof!";
                 }
 
                 isMammal = true;

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -4,7 +4,7 @@ import fspromises from 'fs/promises'
 import os from 'os'
 import path from 'path'
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 import { Uri } from 'vscode'
 
@@ -375,6 +375,10 @@ describe('Agent', () => {
         expect(valid?.isLoggedIn).toBeTruthy()
     }, 10_000)
 
+    beforeEach(async () => {
+        await client.request('testing/reset', null)
+    })
+
     const sumPath = path.join(workspaceRootPath, 'src', 'sum.ts')
     const sumUri = Uri.file(sumPath)
     const animalPath = path.join(workspaceRootPath, 'src', 'animal.ts')
@@ -594,7 +598,7 @@ describe('Agent', () => {
                 name: string;
 
                 makeAnimalSound() {
-                  return "Woof!";
+                  return "Bark!";
                 }
 
                 isMammal = true;
@@ -674,9 +678,6 @@ describe('Agent', () => {
     })
 
     describe('Text documents', () => {
-        // This test fails when running in replay mode with `it.only`. This seems to happen
-        // due to some non-determinism how we construct the prompt. I'm keeping the test in
-        // for now but feel free to `it.skip` it if it's causing problems.
         it('chat/submitMessage (understands the selected text)', async () => {
             await client.request('command/execute', { command: 'cody.search.index-update' })
 
@@ -706,31 +707,23 @@ describe('Agent', () => {
             const lastMessage = await client.firstNonEmptyTranscript(id)
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "The Selected Code: Animal Interface in TypeScript
+              " The Animal interface:
 
-              Purpose:
-              The selected code defines an interface called "Animal" in TypeScript. An interface is a blueprint for creating objects or classes in TypeScript. This interface describes specific properties and methods that an object or class must-have to be considered an "Animal."
+              The Animal interface defines the shape of objects that represent animals. Interfaces in TypeScript are used to define the structure of an object - what properties and methods it should have.
 
-              Inputs:
-              The Animal interface doesn't take any inputs directly. However, if you create an object or class implementing this interface, you must provide the required properties and methods. The properties can be assigned values when you create the implementing object, and the methods should have their logic implemented as well.
+              This interface has three properties:
 
-              Outputs:
-              The Animal interface itself doesn't produce any output or value directly, but objects and classes created using this interface will give output based on the provided property values and implemented method functionalities.
+              1. name - This will be a string property to represent the animal's name.
 
-              How it achieves its purpose:
-              The Animal interface defines three required elements or members:
+              2. makeAnimalSound() - This is a method that will be implemented by classes that implement the Animal interface. It allows each animal to have its own implementation of making a sound.
 
-              1. name (property): This is a string type that stores the animal's name.
-              2. makeAnimalSound (method): This is a function that returns a string representing the sound an animal makes when prompted.
-              3. isMammal (property): This is a boolean type representing whether or not the animal is a mammal.
+              3. isMammal - This is a boolean property that will specify if the animal is a mammal or not.
 
-              When you create an object or class implementing this interface, you must include these three members in the implementing entity.
+              The interface does not contain any actual implementation, just the definition of what properties and methods any class implementing Animal should have. This allows us to define a consistent structure that can be reused across different animal classes.
 
-              Important Logic Flows or Data Transformations:
-              The Animal interface is a static definition and doesn't encompass any active logic flow or data transformation. Implementing classes and objects will contain their logic for individual methods and properties, and the interface is simply a guide.
+              By defining an Animal interface, we can then create multiple classes like Dog, Cat, Bird etc that implement the interface and provide their own specific logic while ensuring they match the general Animal structure.
 
-              Summary:
-              In summary, the Animal interface is a simple TypeScript blueprint for classes or objects representing various animals. It defines three members, including two properties and one method. By using the Animal interface to build classes or objects, developers can ensure consistency in their code and provide structure for interacting with and defining animals."
+              Interfaces are a powerful way to define contracts in TypeScript code and allow different implementations to guarantee they can work together smoothly. This Animal interface creates a reusable way to model animals in a type-safe way."
             `,
                 explainPollyError
             )
@@ -742,48 +735,35 @@ describe('Agent', () => {
             const lastMessage = await client.firstNonEmptyTranscript(id)
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "No new imports needed - using existing libs.
+              " Okay, based on the provided code context, it looks like no test framework or libraries are already in use. Since this is TypeScript code, I will generate Jest unit tests for the Animal interface:
 
-              Test coverage includes:
+              \`\`\`ts
+              // New imports needed
+              import { Animal } from './animal';
 
-              1. Check if the animal sound is correctly returned
-              2. Check if the animal is a mammal
-              3. Check if the animal name is correctly set
+              describe('Animal', () => {
 
-              Test limitations:
+                it('should have a name property', () => {
+                  const animal = {} as Animal;
+                  expect(animal.name).toBeDefined();
+                });
 
-              1. Assumes that the \`makeAnimalSound()\` method returns consistent values for the same animal
-              2. Assumes that the \`isMammal\` property does not change
+                it('should have a makeAnimalSound method', () => {
+                  const animal = {} as Animal;
+                  expect(animal.makeAnimalSound).toBeDefined();
+                  expect(typeof animal.makeAnimalSound).toBe('function');
+                });
 
-              Here is the completed unit test code:
+                it('should have an isMammal property', () => {
+                  const animal = {} as Animal;
+                  expect(animal.isMammal).toBeDefined();
+                  expect(typeof animal.isMammal).toBe('boolean');
+                });
 
-              \`\`\`typescript
-              import { Animal } from "../src/animal";
-
-              describe("Animal", () => {
-                  let animal: Animal;
-
-                  beforeEach(() => {
-                      animal = {
-                          name: "Test Animal",
-                          makeAnimalSound: () => "Test Sound",
-                          isMammal: true
-                      };
-                  });
-
-                  it("checks if the animal sound is correctly returned", () => {
-                      expect(animal.makeAnimalSound()).toBe("Test Sound");
-                  });
-
-                  it("checks if the animal is a mammal", () => {
-                      expect(animal.isMammal).toBeTrue();
-                  });
-
-                  it("checks if the animal name is correctly set", () => {
-                      expect(animal.name).toBe("Test Animal");
-                  });
               });
-              \`\`\`"
+              \`\`\`
+
+              This generates a basic Jest test suite for the Animal interface, validating the name, makeAnimalSound, and isMammal properties. I focused on simple and complete validations of the key functionality. Since no test framework was detected in the context, I imported Jest and created new tests from scratch. Please let me know if you would like me to modify or expand the tests in any way."
             `,
                 explainPollyError
             )
@@ -796,71 +776,72 @@ describe('Agent', () => {
 
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Based on the provided TypeScript code, here are some suggestions for improvement:
+              " Here are 5 potential improvements for the selected TypeScript code:
 
-              1. Add access modifiers to members: By default, all members in an interface are public. Explicitly specifying the access modifier can make the code more readable. Additionally, it is a good practice to follow as it makes it clear to other developers that the member is intended to be accessed from outside the module. For example:
-              \`\`\`typescript
+              1. Add type annotations for method parameters and return types:
+
+              \`\`\`
               export interface Animal {
-                  name: string;
-                  makeAnimalSound(): string;
-                  isMammal: boolean;
+                name: string
+                makeAnimalSound(volume?: number): string
+                isMammal: boolean
               }
               \`\`\`
-              could be changed to:
-              \`\`\`typescript
+
+              Adding explicit types for methods makes the interface clearer and allows TypeScript to catch more errors at compile time.
+
+              2. Make name readonly:
+
+              \`\`\`
               export interface Animal {
-                  readonly name: string;
-                  makeAnimalSound(): string;
-                  isMammal: boolean;
+                readonly name: string
+                // ...
               }
               \`\`\`
-              2. Add type constraints to function parameters: It's a good practice to add type constraints to function parameters. This can improve type safety and make the code more robust. For example:
-              \`\`\`typescript
-              makeAnimalSound(): string;
-              \`\`\`
-              could be changed to:
-              \`\`\`typescript
-              makeAnimalSound(): void;
-              \`\`\`
-              3. Use consistent spacing: Consistent spacing can improve the readability of the code. Make sure to follow the same spacing conventions throughout the file. For example, make sure there is consistent spacing around the \`:\` symbol:
-              \`\`\`typescript
-              name: string
-              makeAnimalSound(): string
-              isMammal: boolean
-              \`\`\`
-              could be changed to:
-              \`\`\`typescript
-              name: string;
-              makeAnimalSound(): string;
-              isMammal: boolean;
-              \`\`\`
-              4. Consider using an abstract class: If the \`Animal\` interface is meant to be implemented by concrete classes, consider using an abstract class instead. This can help ensure that the implementing classes have common behavior and properties. For example:
-              \`\`\`typescript
-              export abstract class Animal {
-                  public readonly name: string;
-                  public isMammal: boolean;
 
-                  constructor(name: string, isMammal: boolean) {
-                      this.name = name;
-                      this.isMammal = isMammal;
-                  }
+              This prevents the name from being reassigned after initialization, making the code more robust.
 
-                  public makeAnimalSound(): void {
-                      // Implement the logic here.
-                  }
-              }
+              3. Add alternate method name:
+
               \`\`\`
-              5. Use TypeScript features such as type aliases: TypeScript has many features that can make the code more readable and maintainable. Consider using type aliases for boolean properties, for example:
-              \`\`\`typescript
-              type IsMammal = boolean;
-
               export interface Animal {
-                  readonly name: string;
-                  makeAnimalSound(): void;
-                  isMammal: IsMammal;
+
+                // ...
+
+                getSound(): string
               }
               \`\`\`
-              Overall, the code follows good design principles but there are some opportunities to enhance the code quality. The proposed changes can make the code more robust, efficient, and align with best practices."
+
+              Adding a method like \`getSound()\` as an alias for \`makeAnimalSound()\` improves readability.
+
+              4. Use boolean getter instead of property for isMammal:
+
+              \`\`\`
+              export interface Animal {
+
+                // ...
+
+                get isMammal(): boolean
+              }
+              \`\`\`
+
+              This allows encapsulation of the logic for determining if mammal.
+
+              5. Extend a base interface like LivingThing:
+
+              \`\`\`
+              interface LivingThing {
+                name: string
+              }
+
+              interface Animal extends LivingThing {
+                // ...
+              }
+              \`\`\`
+
+              This improves maintainability by separating common properties into a base interface.
+
+              Overall, the code is well-written but could benefit from some minor changes like adding types, encapsulation, and semantic method names. The interface follows sound principles like read-only properties andboolean getters. No major issues were found."
             `,
                 explainPollyError
             )

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1333,21 +1333,8 @@ class ContextProvider implements IContextProvider {
             })
             return (await Promise.all(items)).flat()
         })
-        const allResults = (await Promise.all(r0)).flat()
 
-        // Sort results for deterministic ordering for stable tests. Ideally, we
-        // could sort by some numerical score from symf based on how relevant
-        // the matches are for the query.
-        // Feel free to change this behavior to only sort while running tests.
-        allResults.sort((a, b) => {
-            const byUri = a.uri.fsPath.localeCompare(b.uri.fsPath)
-            if (byUri !== 0) {
-                return byUri
-            }
-            return a.text.localeCompare(b.text)
-        })
-
-        return allResults
+        return (await Promise.all(r0)).flat()
     }
 
     private async searchEmbeddingsLocal(text: string): Promise<ContextItem[]> {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -82,6 +82,8 @@ import { InitDoer } from './InitDoer'
 import { DefaultPrompter, type IContextProvider, type IPrompter } from './prompt'
 import { SimpleChatModel, toViewMessage, type ContextItem, type MessageWithContext } from './SimpleChatModel'
 
+const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
+
 interface SimpleChatPanelProviderOptions {
     config: Config
     extensionUri: vscode.Uri
@@ -1334,7 +1336,22 @@ class ContextProvider implements IContextProvider {
             return (await Promise.all(items)).flat()
         })
 
-        return (await Promise.all(r0)).flat()
+        const allResults = (await Promise.all(r0)).flat()
+
+        if (isAgentTesting) {
+            // Sort results for deterministic ordering for stable tests. Ideally, we
+            // could sort by some numerical score from symf based on how relevant
+            // the matches are for the query.
+            allResults.sort((a, b) => {
+                const byUri = a.uri.fsPath.localeCompare(b.uri.fsPath)
+                if (byUri !== 0) {
+                    return byUri
+                }
+                return a.text.localeCompare(b.text)
+            })
+        }
+
+        return allResults
     }
 
     private async searchEmbeddingsLocal(text: string): Promise<ContextItem[]> {

--- a/vscode/src/editor/active-editor.ts
+++ b/vscode/src/editor/active-editor.ts
@@ -28,6 +28,11 @@ interface LastActiveTextEditor {
  */
 let lastActiveTextEditor: LastActiveTextEditor = { active: undefined, ignored: false }
 
+// Used for testing purposes
+export function resetActiveEditor(): void {
+    lastActiveTextEditor = { active: undefined, ignored: false }
+}
+
 // Support file, untitled, and notebooks
 const validFileSchemes = new Set(['file', 'untitled', 'vscode-notebook', 'vscode-notebook-cell'])
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -103,6 +103,10 @@ export type Requests = {
     // the client sends progress/cancel.
     'testing/progressCancelation': [{ title: string }, { result: string }]
 
+    // Only used for testing purposes. Does a best-effort to reset the state
+    // if the agent server. For example, closes all open documents.
+    'testing/reset': [null, null]
+
     // Updates the extension configuration and returns the new
     // authentication status, which indicates whether the provided credentials are
     // valid or not. The agent can't support autocomplete or chat if the credentials


### PR DESCRIPTION
Followup to https://github.com/sourcegraph/cody/pull/2821

Previously, each agent test performed side effects like opening a document that leaked into the next test case. This caused subtle problems like seemingly non-deterministic behavior based on whether you ran an individual test with `it.only` (or `vitest -t`) or all tests. For example, if one test case customized the LLM model then the next test case would use that custom model when running all test together, but the next test would use the default model when running isolated (via `it.only` or `vitest -t`).

This PR fixes the problem by adding a new `testing/reset` request that does a best-effort to reset the environment of the server process between each test case. The current implementation may not reset everything perfectly but it solved the problem of the LLM default along with a few other low-hanging cases (open documents).


## Test plan

Green CI. Optionally, run the tests locally with `it.only` changes to any test. It should always pass in replay mode now.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
