### PR TITLE
use more standard AbortSignal for aborting stream/chat operations

### DIFF
--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -15,7 +15,12 @@ const DEFAULT_CHAT_COMPLETION_PARAMETERS: ChatParameters = {
 export class ChatClient {
     constructor(private completions: SourcegraphCompletionsClient) {}
 
-    public chat(messages: Message[], cb: CompletionCallbacks, params?: Partial<ChatParameters>): () => void {
+    public chat(
+        messages: Message[],
+        cb: CompletionCallbacks,
+        params: Partial<ChatParameters>,
+        abortSignal?: AbortSignal
+    ): void {
         const isLastMessageFromHuman = messages.length > 0 && messages.at(-1)!.speaker === 'human'
 
         const augmentedMessages =
@@ -30,13 +35,14 @@ export class ChatClient {
                 ? messages.concat([{ speaker: 'assistant' }])
                 : messages
 
-        return this.completions.stream(
+        this.completions.stream(
             {
                 ...DEFAULT_CHAT_COMPLETION_PARAMETERS,
                 ...params,
                 messages: augmentedMessages,
             },
-            cb
+            cb,
+            abortSignal
         )
     }
 }

--- a/lib/shared/src/common/abortController.test.ts
+++ b/lib/shared/src/common/abortController.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { dependentAbortController } from './abortController'
+
+describe('derivedAbortController', () => {
+    test('returns an instance of AbortController', () => {
+        const controller = dependentAbortController()
+        expect(controller).toBeInstanceOf(AbortController)
+    })
+
+    test('returns an aborted controller if the signal is already aborted', () => {
+        const signal = new AbortController()
+        signal.abort()
+        const controller = dependentAbortController(signal.signal)
+        expect(controller.signal.aborted).toBe(true)
+    })
+
+    test('aborts when the given signal is aborted', async () =>
+        new Promise<void>(done => {
+            const parent = new AbortController()
+            const controller = dependentAbortController(parent.signal)
+            expect(controller.signal.aborted).toBe(false)
+
+            controller.signal.addEventListener('abort', () => {
+                expect(controller.signal.aborted).toBe(true)
+                done()
+            })
+
+            parent.abort()
+        }))
+
+    test('removes the abort event listener after aborting', () => {
+        const parent = new AbortController()
+        const controller = dependentAbortController(parent.signal)
+        const abortHandler = vi.fn()
+        controller.signal.addEventListener('abort', abortHandler)
+
+        parent.abort()
+        expect(abortHandler).toHaveBeenCalledTimes(1)
+
+        // Emit abort event again to check if the listener has been removed.
+        parent.abort()
+        expect(abortHandler).toHaveBeenCalledTimes(1)
+    })
+})

--- a/lib/shared/src/common/abortController.ts
+++ b/lib/shared/src/common/abortController.ts
@@ -1,0 +1,34 @@
+/**
+ * Create a new AbortController that also aborts the given {@link signal} is aborted.
+ *
+ * This can be used for a operation that is controlled by an {@link AbortSignal} from its caller but
+ * that also needs to create its own {@link AbortController} to control its own operations.
+ */
+export function dependentAbortController(signal?: AbortSignal): AbortController {
+    const controller = new AbortController()
+
+    if (signal?.aborted) {
+        controller.abort()
+    } else if (signal) {
+        const abortHandler = (): void => {
+            signal.removeEventListener('abort', abortHandler)
+            controller.abort()
+        }
+        signal.addEventListener('abort', abortHandler)
+    }
+
+    return controller
+}
+
+/**
+ * Helper function to add an `abort` event listener (and properly remove it).
+ */
+export function onAbort(signal: AbortSignal | undefined, handler: () => void): void {
+    if (signal) {
+        const handlerWithRemoval = (): void => {
+            signal.removeEventListener('abort', handlerWithRemoval)
+            handler()
+        }
+        signal.addEventListener('abort', handlerWithRemoval)
+    }
+}

--- a/lib/shared/src/intent-detector/client.ts
+++ b/lib/shared/src/intent-detector/client.ts
@@ -79,7 +79,7 @@ export class SourcegraphIntentDetectorClient implements IntentDetector {
 
         const result = await new Promise<string>(resolve => {
             let responseText = ''
-            return completionsClient.stream(
+            completionsClient.stream(
                 {
                     fast: true,
                     temperature: 0,

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -1,13 +1,14 @@
 import { fetchEventSource } from '@microsoft/fetch-event-source'
 
+import { dependentAbortController } from '../../common/abortController'
 import { addCustomUserAgent } from '../graphql/client'
 
 import { SourcegraphCompletionsClient } from './client'
 import type { CompletionCallbacks, CompletionParameters, Event } from './types'
 
 export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsClient {
-    public stream(params: CompletionParameters, cb: CompletionCallbacks): () => void {
-        const abort = new AbortController()
+    public stream(params: CompletionParameters, cb: CompletionCallbacks, signal?: AbortSignal): void {
+        const abort = dependentAbortController(signal)
         const headersInstance = new Headers(this.config.customHeaders as HeadersInit)
         addCustomUserAgent(headersInstance)
         headersInstance.set('Content-Type', 'application/json; charset=utf-8')
@@ -74,9 +75,6 @@ export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsC
             abort.abort()
             console.error(error)
         })
-        return () => {
-            abort.abort()
-        }
     }
 }
 

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -60,5 +60,5 @@ export abstract class SourcegraphCompletionsClient {
         }
     }
 
-    public abstract stream(params: CompletionParameters, cb: CompletionCallbacks): () => void
+    public abstract stream(params: CompletionParameters, cb: CompletionCallbacks, signal?: AbortSignal): void
 }

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -1,6 +1,7 @@
 import http from 'http'
 import https from 'https'
 
+import { onAbort } from '../../common/abortController'
 import { logError } from '../../logger'
 import { isError } from '../../utils'
 import { RateLimitError } from '../errors'
@@ -14,7 +15,7 @@ import { type CompletionCallbacks, type CompletionParameters } from './types'
 const isTemperatureZero = process.env.CODY_TEMPERATURE_ZERO === 'true'
 
 export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClient {
-    public stream(params: CompletionParameters, cb: CompletionCallbacks): () => void {
+    public stream(params: CompletionParameters, cb: CompletionCallbacks, signal?: AbortSignal): void {
         if (isTemperatureZero) {
             params = {
                 ...params,
@@ -172,7 +173,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
         request.write(JSON.stringify(params))
         request.end()
 
-        return () => request.destroy()
+        onAbort(signal, () => request.destroy())
     }
 }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -869,7 +869,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         })
 
         this.cancelInProgressCompletion()
-        this.completionCanceller = this.chatClient.chat(
+        const abortController = new AbortController()
+        this.completionCanceller = () => abortController.abort()
+        this.chatClient.chat(
             prompt,
             {
                 onChange: (content: string) => {
@@ -886,7 +888,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     typewriter.stop(error)
                 },
             },
-            { model: this.chatModel.modelID }
+            { model: this.chatModel.modelID },
+            abortController.signal
         )
     }
 

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -82,7 +82,9 @@ export class EditProvider {
         }
 
         let textConsumed = 0
-        this.cancelCompletionCallback = this.config.chat.chat(
+        const abortController = new AbortController()
+        this.cancelCompletionCallback = () => abortController.abort()
+        this.config.chat.chat(
             messages,
             {
                 onChange: text => {
@@ -113,7 +115,8 @@ export class EditProvider {
                     console.error(`Completion request failed: ${err.message}`)
                 },
             },
-            { model, stopSequences }
+            { model, stopSequences },
+            abortController.signal
         )
     }
 


### PR DESCRIPTION
Passing an AbortSignal is more standard and interoperable than the previous way of having them return a `() => void` that cancels the operation.



## Test plan

CI