### PR TITLE
Refactor chat

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -44,7 +44,6 @@ export interface Configuration {
     experimentalSymfContext: boolean
     experimentalTracing: boolean
     experimentalSimpleChatContext: boolean
-    experimentalChatPredictions: boolean
 
     /**
      * Unstable Features for internal testing only

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -130,7 +130,8 @@ type LogEventResponse = unknown
 export interface EmbeddingsSearchResult {
     repoName?: string
     revision?: string
-    uri: URI
+    fileName: string
+    uri: URI // TODO(beyang): this is not guaranteed to exist
     startLine: number
     endLine: number
     content: string

--- a/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
+++ b/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
@@ -126,10 +126,6 @@ class ConfigurationMetadataProcessor implements TelemetryProcessor {
                 value: CONTEXT_SELECTION_ID[this.config.useContext],
             },
             {
-                key: 'chatPredictions',
-                value: this.config.experimentalChatPredictions ? 1 : 0,
-            },
-            {
                 key: 'guardrails',
                 value: this.config.experimentalGuardrails ? 1 : 0,
             }

--- a/lib/shared/src/telemetry/EventLogger.ts
+++ b/lib/shared/src/telemetry/EventLogger.ts
@@ -119,7 +119,6 @@ export class EventLogger {
             extensionDetails: this.extensionDetails,
             configurationDetails: {
                 contextSelection: this.config.useContext,
-                chatPredictions: this.config.experimentalChatPredictions,
                 guardrails: this.config.experimentalGuardrails,
             },
             version: this.extensionDetails.version, // for backcompat

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -40,7 +40,6 @@ interface ChatProps extends ChatClassNames {
     gettingStartedComponentProps?: any
     textAreaComponent: React.FunctionComponent<ChatUITextAreaProps>
     submitButtonComponent: React.FunctionComponent<ChatUISubmitButtonProps>
-    suggestionButtonComponent?: React.FunctionComponent<ChatUISuggestionButtonProps>
     fileLinkComponent: React.FunctionComponent<FileLinkProps>
     symbolLinkComponent: React.FunctionComponent<SymbolLinkProps>
     helpMarkdown?: string
@@ -53,8 +52,6 @@ interface ChatProps extends ChatClassNames {
     feedbackButtonsOnSubmit?: (text: string) => void
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
-    suggestions?: string[]
-    setSuggestions?: (suggestions: undefined | []) => void
     needsEmailVerification?: boolean
     needsEmailVerificationNotice?: React.FunctionComponent
     codyNotEnabledNotice?: React.FunctionComponent
@@ -128,11 +125,6 @@ export interface ChatUISubmitButtonProps {
     onAbortMessageInProgress?: () => void
 }
 
-export interface ChatUISuggestionButtonProps {
-    suggestion: string
-    onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
-}
-
 export interface EditButtonProps {
     className: string
     disabled?: boolean
@@ -168,7 +160,7 @@ export interface UserContextSelectorProps {
     setSelectedChatContext: (arg: number) => void
 }
 
-export type ChatSubmitType = 'user' | 'suggestion' | 'example' | 'user-newchat'
+export type ChatSubmitType = 'user' | 'user-newchat'
 
 export interface ChatModelDropdownMenuProps {
     models: ChatModelProvider[]
@@ -192,7 +184,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     onSubmit,
     textAreaComponent: TextArea,
     submitButtonComponent: SubmitButton,
-    suggestionButtonComponent: SuggestionButton,
     fileLinkComponent,
     symbolLinkComponent,
     helpMarkdown,
@@ -214,8 +205,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     feedbackButtonsOnSubmit,
     copyButtonOnSubmit,
     insertButtonOnSubmit,
-    suggestions,
-    setSuggestions,
     needsEmailVerification = false,
     codyNotEnabledNotice: CodyNotEnabledNotice,
     needsEmailVerificationNotice: NeedsEmailVerificationNotice,
@@ -340,7 +329,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                 return
             }
             onSubmit(input, submitType, chatContextFiles)
-            setSuggestions?.(undefined)
             setChatContextFiles(new Map())
             setSelectedChatContext(0)
             setHistoryIndex(inputHistory.length + 1)
@@ -348,7 +336,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             setDisplayCommands(null)
             setSelectedChatCommand(-1)
         },
-        [messageInProgress, onSubmit, chatContextFiles, setSuggestions, inputHistory, setInputHistory]
+        [messageInProgress, onSubmit, chatContextFiles, inputHistory, setInputHistory]
     )
     const onChatInput = useCallback(
         ({ target }: React.SyntheticEvent) => {
@@ -602,29 +590,10 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     guardrails={guardrails}
                 />
             )}
-
             {isGettingStartedComponentVisible && (
                 <GettingStartedComponent {...gettingStartedComponentProps} submitInput={submitInput} />
             )}
-
             <form className={classNames(styles.inputRow, inputRowClassName)}>
-                {!displayCommands &&
-                !contextSelection &&
-                suggestions !== undefined &&
-                suggestions.length !== 0 &&
-                SuggestionButton ? (
-                    <div className={styles.suggestions}>
-                        {suggestions.map((suggestion: string) =>
-                            suggestion.trim().length > 0 ? (
-                                <SuggestionButton
-                                    key={suggestion}
-                                    suggestion={suggestion}
-                                    onClick={() => submitInput(suggestion, 'suggestion')}
-                                />
-                            ) : null
-                        )}
-                    </div>
-                ) : null}
                 {messageInProgress && AbortMessageInProgressButton && (
                     <div className={classNames(styles.abortButtonContainer)}>
                         <AbortMessageInProgressButton

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -28,6 +28,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - New chats are now the default when the user submits a new quesetion. Previously, follow-up questions were the default, but this frequently led to exceeding the LLM context window, which users interpreted as an error state. Follow-up questions are still accessible via ⌘-Enter or Ctrl-Enter. [pull/2768](https://github.com/sourcegraph/cody/pull/2768)
 - We now allocate no more than 60% of the overall LLM context window for enhanced context. This preserves more room for follow-up questions and context. [pull/2768](https://github.com/sourcegraph/cody/pull/2768)
 - Chat: Renamed the "Restart Chat Session" button to "New Chat Session". [pull/2786](https://github.com/sourcegraph/cody/pull/2786)
+- Removed `cody.experimental.chatPredictions`.
+- Codebase-wide context for custom commands has been disabled.
 
 ## [1.1.3]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -797,12 +797,6 @@
           "markdownDescription": "Adds a Cody icon to the editor title menu for quick access to Cody commands.",
           "default": true
         },
-        "cody.experimental.chatPredictions": {
-          "order": 8,
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Adds suggestions of possible relevant messages in the chat window."
-        },
         "cody.commandCodeLenses": {
           "order": 8,
           "type": "boolean",

--- a/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
+++ b/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
@@ -55,16 +55,16 @@ export class CachedRemoteEmbeddingsClient {
         if (results instanceof Error) {
             return results
         }
-        results.codeResults.forEach(result => {
+        for (const result of results.codeResults) {
             if (!result.uri) {
                 result.uri = vscode.Uri.file(result.fileName)
             }
-        })
-        results.textResults.forEach(result => {
+        }
+        for (const result of results.textResults) {
             if (!result.uri) {
                 result.uri = vscode.Uri.file(result.fileName)
             }
-        })
+        }
         return results
     }
 }

--- a/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
+++ b/vscode/src/chat/CachedRemoteEmbeddingsClient.ts
@@ -46,7 +46,12 @@ export class CachedRemoteEmbeddingsClient {
         if (repoIDs.length !== 1) {
             throw new Error('Only one repoID is supported for now')
         }
-        const results = await this.client.legacySearchEmbeddings(repoIDs[0], query, codeResultsCount, textResultsCount)
+        const results = await this.client.legacySearchEmbeddings(
+            repoIDs[0],
+            query,
+            codeResultsCount,
+            textResultsCount
+        )
         if (results instanceof Error) {
             return results
         }

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -42,7 +42,6 @@ export type Config = Pick<
     | 'accessToken'
     | 'useContext'
     | 'codeActions'
-    | 'experimentalChatPredictions'
     | 'experimentalGuardrails'
     | 'commandCodeLenses'
     | 'experimentalSimpleChatContext'

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -118,11 +118,10 @@ export class ChatManager implements vscode.Disposable {
         const requestID = uuid.v4()
         telemetryService.log('CodyVSCodeExtension:chat-question:submitted', { requestID, ...args })
         const chatProvider = await this.getChatProvider()
-        await chatProvider.handleHumanMessageSubmitted(requestID, question, 'user', [], false)
+        await chatProvider.handleNewUserMessage(requestID, question, 'user-newchat', [], true)
     }
 
     // Execute a command request in a new chat panel
-
     public async executeCommand(
         command: CodyCommand,
         args: CodyCommandArgs,
@@ -143,7 +142,7 @@ export class ChatManager implements vscode.Disposable {
 
         // Else, open a new chanel panel and run the command in the new panel
         const chatProvider = await this.getChatProvider()
-        await chatProvider.handleCommands(command, args)
+        await chatProvider.handleCommand(command, args)
         return chatProvider
     }
 

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -30,7 +30,7 @@ type ChatID = string
 
 export type Config = Pick<
     ConfigurationWithAccessToken,
-    'experimentalGuardrails' | 'experimentalSymfContext' | 'internalUnstable'
+    'experimentalGuardrails' | 'experimentalSymfContext' | 'internalUnstable' | 'useContext'
 >
 
 export interface ChatViewProviderWebview extends Omit<vscode.Webview, 'postMessage'> {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.test.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.test.ts
@@ -3,10 +3,11 @@ import { URI } from 'vscode-uri'
 
 import type { Editor } from '@sourcegraph/cody-shared'
 
-import type { ContextItem } from './SimpleChatModel'
-import { contextFilesToContextItems } from './SimpleChatPanelProvider'
+import { type ContextItem } from './SimpleChatModel'
 
 import '../../testutils/vscode'
+
+import { contextFilesToContextItems } from './SimpleChatPanelProvider'
 
 describe('contextFilesToContextItems', () => {
     test('omits files that could not be read', async () => {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.test.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.test.ts
@@ -3,7 +3,7 @@ import { URI } from 'vscode-uri'
 
 import type { Editor } from '@sourcegraph/cody-shared'
 
-import { type ContextItem } from './SimpleChatModel'
+import type { ContextItem } from './SimpleChatModel'
 
 import '../../testutils/vscode'
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -30,7 +30,10 @@ import {
 import type { View } from '../../../webviews/NavBar'
 import { newCodyCommandArgs, type CodyCommandArgs } from '../../commands'
 import type { CommandsController } from '../../commands/CommandsController'
-import { createDisplayTextWithFileLinks, createDisplayTextWithFileSelection } from '../../commands/prompt/display-text'
+import {
+    createDisplayTextWithFileLinks,
+    createDisplayTextWithFileSelection,
+} from '../../commands/prompt/display-text'
 import { getFullConfig } from '../../configuration'
 import { executeEdit } from '../../edit/execute'
 import {
@@ -40,10 +43,10 @@ import {
 } from '../../editor/utils/editor-context'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import { ContextStatusAggregator } from '../../local-context/enhanced-context-status'
-import { type LocalEmbeddingsController } from '../../local-context/local-embeddings'
-import { type SymfRunner } from '../../local-context/symf'
+import type { LocalEmbeddingsController } from '../../local-context/local-embeddings'
+import type { SymfRunner } from '../../local-context/symf'
 import { logDebug } from '../../log'
-import { type AuthProvider } from '../../services/AuthProvider'
+import type { AuthProvider } from '../../services/AuthProvider'
 import { getProcessInfo } from '../../services/LocalAppDetector'
 import { localStorage } from '../../services/LocalStorageProvider'
 import { telemetryService } from '../../services/telemetry'
@@ -66,11 +69,23 @@ import type { ChatViewProviderWebview, Config } from './ChatPanelsManager'
 import { CodebaseStatusProvider } from './CodebaseStatusProvider'
 import { getCommandContext, getEnhancedContext } from './context'
 import { InitDoer } from './InitDoer'
-import { ContextItem, MessageWithContext, SimpleChatModel, toViewMessage } from './SimpleChatModel'
-import { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
-import { AuthStatus, ChatSubmitType, ConfigurationSubsetForWebview, ExtensionMessage, LocalEnv, WebviewMessage } from '../protocol'
-import { CommandPrompter, DefaultPrompter, IPrompter } from './prompt'
-import { MessageErrorType } from '../MessageProvider'
+import {
+    type ContextItem,
+    type MessageWithContext,
+    SimpleChatModel,
+    toViewMessage,
+} from './SimpleChatModel'
+import type { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
+import type {
+    AuthStatus,
+    ChatSubmitType,
+    ConfigurationSubsetForWebview,
+    ExtensionMessage,
+    LocalEnv,
+    WebviewMessage,
+} from '../protocol'
+import { CommandPrompter, DefaultPrompter, type IPrompter } from './prompt'
+import type { MessageErrorType } from '../MessageProvider'
 
 interface SimpleChatPanelProviderOptions {
     config: Config
@@ -186,8 +201,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
         const viewType = CodyChatPanelViewType
         const panelTitle =
-            this.history.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)?.chatTitle ||
-            getChatPanelTitle(lastQuestion)
+            this.history.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)
+                ?.chatTitle || getChatPanelTitle(lastQuestion)
         const viewColumn = activePanelViewColumn || vscode.ViewColumn.Beside
         const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
         const panel = vscode.window.createWebviewPanel(
@@ -538,8 +553,15 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         }
 
         if (!this.editor.getActiveTextEditorSelectionOrVisibleContent()) {
-            if (command.context?.selection || command.context?.currentFile || command.context?.currentDir) {
-                return this.postError(new Error('Command failed. Please open a file and try again.'), 'transcript')
+            if (
+                command.context?.selection ||
+                command.context?.currentFile ||
+                command.context?.currentDir
+            ) {
+                return this.postError(
+                    new Error('Command failed. Please open a file and try again.'),
+                    'transcript'
+                )
             }
         }
 
@@ -556,7 +578,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         // trigger the context progress indicator
         this.postViewTranscript({ speaker: 'assistant' })
 
-        const prompt = await this.buildPrompt(new CommandPrompter(() => getCommandContext(this.editor, command)))
+        const prompt = await this.buildPrompt(
+            new CommandPrompter(() => getCommandContext(this.editor, command))
+        )
         this.streamAssistantResponse(args.requestID, prompt)
     }
 
@@ -602,7 +626,11 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         // trigger the context progress indicator
         this.postViewTranscript({ speaker: 'assistant' })
 
-        const userContextItems = await contextFilesToContextItems(this.editor, userContextFiles || [], true)
+        const userContextItems = await contextFilesToContextItems(
+            this.editor,
+            userContextFiles || [],
+            true
+        )
         const prompter = new DefaultPrompter(
             userContextItems,
             addEnhancedContext
@@ -635,14 +663,16 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     ...contextSummary,
                     // Flag indicating this is a transcript event to go through ML data pipeline. Only for DotCom users
                     // See https://github.com/sourcegraph/sourcegraph/pull/59524
-                    recordsPrivateMetadataTranscript: authStatus.endpoint && isDotCom(authStatus.endpoint) ? 1 : 0,
+                    recordsPrivateMetadataTranscript:
+                        authStatus.endpoint && isDotCom(authStatus.endpoint) ? 1 : 0,
                 },
                 privateMetadata: {
                     properties,
                     // 🚨 SECURITY: chat transcripts are to be included only for DotCom users AND for V2 telemetry
                     // V2 telemetry exports privateMetadata only for DotCom users
                     // the condition below is an aditional safegaurd measure
-                    promptText: authStatus.endpoint && isDotCom(authStatus.endpoint) ? promptText : undefined,
+                    promptText:
+                        authStatus.endpoint && isDotCom(authStatus.endpoint) ? promptText : undefined,
                 },
             })
         }
@@ -654,7 +684,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             if (isRateLimitError(error)) {
                 this.postError(error, 'transcript')
             } else {
-                this.postError(isError(error) ? error : new Error(`Error generating assistant response: ${error}`))
+                this.postError(
+                    isError(error) ? error : new Error(`Error generating assistant response: ${error}`)
+                )
             }
         }
     }
@@ -662,7 +694,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     /**
      * Constructs the prompt and updates the UI with the context used in the prompt.
      */
-    private async buildPrompt(prompter: IPrompter, sendTelemetry?: (contextSummary: {}) => void): Promise<Message[]> {
+    private async buildPrompt(
+        prompter: IPrompter,
+        sendTelemetry?: (contextSummary: {}) => void
+    ): Promise<Message[]> {
         const { prompt, contextLimitWarnings, newContextUsed } = await prompter.makePrompt(
             this.chatModel,
             getContextWindowForModel(this.authProvider.getAuthStatus(), this.chatModel.modelID)
@@ -756,7 +791,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             if (isRateLimitError(error)) {
                 this.postError(error, 'transcript')
             } else {
-                this.postError(isError(error) ? error : new Error(`Error generating assistant response: ${error}`))
+                this.postError(
+                    isError(error) ? error : new Error(`Error generating assistant response: ${error}`)
+                )
             }
         }
     }
@@ -914,7 +951,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             chatID: this.chatModel.sessionID,
         })
 
