### PR TITLE
add FileURI type for `file`-scheme URIs

### DIFF
--- a/lib/shared/src/common/uri.ts
+++ b/lib/shared/src/common/uri.ts
@@ -1,0 +1,16 @@
+import { type URI } from 'vscode-uri'
+
+/**
+ * A file URI.
+ *
+ * It is helpful to use the {@link FileURI} type instead of just {@link URI} or {@link vscode.Uri}
+ * when the URI is known to be `file`-scheme-only.
+ */
+export type FileURI = URI & { scheme: 'file' }
+
+declare module 'vscode-uri' {
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    export class URI {
+        public static file(fsPath: string): FileURI
+    }
+}

--- a/lib/shared/src/common/uri.ts
+++ b/lib/shared/src/common/uri.ts
@@ -8,6 +8,10 @@ import { type URI } from 'vscode-uri'
  */
 export type FileURI = URI & { scheme: 'file' }
 
+export function isFileURI(uri: URI): uri is FileURI {
+    return uri.scheme === 'file'
+}
+
 declare module 'vscode-uri' {
     // eslint-disable-next-line @typescript-eslint/no-extraneous-class
     export class URI {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -53,6 +53,7 @@ export { basename, dedupeWith, isDefined, isErrorLike, pluralize } from './commo
 export { ProgrammingLanguage, languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './common/languages'
 export { renderMarkdown } from './common/markdown'
 export { isWindows } from './common/platform'
+export type { FileURI } from './common/uri'
 export type {
     AutocompleteTimeouts,
     Configuration,

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -53,7 +53,7 @@ export { basename, dedupeWith, isDefined, isErrorLike, pluralize } from './commo
 export { ProgrammingLanguage, languageFromFilename, markdownCodeBlockLanguageIDForFilename } from './common/languages'
 export { renderMarkdown } from './common/markdown'
 export { isWindows } from './common/platform'
-export type { FileURI } from './common/uri'
+export { isFileURI, type FileURI } from './common/uri'
 export type {
     AutocompleteTimeouts,
     Configuration,
@@ -94,6 +94,7 @@ export type {
     SearchPanelFile,
     SearchPanelSnippet,
 } from './local-context'
+export { logDebug, logError, setLogger } from './logger'
 export {
     MAX_BYTES_PER_FILE,
     MAX_CURRENT_FILE_TOKENS,
@@ -151,4 +152,3 @@ export type { ExtensionDetails } from './telemetry/EventLogger'
 export { testFileUri } from './test/path-helpers'
 export { addTraceparent, getActiveTraceAndSpanId, wrapInActiveSpan } from './tracing'
 export { convertGitCloneURLToCodebaseName, isError } from './utils'
-export { logDebug, logError, setLogger } from './logger'

--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -37,13 +37,13 @@ export interface Result {
     doc: string
     exported: boolean
     lang: string
-    file: string
+    file: URI
     range: Range
     summary: string
 }
 
 export interface IndexedKeywordContextFetcher {
-    getResults(query: string, scopeDirs: string[]): Promise<Promise<Result[]>[]>
+    getResults(query: string, scopeDirs: URI[]): Promise<Promise<Result[]>[]>
 }
 
 /**
@@ -51,9 +51,6 @@ export interface IndexedKeywordContextFetcher {
  */
 export interface SearchPanelFile {
     uri: URI
-    basename: string
-    dirname: string
-    wsname?: string
     snippets: SearchPanelSnippet[]
 }
 

--- a/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
+++ b/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
@@ -2,8 +2,10 @@ import { isEqual } from 'lodash'
 import * as vscode from 'vscode'
 
 import {
+    displayPathBasename,
     isDotCom,
     isError,
+    isFileURI,
     type ContextGroup,
     type ContextProvider,
     type ContextStatusProvider,
@@ -18,7 +20,7 @@ import { getCodebaseFromWorkspaceUri } from '../../repository/repositoryHelpers'
 import { type CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
 
 interface CodebaseIdentifiers {
-    local: string
+    localFolder: vscode.Uri
     remote?: string
     remoteRepoId?: string
     setting?: string
@@ -98,7 +100,7 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
 
         return [
             {
-                name: codebase.local,
+                name: displayPathBasename(codebase.localFolder),
                 providers,
             },
         ]
@@ -169,7 +171,7 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
         const config = getConfiguration()
         if (
             this._currentCodebase !== undefined &&
-            workspaceRoot?.fsPath === this._currentCodebase?.local &&
+            workspaceRoot?.toString() === this._currentCodebase?.localFolder &&
             config.codebase === this._currentCodebase?.setting &&
             this._currentCodebase?.remoteRepoId
         ) {
@@ -179,7 +181,7 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
 
         let newCodebase: CodebaseIdentifiers | null = null
         if (workspaceRoot) {
-            newCodebase = { local: workspaceRoot.fsPath, setting: config.codebase }
+            newCodebase = { localFolder: workspaceRoot, setting: config.codebase }
             const currentFile = getEditor()?.active?.document?.uri
             // Get codebase from config or fallback to getting codebase name from current file URL
             // Always use the codebase from config as this is manually set by the user
@@ -202,9 +204,10 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
         if (!this.symf) {
             return false
         }
-        const newSymfStatus = this._currentCodebase?.local
-            ? await this.symf.getIndexStatus(this._currentCodebase.local)
-            : undefined
+        const newSymfStatus =
+            this._currentCodebase?.localFolder && isFileURI(this._currentCodebase.localFolder)
+                ? await this.symf.getIndexStatus(this._currentCodebase.localFolder)
+                : undefined
         const didSymfStatusChange = this.symfIndexStatus !== newSymfStatus
         this.symfIndexStatus = newSymfStatus
         return didSymfStatusChange

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -1,10 +1,11 @@
-import * as os from 'os'
-import * as path from 'path'
-
 import * as vscode from 'vscode'
 
 import {
+    displayPath,
     hydrateAfterPostMessage,
+    isDefined,
+    isFileURI,
+    type FileURI,
     type Result,
     type SearchPanelFile,
     type SearchPanelSnippet,
@@ -42,8 +43,8 @@ class CancellationManager implements vscode.Disposable {
 }
 
 class IndexManager implements vscode.Disposable {
-    private currentlyRefreshing = new Map<string, Promise<void>>()
-    private scopeDirIndexInProgress: Map<string, Promise<void>> = new Map()
+    private currentlyRefreshing = new Map<string /* uri.toString() */, Promise<void>>()
+    private scopeDirIndexInProgress: Map<string /* uri.toString() */, Promise<void>> = new Map()
     private disposables: vscode.Disposable[] = []
 
     constructor(private symf: SymfRunner) {
@@ -59,37 +60,33 @@ class IndexManager implements vscode.Disposable {
      * This is needed, because the user may have dismissed previous indexing progress
      * messages.
      */
-    public showMessageIfIndexingInProgress = (scopeDirs: string[]): void => {
-        const indexingScopeDirs: string[] = []
+    public showMessageIfIndexingInProgress(scopeDirs: vscode.Uri[]): void {
+        const indexingScopeDirs: vscode.Uri[] = []
         for (const scopeDir of scopeDirs) {
-            if (this.scopeDirIndexInProgress.has(scopeDir)) {
-                const { base, dir, wsName } = getRenderableComponents(scopeDir)
-                const prettyScopeDir = wsName ? path.join(wsName, dir, base) : path.join(dir, base)
-                indexingScopeDirs.push(prettyScopeDir)
+            if (this.scopeDirIndexInProgress.has(scopeDir.toString())) {
+                indexingScopeDirs.push(scopeDir)
             }
         }
         if (indexingScopeDirs.length === 0) {
             return
         }
-        void vscode.window.showWarningMessage(`Still indexing: ${indexingScopeDirs.join(', ')}`)
+        void vscode.window.showWarningMessage(`Still indexing: ${indexingScopeDirs.map(displayPath).join(', ')}`)
     }
 
     public showIndexProgress({ scopeDir, cancel, done }: IndexStartEvent): void {
-        const { base, dir, wsName } = getRenderableComponents(scopeDir)
-        const prettyScopeDir = wsName ? path.join(wsName, dir, base) : path.join(dir, base)
-        if (this.scopeDirIndexInProgress.has(scopeDir)) {
-            void vscode.window.showWarningMessage(`Duplicate index request for ${prettyScopeDir}`)
+        if (this.scopeDirIndexInProgress.has(scopeDir.toString())) {
+            void vscode.window.showWarningMessage(`Duplicate index request for ${displayPath(scopeDir)}`)
             return
         }
-        this.scopeDirIndexInProgress.set(scopeDir, done)
+        this.scopeDirIndexInProgress.set(scopeDir.toString(), done)
         void done.finally(() => {
-            this.scopeDirIndexInProgress.delete(scopeDir)
+            this.scopeDirIndexInProgress.delete(scopeDir.toString())
         })
 
         void vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: `Building Cody search index for ${prettyScopeDir}`,
+                title: `Building Cody search index for ${displayPath(scopeDir)}`,
                 cancellable: true,
             },
             async (_progress, token) => {
@@ -103,26 +100,28 @@ class IndexManager implements vscode.Disposable {
         )
     }
 
-    public refreshIndex(scopeDir: string): Promise<void> {
-        const fromCache = this.currentlyRefreshing.get(scopeDir)
+    public refreshIndex(scopeDir: FileURI): Promise<void> {
+        const fromCache = this.currentlyRefreshing.get(scopeDir.toString())
         if (fromCache) {
             return fromCache
         }
         const result = this.forceRefreshIndex(scopeDir)
-        this.currentlyRefreshing.set(scopeDir, result)
+        this.currentlyRefreshing.set(scopeDir.toString(), result)
         return result
     }
 
-    private async forceRefreshIndex(scopeDir: string): Promise<void> {
+    private async forceRefreshIndex(scopeDir: FileURI): Promise<void> {
         try {
             await this.symf.deleteIndex(scopeDir)
             await this.symf.ensureIndex(scopeDir, { hard: true })
         } catch (error) {
             if (!(error instanceof vscode.CancellationError)) {
-                void vscode.window.showErrorMessage(`Error refreshing search index for ${scopeDir}: ${error}`)
+                void vscode.window.showErrorMessage(
+                    `Error refreshing search index for ${displayPath(scopeDir)}: ${error}`
+                )
             }
         } finally {
-            this.currentlyRefreshing.delete(scopeDir)
+            this.currentlyRefreshing.delete(scopeDir.toString())
         }
     }
 }
@@ -160,26 +159,30 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
                 await this.indexManager.refreshIndex(scopeDirs[0])
             }),
             vscode.commands.registerCommand('cody.search.index-update-all', async () => {
-                const folders = vscode.workspace.workspaceFolders
+                const folders = vscode.workspace.workspaceFolders?.map(folder => folder.uri).filter(isFileURI)
                 if (!folders) {
                     void vscode.window.showWarningMessage('Open a workspace folder to index')
                     return
                 }
                 for (const folder of folders) {
-                    await this.indexManager.refreshIndex(folder.uri.fsPath)
+                    await this.indexManager.refreshIndex(folder)
                 }
             })
         )
         // Kick off search index creation for all workspace folders
         vscode.workspace.workspaceFolders?.forEach(folder => {
-            void this.symfRunner.ensureIndex(folder.uri.fsPath, { hard: false })
+            if (isFileURI(folder.uri)) {
+                void this.symfRunner.ensureIndex(folder.uri, { hard: false })
+            }
         })
         this.disposables.push(
             vscode.workspace.onDidChangeWorkspaceFolders(event => {
                 event.added.forEach(folder => {
-                    void this.symfRunner.ensureIndex(folder.uri.fsPath, {
-                        hard: false,
-                    })
+                    if (isFileURI(folder.uri)) {
+                        void this.symfRunner.ensureIndex(folder.uri, {
+                            hard: false,
+                        })
+                    }
                 })
             })
         )
@@ -302,59 +305,34 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
     }
 }
 
-function getRenderableComponents(filename: string): { base: string; dir: string; wsName?: string } {
-    // get workspace folders
-    const wsFolders = vscode.workspace.workspaceFolders
-    const home = os.homedir()
-
-    const base = path.basename(filename)
-    const absdir = path.dirname(filename)
-
-    if (wsFolders) {
-        for (const wsFolder of wsFolders) {
-            const reldir = path.relative(wsFolder.uri.fsPath, absdir)
-            if (!reldir.startsWith('..')) {
-                return { base, dir: reldir, wsName: wsFolders.length > 1 ? wsFolder.name : undefined }
-            }
-        }
-    }
-
-    // No matches in workspace folders, check home directory
-    const reldir = path.relative(home, absdir)
-    if (!reldir.startsWith('..')) {
-        return { base, dir: reldir }
-    }
-    return { base, dir: absdir }
-}
-
 /**
  * @returns the list of workspace folders to search. The first folder is the active file's folder.
  */
-function getScopeDirs(): string[] {
-    const folders = vscode.workspace.workspaceFolders
+function getScopeDirs(): FileURI[] {
+    const folders = vscode.workspace.workspaceFolders?.map(f => f.uri).filter(isFileURI)
     if (!folders) {
         return []
     }
     const uri = getEditor().active?.document.uri
     if (!uri) {
-        return folders.map(f => f.uri.fsPath)
+        return folders
     }
     const currentFolder = vscode.workspace.getWorkspaceFolder(uri)
     if (!currentFolder) {
-        return folders.map(f => f.uri.fsPath)
+        return folders
     }
 
     return [
-        currentFolder.uri.fsPath,
-        ...folders.filter(folder => folder.uri.toString() !== currentFolder.uri.toString()).map(f => f.uri.fsPath),
-    ]
+        isFileURI(currentFolder.uri) ? currentFolder.uri : undefined,
+        ...folders.filter(folder => folder.toString() !== currentFolder.uri.toString()),
+    ].filter(isDefined)
 }
 
-function groupByFile(results: Result[]): { file: string; results: Result[] }[] {
-    const groups: { file: string; results: Result[] }[] = []
+function groupByFile(results: Result[]): { file: vscode.Uri; results: Result[] }[] {
+    const groups: { file: vscode.Uri; results: Result[] }[] = []
 
     for (const result of results) {
-        const group = groups.find(g => g.file === result.file)
+        const group = groups.find(g => g.file.toString() === result.file.toString())
         if (group) {
             group.results.push(result)
         } else {
@@ -373,15 +351,10 @@ async function resultsToDisplayResults(results: Result[]): Promise<SearchPanelFi
     return (
         await Promise.all(
             groupedResults.map(async group => {
-                const uri = vscode.Uri.file(group.file)
                 try {
-                    const contents = await vscode.workspace.fs.readFile(uri)
-                    const { base, dir, wsName } = getRenderableComponents(group.file)
+                    const contents = await vscode.workspace.fs.readFile(group.file)
                     return {
-                        uri,
-                        basename: base,
-                        dirname: dir,
-                        wsname: wsName,
+                        uri: group.file,
                         snippets: group.results.map((result: Result): SearchPanelSnippet => {
                             return {
                                 contents: textDecoder.decode(
@@ -399,7 +372,7 @@ async function resultsToDisplayResults(results: Result[]): Promise<SearchPanelFi
                                 },
                             }
                         }),
-                    }
+                    } satisfies SearchPanelFile
                 } catch {
                     return null
                 }

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -8,7 +8,7 @@ import React, { useEffect, useMemo, useRef } from 'react'
 import { debounce } from 'lodash'
 import { LRUCache } from 'lru-cache'
 
-import { type SearchPanelFile } from '@sourcegraph/cody-shared'
+import { displayPathBasename, displayPathDirname, type SearchPanelFile } from '@sourcegraph/cody-shared'
 
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
@@ -300,14 +300,13 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                                         <span className={styles.filematchIcon}>
                                             <i className="codicon codicon-file-code" />
                                         </span>
-                                        <span className={styles.filematchTitle} title={result.basename}>
-                                            {result.basename}
+                                        <span className={styles.filematchTitle} title={displayPathBasename(result.uri)}>
+                                            {displayPathBasename(result.uri)}
                                         </span>
                                         <span className={styles.filematchDescription}>
-                                            {result.wsname && (
-                                                <span title={result.wsname}>{result.wsname}&nbsp;&middot;&nbsp;</span>
-                                            )}
-                                            <span title={result.dirname}>{result.dirname}</span>
+                                            <span title={displayPathDirname(result.uri)}>
+                                                {displayPathDirname(result.uri)}
+                                            </span>
                                         </span>
                                     </div>
                                 </div>


### PR DESCRIPTION
TODO: still need to separate this out cleanly, not ready for review

When a URI is accepted *and* it MUST be a `file` URI, it is helpful to use this new `FileURI` type so that the typechecker helps us enforce correctness.

The `isFileURI` helper is a type guard.

## Test plan

CI