### PR TITLE
fix storybooks

### DIFF
--- a/vscode/.storybook/main.ts
+++ b/vscode/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite'
+import { mergeConfig } from 'vite'
 
 const config: StorybookConfig = {
     stories: ['../webviews/**/*.story.@(js|jsx|ts|tsx)'],
@@ -7,8 +8,8 @@ const config: StorybookConfig = {
         name: '@storybook/react-vite',
         options: {},
     },
-    docs: {
-        autodocs: 'tag',
+    viteFinal: async config => {
+        return mergeConfig(config, { define: { 'process.env': {} } })
     },
 }
 export default config


### PR DESCRIPTION
They were erroring because `process` was imported along with `@sourcegraph/cody-shared`.



## Test plan

Run `pnpm -C vscode storybook` and try viewing a story.