-        const chatTitle = this.history.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)?.chatTitle
+        const chatTitle = this.history.getChat(
+            this.authProvider.getAuthStatus(),
+            this.chatModel.sessionID
+        )?.chatTitle
         if (chatTitle) {
             this.handleChatTitle(chatTitle)
             return
@@ -1057,8 +1097,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private updateWebviewPanelTitle(title: string): void {
         if (this.webviewPanel) {
             this.webviewPanel.title =
-                this.history.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)?.chatTitle ||
-                getChatPanelTitle(title)
+                this.history.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)
+                    ?.chatTitle || getChatPanelTitle(title)
         }
     }
 
@@ -1074,7 +1114,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 }
 
-async function newChatModelfromTranscriptJSON(json: TranscriptJSON, modelID: string): Promise<SimpleChatModel> {
+async function newChatModelfromTranscriptJSON(
+    json: TranscriptJSON,
+    modelID: string
+): Promise<SimpleChatModel> {
     const messages: MessageWithContext[][] = json.interactions.map(
         (interaction: InteractionJSON): MessageWithContext[] => {
             return [
@@ -1099,7 +1142,12 @@ async function newChatModelfromTranscriptJSON(json: TranscriptJSON, modelID: str
             ]
         }
     )
-    return new SimpleChatModel(json.chatModel || modelID, (await Promise.all(messages)).flat(), json.id, json.chatTitle)
+    return new SimpleChatModel(
+        json.chatModel || modelID,
+        (await Promise.all(messages)).flat(),
+        json.id,
+        json.chatTitle
+    )
 }
 
 export async function contextFilesToContextItems(

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -6,20 +6,13 @@ import {
     ConfigFeaturesSingleton,
     ContextWindowLimitError,
     hydrateAfterPostMessage,
-    isCodyIgnoredFile,
     isDefined,
     isDotCom,
     isError,
     isFileURI,
     isRateLimitError,
-    MAX_BYTES_PER_FILE,
-    NUM_CODE_RESULTS,
-    NUM_TEXT_RESULTS,
     reformatBotMessageForChat,
-    truncateTextNearestLine,
     Typewriter,
-    uriBasename,
-    type ActiveTextEditorSelectionRange,
     type ChatClient,
     type ChatMessage,
     type CodyCommand,
@@ -31,18 +24,13 @@ import {
     type Guardrails,
     type InteractionJSON,
     type Message,
-    type Result,
     type TranscriptJSON,
 } from '@sourcegraph/cody-shared'
 
 import type { View } from '../../../webviews/NavBar'
 import { newCodyCommandArgs, type CodyCommandArgs } from '../../commands'
 import type { CommandsController } from '../../commands/CommandsController'
-import {
-    createDisplayTextWithFileLinks,
-    createDisplayTextWithFileSelection,
-} from '../../commands/prompt/display-text'
-import { getContextForCommand } from '../../commands/utils/get-context'
+import { createDisplayTextWithFileLinks, createDisplayTextWithFileSelection } from '../../commands/prompt/display-text'
 import { getFullConfig } from '../../configuration'
 import { executeEdit } from '../../edit/execute'
 import {
@@ -52,10 +40,10 @@ import {
 } from '../../editor/utils/editor-context'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import { ContextStatusAggregator } from '../../local-context/enhanced-context-status'
-import type { LocalEmbeddingsController } from '../../local-context/local-embeddings'
-import type { SymfRunner } from '../../local-context/symf'
-import { logDebug, logError } from '../../log'
-import type { AuthProvider } from '../../services/AuthProvider'
+import { type LocalEmbeddingsController } from '../../local-context/local-embeddings'
+import { type SymfRunner } from '../../local-context/symf'
+import { logDebug } from '../../log'
+import { type AuthProvider } from '../../services/AuthProvider'
 import { getProcessInfo } from '../../services/LocalAppDetector'
 import { localStorage } from '../../services/LocalStorageProvider'
 import { telemetryService } from '../../services/telemetry'
@@ -69,32 +57,20 @@ import {
 } from '../../services/utils/codeblock-action-tracker'
 import { openExternalLinks, openLocalFileWithRange } from '../../services/utils/workspace-action'
 import { TestSupport } from '../../test-support'
-import type { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
-import type { MessageErrorType } from '../MessageProvider'
-import type {
-    AuthStatus,
-    ConfigurationSubsetForWebview,
-    ExtensionMessage,
-    LocalEnv,
-    WebviewMessage,
-} from '../protocol'
 import { countGeneratedCode } from '../utils'
 
-import { getChatPanelTitle, openFile, stripContextWrapper } from './chat-helpers'
+import { getChatPanelTitle, openFile, stripContextWrapper, viewRangeToRange } from './chat-helpers'
 import { ChatHistoryManager } from './ChatHistoryManager'
 import { addWebviewViewHTML, CodyChatPanelViewType } from './ChatManager'
 import type { ChatViewProviderWebview, Config } from './ChatPanelsManager'
 import { CodebaseStatusProvider } from './CodebaseStatusProvider'
+import { getCommandContext, getEnhancedContext } from './context'
 import { InitDoer } from './InitDoer'
-import { DefaultPrompter, type IContextProvider, type IPrompter } from './prompt'
-import {
-    SimpleChatModel,
-    toViewMessage,
-    type ContextItem,
-    type MessageWithContext,
-} from './SimpleChatModel'
-
-const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
+import { ContextItem, MessageWithContext, SimpleChatModel, toViewMessage } from './SimpleChatModel'
+import { CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
+import { AuthStatus, ChatSubmitType, ConfigurationSubsetForWebview, ExtensionMessage, LocalEnv, WebviewMessage } from '../protocol'
+import { CommandPrompter, DefaultPrompter, IPrompter } from './prompt'
+import { MessageErrorType } from '../MessageProvider'
 
 interface SimpleChatPanelProviderOptions {
     config: Config
@@ -118,20 +94,7 @@ export interface ChatSession {
 }
 
 export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
-    private _webviewPanel?: vscode.WebviewPanel
-    public get webviewPanel(): vscode.WebviewPanel | undefined {
-        return this._webviewPanel
-    }
-    private _webview?: ChatViewProviderWebview
-    public get webview(): ChatViewProviderWebview | undefined {
-        return this._webview
-    }
-    private initDoer = new InitDoer<boolean | undefined>()
-
     private chatModel: SimpleChatModel
-
-    private extensionUri: vscode.Uri
-    private disposables: vscode.Disposable[] = []
 
     private config: Config
     private readonly authProvider: AuthProvider
@@ -147,9 +110,13 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private readonly commandsController?: CommandsController
 
     private history = new ChatHistoryManager()
-    private prompter: IPrompter = new DefaultPrompter()
-
     private contextFilesQueryCancellation?: vscode.CancellationTokenSource
+
+    // A unique identifier for this SimpleChatPanelProvider instance used to identify it to
+    // container classes that need a handle to this specific panel provider.
+    public get sessionID(): string {
+        return this.chatModel.sessionID
+    }
 
     constructor({
         config,
@@ -175,7 +142,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         this.commandsController = commandsController
         this.editor = editor
         this.treeView = treeView
-        this.chatModel = new SimpleChatModel(this.selectModel(models))
+        this.chatModel = new SimpleChatModel(selectModel(authProvider, models))
         this.guardrails = guardrails
 
         commandsController?.setEnableExperimentalCommands(config.internalUnstable)
@@ -203,43 +170,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         this.disposables.push(this.contextStatusAggregator.addProvider(this.codebaseStatusProvider))
     }
 
-    public get sessionID(): string {
-        return this.chatModel.sessionID
-    }
-
-    // Select the chat model to use in Chat
-    private selectModel(models: ChatModelProvider[]): string {
-        const authStatus = this.authProvider.getAuthStatus()
-        // Free user can only use the default model
-        if (authStatus.isDotCom && authStatus.userCanUpgrade) {
-            return models[0].model
-        }
-        // Check for the last selected model
-        const lastSelectedModelID = localStorage.get('model')
-        if (lastSelectedModelID) {
-            // If the last selected model exists in the list of models then we return it
-            const model = models.find(m => m.model === lastSelectedModelID)
-            if (model) {
-                return lastSelectedModelID
-            }
-        }
-        // If the user has not selected a model before then we return the default model
-        const defaultModel = models.find(m => m.default) || models[0]
-        if (!defaultModel) {
-            throw new Error('No chat model found in server-provided config')
-        }
-        return defaultModel.model
-    }
-
-    private completionCanceller?: () => void
-
-    private cancelInProgressCompletion(): void {
-        if (this.completionCanceller) {
-            this.completionCanceller()
-            this.completionCanceller = undefined
-        }
-    }
-
     /**
      * Creates the webview panel for the Cody chat interface if it doesn't already exist.
      */
@@ -256,7 +186,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
         const viewType = CodyChatPanelViewType
         const panelTitle =
-            this.history.getChat(this.authProvider.getAuthStatus(), this.sessionID)?.chatTitle ||
+            this.history.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)?.chatTitle ||
             getChatPanelTitle(lastQuestion)
         const viewColumn = activePanelViewColumn || vscode.ViewColumn.Beside
         const webviewPath = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webviews')
@@ -339,6 +269,18 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         return panel
     }
 
+    public async setWebviewView(view: View): Promise<void> {
+        if (!this.webviewPanel) {
+            await this.createWebviewPanel()
+        }
+        this.webviewPanel?.reveal()
+
+        await this.postMessage({
+            type: 'view',
+            messages: view,
+        })
+    }
+
     private postContextStatusToWebView(): void {
         logDebug(
             'SimpleChatPanelProvider',
@@ -350,18 +292,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             context: {
                 groups: this.contextStatusAggregator.status,
             },
-        })
-    }
-
-    public async setWebviewView(view: View): Promise<void> {
-        if (!this.webviewPanel) {
-            await this.createWebviewPanel()
-        }
-        this.webviewPanel?.reveal()
-
-        await this.postMessage({
-            type: 'view',
-            messages: view,
         })
     }
 
@@ -382,12 +312,12 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 break
             case 'submit': {
                 const requestID = uuid.v4()
-                await this.handleHumanMessageSubmitted(
+                await this.handleNewUserMessage(
                     requestID,
                     message.text,
                     message.submitType,
                     message.contextFiles ?? [],
-                    message.addEnhancedContext || false
+                    message.addEnhancedContext ?? false
                 )
                 break
             }
@@ -494,6 +424,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         }
     }
 
+    private initDoer = new InitDoer<boolean | undefined>()
     private async onInitialized(): Promise<void> {
         // HACK: this call is necessary to get the webview to set the chatID state,
         // which is necessary on deserialization. It should be invoked before the
@@ -503,7 +434,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             type: 'transcript',
             messages: [],
             isMessageInProgress: false,
-            chatID: this.sessionID,
+            chatID: this.chatModel.sessionID,
         })
 
         this.postChatModels()
@@ -512,6 +443,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         this.initDoer.signalInitialized()
     }
 
+    private disposables: vscode.Disposable[] = []
     public dispose(): void {
         vscode.Disposable.from(...this.disposables).dispose()
         this.disposables = []
@@ -597,58 +529,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         })
     }
 
-    /**
-     * Handles a message submitted by the user.
-     *
-     * Validates the message, checks for slash commands, edit commands,
-     * and sends the message to be handled like a regular chat request.
-     */
-    public async handleHumanMessageSubmitted(
-        requestID: string,
-        text: string,
-        submitType: 'user' | 'user-newchat' | 'suggestion' | 'example',
-        userContextFiles: ContextFile[],
-        addEnhancedContext: boolean
-    ): Promise<void> {
-        if (submitType === 'suggestion') {
-            const args = { requestID }
-            telemetryService.log('CodyVSCodeExtension:chatPredictions:used', args, { hasV2Event: true })
-        }
-        // If this is a slash command, run it with custom command instead
-        if (text.startsWith('/')) {
-            if (text.match(/^\/r(eset)?$/)) {
-                return this.clearAndRestartSession()
-            }
-            if (text.match(/^\/edit(\s)?/)) {
-                return executeEdit({ instruction: text.replace(/^\/(edit)/, '').trim() }, 'chat')
-            }
-            if (text === '/commands-settings') {
-                // User has clicked the settings button for commands
-                return vscode.commands.executeCommand('cody.settings.commands')
-            }
-            const commandArgs = newCodyCommandArgs({ source: 'chat', requestID })
-            const command = await this.commandsController?.startCommand(text, commandArgs)
-            if (command) {
-                return this.handleCommands(command, commandArgs)
-            }
-        }
-
-        // HACK
-        if (submitType === 'user-newchat' && !this.chatModel.isEmpty()) {
-            await this.clearAndRestartSession()
-        }
-
-        await this.handleChatRequest(requestID, text, submitType, userContextFiles, addEnhancedContext)
-    }
-
-    /**
-     * Handles executing a chat command from the user.
-     *
-     * Validates the command, checks for edit commands,
-     * generates a chat request from the command,
-     * and sends it to be handled like a regular chat request.
-     */
-    public async handleCommands(command: CodyCommand, args: CodyCommandArgs): Promise<void> {
+    public async handleCommand(command: CodyCommand, args: CodyCommandArgs): Promise<void> {
         // If it's not a ask command, it's a fixup command. If it's a fixup request, we can exit early
         // This is because startCommand will start the CommandRunner,
         // which would send all fixup requests to the FixupController
@@ -656,111 +537,228 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             return
         }
 
-        // If editor is not active, post error and return early
-        if (command && !this.editor.getActiveTextEditorSelectionOrVisibleContent()) {
-            if (
-                command.context?.selection ||
-                command.context?.currentFile ||
-                command.context?.currentDir
-            ) {
-                return this.postError(
-                    new Error('Command failed. Please open a file and try again.'),
-                    'transcript'
-                )
+        if (!this.editor.getActiveTextEditorSelectionOrVisibleContent()) {
+            if (command.context?.selection || command.context?.currentFile || command.context?.currentDir) {
+                return this.postError(new Error('Command failed. Please open a file and try again.'), 'transcript')
             }
         }
 
         const inputText = [command.slashCommand, command.additionalInput].join(' ')?.trim()
+        const displayText = createDisplayTextWithFileSelection(
+            inputText,
+            this.editor.getActiveTextEditorSelectionOrEntireFile()
+        )
+        const promptText = command.prompt
+        this.chatModel.addHumanMessage({ text: promptText }, displayText)
+        this.updateWebviewPanelTitle(inputText)
+        await this.saveSession(inputText)
 
-        await this.handleChatRequest(args.requestID, inputText, 'user', [], false, command)
+        // trigger the context progress indicator
+        this.postViewTranscript({ speaker: 'assistant' })
+
+        const prompt = await this.buildPrompt(new CommandPrompter(() => getCommandContext(this.editor, command)))
+        this.streamAssistantResponse(args.requestID, prompt)
+    }
+
+    public async handleNewUserMessage(
+        requestID: string,
+        inputText: string,
+        submitType: ChatSubmitType,
+        userContextFiles: ContextFile[],
+        addEnhancedContext: boolean
+    ): Promise<void> {
+        // DEPRECATED (remove after slash commands are removed)
+        // If this is a slash command, run it with custom command instead
+        if (inputText.startsWith('/')) {
+            if (inputText.match(/^\/r(eset)?$/)) {
+                return this.clearAndRestartSession()
+            }
+            if (inputText.match(/^\/edit(\s)?/)) {
+                return executeEdit({ instruction: inputText.replace(/^\/(edit)/, '').trim() }, 'chat')
+            }
+            if (inputText === '/commands-settings') {
+                // User has clicked the settings button for commands
+                return vscode.commands.executeCommand('cody.settings.commands')
+            }
+            const commandArgs = newCodyCommandArgs({ source: 'chat', requestID })
+            const command = await this.commandsController?.startCommand(inputText, commandArgs)
+            if (command) {
+                return this.handleCommand(command, commandArgs)
+            }
+        }
+
+        if (submitType === 'user-newchat' && !this.chatModel.isEmpty()) {
+            await this.clearAndRestartSession()
+        }
+
+        const displayText = userContextFiles?.length
+            ? createDisplayTextWithFileLinks(inputText, userContextFiles)
+            : inputText
+        const promptText = inputText
+        this.chatModel.addHumanMessage({ text: promptText }, displayText)
+        this.updateWebviewPanelTitle(inputText)
+        await this.saveSession(inputText)
+
+        // trigger the context progress indicator
+        this.postViewTranscript({ speaker: 'assistant' })
+
+        const userContextItems = await contextFilesToContextItems(this.editor, userContextFiles || [], true)
+        const prompter = new DefaultPrompter(
+            userContextItems,
+            addEnhancedContext
+                ? query =>
+                      getEnhancedContext(
+                          this.config.useContext,
+                          this.editor,
+                          this.embeddingsClient,
+                          this.localEmbeddings,
+                          this.config.experimentalSymfContext ? this.symf : null,
+                          this.codebaseStatusProvider,
+                          query
+                      )
+                : undefined
+        )
+        const sendTelemetry = (contextSummary: {}): void => {
+            const authStatus = this.authProvider.getAuthStatus()
+            const properties = {
+                requestID,
+                chatModel: this.chatModel.modelID,
+                contextSummary,
+            }
+
+            // Only log chat-question event if it is not a command to avoid double logging for commands
+            telemetryService.log('CodyVSCodeExtension:chat-question:executed', properties, {
+                hasV2Event: true,
+            })
+            telemetryRecorder.recordEvent('cody.chat-question', 'executed', {
+                metadata: {
+                    ...contextSummary,
+                    // Flag indicating this is a transcript event to go through ML data pipeline. Only for DotCom users
+                    // See https://github.com/sourcegraph/sourcegraph/pull/59524
+                    recordsPrivateMetadataTranscript: authStatus.endpoint && isDotCom(authStatus.endpoint) ? 1 : 0,
+                },
+                privateMetadata: {
+                    properties,
+                    // 🚨 SECURITY: chat transcripts are to be included only for DotCom users AND for V2 telemetry
+                    // V2 telemetry exports privateMetadata only for DotCom users
+                    // the condition below is an aditional safegaurd measure
+                    promptText: authStatus.endpoint && isDotCom(authStatus.endpoint) ? promptText : undefined,
+                },
+            })
+        }
+
+        try {
+            const prompt = await this.buildPrompt(prompter, sendTelemetry)
+            this.streamAssistantResponse(requestID, prompt)
+        } catch (error) {
+            if (isRateLimitError(error)) {
+                this.postError(error, 'transcript')
+            } else {
+                this.postError(isError(error) ? error : new Error(`Error generating assistant response: ${error}`))
+            }
+        }
     }
 
     /**
-     * Handles a chat request from chat input or a command.
-     *
-     * Saves the chat session, posts a transcript update, generates the
-     * assistant's response, logs telemetry, and updates the panel title.
+     * Constructs the prompt and updates the UI with the context used in the prompt.
      */
-    private async handleChatRequest(
-        requestID: string,
-        inputText: string,
-        submitType: 'user' | 'suggestion' | 'example' | 'user-newchat',
-        userContextFiles: ContextFile[],
-        addEnhancedContext: boolean,
-        command?: CodyCommand
-    ): Promise<void> {
-        // Display text is the text we will display to the user in the Chat UI
-        // - Append @-files to the display text if we have any
-        // - Append @-file selection for commands
-        // Otherwise, use the input text
-        const displayText = userContextFiles?.length
-            ? createDisplayTextWithFileLinks(inputText, userContextFiles)
-            : command
-              ? createDisplayTextWithFileSelection(
-                      inputText,
-                      this.editor.getActiveTextEditorSelectionOrEntireFile()
-                  )
-              : inputText
-        // The text we will use to send to LLM
-        const promptText = command ? command.prompt : inputText
-        this.chatModel.addHumanMessage({ text: promptText }, displayText)
+    private async buildPrompt(prompter: IPrompter, sendTelemetry?: (contextSummary: {}) => void): Promise<Message[]> {
+        const { prompt, contextLimitWarnings, newContextUsed } = await prompter.makePrompt(
+            this.chatModel,
+            getContextWindowForModel(this.authProvider.getAuthStatus(), this.chatModel.modelID)
+        )
 
-        await this.saveSession(inputText)
-        // trigger the context progress indicator
+        // Update UI based on prompt construction
+        this.chatModel.setNewContextUsed(newContextUsed)
+        if (contextLimitWarnings.length > 0) {
+            const warningMsg = contextLimitWarnings
+                .map(w => (w.trim().endsWith('.') ? w.trim() : w.trim() + '.'))
+                .join(' ')
+            this.postError(new ContextWindowLimitError(warningMsg), 'transcript')
+        }
+
+        if (sendTelemetry) {
+            // Create a summary of how many code snippets of each context source are being
+            // included in the prompt
+            const contextSummary: { [key: string]: number } = {}
+            for (const { source } of newContextUsed) {
+                if (!source) {
+                    continue
+                }
+                if (contextSummary[source]) {
+                    contextSummary[source] += 1
+                } else {
+                    contextSummary[source] = 1
+                }
+            }
+            sendTelemetry(contextSummary)
+        }
+
+        return prompt
+    }
+
+    private streamAssistantResponse(requestID: string, prompt: Message[]): void {
         this.postViewTranscript({ speaker: 'assistant' })
-        await this.generateAssistantResponse(
-            requestID,
-            userContextFiles,
-            addEnhancedContext,
-            contextSummary => {
-                if (submitType !== 'user' && submitType !== 'user-newchat') {
-                    return
-                }
 
-                const authStatus = this.authProvider.getAuthStatus()
-
-                const properties = {
-                    requestID,
-                    chatModel: this.chatModel.modelID,
-                    contextSummary,
-                }
-
-                // Only log chat-question event if it is not a command to avoid double logging for commands
-                if (!command) {
-                    telemetryService.log('CodyVSCodeExtension:chat-question:executed', properties, {
-                        hasV2Event: true,
-                    })
-                    telemetryRecorder.recordEvent('cody.chat-question', 'executed', {
-                        metadata: {
-                            ...contextSummary,
-                            // Flag indicating this is a transcript event to go through ML data pipeline. Only for DotCom users
-                            // See https://github.com/sourcegraph/sourcegraph/pull/59524
-                            recordsPrivateMetadataTranscript:
-                                authStatus.endpoint && isDotCom(authStatus.endpoint) ? 1 : 0,
-                        },
-                        privateMetadata: {
-                            properties,
-                            // 🚨 SECURITY: chat transcripts are to be included only for DotCom users AND for V2 telemetry
-                            // V2 telemetry exports privateMetadata only for DotCom users
-                            // the condition below is an aditional safegaurd measure
-                            promptText:
-                                authStatus.endpoint && isDotCom(authStatus.endpoint)
-                                    ? promptText
-                                    : undefined,
+        this.sendLLMRequest(prompt, {
+            update: content => {
+                this.postViewTranscript(
+                    toViewMessage({
+                        message: {
+                            speaker: 'assistant',
+                            text: content,
                         },
                     })
+                )
+            },
+            close: content => {
+                this.addBotMessage(requestID, content)
+            },
+            error: (partialResponse, error) => {
+                if (!isAbortError(error)) {
+                    this.postError(error, 'transcript')
+                }
+                try {
+                    // We should still add the partial response if there was an error
+                    // This'd throw an error if one has already been added
+                    this.addBotMessage(requestID, partialResponse)
+                } catch {
+                    console.error('Streaming Error', error)
                 }
             },
-            command
-        )
-        // Set the title of the webview panel
-        this.updateWebviewPanelTitle(inputText)
+        })
     }
 
     private async handleEdit(requestID: string, text: string): Promise<void> {
         this.chatModel.updateLastHumanMessage({ text })
         this.postViewTranscript()
-        await this.generateAssistantResponse(requestID)
+
+        const prompter = new DefaultPrompter(
+            [], // TODO(beyang): support user context items in the edit input
+            (
+                query // TODO(beyang): get useEnhancedContext
+            ) =>
+                getEnhancedContext(
+                    this.config.useContext,
+                    this.editor,
+                    this.embeddingsClient,
+                    this.localEmbeddings,
+                    this.config.experimentalSymfContext ? this.symf : null,
+                    this.codebaseStatusProvider,
+                    query
+                )
+        )
+
+        try {
+            const prompt = await this.buildPrompt(prompter)
+            this.streamAssistantResponse(requestID, prompt)
+        } catch (error) {
+            if (isRateLimitError(error)) {
+                this.postError(error, 'transcript')
+            } else {
+                this.postError(isError(error) ? error : new Error(`Error generating assistant response: ${error}`))
+            }
+        }
     }
 
     private async postViewConfig(): Promise<void> {
@@ -782,107 +780,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             workspaceFolderUris,
         })
         logDebug('SimpleChatPanelProvider', 'updateViewConfig', { verbose: configForWebview })
-    }
-
-    private async generateAssistantResponse(
-        requestID: string,
-        userContextFiles?: ContextFile[],
-        addEnhancedContext = true,
-        sendTelemetry?: (contextSummary: Record<string, number>) => void,
-        command?: CodyCommand
-    ): Promise<void> {
-        try {
-            const contextWindowBytes = getContextWindowForModel(
-                this.authProvider.getAuthStatus(),
-                this.chatModel.modelID
-            )
-
-            const userContextItems = await contextFilesToContextItems(
-                this.editor,
-                userContextFiles || [],
-                true
-            )
-            const contextProvider = new ContextProvider(
-                userContextItems,
-                this.editor,
-                this.embeddingsClient,
-                this.localEmbeddings,
-                this.config.experimentalSymfContext ? this.symf : null,
-                this.codebaseStatusProvider
-            )
-            const { prompt, contextLimitWarnings, newContextUsed } = await this.prompter.makePrompt(
-                this.chatModel,
-                contextProvider,
-                addEnhancedContext,
-                contextWindowBytes,
-                command
-            )
-
-            this.chatModel.setNewContextUsed(newContextUsed)
-
-            if (contextLimitWarnings.length > 0) {
-                const warningMsg = contextLimitWarnings
-                    .map(w => (w.trim().endsWith('.') ? w.trim() : `${w.trim()}.`))
-                    .join(' ')
-                this.postError(new ContextWindowLimitError(warningMsg), 'transcript')
-            }
-
-            if (sendTelemetry) {
-                // Create a summary of how many code snippets of each context source are being
-                // included in the prompt
-                const contextSummary: { [key: string]: number } = {}
-                for (const { source } of newContextUsed) {
-                    if (!source) {
-                        continue
-                    }
-                    if (contextSummary[source]) {
-                        contextSummary[source] += 1
-                    } else {
-                        contextSummary[source] = 1
-                    }
-                }
-                sendTelemetry(contextSummary)
-            }
-
-            this.postViewTranscript({ speaker: 'assistant' })
-
-            await this.sendLLMRequest(prompt, {
-                update: content => {
-                    this.postViewTranscript(
-                        toViewMessage({
-                            message: {
-                                speaker: 'assistant',
-                                text: content,
-                            },
-                            newContextUsed,
-                        })
-                    )
-                },
-                close: content => {
-                    this.addBotMessage(requestID, content)
-                },
-                error: (partialResponse, error) => {
-                    if (!isAbortError(error)) {
-                        this.postError(error, 'transcript')
-                    }
-                    try {
-                        // We should still add the partial response if there was an error
-                        // This'd throw an error if one has already been added
-                        this.addBotMessage(requestID, partialResponse)
-                    } catch {
-                        console.error('Streaming Error', error)
-                    }
-                },
-            })
-        } catch (error) {
-            if (isRateLimitError(error)) {
-                this.postError(error, 'transcript')
-            } else {
-                this.postError(
-                    isError(error) ? error : new Error(`Error generating assistant response: ${error}`)
-                )
-            }
-        }
     }
 
     /**
@@ -938,6 +835,13 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     typewriter.stop(message.error)
                 }
             }
+        }
+    }
+    private completionCanceller?: () => void
+    private cancelInProgressCompletion(): void {
+        if (this.completionCanceller) {
+            this.completionCanceller()
+            this.completionCanceller = undefined
         }
     }
 
@@ -1007,13 +911,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             type: 'transcript',
             messages,
             isMessageInProgress: !!messageInProgress,
-            chatID: this.sessionID,
+            chatID: this.chatModel.sessionID,
         })
 
-        const chatTitle = this.history.getChat(
-            this.authProvider.getAuthStatus(),
-            this.sessionID
-        )?.chatTitle
+        const chatTitle = this.history.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)?.chatTitle
         if (chatTitle) {
             this.handleChatTitle(chatTitle)
             return
@@ -1131,6 +1032,19 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     /**
+     * Webview state
+     */
+    private extensionUri: vscode.Uri
+    private _webviewPanel?: vscode.WebviewPanel
+    public get webviewPanel(): vscode.WebviewPanel | undefined {
+        return this._webviewPanel
+    }
+    private _webview?: ChatViewProviderWebview
+    public get webview(): ChatViewProviderWebview | undefined {
+        return this._webview
+    }
+
+    /**
      * Posts a message to the webview, pending initialization.
      *
      * cody-invariant: this.webview?.postMessage should never be invoked directly
@@ -1143,7 +1057,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private updateWebviewPanelTitle(title: string): void {
         if (this.webviewPanel) {
             this.webviewPanel.title =
-                this.history.getChat(this.authProvider.getAuthStatus(), this.sessionID)?.chatTitle ||
+                this.history.getChat(this.authProvider.getAuthStatus(), this.chatModel.sessionID)?.chatTitle ||
                 getChatPanelTitle(title)
         }
     }
@@ -1160,458 +1074,32 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 }
 
-class ContextProvider implements IContextProvider {
-    constructor(
-        private userContext: ContextItem[],
-        private editor: VSCodeEditor,
-        private embeddingsClient: CachedRemoteEmbeddingsClient | null,
-        private localEmbeddings: LocalEmbeddingsController | null,
-        private symf: SymfRunner | null,
-        private codebaseStatusProvider: CodebaseStatusProvider
-    ) {}
-
-    public getExplicitContext(): ContextItem[] {
-        return this.userContext
-    }
-
-    private getUserAttentionContext(): ContextItem[] {
-        return this.getVisibleEditorContext()
-    }
-
-    public async getSmartSelectionContext(): Promise<ContextItem[]> {
-        const smartSelection = await this.editor.getActiveTextEditorSmartSelection()
-        const selection = smartSelection || this.editor.getActiveTextEditorSelectionOrVisibleContent()
-        if (!selection?.selectedText || isCodyIgnoredFile(selection.fileUri)) {
-            return []
+async function newChatModelfromTranscriptJSON(json: TranscriptJSON, modelID: string): Promise<SimpleChatModel> {
+    const messages: MessageWithContext[][] = json.interactions.map(
+        (interaction: InteractionJSON): MessageWithContext[] => {
+            return [
+                {
+                    message: {
+                        speaker: 'human',
+                        text: interaction.humanMessage.text,
+                    },
+                    displayText: interaction.humanMessage.displayText,
+                    newContextUsed: deserializedContextFilesToContextItems(
+                        interaction.usedContextFiles,
+                        interaction.fullContext
+                    ),
+                },
+                {
+                    message: {
+                        speaker: 'assistant',
+                        text: interaction.assistantMessage.text,
+                    },
+                    displayText: interaction.assistantMessage.displayText,
+                },
+            ]
         }
-        let range: vscode.Range | undefined
-        if (selection.selectionRange) {
-            range = new vscode.Range(
-                selection.selectionRange.start.line,
-                selection.selectionRange.start.character,
-                selection.selectionRange.end.line,
-                selection.selectionRange.end.character
-            )
-        }
-
-        return [
-            {
-                text: selection.selectedText,
-                uri: selection.fileUri,
-                range,
-                source: 'selection',
-            },
-        ]
-    }
-
-    public getCurrentSelectionContext(): ContextItem[] {
-        const selection = this.editor.getActiveTextEditorSelection()
-        if (!selection?.selectedText || isCodyIgnoredFile(selection.fileUri)) {
-            return []
-        }
-        let range: vscode.Range | undefined
-        if (selection.selectionRange) {
-            range = new vscode.Range(
-                selection.selectionRange.start.line,
-                selection.selectionRange.start.character,
-                selection.selectionRange.end.line,
-                selection.selectionRange.end.character
-            )
-        }
-
-        return [
-            {
-                text: selection.selectedText,
-                uri: selection.fileUri,
-                range,
-                source: 'selection',
-            },
-        ]
-    }
-
-    private getVisibleEditorContext(): ContextItem[] {
-        const visible = this.editor.getActiveTextEditorVisibleContent()
-        const fileUri = visible?.fileUri
-        if (!visible || !fileUri) {
-            return []
-        }
-        if (isCodyIgnoredFile(fileUri) || !visible.content.trim()) {
-            return []
-        }
-        return [
-            {
-                text: visible.content,
-                uri: fileUri,
-                source: 'editor',
-            },
-        ]
-    }
-
-    public async getEnhancedContext(text: string): Promise<ContextItem[]> {
-        const config = vscode.workspace.getConfiguration('cody')
-        const useContextConfig = config.get('useContext')
-
-        const searchContext: ContextItem[] = []
-
-        // use user attention context only if config is set to none
-        if (useContextConfig === 'none') {
-            logDebug('SimpleChatPanelProvider', 'getEnhancedContext > none')
-            searchContext.push(...this.getUserAttentionContext())
-            return searchContext
-        }
-
-        let hasEmbeddingsContext = false
-        // Get embeddings context if useContext Config is not set to 'keyword' only
-        if (useContextConfig !== 'keyword') {
-            logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (start)')
-            const localEmbeddingsResults = this.searchEmbeddingsLocal(text)
-            const remoteEmbeddingsResults = this.searchEmbeddingsRemote(text)
-            try {
-                const r = await localEmbeddingsResults
-                hasEmbeddingsContext = hasEmbeddingsContext || r.length > 0
-                searchContext.push(...r)
-            } catch (error) {
-                logDebug('SimpleChatPanelProvider', 'getEnhancedContext > local embeddings', error)
-            }
-            try {
-                const r = await remoteEmbeddingsResults
-                hasEmbeddingsContext = hasEmbeddingsContext || r.length > 0
-                searchContext.push(...r)
-            } catch (error) {
-                logDebug('SimpleChatPanelProvider', 'getEnhancedContext > remote embeddings', error)
-            }
-            logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (end)')
-        }
-
-        // Fallback to symf if embeddings provided no results or if useContext is set to 'keyword' specifically
-        if (!hasEmbeddingsContext && this.symf) {
-            logDebug('SimpleChatPanelProvider', 'getEnhancedContext > search')
-            try {
-                searchContext.push(...(await this.searchSymf(text)))
-            } catch (error) {
-                // TODO(beyang): handle this error better
-                logDebug('SimpleChatPanelProvider.getEnhancedContext', 'searchSymf error', error)
-            }
-        }
-
-        const priorityContext: ContextItem[] = []
-        const selectionContext = this.getCurrentSelectionContext()
-        if (selectionContext.length > 0) {
-            priorityContext.push(...selectionContext)
-        } else if (this.needsUserAttentionContext(text)) {
-            // Query refers to current editor
-            priorityContext.push(...this.getUserAttentionContext())
-        } else if (this.needsReadmeContext(text)) {
-            // Query refers to project, so include the README
-            let containsREADME = false
-            for (const contextItem of searchContext) {
-                const basename = uriBasename(contextItem.uri)
-                if (
-                    basename.toLocaleLowerCase() === 'readme' ||
-                    basename.toLocaleLowerCase().startsWith('readme.')
-                ) {
-                    containsREADME = true
-                    break
-                }
-            }
-            if (!containsREADME) {
-                priorityContext.push(...(await this.getReadmeContext()))
-            }
-        }
-
-        return priorityContext.concat(searchContext)
-    }
-
-    public async getCommandContext(command: CodyCommand): Promise<ContextItem[]> {
-        logDebug('SimpleChatPanelProvider.getCommandContext', command.slashCommand)
-
-        const contextMessages: ContextMessage[] = []
-        const contextItems: ContextItem[] = []
-
-        contextMessages.push(...(await getContextForCommand(this.editor, command)))
-        // Turn ContextMessages to ContextItems
-        for (const msg of contextMessages) {
-            if (msg.file?.uri && msg.file?.content) {
-                contextItems.push({
-                    uri: msg.file?.uri,
-                    text: msg.file?.content,
-                    range: viewRangeToRange(msg.file?.range),
-                    source: msg.file?.source || 'editor',
-                })
-            }
-        }
-        // Add codebase ContextItems last
-        if (command.context?.codebase) {
-            contextItems.push(...(await this.getEnhancedContext(command.prompt)))
-        }
-
-        return contextItems
-    }
-
-    /**
-     * Uses symf to conduct a local search within the current workspace folder
-     */
-    private async searchSymf(userText: string, blockOnIndex = false): Promise<ContextItem[]> {
-        if (!this.symf) {
-            return []
-        }
-        const workspaceRoot = this.editor.getWorkspaceRootUri()
-        if (!workspaceRoot || !isFileURI(workspaceRoot)) {
-            return []
-        }
-
-        const indexExists = await this.symf.getIndexStatus(workspaceRoot)
-        if (indexExists !== 'ready' && !blockOnIndex) {
-            void this.symf.ensureIndex(workspaceRoot, { hard: false })
-            return []
-        }
-
-        const r0 = (await this.symf.getResults(userText, [workspaceRoot])).flatMap(async results => {
-            const items = (await results).flatMap(
-                async (result: Result): Promise<ContextItem[] | ContextItem> => {
-                    if (isCodyIgnoredFile(result.file)) {
-                        return []
-                    }
-                    const range = new vscode.Range(
-                        result.range.startPoint.row,
-                        result.range.startPoint.col,
-                        result.range.endPoint.row,
-                        result.range.endPoint.col
-                    )
-
-                    let text: string | undefined
-                    try {
-                        text = await this.editor.getTextEditorContentForFile(result.file, range)
-                        if (!text) {
-                            return []
-                        }
-                    } catch (error) {
-                        logError(
-                            'SimpleChatPanelProvider.searchSymf',
-                            `Error getting file contents: ${error}`
-                        )
-                        return []
-                    }
-                    return {
-                        uri: result.file,
-                        range,
-                        source: 'search',
-                        text,
-                    }
-                }
-            )
-            return (await Promise.all(items)).flat()
-        })
-
-        const allResults = (await Promise.all(r0)).flat()
-
-        if (isAgentTesting) {
-            // Sort results for deterministic ordering for stable tests. Ideally, we
-            // could sort by some numerical score from symf based on how relevant
-            // the matches are for the query.
-            allResults.sort((a, b) => {
-                const byUri = a.uri.fsPath.localeCompare(b.uri.fsPath)
-                if (byUri !== 0) {
-                    return byUri
-                }
-                return a.text.localeCompare(b.text)
-            })
-        }
-
-        return allResults
-    }
-
-    private async searchEmbeddingsLocal(text: string): Promise<ContextItem[]> {
-        if (!this.localEmbeddings) {
-            return []
-        }
-
-        logDebug('SimpleChatPanelProvider', 'getEnhancedContext > searching local embeddings')
-        const contextItems: ContextItem[] = []
-        const embeddingsResults = await this.localEmbeddings.getContext(
-            text,
-            NUM_CODE_RESULTS + NUM_TEXT_RESULTS
-        )
-
-        for (const result of embeddingsResults) {
-            const range = new vscode.Range(
-                new vscode.Position(result.startLine, 0),
-                new vscode.Position(result.endLine, 0)
-            )
-
-            // Filter out ignored files
-            if (!isCodyIgnoredFile(result.uri)) {
-                contextItems.push({
-                    uri: result.uri,
-                    range,
-                    text: result.content,
-                    source: 'embeddings',
-                })
-            }
-        }
-        return contextItems
-    }
-
-    // Note: does not throw error if remote embeddings are not available, just returns empty array
-    private async searchEmbeddingsRemote(text: string): Promise<ContextItem[]> {
-        if (!this.embeddingsClient) {
-            return []
-        }
-        const codebase = await this.codebaseStatusProvider?.currentCodebase()
-        if (!codebase?.remote) {
-            return []
-        }
-        const repoId = await this.embeddingsClient.getRepoIdIfEmbeddingExists(codebase.remote)
-        if (isError(repoId)) {
-            throw new Error(`Error retrieving repo ID: ${repoId}`)
-        }
-        if (!repoId) {
-            return []
-        }
-
-        const workspaceFolder = vscode.workspace.workspaceFolders?.at(0)
-        if (!workspaceFolder) {
-            return []
-        }
-
-        logDebug('SimpleChatPanelProvider', 'getEnhancedContext > searching remote embeddings')
-        const contextItems: ContextItem[] = []
-        const embeddings = await this.embeddingsClient.search(
-            [repoId],
-            text,
-            NUM_CODE_RESULTS,
-            NUM_TEXT_RESULTS
-        )
-        if (isError(embeddings)) {
-            throw new Error(`Error retrieving embeddings: ${embeddings}`)
-        }
-        for (const codeResult of embeddings.codeResults) {
-            const range = new vscode.Range(
-                new vscode.Position(codeResult.startLine, 0),
-                new vscode.Position(codeResult.endLine, 0)
-            )
-            if (!isCodyIgnoredFile(codeResult.uri)) {
-                contextItems.push({
-                    uri: codeResult.uri,
-                    range,
-                    text: codeResult.content,
-                    source: 'embeddings',
-                })
-            }
-        }
-
-        for (const textResult of embeddings.textResults) {
-            const range = new vscode.Range(
-                new vscode.Position(textResult.startLine, 0),
-                new vscode.Position(textResult.endLine, 0)
-            )
-            if (!isCodyIgnoredFile(textResult.uri)) {
-                contextItems.push({
-                    uri: textResult.uri,
-                    range,
-                    text: textResult.content,
-                    source: 'embeddings',
-                })
-            }
-        }
-
-        return contextItems
-    }
-
-    private needsReadmeContext(input: string): boolean {
-        input = input.toLowerCase()
-        const question = extractQuestion(input)
-        if (!question) {
-            return false
-        }
-
-        // split input into words, discarding spaces and punctuation
-        const words = input.split(/\W+/).filter(w => w.length > 0)
-        const bagOfWords = Object.fromEntries(words.map(w => [w, true]))
-
-        const projectSignifiers = [
-            'project',
-            'repository',
-            'repo',
-            'library',
-            'package',
-            'module',
-            'codebase',
-        ]
-        const questionIndicators = ['what', 'how', 'describe', 'explain', '?']
-
-        const workspaceUri = this.editor.getWorkspaceRootUri()
-        if (workspaceUri) {
-            const rootBase = workspaceUri.toString().split('/').at(-1)
-            if (rootBase) {
-                projectSignifiers.push(rootBase.toLowerCase())
-            }
-        }
-
-        let containsProjectSignifier = false
-        for (const p of projectSignifiers) {
-            if (bagOfWords[p]) {
-                containsProjectSignifier = true
-                break
-            }
-        }
-
-        let containsQuestionIndicator = false
-        for (const q of questionIndicators) {
-            if (bagOfWords[q]) {
-                containsQuestionIndicator = true
-                break
-            }
-        }
-
-        return containsQuestionIndicator && containsProjectSignifier
-    }
-
-    private static userAttentionRegexps: RegExp[] = [
-        /editor/,
-        /(open|current|this|entire)\s+file/,
-        /current(ly)?\s+open/,
-        /have\s+open/,
-    ]
-
-    private needsUserAttentionContext(input: string): boolean {
-        const inputLowerCase = input.toLowerCase()
-        // If the input matches any of the `editorRegexps` we assume that we have to include
-        // the editor context (e.g., currently open file) to the overall message context.
-        for (const regexp of ContextProvider.userAttentionRegexps) {
-            if (inputLowerCase.match(regexp)) {
-                return true
-            }
-        }
-        return false
-    }
-
-    private async getReadmeContext(): Promise<ContextItem[]> {
-        // global pattern for readme file
-        const readmeGlobalPattern = '{README,README.,readme.,Readm.}*'
-        const readmeUri = (await vscode.workspace.findFiles(readmeGlobalPattern, undefined, 1)).at(0)
-        if (!readmeUri || isCodyIgnoredFile(readmeUri)) {
-            return []
-        }
-        const readmeDoc = await vscode.workspace.openTextDocument(readmeUri)
-        const readmeText = readmeDoc.getText()
-        const { truncated: truncatedReadmeText, range } = truncateTextNearestLine(
-            readmeText,
-            MAX_BYTES_PER_FILE
-        )
-        if (truncatedReadmeText.length === 0) {
-            return []
-        }
-
-        return [
-            {
-                uri: readmeUri,
-                text: truncatedReadmeText,
-                range: viewRangeToRange(range),
-                source: 'editor',
-            },
-        ]
-    }
+    )
+    return new SimpleChatModel(json.chatModel || modelID, (await Promise.all(messages)).flat(), json.id, json.chatTitle)
 }
 
 export async function contextFilesToContextItems(
@@ -1645,49 +1133,6 @@ export async function contextFilesToContextItems(
     ).filter(isDefined)
 }
 
-function viewRangeToRange(range?: ActiveTextEditorSelectionRange): vscode.Range | undefined {
-    if (!range) {
-        return undefined
-    }
-    return new vscode.Range(range.start.line, range.start.character, range.end.line, range.end.character)
-}
-
-async function newChatModelfromTranscriptJSON(
-    json: TranscriptJSON,
-    modelID: string
-): Promise<SimpleChatModel> {
-    const messages: MessageWithContext[][] = json.interactions.map(
-        (interaction: InteractionJSON): MessageWithContext[] => {
-            return [
-                {
-                    message: {
-                        speaker: 'human',
-                        text: interaction.humanMessage.text,
-                    },
-                    displayText: interaction.humanMessage.displayText,
-                    newContextUsed: deserializedContextFilesToContextItems(
-                        interaction.usedContextFiles,
-                        interaction.fullContext
-                    ),
-                },
-                {
-                    message: {
-                        speaker: 'assistant',
-                        text: interaction.assistantMessage.text,
-                    },
-                    displayText: interaction.assistantMessage.displayText,
-                },
-            ]
-        }
-    )
-    return new SimpleChatModel(
-        json.chatModel || modelID,
-        (await Promise.all(messages)).flat(),
-        json.id,
-        json.chatTitle
-    )
-}
-
 function deserializedContextFilesToContextItems(
     files: ContextFile[],
     contextMessages: ContextMessage[]
@@ -1716,18 +1161,6 @@ function deserializedContextFilesToContextItems(
             source: file.source,
         }
     })
-}
-
-function extractQuestion(input: string): string | undefined {
-    input = input.trim()
-    const q = input.indexOf('?')
-    if (q !== -1) {
-        return input.slice(0, q + 1).trim()
-    }
-    if (input.length < 100) {
-        return input
-    }
-    return undefined
 }
 
 function isAbortError(error: Error): boolean {
@@ -1765,4 +1198,28 @@ function getContextWindowForModel(authStatus: AuthStatus, modelID: string): numb
         return 28000 // 7000 tokens * 4 bytes per token
     }
     return 28000 // assume default to Claude-2-like model
+}
+
+// Select the chat model to use in Chat
+function selectModel(authProvider: AuthProvider, models: ChatModelProvider[]): string {
+    const authStatus = authProvider.getAuthStatus()
+    // Free user can only use the default model
+    if (authStatus.isDotCom && authStatus.userCanUpgrade) {
+        return models[0].model
+    }
+    // Check for the last selected model
+    const lastSelectedModelID = localStorage.get('model')
+    if (lastSelectedModelID) {
+        // If the last selected model exists in the list of models then we return it
+        const model = models.find(m => m.model === lastSelectedModelID)
+        if (model) {
+            return lastSelectedModelID
+        }
+    }
+    // If the user has not selected a model before then we return the default model
+    const defaultModel = models.find(m => m.default) || models[0]
+    if (!defaultModel) {
+        throw new Error('No chat model found in server-provided config')
+    }
+    return defaultModel.model
 }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -545,9 +545,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     public async handleCommand(command: CodyCommand, args: CodyCommandArgs): Promise<void> {
-        // If it's not a ask command, it's a fixup command. If it's a fixup request, we can exit early
+        // If it's not an ask command, it's a fixup command, so we can exit early.
         // This is because startCommand will start the CommandRunner,
-        // which would send all fixup requests to the FixupController
+        // which would send all fixup command requests to the FixupController
         if (command.mode !== 'ask') {
             return
         }
@@ -654,7 +654,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 contextSummary,
             }
 
-            // Only log chat-question event if it is not a command to avoid double logging for commands
             telemetryService.log('CodyVSCodeExtension:chat-question:executed', properties, {
                 hasV2Event: true,
             })
@@ -670,7 +669,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     properties,
                     // 🚨 SECURITY: chat transcripts are to be included only for DotCom users AND for V2 telemetry
                     // V2 telemetry exports privateMetadata only for DotCom users
-                    // the condition below is an aditional safegaurd measure
+                    // the condition below is an aditional safeguard measure
                     promptText:
                         authStatus.endpoint && isDotCom(authStatus.endpoint) ? promptText : undefined,
                 },
@@ -707,7 +706,13 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         this.chatModel.setNewContextUsed(newContextUsed)
         if (contextLimitWarnings.length > 0) {
             const warningMsg = contextLimitWarnings
-                .map(w => (w.trim().endsWith('.') ? w.trim() : w.trim() + '.'))
+                .map(w => {
+                    w = w.trim()
+                    if (!w.endsWith('.')) {
+                        w += '.'
+                    }
+                    return w
+                })
                 .join(' ')
             this.postError(new ContextWindowLimitError(warningMsg), 'transcript')
         }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -646,7 +646,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                       )
                 : undefined
         )
