### PR TITLE
move ollama client to lib/shared

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -107,6 +107,7 @@ export type { GraphContextFetcher } from './graph-context'
 export { GuardrailsPost, summariseAttribution } from './guardrails'
 export type { Attribution, Guardrails } from './guardrails'
 export { SourcegraphGuardrailsClient } from './guardrails/client'
+export { STOP_REASON_STREAMING_CHUNK } from './inferenceClient/misc'
 export type { IntentClassificationOption, IntentDetector } from './intent-detector'
 export { SourcegraphIntentDetectorClient } from './intent-detector/client'
 export type {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -125,6 +125,7 @@ export type {
     SearchPanelSnippet,
 } from './local-context'
 export { logDebug, logError, setLogger } from './logger'
+export { createOllamaClient, type OllamaGenerateParams } from './ollama/ollama-client'
 export {
     MAX_BYTES_PER_FILE,
     MAX_CURRENT_FILE_TOKENS,

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -107,7 +107,12 @@ export type { GraphContextFetcher } from './graph-context'
 export { GuardrailsPost, summariseAttribution } from './guardrails'
 export type { Attribution, Guardrails } from './guardrails'
 export { SourcegraphGuardrailsClient } from './guardrails/client'
-export { STOP_REASON_STREAMING_CHUNK } from './inferenceClient/misc'
+export {
+    STOP_REASON_STREAMING_CHUNK,
+    type CodeCompletionsClient,
+    type CodeCompletionsParams,
+    type CompletionResponseGenerator,
+} from './inferenceClient/misc'
 export type { IntentClassificationOption, IntentDetector } from './intent-detector'
 export { SourcegraphIntentDetectorClient } from './intent-detector/client'
 export type {

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -1,3 +1,6 @@
+import type { CompletionsClientConfig } from '../sourcegraph-api/completions/client'
+import type { CompletionParameters, CompletionResponse } from '../sourcegraph-api/completions/types'
+
 /**
  * Marks the yielded value as an incomplete response.
  *
@@ -5,3 +8,11 @@
  * all possible response types.
  */
 export const STOP_REASON_STREAMING_CHUNK = 'cody-streaming-chunk'
+
+export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'> & { timeoutMs: number }
+export type CompletionResponseGenerator = AsyncGenerator<CompletionResponse>
+
+export interface CodeCompletionsClient<T = CodeCompletionsParams> {
+    complete(params: T, abortController: AbortController): CompletionResponseGenerator
+    onConfigurationChange(newConfig: CompletionsClientConfig): void
+}

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -1,0 +1,7 @@
+/**
+ * Marks the yielded value as an incomplete response.
+ *
+ * TODO: migrate to union of multiple `CompletionResponse` types to explicitly document
+ * all possible response types.
+ */
+export const STOP_REASON_STREAMING_CHUNK = 'cody-streaming-chunk'

--- a/lib/shared/src/ollama/ollama-client.ts
+++ b/lib/shared/src/ollama/ollama-client.ts
@@ -1,17 +1,14 @@
+import { isDefined } from '../common'
+import type { OllamaGenerateParameters, OllamaOptions } from '../configuration'
 import {
     STOP_REASON_STREAMING_CHUNK,
-    isAbortError,
-    isDefined,
-    isError,
-    isNodeResponse,
     type CodeCompletionsClient,
-    type CompletionLogger,
     type CompletionResponseGenerator,
-    type OllamaGenerateParameters,
-    type OllamaOptions,
-} from '@sourcegraph/cody-shared'
-
-import { logDebug } from '../../log'
+} from '../inferenceClient/misc'
+import type { CompletionLogger } from '../sourcegraph-api/completions/client'
+import { isAbortError } from '../sourcegraph-api/errors'
+import { isNodeResponse } from '../sourcegraph-api/graphql/client'
+import { isError } from '../utils'
 
 /**
  * @see https://sourcegraph.com/github.com/jmorganca/ollama/-/blob/api/types.go?L35
@@ -53,7 +50,8 @@ const RESPONSE_SEPARATOR = /\r?\n/
  */
 export function createOllamaClient(
     ollamaOptions: OllamaOptions,
-    logger?: CompletionLogger
+    logger?: CompletionLogger,
+    logDebug?: (filterLabel: string, text: string, ...args: unknown[]) => void
 ): CodeCompletionsClient<OllamaGenerateParams> {
     async function* complete(
         params: OllamaGenerateParams,
@@ -99,7 +97,7 @@ export function createOllamaClient(
                     if (line.done && line.total_duration) {
                         const timingInfo = formatOllamaTimingInfo(line)
                         // TODO(valery): yield debug message with timing info to a tracer
-                        logDebug('ollama', 'generation done', timingInfo.join(' '))
+                        logDebug?.('ollama', 'generation done', timingInfo.join(' '))
                     }
                 }
             }

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -2,6 +2,7 @@ import {
     FeatureFlag,
     NetworkError,
     RateLimitError,
+    STOP_REASON_STREAMING_CHUNK,
     TracedError,
     addTraceparent,
     featureFlagProvider,
@@ -9,29 +10,15 @@ import {
     isAbortError,
     isNodeResponse,
     isRateLimitError,
+    type CodeCompletionsClient,
+    type CodeCompletionsParams,
     type CompletionLogger,
-    type CompletionParameters,
     type CompletionResponse,
+    type CompletionResponseGenerator,
     type CompletionsClientConfig,
 } from '@sourcegraph/cody-shared'
 
 import { fetch } from '../fetch'
-
-export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'> & { timeoutMs: number }
-export type CompletionResponseGenerator = AsyncGenerator<CompletionResponse>
-
-export interface CodeCompletionsClient<T = CodeCompletionsParams> {
-    complete(params: T, abortController: AbortController): CompletionResponseGenerator
-    onConfigurationChange(newConfig: CompletionsClientConfig): void
-}
-
-/**
- * Marks the yielded value as an incomplete response.
- *
- * TODO: migrate to union of multiple `CompletionResponse` types to explicitly document
- * all possible response types.
- */
-export const STOP_REASON_STREAMING_CHUNK = 'cody-streaming-chunk'
 
 /**
  * Access the code completion LLM APIs via a Sourcegraph server instance.

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -1,12 +1,17 @@
 import * as vscode from 'vscode'
 
-import { FeatureFlag, featureFlagProvider, isDotCom, type Configuration } from '@sourcegraph/cody-shared'
+import {
+    FeatureFlag,
+    featureFlagProvider,
+    isDotCom,
+    type CodeCompletionsClient,
+    type Configuration,
+} from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 import type { AuthProvider } from '../services/AuthProvider'
 import type { CodyStatusBar } from '../services/StatusBar'
 
-import type { CodeCompletionsClient } from './client'
 import type { ContextStrategy } from './context/context-strategy'
 import type { BfgRetriever } from './context/retrievers/bfg/bfg-retriever'
 import { InlineCompletionItemProvider } from './inline-completion-item-provider'

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -4,14 +4,15 @@ import { expect } from 'vitest'
 import {
     STOP_REASON_STREAMING_CHUNK,
     testFileUri,
+    type CodeCompletionsClient,
     type CompletionParameters,
     type CompletionResponse,
+    type CompletionResponseGenerator,
 } from '@sourcegraph/cody-shared'
 
 import type { SupportedLanguage } from '../../tree-sitter/grammars'
 import { updateParseTreeCache } from '../../tree-sitter/parse-tree-cache'
 import { getParser } from '../../tree-sitter/parser'
-import type { CodeCompletionsClient, CompletionResponseGenerator } from '../client'
 import { ContextMixer } from '../context/context-mixer'
 import { DefaultContextStrategyFactory } from '../context/context-strategy'
 import { getCompletionIntent } from '../doc-context-getters'

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -2,6 +2,7 @@ import { isEqual } from 'lodash'
 import { expect } from 'vitest'
 
 import {
+    STOP_REASON_STREAMING_CHUNK,
     testFileUri,
     type CompletionParameters,
     type CompletionResponse,
@@ -10,11 +11,7 @@ import {
 import type { SupportedLanguage } from '../../tree-sitter/grammars'
 import { updateParseTreeCache } from '../../tree-sitter/parse-tree-cache'
 import { getParser } from '../../tree-sitter/parser'
-import {
-    STOP_REASON_STREAMING_CHUNK,
-    type CodeCompletionsClient,
-    type CompletionResponseGenerator,
-} from '../client'
+import type { CodeCompletionsClient, CompletionResponseGenerator } from '../client'
 import { ContextMixer } from '../context/context-mixer'
 import { DefaultContextStrategyFactory } from '../context/context-strategy'
 import { getCompletionIntent } from '../doc-context-getters'

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -1,16 +1,21 @@
 import * as anthropic from '@anthropic-ai/sdk'
 import * as vscode from 'vscode'
 
-import { displayPath, tokensToChars, type Message } from '@sourcegraph/cody-shared'
+import {
+    displayPath,
+    tokensToChars,
+    type CodeCompletionsClient,
+    type CodeCompletionsParams,
+    type Message,
+} from '@sourcegraph/cody-shared'
 
-import type { CodeCompletionsClient, CodeCompletionsParams } from '../client'
 import {
     CLOSING_CODE_TAG,
+    MULTILINE_STOP_SEQUENCE,
+    OPENING_CODE_TAG,
     extractFromCodeBlock,
     fixBadCompletionStart,
     getHeadAndTail,
-    MULTILINE_STOP_SEQUENCE,
-    OPENING_CODE_TAG,
     trimLeadingWhitespaceUntilNewline,
     type PrefixComponents,
 } from '../text-processing'

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import {
     graphqlClient,
+    type CodeCompletionsClient,
     type CodyLLMSiteConfiguration,
     type Configuration,
     type GraphQLAPIClientConfig,
 } from '@sourcegraph/cody-shared'
 
 import { DEFAULT_VSCODE_SETTINGS } from '../../testutils/mocks'
-import type { CodeCompletionsClient } from '../client'
 
 import { createProviderConfig } from './create-provider'
 

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -1,12 +1,12 @@
 import {
     FeatureFlag,
     featureFlagProvider,
+    type CodeCompletionsClient,
     type CodyLLMSiteConfiguration,
     type Configuration,
 } from '@sourcegraph/cody-shared'
 
 import { logError } from '../../log'
-import type { CodeCompletionsClient } from '../client'
 
 import { createProviderConfig as createAnthropicProviderConfig } from './anthropic'
 import {

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -1,6 +1,8 @@
+import { STOP_REASON_STREAMING_CHUNK } from '@sourcegraph/cody-shared'
+
 import { addAutocompleteDebugEvent } from '../../services/open-telemetry/debug-utils'
 import { canUsePartialCompletion } from '../can-use-partial-completion'
-import { STOP_REASON_STREAMING_CHUNK, type CompletionResponseGenerator } from '../client'
+import type { CompletionResponseGenerator } from '../client'
 import type { DocumentContext } from '../get-current-doc-context'
 import { getFirstLine } from '../text-processing'
 import { parseAndTruncateCompletion } from '../text-processing/parse-and-truncate-completion'

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -1,8 +1,7 @@
-import { STOP_REASON_STREAMING_CHUNK } from '@sourcegraph/cody-shared'
+import { STOP_REASON_STREAMING_CHUNK, type CompletionResponseGenerator } from '@sourcegraph/cody-shared'
 
 import { addAutocompleteDebugEvent } from '../../services/open-telemetry/debug-utils'
 import { canUsePartialCompletion } from '../can-use-partial-completion'
-import type { CompletionResponseGenerator } from '../client'
 import type { DocumentContext } from '../get-current-doc-context'
 import { getFirstLine } from '../text-processing'
 import { parseAndTruncateCompletion } from '../text-processing/parse-and-truncate-completion'

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -1,9 +1,14 @@
 import * as vscode from 'vscode'
 
-import { displayPath, tokensToChars, type AutocompleteTimeouts } from '@sourcegraph/cody-shared'
+import {
+    displayPath,
+    tokensToChars,
+    type AutocompleteTimeouts,
+    type CodeCompletionsClient,
+    type CodeCompletionsParams,
+} from '@sourcegraph/cody-shared'
 
 import { getLanguageConfig } from '../../tree-sitter/language'
-import type { CodeCompletionsClient, CodeCompletionsParams } from '../client'
 import { CLOSING_CODE_TAG, getHeadAndTail, OPENING_CODE_TAG } from '../text-processing'
 import type { ContextSnippet } from '../types'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'

--- a/vscode/src/completions/providers/get-completion-params.ts
+++ b/vscode/src/completions/providers/get-completion-params.ts
@@ -1,6 +1,4 @@
-import type { AutocompleteTimeouts } from '@sourcegraph/cody-shared'
-
-import type { CodeCompletionsParams } from '../client'
+import type { AutocompleteTimeouts, CodeCompletionsParams } from '@sourcegraph/cody-shared'
 
 import {
     fetchAndProcessCompletions,

--- a/vscode/src/completions/providers/ollama-client.ts
+++ b/vscode/src/completions/providers/ollama-client.ts
@@ -4,13 +4,14 @@ import {
     isDefined,
     isError,
     isNodeResponse,
+    type CodeCompletionsClient,
     type CompletionLogger,
+    type CompletionResponseGenerator,
     type OllamaGenerateParameters,
     type OllamaOptions,
 } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../../log'
-import type { CodeCompletionsClient, CompletionResponseGenerator } from '../client'
 
 /**
  * @see https://sourcegraph.com/github.com/jmorganca/ollama/-/blob/api/types.go?L35

--- a/vscode/src/completions/providers/ollama-client.ts
+++ b/vscode/src/completions/providers/ollama-client.ts
@@ -1,4 +1,5 @@
 import {
+    STOP_REASON_STREAMING_CHUNK,
     isAbortError,
     isDefined,
     isError,
@@ -9,11 +10,7 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../../log'
-import {
-    STOP_REASON_STREAMING_CHUNK,
-    type CodeCompletionsClient,
-    type CompletionResponseGenerator,
-} from '../client'
+import type { CodeCompletionsClient, CompletionResponseGenerator } from '../client'
 
 /**
  * @see https://sourcegraph.com/github.com/jmorganca/ollama/-/blob/api/types.go?L35

--- a/vscode/src/completions/providers/unstable-ollama.ts
+++ b/vscode/src/completions/providers/unstable-ollama.ts
@@ -1,6 +1,11 @@
 import type * as vscode from 'vscode'
 
-import { displayPath, type OllamaOptions } from '@sourcegraph/cody-shared'
+import {
+    createOllamaClient,
+    displayPath,
+    type OllamaGenerateParams,
+    type OllamaOptions,
+} from '@sourcegraph/cody-shared'
 
 import { logger } from '../../log'
 import { getLanguageConfig } from '../../tree-sitter/language'
@@ -8,7 +13,6 @@ import type { ContextSnippet } from '../types'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 
 import { fetchAndProcessCompletions, type FetchCompletionResult } from './fetch-and-process-completions'
-import { createOllamaClient, type OllamaGenerateParams } from './ollama-client'
 import {
     Provider,
     type CompletionProviderTracer,

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -1,8 +1,12 @@
 import * as vscode from 'vscode'
 
-import { displayPath, tokensToChars } from '@sourcegraph/cody-shared'
+import {
+    displayPath,
+    tokensToChars,
+    type CodeCompletionsClient,
+    type CodeCompletionsParams,
+} from '@sourcegraph/cody-shared'
 
-import type { CodeCompletionsClient, CodeCompletionsParams } from '../client'
 import {
     CLOSING_CODE_TAG,
     MULTILINE_STOP_SEQUENCE,

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -3,21 +3,19 @@ import type * as vscode from 'vscode'
 import {
     ChatClient,
     CodebaseContext,
-    graphqlClient,
-    isError,
     SourcegraphEmbeddingsSearchClient,
     SourcegraphGuardrailsClient,
     SourcegraphIntentDetectorClient,
+    graphqlClient,
+    isError,
+    type CodeCompletionsClient,
     type ConfigurationWithAccessToken,
     type Editor,
     type Guardrails,
     type IntentDetector,
 } from '@sourcegraph/cody-shared'
 
-import {
-    createClient as createCodeCompletionsClint,
-    type CodeCompletionsClient,
-} from './completions/client'
+import { createClient as createCodeCompletionsClient } from './completions/client'
 import type { PlatformContext } from './extension.common'
 import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
 import type { SymfRunner } from './local-context/symf'
@@ -67,7 +65,7 @@ export async function configureExternalServices(
     const sentryService = platform.createSentryService?.(initialConfig)
     const openTelemetryService = platform.createOpenTelemetryService?.(initialConfig)
     const completionsClient = platform.createCompletionsClient(initialConfig, logger)
-    const codeCompletionsClient = createCodeCompletionsClint(initialConfig, logger)
+    const codeCompletionsClient = createCodeCompletionsClient(initialConfig, logger)
 
     const symfRunner = platform.createSymfRunner?.(
         context,


### PR DESCRIPTION
This is in preparation for support for Ollama as a chat backend (not just Ollama completions as was [released in v1.1.0](https://sourcegraph.com/blog/cody-vscode-1.1.0-release)).

No behavioral change; just moving code:

- ollama client
- CodeCompletions{Client,Params} and CompletionResponseGenerator
- STOP_REASON_STREAMING_CHUNK

## Test plan

CI