### PR TITLE
resolve remote embeddings fileNames to URIs

### DIFF
--- a/lib/shared/src/codebase-context/index.ts
+++ b/lib/shared/src/codebase-context/index.ts
@@ -51,6 +51,7 @@ export class CodebaseContext {
      * the most important context message appears *last*)
      */
     public async getContextMessages(
+        workspaceFolderUri: URI,
         query: string,
         options: ContextSearchOptions
     ): Promise<ContextMessage[]> {
@@ -63,7 +64,7 @@ export class CodebaseContext {
                 return []
             default: {
                 return this.localEmbeddings || this.embeddings
-                    ? this.getEmbeddingsContextMessages(query, options)
+                    ? this.getEmbeddingsContextMessages(workspaceFolderUri, query, options)
                     : this.getLocalContextMessages(query, options)
             }
         }
@@ -73,10 +74,11 @@ export class CodebaseContext {
     // We can gradually eliminate them from the prompt, instead of losing them all at once with a single large messeage
     // when we run out of tokens.
     private async getEmbeddingsContextMessages(
+        workspaceFolderUri: URI,
         query: string,
         options: ContextSearchOptions
     ): Promise<ContextMessage[]> {
-        const combinedResults = await this.getEmbeddingSearchResults(query, options)
+        const combinedResults = await this.getEmbeddingSearchResults(workspaceFolderUri, query, options)
 
         return groupResultsByFile(combinedResults)
             .reverse() // Reverse results so that they appear in ascending order of importance (least -> most).
@@ -85,6 +87,7 @@ export class CodebaseContext {
     }
 
     private async getEmbeddingSearchResults(
+        workspaceFolderUri: URI,
         query: string,
         options: ContextSearchOptions
     ): Promise<EmbeddingsSearchResult[]> {
@@ -97,6 +100,7 @@ export class CodebaseContext {
 
         if (this.embeddings) {
             const embeddingsSearchResults = await this.embeddings.search(
+                workspaceFolderUri,
                 query,
                 options.numCodeResults,
                 options.numTextResults

--- a/lib/shared/src/embeddings/index.ts
+++ b/lib/shared/src/embeddings/index.ts
@@ -1,3 +1,4 @@
+import type { URI } from 'vscode-uri'
 import type * as status from '../codebase-context/context-status'
 import type { EmbeddingsSearchResults } from '../sourcegraph-api/graphql/client'
 
@@ -5,6 +6,7 @@ export interface EmbeddingsSearch extends status.ContextStatusProvider {
     repoId: string
     endpoint: string
     search(
+        workspaceFolderUri: URI,
         query: string,
         codeResultsCount: number,
         textResultsCount: number

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -110,12 +110,21 @@ interface RepositoryEmbeddingExistsResponse {
     repository: { id: string; embeddingExists: boolean } | null
 }
 
+/**
+ * {@link EmbeddingsSearchResults} with `fileName` instead of `uri` fields in the array elements,
+ * because that is what GraphQL returns.
+ */
+interface EmbeddingsSearchResultsWithoutURIs {
+    codeResults: (Omit<EmbeddingsSearchResult, 'uri'> & { fileName: string })[]
+    textResults: (Omit<EmbeddingsSearchResult, 'uri'> & { fileName: string })[]
+}
+
 interface EmbeddingsSearchResponse {
-    embeddingsSearch: EmbeddingsSearchResults
+    embeddingsSearch: EmbeddingsSearchResultsWithoutURIs
 }
 
 interface EmbeddingsMultiSearchResponse {
-    embeddingsMultiSearch: EmbeddingsSearchResults
+    embeddingsMultiSearch: EmbeddingsSearchResultsWithoutURIs
 }
 
 interface SearchAttributionResponse {
@@ -127,11 +136,14 @@ interface SearchAttributionResponse {
 
 type LogEventResponse = unknown
 
+/**
+ * Values of this type come from the GraphQL API as {@link EmbeddingsSearchResultsWithoutURIs}, but
+ * the `fileName` values are resolved to URIs for all other callers.
+ */
 export interface EmbeddingsSearchResult {
     repoName?: string
     revision?: string
-    fileName: string
-    uri: URI // TODO(beyang): this is not guaranteed to exist
+    uri: URI
     startLine: number
     endLine: number
     content: string
@@ -614,7 +626,7 @@ export class SourcegraphGraphQLAPIClient {
         query: string,
         codeResultsCount: number,
         textResultsCount: number
-    ): Promise<EmbeddingsSearchResults | Error> {
+    ): Promise<EmbeddingsSearchResultsWithoutURIs | Error> {
         return this.fetchSourcegraphAPI<APIResponse<EmbeddingsMultiSearchResponse>>(
             SEARCH_EMBEDDINGS_QUERY,
             {
@@ -632,7 +644,7 @@ export class SourcegraphGraphQLAPIClient {
         query: string,
         codeResultsCount: number,
         textResultsCount: number
-    ): Promise<EmbeddingsSearchResults | Error> {
+    ): Promise<EmbeddingsSearchResultsWithoutURIs | Error> {
         return this.fetchSourcegraphAPI<APIResponse<EmbeddingsSearchResponse>>(
             LEGACY_SEARCH_EMBEDDINGS_QUERY,
             {

--- a/lib/shared/src/test/mocks.ts
+++ b/lib/shared/src/test/mocks.ts
@@ -22,12 +22,13 @@ export class MockEmbeddingsClient implements EmbeddingsSearch {
     }
 
     public search(
+        workspaceFolderUri: URI,
         query: string,
         codeResultsCount: number,
         textResultsCount: number
     ): Promise<EmbeddingsSearchResults | Error> {
         return (
-            this.mocks.search?.(query, codeResultsCount, textResultsCount) ??
+            this.mocks.search?.(workspaceFolderUri, query, codeResultsCount, textResultsCount) ??
             Promise.resolve({ codeResults: [], textResults: [] })
         )
     }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -62,20 +62,8 @@ import { openExternalLinks, openLocalFileWithRange } from '../../services/utils/
 import { TestSupport } from '../../test-support'
 import { countGeneratedCode } from '../utils'
 
-import { getChatPanelTitle, openFile, stripContextWrapper, viewRangeToRange } from './chat-helpers'
-import { ChatHistoryManager } from './ChatHistoryManager'
-import { addWebviewViewHTML, CodyChatPanelViewType } from './ChatManager'
-import type { ChatViewProviderWebview, Config } from './ChatPanelsManager'
-import { CodebaseStatusProvider } from './CodebaseStatusProvider'
-import { getCommandContext, getEnhancedContext } from './context'
-import { InitDoer } from './InitDoer'
-import {
-    type ContextItem,
-    type MessageWithContext,
-    SimpleChatModel,
-    toViewMessage,
-} from './SimpleChatModel'
 import type { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
+import type { MessageErrorType } from '../MessageProvider'
 import type {
     AuthStatus,
     ChatSubmitType,
@@ -84,8 +72,20 @@ import type {
     LocalEnv,
     WebviewMessage,
 } from '../protocol'
+import { getChatPanelTitle, openFile, stripContextWrapper, viewRangeToRange } from './chat-helpers'
+import { ChatHistoryManager } from './ChatHistoryManager'
+import { addWebviewViewHTML, CodyChatPanelViewType } from './ChatManager'
+import type { ChatViewProviderWebview, Config } from './ChatPanelsManager'
+import { CodebaseStatusProvider } from './CodebaseStatusProvider'
+import { getCommandContext, getEnhancedContext } from './context'
+import { InitDoer } from './InitDoer'
 import { CommandPrompter, DefaultPrompter, type IPrompter } from './prompt'
-import type { MessageErrorType } from '../MessageProvider'
+import {
+    SimpleChatModel,
+    toViewMessage,
+    type ContextItem,
+    type MessageWithContext,
+} from './SimpleChatModel'
 
 interface SimpleChatPanelProviderOptions {
     config: Config

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -3,15 +3,15 @@ import * as vscode from 'vscode'
 import {
     isCodyIgnoredFile,
     isError,
+    isFileURI,
     MAX_BYTES_PER_FILE,
     NUM_CODE_RESULTS,
     NUM_TEXT_RESULTS,
     truncateTextNearestLine,
+    uriBasename,
     type CodyCommand,
     type ConfigurationUseContext,
     type Result,
-    isFileURI,
-    uriBasename,
 } from '@sourcegraph/cody-shared'
 
 import { getContextForCommand } from '../../commands/utils/get-context'
@@ -248,7 +248,13 @@ async function searchEmbeddingsRemote(
 
     logDebug('SimpleChatPanelProvider', 'getEnhancedContext > searching remote embeddings')
     const contextItems: ContextItem[] = []
-    const embeddings = await embeddingsClient.search([repoId], text, NUM_CODE_RESULTS, NUM_TEXT_RESULTS)
+    const embeddings = await embeddingsClient.search(
+        workspaceFolder.uri,
+        [repoId],
+        text,
+        NUM_CODE_RESULTS,
+        NUM_TEXT_RESULTS
+    )
     if (isError(embeddings)) {
         throw new Error(`Error retrieving embeddings: ${embeddings}`)
     }

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -1,4 +1,4 @@
-import type * as vscode from 'vscode'
+import * as vscode from 'vscode'
 
 import {
     MAX_CURRENT_FILE_TOKENS,
@@ -176,10 +176,18 @@ async function getContextMessagesFromSelection(
     { fileUri, repoName, revision }: { fileUri: vscode.Uri; repoName?: string; revision?: string },
     codebaseContext: CodebaseContext
 ): Promise<ContextMessage[]> {
-    const selectedTextContext = await codebaseContext.getContextMessages(selectedText, {
-        numCodeResults: 4,
-        numTextResults: 0,
-    })
+    const workspaceFolderUri = vscode.workspace.workspaceFolders?.at(0)?.uri
+    if (!workspaceFolderUri) {
+        return []
+    }
+    const selectedTextContext = await codebaseContext.getContextMessages(
+        workspaceFolderUri,
+        selectedText,
+        {
+            numCodeResults: 4,
+            numTextResults: 0,
+        }
+    )
 
     return selectedTextContext.concat(
         [precedingText, followingText]


### PR DESCRIPTION
This fixes an issue with remote embeddings where attempting to run a chat that fetched remote embeddings would completely fail with an error from trying to dereference `.scheme` on an undefined value.
    
The Sourcegraph GraphQL API returns remote embeddings results with `fileName` fields. We need to resolve this to a `uri` so that we don't pass around a relative fileName that we don't know how to resolve. To resolve it, we assume (as do other context sources) that the context is for the first workspace folder in VS Code. We need to pass this around as `workspaceFolderUri`, which is ugly but is the smallest change that will make this work. The remote embeddings code is going away soon anyway, so IMO this solution suffices.

## Test plan

Using remote embeddings, run a chat that gets context and ensure there is no URI error blocking it. Run an inline edit as well.
    
Co-authored-by: Quinn Slack <quinn@slack.org>