### PR TITLE
fix: doc command with empty chat

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -465,8 +465,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
      * Removes any existing messages from the provided index,
      * before submitting the replacement text as a new question.
      * When no index is provided, default to the last human message.
-     *
-     * TODO (bee) set index as required once confirmed this change doesn't affect other clients
      */
     private async handleEdit(
         requestID: string,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -301,7 +301,8 @@ const register = async (
     ): Promise<ChatSession | undefined> => {
         const commandArgs = newCodyCommandArgs(args)
         const command = await commandsController?.startCommand(commandKey, commandArgs)
-        if (!command) {
+        // Stop processing the command if it is not an ask(chat) request
+        if (!command || command.mode !== 'ask') {
             return
         }
 


### PR DESCRIPTION
Close https://github.com/sourcegraph/cody/issues/2885

Fix issue where executing the doc command opens an empty chat panel.

This is because the edit command was sent to chat provider for processing after being routed to fixup controller.

There is a WIP to refactor the relationship between commands and chat to address this issue but for now  we will have to check if the command is a chat command or edit command at the top level.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Run doc command to confirm a new chat window is not opened.