### PR TITLE
use async generator for completions and chat clients

### DIFF
--- a/lib/shared/src/intent-detector/client.ts
+++ b/lib/shared/src/intent-detector/client.ts
@@ -82,43 +82,39 @@ export class SourcegraphIntentDetectorClient implements IntentDetector {
         const preamble = this.buildInitialTranscript(options)
         const examples = this.buildExampleTranscript(options)
 
-        const result = await new Promise<string>(resolve => {
-            let responseText = ''
-            completionsClient.stream(
+        let result = ''
+        const stream = completionsClient.stream({
+            fast: true,
+            temperature: 0,
+            maxTokensToSample: ANSWER_TOKENS,
+            topK: -1,
+            topP: -1,
+            messages: [
+                ...preamble,
+                ...examples,
                 {
-                    fast: true,
-                    temperature: 0,
-                    maxTokensToSample: ANSWER_TOKENS,
-                    topK: -1,
-                    topP: -1,
-                    messages: [
-                        ...preamble,
-                        ...examples,
-                        {
-                            speaker: 'human',
-                            text: input,
-                        },
-                        {
-                            speaker: 'assistant',
-                        },
-                    ],
+                    speaker: 'human',
+                    text: input,
                 },
                 {
-                    onChange: (text: string) => {
-                        responseText = text
-                    },
-                    onComplete: () => {
-                        resolve(responseText)
-                    },
-                    onError: (error: Error, statusCode?: number) => {
-                        console.error(
-                            `Error detecting intent: Status code ${statusCode}: ${error.message}`
-                        )
-                        resolve(fallback)
-                    },
-                }
-            )
+                    speaker: 'assistant',
+                },
+            ],
         })
+        for await (const message of stream) {
+            switch (message.type) {
+                case 'change': {
+                    result = message.text
+                    break
+                }
+                case 'error': {
+                    console.error(
+                        `Error detecting intent: Status code ${message.statusCode}: ${message.error.message}`
+                    )
+                    return fallback
+                }
+            }
+        }
 
         const responseClassification = result.match(/<classification>(.*?)<\/classification>/)?.[1]
         if (!responseClassification) {

--- a/lib/shared/src/sourcegraph-api/completions/browserClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/browserClient.ts
@@ -7,7 +7,11 @@ import { SourcegraphCompletionsClient } from './client'
 import type { CompletionCallbacks, CompletionParameters, Event } from './types'
 
 export class SourcegraphBrowserCompletionsClient extends SourcegraphCompletionsClient {
-    public stream(params: CompletionParameters, cb: CompletionCallbacks, signal?: AbortSignal): void {
+    protected _streamWithCallbacks(
+        params: CompletionParameters,
+        cb: CompletionCallbacks,
+        signal?: AbortSignal
+    ): void {
         const abort = dependentAbortController(signal)
         const headersInstance = new Headers(this.config.customHeaders as HeadersInit)
         addCustomUserAgent(headersInstance)

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -15,7 +15,11 @@ import type { CompletionCallbacks, CompletionParameters } from './types'
 const isTemperatureZero = process.env.CODY_TEMPERATURE_ZERO === 'true'
 
 export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClient {
-    public stream(params: CompletionParameters, cb: CompletionCallbacks, signal?: AbortSignal): void {
+    protected _streamWithCallbacks(
+        params: CompletionParameters,
+        cb: CompletionCallbacks,
+        signal?: AbortSignal
+    ): void {
         if (isTemperatureZero) {
             params = {
                 ...params,

--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -36,15 +36,21 @@ export interface CompletionParameters {
 
 export interface CompletionCallbacks {
     onChange: (text: string) => void
-    /**
-     * Only called when a stream successfully completes. If an error is
-     * encountered, this is never called.
-     */
     onComplete: () => void
-    /**
-     * Only called when a stream fails or encounteres an error. This should be
-     * assumed to be a "complete" event, and no other callbacks will be called
-     * afterwards.
-     */
     onError: (error: Error, statusCode?: number) => void
 }
+
+/**
+ * Values for the completion generator that represent the progress of a streaming completion.
+ *
+ * - `change`: Called when new text is received. The `text` is the full text, not just the new text
+ *   since the last `change` value.
+ * - `complete`: Only called when a stream successfully completes. If an error is encountered, this
+ *   is never called.
+ * - `error`: Only called when a stream fails or encounteres an error. This should be assumed to be
+ *   a "complete" event, and no other callbacks will be called afterwards.
+ */
+export type CompletionGeneratorValue =
+    | { type: 'change'; text: string }
+    | { type: 'complete' }
+    | { type: 'error'; error: Error; statusCode?: number }

--- a/vscode/src/local-context/symfExpandQuery.ts
+++ b/vscode/src/local-context/symfExpandQuery.ts
@@ -2,68 +2,55 @@ import { XMLParser } from 'fast-xml-parser'
 
 import type { SourcegraphCompletionsClient } from '@sourcegraph/cody-shared'
 
-export function symfExpandQuery(
+export async function symfExpandQuery(
     completionsClient: SourcegraphCompletionsClient,
     query: string
 ): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-        const streamingText: string[] = []
-        completionsClient.stream(
+    const stream = completionsClient.stream({
+        messages: [
             {
-                messages: [
-                    {
-                        speaker: 'human',
-                        text: `You are helping the user search over a codebase. List some filename fragments that would match files relevant to read to answer the user's query. Present your results in an XML list in the following format: <keywords><keyword><value>a single keyword</value><variants>a space separated list of synonyms and variants of the keyword, including acronyms, abbreviations, and expansions</variants><weight>a numerical weight between 0.0 and 1.0 that indicates the importance of the keyword</weight></keyword></keywords>. Here is the user query: <userQuery>${query}</userQuery>`,
-                    },
-                    { speaker: 'assistant' },
-                ],
-                maxTokensToSample: 400,
-                temperature: 0,
-                topK: 1,
-                fast: true,
+                speaker: 'human',
+                text: `You are helping the user search over a codebase. List some filename fragments that would match files relevant to read to answer the user's query. Present your results in an XML list in the following format: <keywords><keyword><value>a single keyword</value><variants>a space separated list of synonyms and variants of the keyword, including acronyms, abbreviations, and expansions</variants><weight>a numerical weight between 0.0 and 1.0 that indicates the importance of the keyword</weight></keyword></keywords>. Here is the user query: <userQuery>${query}</userQuery>`,
             },
-            {
-                onChange(text) {
-                    streamingText.push(text)
-                },
-                onComplete() {
-                    const text = streamingText.at(-1) ?? ''
-                    try {
-                        const parser = new XMLParser()
-                        const document = parser.parse(text) as
-                            | undefined
-                            | {
-                                  keywords?: {
-                                      keyword?: {
-                                          value?: string
-                                          variants?: string
-                                          weight?: number
-                                      }[]
-                                  }
-                              }
-                        const keywords = document?.keywords?.keyword ?? []
-                        const result = new Set<string>()
-                        for (const { value, variants } of keywords) {
-                            if (typeof value === 'string' && value) {
-                                result.add(value)
-                            }
-                            if (typeof variants === 'string') {
-                                for (const variant of variants.split(' ')) {
-                                    if (variant) {
-                                        result.add(variant)
-                                    }
-                                }
-                            }
-                        }
-                        resolve([...result].sort().join(' '))
-                    } catch (error) {
-                        reject(error)
-                    }
-                },
-                onError(error) {
-                    reject(error)
-                },
-            }
-        )
+            { speaker: 'assistant' },
+        ],
+        maxTokensToSample: 400,
+        temperature: 0,
+        topK: 1,
+        fast: true,
     })
+
+    const streamingText: string[] = []
+    for await (const message of stream) {
+        switch (message.type) {
+            case 'change': {
+                streamingText.push(message.text)
+                break
+            }
+            case 'error': {
+                throw message.error
+            }
+        }
+    }
+
+    const text = streamingText.at(-1) ?? ''
+    const parser = new XMLParser()
+    const document = parser.parse(text)
+    const keywords: { value?: string; variants?: string; weight?: number }[] =
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        document?.keywords?.keyword ?? []
+    const result = new Set<string>()
+    for (const { value, variants } of keywords) {
+        if (typeof value === 'string' && value) {
+            result.add(value)
+        }
+        if (typeof variants === 'string') {
+            for (const variant of variants.split(' ')) {
+                if (variant) {
+                    result.add(variant)
+                }
+            }
+        }
+    }
+    return [...result].sort().join(' ')
 }


### PR DESCRIPTION
This is more idiomatic JavaScript, is cleaner, and is more interoperable than custom callbacks.

The underlying implementations (`_streamWithCallbacks` methods) still use callbacks. That can be addressed separately. It's a nice win for callers to not need to use callbacks.



## Test plan

CI and e2e tests. Confirmed that completions, chat, and inline edits work manually.