### PR TITLE
Further clean up SimpleChatPanelProvider and document invariants

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -560,7 +560,7 @@ export class Agent extends MessageHandler {
         })
 
         this.registerAuthenticatedRequest('chat/restore', async ({ modelID, messages, chatID }) => {
-            const chatModel = new SimpleChatModel(modelID, [], chatID, undefined)
+            const chatModel = new SimpleChatModel(modelID, [], chatID)
             for (const message of messages) {
                 if (message.error) {
                     chatModel.addErrorAsBotMessage(message.error)

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -28,7 +28,7 @@ import { SimpleChatPanelProvider } from './SimpleChatPanelProvider'
 
 type ChatID = string
 
-export type Config = Pick<
+export type ChatPanelConfig = Pick<
     ConfigurationWithAccessToken,
     'experimentalGuardrails' | 'experimentalSymfContext' | 'internalUnstable' | 'useContext'
 >
@@ -255,7 +255,7 @@ export class ChatPanelsManager implements vscode.Disposable {
                     const provider =
                         this.panelProviders.find(p => p.sessionID === chatID) ||
                         this.panelProviders.find(p => p.sessionID === chatIDUTC)
-                    provider?.handleChatTitle(title)
+                    provider?.setChatTitle(title)
                 }
             })
     }

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -13,7 +13,7 @@ import {
     type TranscriptJSON,
 } from '@sourcegraph/cody-shared'
 
-import { contextItemsToContextFiles } from './chat-helpers'
+import { contextItemsToContextFiles, getChatPanelTitle } from './chat-helpers'
 
 export interface MessageWithContext {
     message: Message
@@ -36,7 +36,7 @@ export class SimpleChatModel {
         public modelID: string,
         private messagesWithContext: MessageWithContext[] = [],
         public readonly sessionID: string = new Date(Date.now()).toUTCString(),
-        public chatTitle?: string
+        private customChatTitle?: string
     ) {}
 
     public isEmpty(): boolean {
@@ -124,8 +124,23 @@ export class SimpleChatModel {
         return this.messagesWithContext
     }
 
-    public setChatTitle(title: string): void {
-        this.chatTitle = title
+    public getChatTitle(): string {
+        if (this.customChatTitle) {
+            return this.customChatTitle
+        }
+        const text = this.getLastHumanMessage()?.displayText
+        if (text) {
+            return getChatPanelTitle(text)
+        }
+        return 'New Chat'
+    }
+
+    public getCustomChatTitle(): string | undefined {
+        return this.customChatTitle
+    }
+
+    public setCustomChatTitle(title: string): void {
+        this.customChatTitle = title
     }
 
     /**
@@ -141,7 +156,7 @@ export class SimpleChatModel {
         return {
             id: this.sessionID,
             chatModel: this.modelID,
-            chatTitle: this.chatTitle,
+            chatTitle: this.getCustomChatTitle(),
             lastInteractionTimestamp: this.sessionID,
             interactions,
         }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -111,6 +111,29 @@ export interface ChatSession {
  * SimpleChatPanelProvider is the view controller class for the chat panel.
  * It handles all events sent from the view, keeps track of the underlying chat model,
  * and interacts with the rest of the extension.
+ *
+ * Its methods are grouped into the following sections, each of which is demarcated
+ * by a comment block (search for "// Section: "):
+ *
+ * 1. top-level view action handlers
+ * 2. view updaters
+ * 3. chat request lifecycle methods
+ * 4. session management
+ * 5. webview container management
+ * 6. other public accessors and mutators
+ *
+ * The following invariants should be maintained:
+ * 1. top-level view action handlers
+ *    a. should all follow the handle$ACTION naming convention
+ *    b. should be private (with the existing exceptions)
+ * 2 view updaters
+ *    a. should all follow the post$ACTION naming convention
+ *    b. should NOT mutate model state
+ * 3. Do NOT introduce new public fields or methods. The public
+ *    interface of this class should be kept small in order to
+ *    avoid tight coupling with other classes. If communication
+ *    with other components outside the model and view is needed,
+ *    we should implement an broadcast/subscription design.
  */
 export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private chatModel: SimpleChatModel
@@ -271,7 +294,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     // =======================================================================
-    // Top-level view action handlers
+    // Section: top-level view action handlers
     // =======================================================================
 
     // When the webview sends the 'ready' message, respond by posting the view config
@@ -600,7 +623,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     // =======================================================================
-    // Webview updaters
+    // Section: view updaters
     // =======================================================================
 
     private postEmptyMessageInProgress(): void {
@@ -660,9 +683,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         })
     }
 
-    /**
-     * Send a list of commands to webview that can be triggered via chat input box with slash
-     */
+    // Send a list of commands to webview that can be triggered via chat input box with slash
     private async postCodyCommands(): Promise<void> {
         const send = async (): Promise<void> => {
             await this.commandsController?.refresh()
@@ -670,7 +691,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             // HACK: filter out commands that make inline changes and /ask (synonymous with a generic question)
             const prompts =
                 allCommands?.filter(([id, { mode }]) => {
-                    /** The /ask command is only useful outside of chat */
+                    // The /ask command is only useful outside of chat
                     const isRedundantCommand = id === '/ask'
                     return !isRedundantCommand
                 }) || []
@@ -714,7 +735,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     // =======================================================================
-    // Chat request lifecycle methods
+    // Section: chat request lifecycle methods
     // =======================================================================
 
     /**
@@ -900,7 +921,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     // =======================================================================
-    // Session management
+    // Section: session management
     // =======================================================================
 
     // A unique identifier for this SimpleChatPanelProvider instance used to identify
@@ -952,7 +973,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         this.postViewTranscript()
     }
     // =======================================================================
-    // Webview state and methods
+    // Section: webview container management
     // =======================================================================
 
     private extensionUri: vscode.Uri
@@ -1077,7 +1098,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     // =======================================================================
-    // Other public accessors and mutators
+    // Section: other public accessors and mutators
     // =======================================================================
 
     public setChatTitle(title: string): void {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -9,7 +9,6 @@ import type {
     ConfigurationWithAccessToken,
     ContextFile,
     ContextFileType,
-    CustomCommandType,
     EnhancedContextContextT,
     SearchPanelFile,
     TelemetryEventProperties,
@@ -73,7 +72,6 @@ export type WebviewMessage =
           authMethod?: AuthMethod
       }
     | { command: 'abort' }
-    | { command: 'custom-prompt'; title: string; value?: CustomCommandType }
     | { command: 'reload' }
     | {
           command: 'simplified-onboarding'

--- a/vscode/src/test-support.ts
+++ b/vscode/src/test-support.ts
@@ -38,6 +38,6 @@ export class TestSupport {
     public chatPanelProvider = new Rendezvous<SimpleChatPanelProvider>()
 
     public async chatMessages(): Promise<ChatMessage[]> {
-        return (await this.chatPanelProvider.get()).transcriptForTesting(this)
+        return (await this.chatPanelProvider.get()).getViewTranscript()
     }
 }


### PR DESCRIPTION
Implements some follow-up tasks from https://github.com/sourcegraph/cody/pull/2848:

* Move methods around in SimpleChatPanelProvider for greater clarity (not doing in this PR to avoid making the diff larger)
* https://github.com/sourcegraph/cody/pull/2848#discussion_r1461314572

We establish strong naming conventions for methods and document invariants that should hold to prevent future quality regressions that may make the logic more difficult to reason about.

## Test plan

There should be no behavior changes