### PR TITLE
POC: test out grit for shared-imports

### DIFF
--- a/.grit/.gitignore
+++ b/.grit/.gitignore
@@ -1,0 +1,2 @@
+.gritmodules*
+*.log

--- a/.grit/grit.yaml
+++ b/.grit/grit.yaml
@@ -1,0 +1,16 @@
+version: 0.0.1
+patterns:
+  - name: github.com/getgrit/stdlib#*
+  - name: no_shared_imports
+    level: error
+    description: |
+      Please import from @sourcegraph/cody-shared instead of subpaths.
+      If you need to use something that is not exported by @sourcegraph/cody-shared, just update lib/shared/src/index.ts to export the thing you need.
+      Reasons for this restriction: (1) enforce a clean boundary between the internal and external API of the shared lib,
+      (2) avoid accidentally bundling multiple copies of the shared lib.
+    body: |
+      language js
+
+      file($name, $body) where {
+        $body <: contains `import $_ from "@sourcegraph/cody-shared/$_"`
+      }


### PR DESCRIPTION
https://github.com/sourcegraph/cody/pull/2836 discarded the [`no-restricted-imports` rule](https://github.com/sourcegraph/cody/pull/2836/files#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5L64-L76).

This is mostly an attempt to see how fast it would be to replicate this with GritQL.

```
$ time grit check
grit check  0.39s user 0.15s system 270% cpu 0.201 total
```