### PR TITLE
Clean up chat editor title buttons & history separators

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -36,6 +36,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Better cancellation of requests that are no longer relevant. [pull/2855](https://github.com/sourcegraph/cody/pull/2855)
 - Updated Enhanced Context popover copy and added a link to the docs. [pull/2864](https://github.com/sourcegraph/cody/pull/2864)
 - Include meta information about unit test files in Autocomplete analytics. [pull/2868](https://github.com/sourcegraph/cody/pull/2868)
+- Cleaned up chat editor title buttons & history separators. [pull/2895](https://github.com/sourcegraph/cody/pull/2895)
 
 ## [1.1.3]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -452,11 +452,11 @@
       {
         "command": "cody.chat.history.panel",
         "category": "Cody",
-        "title": "Show History",
+        "title": "Chat History",
         "group": "Cody",
         "icon": "$(list-unordered)",
         "when": "cody.activated && cody.hasChatHistory"
-      },
+    },
       {
         "command": "cody.search.index-update",
         "category": "Cody",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -701,25 +701,19 @@
         {
           "command": "cody.chat.panel.new",
           "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
-          "group": "navigation",
-          "visibility": "visible"
-        },
-        {
-          "command": "cody.chat.panel.reset",
-          "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
           "group": "navigation@0",
           "visibility": "visible"
         },
         {
           "command": "cody.settings.extension.chat",
           "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
-          "group": "navigation@1",
+          "group": "navigation@2",
           "visibility": "visible"
         },
         {
           "command": "cody.chat.history.panel",
           "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
-          "group": "navigation",
+          "group": "navigation@1",
           "visibility": "visible"
         }
       ],

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -701,19 +701,19 @@
         {
           "command": "cody.chat.panel.new",
           "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
-          "group": "navigation@0",
-          "visibility": "visible"
-        },
-        {
-          "command": "cody.settings.extension.chat",
-          "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
-          "group": "navigation@2",
+          "group": "navigation@1",
           "visibility": "visible"
         },
         {
           "command": "cody.chat.history.panel",
           "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
-          "group": "navigation@1",
+          "group": "navigation@2",
+          "visibility": "visible"
+        },
+        {
+          "command": "cody.settings.extension.chat",
+          "when": "activeWebviewPanelId == cody.chatPanel && cody.activated",
+          "group": "navigation@3",
           "visibility": "visible"
         }
       ],

--- a/vscode/src/services/HistoryChat.ts
+++ b/vscode/src/services/HistoryChat.ts
@@ -124,7 +124,7 @@ export async function displayHistoryQuickPick(authStatus: AuthStatus): Promise<v
 
     for (const [groupName, chats] of Object.entries(groupedChats)) {
         if (chats.length > 0) {
-            addGroupSeparator(groupName)
+            addGroupSeparator(groupName.toLowerCase())
 
             for (const chat of chats) {
                 quickPickItems.push({


### PR DESCRIPTION
Cleans up the History quickpick titles, and the editor title buttons (removes the chat reset icon now we have a dedicated button).

Before:

![CleanShot 2024-01-25 at 23 41 59@2x](https://github.com/sourcegraph/cody/assets/153/857ff1f8-e9dd-4f23-bea9-60b5250b0952)

After:

![CleanShot 2024-01-25 at 23 40 28@2x](https://github.com/sourcegraph/cody/assets/153/2dfbf49f-ec5d-4a55-b44f-c60ab7c53d8f)

## Test plan

- Loaded chat
- Verified buttons & history view