### PR TITLE
Move context warnings from the UI to the debug log

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -150,7 +150,6 @@ export type {
 export { DOTCOM_URL, LOCAL_APP_URL, isDotCom } from './sourcegraph-api/environments'
 export {
     AbortError,
-    ContextWindowLimitError,
     NetworkError,
     RateLimitError,
     TimeoutError,

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -106,12 +106,3 @@ export function isAbortError(error: unknown): error is AbortError {
 }
 
 export class TimeoutError extends Error {}
-
-export class ContextWindowLimitError extends Error {
-    public static readonly errorName = 'ContextWindowLimitError'
-    public readonly name = ContextWindowLimitError.errorName
-
-    constructor(public readonly message: string) {
-        super(message)
-    }
-}

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { ContextWindowLimitError, RateLimitError, type ChatError } from '@sourcegraph/cody-shared'
+import { RateLimitError, type ChatError } from '@sourcegraph/cody-shared'
 
 import type { ApiPostMessage, ChatButtonProps, UserAccountInfo } from '../Chat'
 
@@ -26,16 +26,6 @@ export const ErrorItem: React.FunctionComponent<{
         )
     }
 
-    if (typeof error !== 'string' && error.name === ContextWindowLimitError.errorName && postMessage) {
-        return (
-            <ContextWindowLimitErrorItem
-                error={error as ContextWindowLimitError}
-                ChatButtonComponent={ChatButtonComponent}
-                postMessage={postMessage}
-            />
-        )
-    }
-
     return <RequestErrorItem error={error.message} />
 })
 
@@ -49,44 +39,6 @@ export const RequestErrorItem: React.FunctionComponent<{
         <div className={styles.requestError}>
             <span className={styles.requestErrorTitle}>Request Failed: </span>
             {error}
-        </div>
-    )
-})
-
-const ContextWindowLimitErrorItem: React.FunctionComponent<{
-    error: ContextWindowLimitError
-    ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
-    postMessage: ApiPostMessage
-}> = React.memo(function ContextWindowLimitErrorItemContent({
-    error,
-    ChatButtonComponent,
-    postMessage,
-}) {
-    const onClick = useCallback(() => {
-        postMessage({ command: 'reset' })
-    }, [postMessage])
-
-    return (
-        <div className={styles.errorItem}>
-            <div className={styles.icon}>
-                <span className="codicon codicon-warning" />
-            </div>
-            <div className={styles.body}>
-                <header>
-                    <h1>Context Limit Reached</h1>
-                    <p>{error.message}</p>
-                </header>
-                {ChatButtonComponent && (
-                    <div className={styles.actions}>
-                        <ChatButtonComponent
-                            label="Start New Chat"
-                            action=""
-                            appearance="primary"
-                            onClick={onClick}
-                        />
-                    </div>
-                )}
-            </div>
         </div>
     )
 })

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -36,6 +36,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Better cancellation of requests that are no longer relevant. [pull/2855](https://github.com/sourcegraph/cody/pull/2855)
 - Updated Enhanced Context popover copy and added a link to the docs. [pull/2864](https://github.com/sourcegraph/cody/pull/2864)
 - Include meta information about unit test files in Autocomplete analytics. [pull/2868](https://github.com/sourcegraph/cody/pull/2868)
+- Moved the Context Limit errors in chat into the deboug log output. [pull/2891](https://github.com/sourcegraph/cody/pull/2891)
 
 ## [1.1.3]
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode'
 import {
     ChatModelProvider,
     ConfigFeaturesSingleton,
-    ContextWindowLimitError,
     hydrateAfterPostMessage,
     isDefined,
     isDotCom,
@@ -766,25 +765,13 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         prompter: IPrompter,
         sendTelemetry?: (contextSummary: any) => void
     ): Promise<Message[]> {
-        const { prompt, contextLimitWarnings, newContextUsed } = await prompter.makePrompt(
+        const { prompt, newContextUsed } = await prompter.makePrompt(
             this.chatModel,
             getContextWindowForModel(this.authProvider.getAuthStatus(), this.chatModel.modelID)
         )
 
         // Update UI based on prompt construction
         this.chatModel.setNewContextUsed(newContextUsed)
-        if (contextLimitWarnings.length > 0) {
-            const warningMsg = contextLimitWarnings
-                .map(w => {
-                    w = w.trim()
-                    if (!w.endsWith('.')) {
-                        w += '.'
-                    }
-                    return w
-                })
-                .join(' ')
-            this.postError(new ContextWindowLimitError(warningMsg), 'transcript')
-        }
 
         if (sendTelemetry) {
             // Create a summary of how many code snippets of each context source are being

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -12,11 +12,10 @@ describe('DefaultPrompter', () => {
         const chat = new SimpleChatModel('a-model-id')
         chat.addHumanMessage({ text: 'Hello' })
 
-        const {
-            prompt,
-            contextLimitWarnings: warnings,
-            newContextUsed,
-        } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(chat, 100000)
+        const { prompt, newContextUsed } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(
+            chat,
+            100000
+        )
 
         expect(prompt).toMatchInlineSnapshot(`
           [
@@ -34,7 +33,6 @@ describe('DefaultPrompter', () => {
             },
           ]
         `)
-        expect(warnings).toMatchInlineSnapshot('[]')
         expect(newContextUsed).toMatchInlineSnapshot('[]')
     })
 
@@ -50,11 +48,10 @@ describe('DefaultPrompter', () => {
         const chat = new SimpleChatModel('a-model-id')
         chat.addHumanMessage({ text: 'Hello' })
 
-        const {
-            prompt,
-            contextLimitWarnings: warnings,
-            newContextUsed,
-        } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(chat, 100000)
+        const { prompt, newContextUsed } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(
+            chat,
+            100000
+        )
 
         expect(prompt).toMatchInlineSnapshot(`
           [
@@ -72,7 +69,6 @@ describe('DefaultPrompter', () => {
             },
           ]
         `)
-        expect(warnings).toMatchInlineSnapshot('[]')
         expect(newContextUsed).toMatchInlineSnapshot('[]')
     })
 })

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -12,10 +12,9 @@ describe('DefaultPrompter', () => {
         const chat = new SimpleChatModel('a-model-id')
         chat.addHumanMessage({ text: 'Hello' })
 
-        const { prompt, newContextUsed } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(
-            chat,
-            100000
-        )
+        const { prompt, newContextUsed } = await new DefaultPrompter([], () =>
+            Promise.resolve([])
+        ).makePrompt(chat, 100000)
 
         expect(prompt).toMatchInlineSnapshot(`
           [
@@ -48,10 +47,9 @@ describe('DefaultPrompter', () => {
         const chat = new SimpleChatModel('a-model-id')
         chat.addHumanMessage({ text: 'Hello' })
 
-        const { prompt, newContextUsed } = await new DefaultPrompter([], () => Promise.resolve([])).makePrompt(
-            chat,
-            100000
-        )
+        const { prompt, newContextUsed } = await new DefaultPrompter([], () =>
+            Promise.resolve([])
+        ).makePrompt(chat, 100000)
 
         expect(prompt).toMatchInlineSnapshot(`
           [


### PR DESCRIPTION
The context warnings in the UI are creating more confusion than they're worth, so we'll move them to the debug output and work on better ways of surfacing these issues as necessary in the transcript view.

## Test plan

- Recreate each warning scenario
- Verify code behaves well