### PR TITLE
skip remote embeddings detection for dotcom

### DIFF
--- a/lib/shared/src/embeddings/EmbeddingsDetector.ts
+++ b/lib/shared/src/embeddings/EmbeddingsDetector.ts
@@ -6,7 +6,7 @@ import { SourcegraphEmbeddingsSearchClient } from './client'
 // A factory for SourcegraphEmbeddingsSearchClients. Queries the client connection and app (if
 // available) for remote embeddings in parallel and returns the one with embeddings available.
 export const EmbeddingsDetector = {
-    // Creates an remote embeddings search client with the first client in `clients`
+    // Creates a remote embeddings search client with the first client in `clients`
     // that has remote embeddings. If none have remote embeddings, returns undefined. If all
     // fail, returns the first error.
     async newEmbeddingsSearchClient(

--- a/lib/shared/src/embeddings/EmbeddingsDetector.ts
+++ b/lib/shared/src/embeddings/EmbeddingsDetector.ts
@@ -1,19 +1,25 @@
+import { isDotCom } from '../sourcegraph-api/environments'
 import { type SourcegraphGraphQLAPIClient } from '../sourcegraph-api/graphql/client'
 
 import { SourcegraphEmbeddingsSearchClient } from './client'
 
-// A factory for SourcegraphEmbeddingsSearchClients. Queries the client
-// connection and app (if available) in parallel and returns the one with
-// embeddings available.
+// A factory for SourcegraphEmbeddingsSearchClients. Queries the client connection and app (if
+// available) for remote embeddings in parallel and returns the one with embeddings available.
 export const EmbeddingsDetector = {
-    // Creates an embeddings search client with the first client in `clients`
-    // that has embeddings. If none have embeddings, returns undefined. If all
+    // Creates an remote embeddings search client with the first client in `clients`
+    // that has remote embeddings. If none have remote embeddings, returns undefined. If all
     // fail, returns the first error.
     async newEmbeddingsSearchClient(
         clients: readonly SourcegraphGraphQLAPIClient[],
         codebase: string,
         codebaseLocalName: string
     ): Promise<SourcegraphEmbeddingsSearchClient | Error | undefined> {
+        // Remote embeddings are never used anymore for dotcom.
+        const hasNonDotComClient = clients.some(client => !isDotCom(client.endpoint))
+        if (!hasNonDotComClient) {
+            return undefined
+        }
+
         let firstError: Error | undefined
         let allFailed = true
         for (const promise of clients.map(client => this.detectEmbeddings(client, codebase, codebaseLocalName))) {


### PR DESCRIPTION
Remote embeddings are no longer used on dotcom, so this skips an unnecessary step. Even if remote embeddings would be found, they would not be used because the embeddings search methods already perform the check that was added here.



## Test plan

CI