### PR TITLE
Restrict chat input to 80% of viewport height

### DIFF
--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -118,6 +118,8 @@ body[data-vscode-theme-kind='vscode-light'] .transcript-item pre>code {
     width: 100%;
     overflow: hidden;
     min-height: 3.5rem;
+    /* Don't allow the input box to become larger than the webview to avoid submit buttons going off the screen */
+    max-height: 80vh; /* 80% of viewport height */
     /* Place on top of each other */
     grid-area: 1 / 1 / 2 / 2;
 }


### PR DESCRIPTION
This avoids the chat box being taller than the webview, which can cause the buttons to be pushed off the bottom of the screen.

Fixes #2824

https://github.com/sourcegraph/cody/assets/1078012/7b048659-45ff-42e0-84f2-f587cdd5c159

## Test plan

Paste large input of press Shift+Enter repeatedly to add more lines to the chat input than fit on the screen.