-        const sendTelemetry = (contextSummary: {}): void => {
+        const sendTelemetry = (contextSummary: any): void => {
             const authStatus = this.authProvider.getAuthStatus()
             const properties = {
                 requestID,
@@ -695,7 +695,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
      */
     private async buildPrompt(
         prompter: IPrompter,
-        sendTelemetry?: (contextSummary: {}) => void
+        sendTelemetry?: (contextSummary: any) => void
     ): Promise<Message[]> {
         const { prompt, contextLimitWarnings, newContextUsed } = await prompter.makePrompt(
             this.chatModel,

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -131,3 +131,10 @@ export function getChatPanelTitle(lastDisplayText?: string, truncateTitle = true
     // truncate title that is too long
     return lastDisplayText.length > 25 ? `${lastDisplayText.slice(0, 25).trim()}...` : lastDisplayText
 }
+
+export function viewRangeToRange(range?: ActiveTextEditorSelectionRange): vscode.Range | undefined {
+    if (!range) {
+        return undefined
+    }
+    return new vscode.Range(range.start.line, range.start.character, range.end.line, range.end.character)
+}

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -1,0 +1,445 @@
+import * as vscode from 'vscode'
+
+import {
+    isCodyIgnoredFile,
+    isError,
+    MAX_BYTES_PER_FILE,
+    NUM_CODE_RESULTS,
+    NUM_TEXT_RESULTS,
+    truncateTextNearestLine,
+    type CodyCommand,
+    type ConfigurationUseContext,
+    type Result,
+    isFileURI,
+    uriBasename,
+} from '@sourcegraph/cody-shared'
+
+import { getContextForCommand } from '../../commands/utils/get-context'
+import { type VSCodeEditor } from '../../editor/vscode-editor'
+import { type LocalEmbeddingsController } from '../../local-context/local-embeddings'
+import { type SymfRunner } from '../../local-context/symf'
+import { logDebug, logError } from '../../log'
+import { type CachedRemoteEmbeddingsClient } from '../CachedRemoteEmbeddingsClient'
+
+import { viewRangeToRange } from './chat-helpers'
+import { type CodebaseStatusProvider } from './CodebaseStatusProvider'
+import { type ContextItem } from './SimpleChatModel'
+
+const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
+
+export async function getEnhancedContext(
+    useContextConfig: ConfigurationUseContext,
+    editor: VSCodeEditor,
+    embeddingsClient: CachedRemoteEmbeddingsClient,
+    localEmbeddings: LocalEmbeddingsController | null,
+    symf: SymfRunner | null,
+    codebaseStatusProvider: CodebaseStatusProvider,
+    text: string
+): Promise<ContextItem[]> {
+    const searchContext: ContextItem[] = []
+
+    // use user attention context only if config is set to none
+    if (useContextConfig === 'none') {
+        logDebug('SimpleChatPanelProvider', 'getEnhancedContext > none')
+        searchContext.push(...getVisibleEditorContext(editor))
+        return searchContext
+    }
+
+    let hasEmbeddingsContext = false
+    // Get embeddings context if useContext Config is not set to 'keyword' only
+    if (useContextConfig !== 'keyword') {
+        logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (start)')
+        const localEmbeddingsResults = searchEmbeddingsLocal(localEmbeddings, text)
+        const remoteEmbeddingsResults = searchEmbeddingsRemote(embeddingsClient, codebaseStatusProvider, text)
+        try {
+            const r = await localEmbeddingsResults
+            hasEmbeddingsContext = hasEmbeddingsContext || r.length > 0
+            searchContext.push(...r)
+        } catch (error) {
+            logDebug('SimpleChatPanelProvider', 'getEnhancedContext > local embeddings', error)
+        }
+        try {
+            const r = await remoteEmbeddingsResults
+            hasEmbeddingsContext = hasEmbeddingsContext || r.length > 0
+            searchContext.push(...r)
+        } catch (error) {
+            logDebug('SimpleChatPanelProvider', 'getEnhancedContext > remote embeddings', error)
+        }
+        logDebug('SimpleChatPanelProvider', 'getEnhancedContext > embeddings (end)')
+    }
+
+    // Fallback to symf if embeddings provided no results or if useContext is set to 'keyword' specifically
+    if (!hasEmbeddingsContext && symf) {
+        logDebug('SimpleChatPanelProvider', 'getEnhancedContext > search')
+        try {
+            searchContext.push(...(await searchSymf(symf, editor, text)))
+        } catch (error) {
+            // TODO(beyang): handle this error better
+            logDebug('SimpleChatPanelProvider.getEnhancedContext', 'searchSymf error', error)
+        }
+    }
+
+    const priorityContext: ContextItem[] = []
+    const selectionContext = getCurrentSelectionContext(editor)
+    if (selectionContext.length > 0) {
+        priorityContext.push(...selectionContext)
+    } else if (needsUserAttentionContext(text)) {
+        // Query refers to current editor
+        priorityContext.push(...getVisibleEditorContext(editor))
+    } else if (needsReadmeContext(editor, text)) {
+        // Query refers to project, so include the README
+        let containsREADME = false
+        for (const contextItem of searchContext) {
+            const basename = uriBasename(contextItem.uri)
+            if (
+                basename.toLocaleLowerCase() === 'readme' ||
+                basename.toLocaleLowerCase().startsWith('readme.')
+            ) {
+                containsREADME = true
+                break
+            }
+        }
+        if (!containsREADME) {
+            priorityContext.push(...(await getReadmeContext()))
+        }
+    }
+
+    return priorityContext.concat(searchContext)
+}
+
+/**
+ * Uses symf to conduct a local search within the current workspace folder
+ */
+async function searchSymf(
+    symf: SymfRunner | null,
+    editor: VSCodeEditor,
+    userText: string,
+    blockOnIndex = false
+): Promise<ContextItem[]> {
+    if (!symf) {
+        return []
+    }
+    const workspaceRoot = editor.getWorkspaceRootUri()
+    if (!workspaceRoot || !isFileURI(workspaceRoot)) {
+        return []
+    }
+
+    const indexExists = await symf.getIndexStatus(workspaceRoot)
+    if (indexExists !== 'ready' && !blockOnIndex) {
+        void symf.ensureIndex(workspaceRoot, { hard: false })
+        return []
+    }
+
+    const r0 = (await symf.getResults(userText, [workspaceRoot])).flatMap(async results => {
+        const items = (await results).flatMap(async (result: Result): Promise<ContextItem[] | ContextItem> => {
+            if (isCodyIgnoredFile(result.file)) {
+                return []
+            }
+            const range = new vscode.Range(
+                result.range.startPoint.row,
+                result.range.startPoint.col,
+                result.range.endPoint.row,
+                result.range.endPoint.col
+            )
+
+            let text: string | undefined
+            try {
+                text = await editor.getTextEditorContentForFile(result.file, range)
+                if (!text) {
+                    return []
+                }
+            } catch (error) {
+                logError('SimpleChatPanelProvider.searchSymf', `Error getting file contents: ${error}`)
+                return []
+            }
+            return {
+                uri: result.file,
+                range,
+                source: 'search',
+                text,
+            }
+        })
+        return (await Promise.all(items)).flat()
+    })
+
+    const allResults = (await Promise.all(r0)).flat()
+
+    if (isAgentTesting) {
+        // Sort results for deterministic ordering for stable tests. Ideally, we
+        // could sort by some numerical score from symf based on how relevant
+        // the matches are for the query.
+        allResults.sort((a, b) => {
+            const byUri = a.uri.fsPath.localeCompare(b.uri.fsPath)
+            if (byUri !== 0) {
+                return byUri
+            }
+            return a.text.localeCompare(b.text)
+        })
+    }
+
+    return allResults
+}
+
+async function searchEmbeddingsLocal(
+    localEmbeddings: LocalEmbeddingsController | null,
+    text: string
+): Promise<ContextItem[]> {
+    if (!localEmbeddings) {
+        return []
+    }
+
+    logDebug('SimpleChatPanelProvider', 'getEnhancedContext > searching local embeddings')
+    const contextItems: ContextItem[] = []
+    const embeddingsResults = await localEmbeddings.getContext(
+        text,
+        NUM_CODE_RESULTS + NUM_TEXT_RESULTS
+    )
+
+    for (const result of embeddingsResults) {
+        const range = new vscode.Range(
+            new vscode.Position(result.startLine, 0),
+            new vscode.Position(result.endLine, 0)
+        )
+
+        // Filter out ignored files
+        if (!isCodyIgnoredFile(result.uri)) {
+            contextItems.push({
+                uri: result.uri,
+                range,
+                text: result.content,
+                source: 'embeddings',
+            })
+        }
+    }
+    return contextItems
+}
+
+// Note: does not throw error if remote embeddings are not available, just returns empty array
+async function searchEmbeddingsRemote(
+    embeddingsClient: CachedRemoteEmbeddingsClient | null,
+    codebaseStatusProvider: CodebaseStatusProvider,
+    text: string
+): Promise<ContextItem[]> {
+    if (!embeddingsClient) {
+        return []
+    }
+    const codebase = await codebaseStatusProvider?.currentCodebase()
+    if (!codebase?.remote) {
+        return []
+    }
+    const repoId = await embeddingsClient.getRepoIdIfEmbeddingExists(codebase.remote)
+    if (isError(repoId)) {
+        throw new Error(`Error retrieving repo ID: ${repoId}`)
+    }
+    if (!repoId) {
+        return []
+    }
+
+    const workspaceFolder = vscode.workspace.workspaceFolders?.at(0)
+    if (!workspaceFolder) {
+        return []
+    }
+
+    logDebug('SimpleChatPanelProvider', 'getEnhancedContext > searching remote embeddings')
+    const contextItems: ContextItem[] = []
+    const embeddings = await embeddingsClient.search(
+        [repoId],
+        text,
+        NUM_CODE_RESULTS,
+        NUM_TEXT_RESULTS
+    )
+    if (isError(embeddings)) {
+        throw new Error(`Error retrieving embeddings: ${embeddings}`)
+    }
+    for (const codeResult of embeddings.codeResults) {
+        const range = new vscode.Range(
+            new vscode.Position(codeResult.startLine, 0),
+            new vscode.Position(codeResult.endLine, 0)
+        )
+        if (!isCodyIgnoredFile(codeResult.uri)) {
+            contextItems.push({
+                uri: codeResult.uri,
+                range,
+                text: codeResult.content,
+                source: 'embeddings',
+            })
+        }
+    }
+
+    for (const textResult of embeddings.textResults) {
+        const range = new vscode.Range(
+            new vscode.Position(textResult.startLine, 0),
+            new vscode.Position(textResult.endLine, 0)
+        )
+        if (!isCodyIgnoredFile(textResult.uri)) {
+            contextItems.push({
+                uri: textResult.uri,
+                range,
+                text: textResult.content,
+                source: 'embeddings',
+            })
+        }
+    }
+
+    return contextItems
+}
+
+const userAttentionRegexps: RegExp[] = [
+    /editor/,
+    /(open|current|this|entire)\s+file/,
+    /current(ly)?\s+open/,
+    /have\s+open/,
+]
+
+function getCurrentSelectionContext(editor: VSCodeEditor): ContextItem[] {
+    const selection = editor.getActiveTextEditorSelection()
+    if (!selection?.selectedText || isCodyIgnoredFile(selection.fileUri)) {
+        return []
+    }
+    let range: vscode.Range | undefined
+    if (selection.selectionRange) {
+        range = new vscode.Range(
+            selection.selectionRange.start.line,
+            selection.selectionRange.start.character,
+            selection.selectionRange.end.line,
+            selection.selectionRange.end.character
+        )
+    }
+
+    return [
+        {
+            text: selection.selectedText,
+            uri: selection.fileUri,
+            range,
+            source: 'selection',
+        },
+    ]
+}
+
+function getVisibleEditorContext(editor: VSCodeEditor): ContextItem[] {
+    const visible = editor.getActiveTextEditorVisibleContent()
+    const fileUri = visible?.fileUri
+    if (!visible || !fileUri) {
+        return []
+    }
+    if (isCodyIgnoredFile(fileUri) || !visible.content.trim()) {
+        return []
+    }
+    return [
+        {
+            text: visible.content,
+            uri: fileUri,
+            source: 'editor',
+        },
+    ]
+}
+
+function needsUserAttentionContext(input: string): boolean {
+    const inputLowerCase = input.toLowerCase()
+    // If the input matches any of the `editorRegexps` we assume that we have to include
+    // the editor context (e.g., currently open file) to the overall message context.
+    for (const regexp of userAttentionRegexps) {
+        if (inputLowerCase.match(regexp)) {
+            return true
+        }
+    }
+    return false
+}
+
+function needsReadmeContext(editor: VSCodeEditor, input: string): boolean {
+    input = input.toLowerCase()
+    const question = extractQuestion(input)
+    if (!question) {
+        return false
+    }
+
+    // split input into words, discarding spaces and punctuation
+    const words = input.split(/\W+/).filter(w => w.length > 0)
+    const bagOfWords = Object.fromEntries(words.map(w => [w, true]))
+
+    const projectSignifiers = ['project', 'repository', 'repo', 'library', 'package', 'module', 'codebase']
+    const questionIndicators = ['what', 'how', 'describe', 'explain', '?']
+
+    const workspaceUri = editor.getWorkspaceRootUri()
+    if (workspaceUri) {
+        const rootBase = workspaceUri.toString().split('/').at(-1)
+        if (rootBase) {
+            projectSignifiers.push(rootBase.toLowerCase())
+        }
+    }
+
+    let containsProjectSignifier = false
+    for (const p of projectSignifiers) {
+        if (bagOfWords[p]) {
+            containsProjectSignifier = true
+            break
+        }
+    }
+
+    let containsQuestionIndicator = false
+    for (const q of questionIndicators) {
+        if (bagOfWords[q]) {
+            containsQuestionIndicator = true
+            break
+        }
+    }
+
+    return containsQuestionIndicator && containsProjectSignifier
+}
+async function getReadmeContext(): Promise<ContextItem[]> {
+    // global pattern for readme file
+    const readmeGlobalPattern = '{README,README.,readme.,Readm.}*'
+    const readmeUri = (await vscode.workspace.findFiles(readmeGlobalPattern, undefined, 1)).at(0)
+    if (!readmeUri || isCodyIgnoredFile(readmeUri)) {
+        return []
+    }
+    const readmeDoc = await vscode.workspace.openTextDocument(readmeUri)
+    const readmeText = readmeDoc.getText()
+    const { truncated: truncatedReadmeText, range } = truncateTextNearestLine(readmeText, MAX_BYTES_PER_FILE)
+    if (truncatedReadmeText.length === 0) {
+        return []
+    }
+
+    return [
+        {
+            uri: readmeUri,
+            text: truncatedReadmeText,
+            range: viewRangeToRange(range),
+            source: 'editor',
+        },
+    ]
+}
+
+export async function getCommandContext(editor: VSCodeEditor, command: CodyCommand): Promise<ContextItem[]> {
+    logDebug('SimpleChatPanelProvider.getCommandContext', command.slashCommand)
+
+    const contextItems: ContextItem[] = []
+    const contextMessages = await getContextForCommand(editor, command)
+    // Turn ContextMessages to ContextItems
+    for (const msg of contextMessages) {
+        if (msg.file?.uri && msg.file?.content) {
+            contextItems.push({
+                uri: msg.file?.uri,
+                text: msg.file?.content,
+                range: viewRangeToRange(msg.file?.range),
+                source: msg.file?.source || 'editor',
+            })
+        }
+    }
+
+    // TODO(beyang): add codebase context when command.context.codebase is true
+
+    return contextItems
+}
+
+function extractQuestion(input: string): string | undefined {
+    input = input.trim()
+    const q = input.indexOf('?')
+    if (q !== -1) {
+        return input.slice(0, q + 1).trim()
+    }
+    if (input.length < 100) {
+        return input
+    }
+    return undefined
+}

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -1,8 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as vscode from 'vscode'
-
-import { DefaultPrompter } from './prompt'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SimpleChatModel } from './SimpleChatModel'
+import { DefaultPrompter } from './prompt'
 
 describe('DefaultPrompter', () => {
     afterEach(() => {
@@ -17,16 +16,9 @@ describe('DefaultPrompter', () => {
             prompt,
             contextLimitWarnings: warnings,
             newContextUsed,
-        } = await new DefaultPrompter().makePrompt(
-            chat,
-            {
-                getExplicitContext: () => [],
-                getEnhancedContext: () => Promise.resolve([]),
-                getCommandContext: () => Promise.resolve([]),
-            },
-            true,
-            100000
-        )
+        } = await new DefaultPrompter(
+            [], () => Promise.resolve([])
+        ).makePrompt(chat,100000)
 
         expect(prompt).toMatchInlineSnapshot(`
           [
@@ -64,14 +56,8 @@ describe('DefaultPrompter', () => {
             prompt,
             contextLimitWarnings: warnings,
             newContextUsed,
-        } = await new DefaultPrompter().makePrompt(
+        } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(
             chat,
-            {
-                getExplicitContext: () => [],
-                getEnhancedContext: () => Promise.resolve([]),
-                getCommandContext: () => Promise.resolve([]),
-            },
-            true,
             100000
         )
 

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -16,9 +16,7 @@ describe('DefaultPrompter', () => {
             prompt,
             contextLimitWarnings: warnings,
             newContextUsed,
-        } = await new DefaultPrompter(
-            [], () => Promise.resolve([])
-        ).makePrompt(chat,100000)
+        } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(chat, 100000)
 
         expect(prompt).toMatchInlineSnapshot(`
           [
@@ -56,10 +54,7 @@ describe('DefaultPrompter', () => {
             prompt,
             contextLimitWarnings: warnings,
             newContextUsed,
-        } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(
-            chat,
-            100000
-        )
+        } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(chat, 100000)
 
         expect(prompt).toMatchInlineSnapshot(`
           [

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -9,7 +9,6 @@ import {
     populateCurrentSelectedCodeContextTemplate,
     populateMarkdownContextTemplate,
     ProgrammingLanguage,
-    type CodyCommand,
     type Message,
 } from '@sourcegraph/cody-shared'
 
@@ -23,30 +22,76 @@ import {
 } from './SimpleChatModel'
 
 export interface IContextProvider {
-    // Context explicitly specified by user
-    getExplicitContext(): ContextItem[]
-
     // Relevant context pulled from the editor state and broader repository
     getEnhancedContext(query: string): Promise<ContextItem[]>
+}
 
-    getCommandContext(command: CodyCommand): Promise<ContextItem[]>
+interface PromptInfo {
+    prompt: Message[]
+    contextLimitWarnings: string[]
+    newContextUsed: ContextItem[]
 }
 
 export interface IPrompter {
-    makePrompt(
-        chat: SimpleChatModel,
-        contextProvider: IContextProvider,
-        useEnhancedContext: boolean,
-        byteLimit: number,
-        command?: CodyCommand
-    ): Promise<{
-        prompt: Message[]
-        contextLimitWarnings: string[]
-        newContextUsed: ContextItem[]
-    }>
+    makePrompt(chat: SimpleChatModel, byteLimit: number): Promise<PromptInfo>
+}
+
+export class CommandPrompter implements IPrompter {
+    constructor(private getContextItems: () => Promise<ContextItem[]>) {}
+    public async makePrompt(chat: SimpleChatModel, byteLimit: number): Promise<PromptInfo> {
+        const promptBuilder = new PromptBuilder(byteLimit)
+        const newContextUsed: ContextItem[] = []
+        const warnings: string[] = []
+        const preInstruction: string | undefined = vscode.workspace.getConfiguration('cody.chat').get('preInstruction')
+
+        const preambleMessages = getSimplePreamble(preInstruction)
+        const preambleSucceeded = promptBuilder.tryAddToPrefix(preambleMessages)
+        if (!preambleSucceeded) {
+            throw new Error(`Preamble length exceeded context window size ${byteLimit}`)
+        }
+
+        // Add existing transcript messages
+        const reverseTranscript: MessageWithContext[] = [...chat.getMessagesWithContext()].reverse()
+        for (let i = 0; i < reverseTranscript.length; i++) {
+            const messageWithContext = reverseTranscript[i]
+            const contextLimitReached = promptBuilder.tryAdd(messageWithContext.message)
+            if (!contextLimitReached) {
+                warnings.push(
+                    `Ignored ${reverseTranscript.length - i} transcript messages due to context limit`
+                )
+                return {
+                    prompt: promptBuilder.build(),
+                    contextLimitWarnings: warnings,
+                    newContextUsed,
+                }
+            }
+        }
+
+        const contextItems = await this.getContextItems()
+        const { limitReached, used, ignored } = promptBuilder.tryAddContext(
+            contextItems,
+            Math.floor(byteLimit * 0.6) // Allocate no more than 60% of context window to enhanced context
+        )
+        newContextUsed.push(...used)
+        if (limitReached) {
+            // TODO(beyang): we're masking this error (repro: try /explain),
+            // we should improve the commands context selection process
+            logDebug('CommandPrompter', 'makePrompt', `context limit reached, ignored ${ignored.length} items`)
+        }
+
+        return {
+            prompt: promptBuilder.build(),
+            contextLimitWarnings: warnings,
+            newContextUsed,
+        }
+    }
 }
 
 export class DefaultPrompter implements IPrompter {
+    constructor(
+        private explicitContext: ContextItem[],
+        private getEnhancedContext?: (query: string) => Promise<ContextItem[]>
+    ) {}
     // Constructs the raw prompt to send to the LLM, with message order reversed, so we can construct
     // an array with the most important messages (which appear most important first in the reverse-prompt.
     //
@@ -54,10 +99,7 @@ export class DefaultPrompter implements IPrompter {
     // the new context that was used in the prompt for the current message.
     public async makePrompt(
         chat: SimpleChatModel,
-        contextProvider: IContextProvider,
-        useEnhancedContext: boolean,
-        byteLimit: number,
-        command?: CodyCommand
+        byteLimit: number
     ): Promise<{
         prompt: Message[]
         contextLimitWarnings: string[]
@@ -95,10 +137,7 @@ export class DefaultPrompter implements IPrompter {
 
         {
             // Add context from new user-specified context items
-            const { limitReached, used } = promptBuilder.tryAddContext(
-                contextProvider.getExplicitContext(),
-                (item: ContextItem) => this.renderContextItem(item)
-            )
+            const { limitReached, used } = promptBuilder.tryAddContext(this.explicitContext)
             newContextUsed.push(...used)
             if (limitReached) {
                 warnings.push('Ignored current user-specified context items due to context limit')
@@ -111,8 +150,7 @@ export class DefaultPrompter implements IPrompter {
         {
             // Add context from previous messages
             const { limitReached } = promptBuilder.tryAddContext(
-                reverseTranscript.flatMap((message: MessageWithContext) => message.newContextUsed || []),
-                (item: ContextItem) => this.renderContextItem(item)
+                reverseTranscript.flatMap((message: MessageWithContext) => message.newContextUsed || [])
             )
             if (limitReached) {
                 warnings.push('Ignored prior context items due to context limit')
@@ -127,14 +165,11 @@ export class DefaultPrompter implements IPrompter {
         if (lastMessage.message.speaker === 'assistant') {
             throw new Error('Last message in prompt needs speaker "human", but was "assistant"')
         }
-        if (useEnhancedContext || command) {
+        if (this.getEnhancedContext) {
             // Add additional context from current editor or broader search
-            const additionalContextItems = command
-                ? await contextProvider.getCommandContext(command)
-                : await contextProvider.getEnhancedContext(lastMessage.message.text)
+            const additionalContextItems = await this.getEnhancedContext(lastMessage.message.text)
             const { limitReached, used, ignored } = promptBuilder.tryAddContext(
                 additionalContextItems,
-                (item: ContextItem) => this.renderContextItem(item),
                 Math.floor(byteLimit * 0.6) // Allocate no more than 60% of context window to enhanced context
             )
             newContextUsed.push(...used)
@@ -152,36 +187,33 @@ export class DefaultPrompter implements IPrompter {
             newContextUsed,
         }
     }
+}
 
-    private renderContextItem(contextItem: ContextItem): Message[] {
-        // Do not create context item for empty file
-        if (!contextItem.text?.trim()?.length) {
-            return []
-        }
-        let messageText: string
-        if (contextItem.source === 'selection') {
-            messageText = populateCurrentSelectedCodeContextTemplate(contextItem.text, contextItem.uri)
-        } else if (contextItem.source === 'editor') {
-            // This template text works well with prompts in our commands
-            // Using populateCodeContextTemplate here will cause confusion to Cody
-            const templateText = 'Codebase context from file path {fileName}: '
-            messageText = populateContextTemplateFromText(
-                templateText,
-                contextItem.text,
-                contextItem.uri
-            )
-        } else if (contextItem.source === 'terminal') {
-            messageText = contextItem.text
-        } else if (languageFromFilename(contextItem.uri) === ProgrammingLanguage.Markdown) {
-            messageText = populateMarkdownContextTemplate(contextItem.text, contextItem.uri)
-        } else {
-            messageText = populateCodeContextTemplate(contextItem.text, contextItem.uri)
-        }
-        return [
-            { speaker: 'human', text: messageText },
-            { speaker: 'assistant', text: 'Ok.' },
-        ]
+
+function renderContextItem(contextItem: ContextItem): Message[] {
+    // Do not create context item for empty file
+    if (!contextItem.text?.trim()?.length) {
+        return []
     }
+    let messageText: string
+    if (contextItem.source === 'selection') {
+        messageText = populateCurrentSelectedCodeContextTemplate(contextItem.text, contextItem.uri)
+    } else if (contextItem.source === 'editor') {
+        // This template text works well with prompts in our commands
+        // Using populateCodeContextTemplate here will cause confusion to Cody
+        const templateText = 'Codebase context from file path {fileName}: '
+        messageText = populateContextTemplateFromText(templateText, contextItem.text, contextItem.uri)
+    } else if (contextItem.source === 'terminal') {
+        messageText = contextItem.text
+    } else if (languageFromFilename(contextItem.uri) === ProgrammingLanguage.Markdown) {
+        messageText = populateMarkdownContextTemplate(contextItem.text, contextItem.uri)
+    } else {
+        messageText = populateCodeContextTemplate(contextItem.text, contextItem.uri)
+    }
+    return [
+        { speaker: 'human', text: messageText },
+        { speaker: 'assistant', text: 'Ok.' },
+    ]
 }
 
 /**
@@ -235,7 +267,6 @@ class PromptBuilder {
      */
     public tryAddContext(
         contextItems: ContextItem[],
-        renderContextItem: (contextItem: ContextItem) => Message[],
         byteLimit?: number
     ): {
         limitReached: boolean

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -42,7 +42,9 @@ export class CommandPrompter implements IPrompter {
         const promptBuilder = new PromptBuilder(byteLimit)
         const newContextUsed: ContextItem[] = []
         const warnings: string[] = []
-        const preInstruction: string | undefined = vscode.workspace.getConfiguration('cody.chat').get('preInstruction')
+        const preInstruction: string | undefined = vscode.workspace
+            .getConfiguration('cody.chat')
+            .get('preInstruction')
 
         const preambleMessages = getSimplePreamble(preInstruction)
         const preambleSucceeded = promptBuilder.tryAddToPrefix(preambleMessages)
@@ -76,7 +78,11 @@ export class CommandPrompter implements IPrompter {
         if (limitReached) {
             // TODO(beyang): we're masking this error (repro: try /explain),
             // we should improve the commands context selection process
-            logDebug('CommandPrompter', 'makePrompt', `context limit reached, ignored ${ignored.length} items`)
+            logDebug(
+                'CommandPrompter',
+                'makePrompt',
+                `context limit reached, ignored ${ignored.length} items`
+            )
         }
 
         return {
@@ -188,7 +194,6 @@ export class DefaultPrompter implements IPrompter {
         }
     }
 }
-
 
 function renderContextItem(contextItem: ContextItem): Message[] {
     // Do not create context item for empty file

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -15,7 +15,7 @@ import type {
     TelemetryEventProperties,
     UserLocalHistory,
 } from '@sourcegraph/cody-shared'
-import { type CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
+import type { CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
 
 import type { View } from '../../webviews/NavBar'
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -15,8 +15,7 @@ import type {
     TelemetryEventProperties,
     UserLocalHistory,
 } from '@sourcegraph/cody-shared'
-import type { ChatSubmitType } from '@sourcegraph/cody-ui/src/Chat'
-import type { CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
+import { type CodeBlockMeta } from '@sourcegraph/cody-ui/src/chat/CodeBlocks'
 
 import type { View } from '../../webviews/NavBar'
 
@@ -109,7 +108,6 @@ export type ExtensionMessage =
     | ({ type: 'transcript' } & ExtensionTranscriptMessage)
     | { type: 'view'; messages: View }
     | { type: 'errors'; errors: string }
-    | { type: 'suggestions'; suggestions: string[] }
     | { type: 'notice'; notice: { key: string } }
     | { type: 'custom-prompts'; prompts: [string, CodyCommand][] }
     | { type: 'transcript-errors'; isTranscriptError: boolean }
@@ -129,6 +127,8 @@ interface ExtensionAttributionMessage {
     }
     error?: string
 }
+
+export type ChatSubmitType = 'user' | 'user-newchat'
 
 interface WebviewSubmitMessage {
     text: string

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -211,7 +211,10 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                 case selectedCommandID === menu_options.chat.slashCommand: {
                     let input = userPrompt.trim()
                     if (input) {
-                        await vscode.commands.executeCommand('cody.action.commands.exec', `${selectedCommandID} input`)
+                        await vscode.commands.executeCommand(
+                            'cody.action.commands.exec',
+                            `${selectedCommandID} input`
+                        )
                         return
                     }
                     input = await showAskQuestionQuickPick()

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -211,15 +211,14 @@ export class CommandsController implements VsCodeCommandsController, vscode.Disp
                 case selectedCommandID === menu_options.chat.slashCommand: {
                     let input = userPrompt.trim()
                     if (input) {
-                        return await vscode.commands.executeCommand('cody.action.chat', input, {
-                            source: 'command',
-                        })
+                        await vscode.commands.executeCommand('cody.action.commands.exec', `${selectedCommandID} input`)
+                        return
                     }
                     input = await showAskQuestionQuickPick()
-                    await vscode.commands.executeCommand('cody.chat.panel.new')
-                    return await vscode.commands.executeCommand('cody.action.chat', input, {
-                        source: 'command',
-                    })
+                    return await vscode.commands.executeCommand(
+                        'cody.action.commands.exec',
+                        `${selectedCommandID} ${input}`
+                    )
                 }
                 case selectedCommandID === menu_options.fix.slashCommand: {
                     const source = 'menu'

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -35,8 +35,6 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.languages':
                         return { '*': true }
-                    case 'cody.experimental.chatPredictions':
-                        return true
                     case 'cody.commandCodeLenses':
                         return true
                     case 'cody.editorTitleCommandIcon':
@@ -114,7 +112,6 @@ describe('getConfiguration', () => {
             autocompleteLanguages: {
                 '*': true,
             },
-            experimentalChatPredictions: true,
             commandCodeLenses: true,
             experimentalSimpleChatContext: true,
             experimentalSymfContext: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -108,7 +108,6 @@ export function getConfiguration(
         internalUnstable: getHiddenSetting('internal.unstable', isTesting),
 
         autocompleteExperimentalGraphContext,
-        experimentalChatPredictions: getHiddenSetting('experimental.chatPredictions', isTesting),
         experimentalSimpleChatContext: getHiddenSetting('experimental.simpleChatContext', true),
         experimentalSymfContext: getHiddenSetting('experimental.symfContext', true),
 

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -778,7 +778,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
     },
     commandCodeLenses: false,
     editorTitleCommandIcon: true,
-    experimentalChatPredictions: false,
     experimentalGuardrails: false,
     experimentalLocalSymbols: false,
     experimentalSimpleChatContext: true,

--- a/vscode/test/e2e/command.test.ts
+++ b/vscode/test/e2e/command.test.ts
@@ -15,7 +15,7 @@ test('submit command from command palette', async ({ page, sidebar }) => {
     await page.getByRole('tab', { name: 'index.html' }).hover()
 
     // Bring the cody sidebar to the foreground
-    await page.click('[aria-label="Cody"]')
+    await page.click('.badge[aria-label="Cody"]')
 
     await page.getByText('Explain code').hover()
     await page.getByText('Explain code').click()

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -20,7 +20,7 @@ test('open the Custom Commands in sidebar and add new user command', async ({ pa
     await page.getByRole('tab', { name: 'index.html' }).hover()
 
     // Bring the cody sidebar to the foreground
-    await page.click('[aria-label="Cody"]')
+    await page.click('.badge[aria-label="Cody"]')
 
     // Open the new chat panel
     await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()

--- a/vscode/test/integration/chat.test.ts
+++ b/vscode/test/integration/chat.test.ts
@@ -26,7 +26,7 @@ suite('Chat', function () {
     test('sends and receives a message', async () => {
         await vscode.commands.executeCommand('cody.chat.panel.new')
         const chatView = await getChatViewProvider()
-        await chatView.handleHumanMessageSubmitted('test', 'hello from the human', 'user', [], false)
+        await chatView.handleNewUserMessage('test', 'hello from the human', 'user', [], false)
 
         assert.match((await getTranscript(0)).displayText || '', /^hello from the human$/)
         await waitUntil(async () =>
@@ -39,7 +39,7 @@ suite('Chat', function () {
         await getTextEditorWithSelection()
         await vscode.commands.executeCommand('cody.chat.panel.new')
         const chatView = await getChatViewProvider()
-        await chatView.handleHumanMessageSubmitted('test', 'hello from the human', 'user', [], false)
+        await chatView.handleNewUserMessage('test', 'hello from the human', 'user', [], false)
 
         // Display text should include file link at the end of message
         assert.match((await getTranscript(0)).displayText || '', /^hello from the human$/)

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -53,7 +53,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const [contextSelection, setContextSelection] = useState<ContextFile[] | null>(null)
 
     const [errorMessages, setErrorMessages] = useState<string[]>([])
-    const [suggestions, setSuggestions] = useState<string[] | undefined>()
     const [myPrompts, setMyPrompts] = useState<
         [string, CodyCommand & { isLastInGroup?: boolean; instruction?: string }][] | null
     >(null)
@@ -135,9 +134,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         break
                     case 'view':
                         setView(message.messages)
-                        break
-                    case 'suggestions':
-                        setSuggestions(message.suggestions)
                         break
                     case 'custom-prompts': {
                         let prompts: [
@@ -300,8 +296,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                                         inputHistory={inputHistory}
                                         setInputHistory={setInputHistory}
                                         vscodeAPI={vscodeAPI}
-                                        suggestions={suggestions}
-                                        setSuggestions={setSuggestions}
                                         telemetryService={telemetryService}
                                         chatCommands={myPrompts || undefined}
                                         isTranscriptError={isTranscriptError}

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -17,7 +17,6 @@ import {
     type ChatButtonProps,
     type ChatSubmitType,
     type ChatUISubmitButtonProps,
-    type ChatUISuggestionButtonProps,
     type ChatUITextAreaProps,
     type EditButtonProps,
     type FeedbackButtonsProps,
@@ -51,8 +50,6 @@ interface ChatboxProps {
     setInputHistory: (history: string[]) => void
     vscodeAPI: VSCodeWrapper
     telemetryService: TelemetryService
-    suggestions?: string[]
-    setSuggestions?: (suggestions: undefined | string[]) => void
     chatCommands?: [string, CodyCommand][]
     isTranscriptError: boolean
     contextSelection?: ContextFile[] | null
@@ -74,8 +71,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     setInputHistory,
     vscodeAPI,
     telemetryService,
-    suggestions,
-    setSuggestions,
     chatCommands,
     isTranscriptError,
     contextSelection,
@@ -192,7 +187,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             onSubmit={onSubmit}
             textAreaComponent={TextArea}
             submitButtonComponent={SubmitButton}
-            suggestionButtonComponent={SuggestionButton}
             fileLinkComponent={FileLink}
             symbolLinkComponent={SymbolLink}
             className={styles.innerContainer}
@@ -211,8 +205,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             feedbackButtonsOnSubmit={onFeedbackBtnClick}
             copyButtonOnSubmit={onCopyBtnClick}
             insertButtonOnSubmit={onInsertBtnClick}
-            suggestions={suggestions}
-            setSuggestions={setSuggestions}
             onAbortMessageInProgress={abortMessageInProgress}
             isTranscriptError={isTranscriptError}
             // TODO: We should fetch this from the server and pass a pretty component
@@ -361,15 +353,6 @@ const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({
             <i className="codicon codicon-comment" />
         )}
     </VSCodeButton>
-)
-
-const SuggestionButton: React.FunctionComponent<ChatUISuggestionButtonProps> = ({
-    suggestion,
-    onClick,
-}) => (
-    <button className={styles.suggestionButton} type="button" onClick={onClick}>
-        {suggestion}
-    </button>
 )
 
 const EditButton: React.FunctionComponent<EditButtonProps> = ({


### PR DESCRIPTION
This PR addresses some code quality issues and complexity in the chat implementation.
* https://github.com/sourcegraph/cody/pull/2542 introduced a separate code path for handling command-initiated chats. This introduced a flag that special-cased handling of commands in a number of places—in the view controller (SimpleChatPanelProvider), prompt constructor, and context fetcher. These flags make chat more difficult to reason about, requiring the dev to reason about the conditional flag at multiple places in the lifecycle of a chat request.

Code changes
* Instead of checking a flag to see if the user request was a command in `DefaultPrompter`, introduces a new `CommandPrompter` to customize prompt construction for commands
* Breaks apart `ContextProvider` into separate functions, moved to a `context.ts` file. Enhanced context can be fetched by either prompter.
* Simplifies the core code paths in `SimpleChatPanelProvider`. Now there are two top-level message handlers: `handleNewUserMessage` (for regular chat) and `handleCommand` (for commands). These then execute the necessary steps without entangling other methods that must then support both code paths via conditional.
  * Previously, we had the following mess:
    * `executeChat` -> `handleHumanMessageSubmitted`
    * `handleHumanMessageSubmitted` -> 'handleChatRequest` OR `handleCommands`
    * `handleCommands` -> `handleChatRequest`
    * `handleChatRequest` -> `generateAssistantResponse`

Behavior changes
* This change removes the already defunct `cody.experimental.chatPredictions` setting.
* This change disables codebase-wide context fetching for commands. This field appears unused by first-party commands, and it's unclear whether it was actually being used for custom commands.

Follow-up work: This PR also flags some outstanding bugs uncovered in the refactor:
* Update chat "edit" to support user-specified context items and the value of the enhanced context selector
* Many commands overflow the context window currently (though we're masking the error so it's not obvious to the end user)
* Remove codebase context from custom commands or add support for fetching it
* Handle symf errors better
* Move methods around in SimpleChatPanelProvider for greater clarity (not doing in this PR to avoid making the diff larger)
* https://github.com/sourcegraph/cody/pull/2848#discussion_r1461315316
* https://github.com/sourcegraph/cody/pull/2848#discussion_r1461314572
* https://github.com/sourcegraph/cody/pull/2848#discussion_r1461314120
* https://github.com/sourcegraph/cody/pull/2848#discussion_r1461335084

## Test plan

- [ ] Test chat with enhanced context
- [ ] Test chat without context
- [ ] Test all first-party commands
- [ ] Test a custom command