### PR TITLE
VS Code chat UI matches design

### DIFF
--- a/lib/shared/src/guardrails/index.ts
+++ b/lib/shared/src/guardrails/index.ts
@@ -14,7 +14,10 @@ export interface Guardrails {
     searchAttribution(snippet: string): Promise<Attribution | Error>
 }
 
-const timeout = 2000
+// 10s timeout is enough to serve most attribution requests.
+// It's a better user experience for chat attribution to wait
+// a few seconds more and get attribution result.
+const timeout = 10000
 
 // GuardrailsPost implements Guardrails interface by synchronizing on message
 // passing between webview and extension process.

--- a/lib/ui/src/chat/CodeBlocks.module.css
+++ b/lib/ui/src/chat/CodeBlocks.module.css
@@ -13,11 +13,6 @@
     display: flex;
 }
 
-.flex-filler {
-    display: flex;
-    flex-grow: 1;
-}
-
 .copy-button,
 .insert-button,
 .attribution-icon,
@@ -32,6 +27,7 @@
 .attribution-container {
     all: unset;
     display: flex;
+    margin-left: auto;
 }
 
 .copy-button,

--- a/lib/ui/src/chat/CodeBlocks.module.css
+++ b/lib/ui/src/chat/CodeBlocks.module.css
@@ -24,6 +24,11 @@
     background-color: transparent;
 }
 
+.status {
+    font-size: 12px;
+    line-height: 1;
+}
+
 .attribution-container {
     all: unset;
     display: flex;

--- a/lib/ui/src/chat/CodeBlocks.module.css
+++ b/lib/ui/src/chat/CodeBlocks.module.css
@@ -29,6 +29,11 @@
     background-color: transparent;
 }
 
+.attribution-container {
+    all: unset;
+    display: flex;
+}
+
 .copy-button,
 .insert-button {
     cursor: pointer;

--- a/lib/ui/src/chat/CodeBlocks.module.css
+++ b/lib/ui/src/chat/CodeBlocks.module.css
@@ -1,16 +1,11 @@
 .container {
     display: flex;
     align-items: center;
-
-    border-style: solid;
-    border-width: 1px;
-
     border-style: solid;
     border-width: 1px;
     border-color: var(--vscode-sideBarSectionHeader-border);
     border-bottom-left-radius: 2px;
     border-bottom-right-radius: 2px;
-
     padding: 4px;
 }
 
@@ -25,7 +20,8 @@
 
 .copy-button,
 .insert-button,
-.attribution-icon {
+.attribution-icon,
+.spinner {
     all: unset;
     padding: 3px;
     width: 16px;
@@ -41,9 +37,25 @@
 .attribution-icon-unavailable {
     color: var(--hl-dark-yellow);
 }
+
 .attribution-icon-found {
     color: var(--hl-dark-red);
 }
+
 .attribution-icon-not-found {
     color: var(--hl-dark-green);
+}
+
+.spinner {
+    display: flex;
+    align-items: center;
+}
+
+.codicon-loading {
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
 }

--- a/lib/ui/src/chat/CodeBlocks.module.css
+++ b/lib/ui/src/chat/CodeBlocks.module.css
@@ -21,10 +21,10 @@
 .copy-button,
 .insert-button,
 .attribution-icon,
-.spinner {
+.status {
     all: unset;
     padding: 3px;
-    width: 16px;
+    min-width: 16px;  /* Status element needs to be able to expand. */
     height: 16px;
     background-color: transparent;
 }
@@ -35,18 +35,14 @@
 }
 
 .attribution-icon-unavailable {
-    color: var(--hl-dark-yellow);
+    color: var(--hl-orange);
 }
 
 .attribution-icon-found {
     color: var(--hl-dark-red);
 }
 
-.attribution-icon-not-found {
-    color: var(--hl-dark-green);
-}
-
-.spinner {
+.status {
     display: flex;
     align-items: center;
 }

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -198,9 +198,15 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                         attributionContainer.setAttribute('data-testid', 'attribution-indicator')
                         buttons.append(attributionContainer)
 
+                        const spinnerContainer = document.createElement('div')
+                        spinnerContainer.className = styles.spinner
+                        spinnerContainer.innerHTML = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`
+                        buttons.append(spinnerContainer)
+
                         guardrails
                             .searchAttribution(preText)
                             .then(attribution => {
+                                spinnerContainer.innerHTML = '<i class="codicon codicon-pass"></i>'
                                 if (isError(attribution)) {
                                     attributionContainer.classList.add(styles.attributionIconUnavailable)
                                     attributionContainer.title = 'Attribution search unavailable.'
@@ -227,7 +233,9 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                                 attributionContainer.title = 'Attribution not found.'
                             })
                             .catch(error => {
-                                console.error('promise failed', error)
+                                attributionContainer.classList.add(styles.attributionIconUnavailable)
+                                attributionContainer.title = `Attribution search unavailable. ${error.message}`
+                                return
                             })
                     }
 

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -256,34 +256,35 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                         eventMetadata
                     )
                     if (guardrails) {
-                        const flexFiller = document.createElement('div')
-                        flexFiller.classList.add(styles.flexFiller)
-                        buttons.append(flexFiller)
                         const container = document.createElement("div");
                         container.classList.add(styles.attributionContainer);
                         buttons.append(container);
 
                         const g = new GuardrailsStatusController(container);
-                        g.setPending()
+                        g.setPending();
 
                         guardrails
                             .searchAttribution(preText)
-                            .then(attribution => {
+                            .then((attribution) => {
                                 if (isError(attribution)) {
-                                    g.setUnavailable()
-                                } else if (attribution.repositories.length === 0) {
-                                    g.setSuccess()
+                                    g.setUnavailable();
+                                } else if (
+                                    attribution.repositories.length === 0
+                                ) {
+                                    g.setSuccess();
                                 } else {
                                     g.setFailure(
-                                        attribution.repositories.map(r => r.name),
+                                        attribution.repositories.map(
+                                            (r) => r.name
+                                        ),
                                         attribution.limitHit
-                                    )
+                                    );
                                 }
                             })
                             .catch(() => {
-                                g.setUnavailable()
-                                return
-                            })
+                                g.setUnavailable();
+                                return;
+                            });
                     }
 
                     // Insert the buttons after the pre using insertBefore() because there is no insertAfter()

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -259,7 +259,11 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                         const flexFiller = document.createElement('div')
                         flexFiller.classList.add(styles.flexFiller)
                         buttons.append(flexFiller)
-                        const g = new GuardrailsStatusController(buttons)
+                        const container = document.createElement("div");
+                        container.classList.add(styles.attributionContainer);
+                        buttons.append(container);
+
+                        const g = new GuardrailsStatusController(container);
                         g.setPending()
 
                         guardrails

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -160,29 +160,29 @@ function createCodeBlockActionButton(
  * when attribution is enabled.
  */
 class GuardrailsStatusController {
-    readonly statusSpinning = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`;
-    readonly statusPass = '<i class="codicon codicon-pass"></i>';
-    readonly statusFailed = "Guard Rails Check Failed";
-    readonly statusUnavailable = "Guard Rails API Error";
+    readonly statusSpinning = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`
+    readonly statusPass = '<i class="codicon codicon-pass"></i>'
+    readonly statusFailed = 'Guard Rails Check Failed'
+    readonly statusUnavailable = 'Guard Rails API Error'
 
-    readonly iconClass = "guardrails-icon";
-    readonly statusClass = "guardrails-status";
+    readonly iconClass = 'guardrails-icon'
+    readonly statusClass = 'guardrails-status'
 
-    private status: HTMLElement;
+    private status: HTMLElement
 
     constructor(public container: HTMLElement) {
         this.findOrAppend(this.iconClass, () => {
-            const icon = document.createElement("div");
-            icon.innerHTML = ShieldIcon;
-            icon.classList.add(styles.attributionIcon, this.iconClass);
-            icon.setAttribute("data-testid", "attribution-indicator");
-            return icon;
-        });
+            const icon = document.createElement('div')
+            icon.innerHTML = ShieldIcon
+            icon.classList.add(styles.attributionIcon, this.iconClass)
+            icon.setAttribute('data-testid', 'attribution-indicator')
+            return icon
+        })
         this.status = this.findOrAppend(this.statusClass, () => {
-            const status = document.createElement("div");
-            status.classList.add(styles.status, this.statusClass);
-            return status;
-        });
+            const status = document.createElement('div')
+            status.classList.add(styles.status, this.statusClass)
+            return status
+        })
     }
 
     /**
@@ -190,8 +190,8 @@ class GuardrailsStatusController {
      * to the attribution shield icon.
      */
     public setPending() {
-        this.container.title = "Guard Rails: Running Code Attribution Check…";
-        this.status.innerHTML = this.statusSpinning;
+        this.container.title = 'Guard Rails: Running Code Attribution Check…'
+        this.status.innerHTML = this.statusSpinning
     }
 
     /**
@@ -199,8 +199,8 @@ class GuardrailsStatusController {
      * of shield icon to a checkmark.
      */
     public setSuccess() {
-        this.container.title = "Guard Rails Check Passed";
-        this.status.innerHTML = this.statusPass;
+        this.container.title = 'Guard Rails Check Passed'
+        this.status.innerHTML = this.statusPass
     }
 
     /**
@@ -209,9 +209,9 @@ class GuardrailsStatusController {
      * where attribution was found, and whether the attribution limit was hit.
      */
     public setFailure(repos: string[], limitHit: boolean) {
-        this.container.classList.add(styles.attributionIconFound);
-        this.container.title = this.tooltip(repos, limitHit);
-        this.status.innerHTML = this.statusFailed;
+        this.container.classList.add(styles.attributionIconFound)
+        this.container.title = this.tooltip(repos, limitHit)
+        this.status.innerHTML = this.statusFailed
     }
 
     /**
@@ -220,33 +220,28 @@ class GuardrailsStatusController {
      * search is unavailable.
      */
     public setUnavailable() {
-        this.container.classList.add(styles.attributionIconUnavailable);
-        this.container.title = "Attribution search unavailable.";
-        this.status.innerHTML = this.statusUnavailable;
+        this.container.classList.add(styles.attributionIconUnavailable)
+        this.container.title = 'Attribution search unavailable.'
+        this.status.innerHTML = this.statusUnavailable
     }
 
-    private findOrAppend(
-        className: string,
-        make: () => HTMLElement
-    ): HTMLElement {
-        const elements = this.container.getElementsByClassName(className);
+    private findOrAppend(className: string, make: () => HTMLElement): HTMLElement {
+        const elements = this.container.getElementsByClassName(className)
         if (elements.length > 0) {
-            return elements[0] as HTMLElement;
+            return elements[0] as HTMLElement
         }
-        const newElement = make();
-        this.container.append(newElement);
-        return newElement;
+        const newElement = make()
+        this.container.append(newElement)
+        return newElement
     }
 
     private tooltip(repos: string[], limitHit: boolean) {
-        const prefix = "Guard Rails Check Failed. Code found in";
+        const prefix = 'Guard Rails Check Failed. Code found in'
         if (repos.length === 1) {
-            return `${prefix} ${repos[0]}.`;
+            return `${prefix} ${repos[0]}.`
         }
-        const tooltip = `${prefix} ${repos.length} repositories: ${repos.join(
-            ", "
-        )}`;
-        return limitHit ? `${tooltip} or more...` : `${tooltip}.`;
+        const tooltip = `${prefix} ${repos.length} repositories: ${repos.join(', ')}`
+        return limitHit ? `${tooltip} or more...` : `${tooltip}.`
     }
 }
 
@@ -284,35 +279,31 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                         eventMetadata
                     )
                     if (guardrails) {
-                        const container = document.createElement("div");
-                        container.classList.add(styles.attributionContainer);
-                        buttons.append(container);
+                        const container = document.createElement('div')
+                        container.classList.add(styles.attributionContainer)
+                        buttons.append(container)
 
-                        const g = new GuardrailsStatusController(container);
-                        g.setPending();
+                        const g = new GuardrailsStatusController(container)
+                        g.setPending()
 
                         guardrails
                             .searchAttribution(preText)
-                            .then((attribution) => {
+                            .then(attribution => {
                                 if (isError(attribution)) {
-                                    g.setUnavailable();
-                                } else if (
-                                    attribution.repositories.length === 0
-                                ) {
-                                    g.setSuccess();
+                                    g.setUnavailable()
+                                } else if (attribution.repositories.length === 0) {
+                                    g.setSuccess()
                                 } else {
                                     g.setFailure(
-                                        attribution.repositories.map(
-                                            (r) => r.name
-                                        ),
+                                        attribution.repositories.map(r => r.name),
                                         attribution.limitHit
-                                    );
+                                    )
                                 }
                             })
                             .catch(() => {
-                                g.setUnavailable();
-                                return;
-                            });
+                                g.setUnavailable()
+                                return
+                            })
                     }
 
                     // Insert the buttons after the pre using insertBefore() because there is no insertAfter()

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -154,71 +154,99 @@ function createCodeBlockActionButton(
     return button
 }
 
+/*
+ * GuardrailsStatusController manages the bit of UI with shield icon,
+ * and spinner/check mark/status in the bottom-right corner of CodeBlocks
+ * when attribution is enabled.
+ */
 class GuardrailsStatusController {
-    readonly statusSpinning = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`
-    readonly statusPass = '<i class="codicon codicon-pass"></i>'
-    readonly statusFailed = 'Guard Rails Check Failed'
-    readonly statusUnavailable = 'Guard Rails API Error'
+    readonly statusSpinning = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`;
+    readonly statusPass = '<i class="codicon codicon-pass"></i>';
+    readonly statusFailed = "Guard Rails Check Failed";
+    readonly statusUnavailable = "Guard Rails API Error";
 
-    readonly iconClass = 'guardrails-icon'
-    readonly statusClass = 'guardrails-status'
+    readonly iconClass = "guardrails-icon";
+    readonly statusClass = "guardrails-status";
 
-    private status: HTMLElement
+    private status: HTMLElement;
 
     constructor(public container: HTMLElement) {
         this.findOrAppend(this.iconClass, () => {
-            const icon = document.createElement('div')
-            icon.innerHTML = ShieldIcon
-            icon.classList.add(styles.attributionIcon, this.iconClass)
-            icon.setAttribute('data-testid', 'attribution-indicator')
-            return icon
-        })
+            const icon = document.createElement("div");
+            icon.innerHTML = ShieldIcon;
+            icon.classList.add(styles.attributionIcon, this.iconClass);
+            icon.setAttribute("data-testid", "attribution-indicator");
+            return icon;
+        });
         this.status = this.findOrAppend(this.statusClass, () => {
-            const status = document.createElement('div')
-            status.classList.add(styles.status, this.statusClass)
-            return status
-        })
+            const status = document.createElement("div");
+            status.classList.add(styles.status, this.statusClass);
+            return status;
+        });
     }
 
+    /**
+     * setPending displays a spinner next
+     * to the attribution shield icon.
+     */
     public setPending() {
-        this.container.title = 'Guard Rails: Running Code Attribution Check…'
-        this.status.innerHTML = this.statusSpinning
+        this.container.title = "Guard Rails: Running Code Attribution Check…";
+        this.status.innerHTML = this.statusSpinning;
     }
 
+    /**
+     * setSuccess changes spinner on the right-hand side
+     * of shield icon to a checkmark.
+     */
     public setSuccess() {
-        this.container.title = 'Guard Rails Check Passed'
-        this.status.innerHTML = this.statusPass
+        this.container.title = "Guard Rails Check Passed";
+        this.status.innerHTML = this.statusPass;
     }
 
+    /**
+     * setFailure displays a failure message instead of spinner
+     * on the right-hand side of shield icon. Tooltip indicates
+     * where attribution was found, and whether the attribution limit was hit.
+     */
     public setFailure(repos: string[], limitHit: boolean) {
-        this.container.classList.add(styles.attributionIconFound)
-        this.container.title = this.tooltip(repos, limitHit)
-        this.status.innerHTML = this.statusFailed
+        this.container.classList.add(styles.attributionIconFound);
+        this.container.title = this.tooltip(repos, limitHit);
+        this.status.innerHTML = this.statusFailed;
     }
 
+    /**
+     * setUnavailable displays a failure message instead of spinner
+     * on the right-hand side of shield icon. It indicates that attribution
+     * search is unavailable.
+     */
     public setUnavailable() {
-        this.container.classList.add(styles.attributionIconUnavailable)
-        this.container.title = 'Attribution search unavailable.'
-        this.status.innerHTML = this.statusUnavailable
+        this.container.classList.add(styles.attributionIconUnavailable);
+        this.container.title = "Attribution search unavailable.";
+        this.status.innerHTML = this.statusUnavailable;
     }
 
-    private findOrAppend(className: string, make: () => HTMLElement): HTMLElement {
-        const elements = this.container.getElementsByClassName(className)
+    private findOrAppend(
+        className: string,
+        make: () => HTMLElement
+    ): HTMLElement {
+        const elements = this.container.getElementsByClassName(className);
         if (elements.length > 0) {
-            return elements[0] as HTMLElement
+            return elements[0] as HTMLElement;
         }
-        const newElement = make()
-        this.container.append(newElement)
-        return newElement
+        const newElement = make();
+        this.container.append(newElement);
+        return newElement;
     }
 
     private tooltip(repos: string[], limitHit: boolean) {
-        const prefix = 'Guard Rails Check Failed. Code found in'
+        const prefix = "Guard Rails Check Failed. Code found in";
         if (repos.length === 1) {
-            return `${prefix} ${repos[0]}.`
+            return `${prefix} ${repos[0]}.`;
         }
-        const tooltip = `${prefix} ${repos.length} repositories: ${repos.join(', ')}`
-        return limitHit ? `${tooltip} or more...` : `${tooltip}.`
+        const tooltip = `${prefix} ${repos.length} repositories: ${repos.join(
+            ", "
+        )}`;
+        return limitHit ? `${tooltip} or more...` : `${tooltip}.`;
     }
 }
 

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -155,75 +155,70 @@ function createCodeBlockActionButton(
 }
 
 class GuardrailsStatusController {
-    readonly statusSpinning = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`;
-    readonly statusPass = '<i class="codicon codicon-pass"></i>';
-    readonly statusFailed = "Guard Rails Check Failed";
-    readonly statusUnavailable = "Guard Rails API Error";
+    readonly statusSpinning = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`
+    readonly statusPass = '<i class="codicon codicon-pass"></i>'
+    readonly statusFailed = 'Guard Rails Check Failed'
+    readonly statusUnavailable = 'Guard Rails API Error'
 
-    readonly iconClass = "guardrails-icon";
-    readonly statusClass = "guardrails-status";
+    readonly iconClass = 'guardrails-icon'
+    readonly statusClass = 'guardrails-status'
 
-    private status: HTMLElement;
+    private status: HTMLElement
 
     constructor(public container: HTMLElement) {
         this.findOrAppend(this.iconClass, () => {
-            const icon = document.createElement("div");
-            icon.innerHTML = ShieldIcon;
-            icon.classList.add(styles.attributionIcon, this.iconClass);
-            icon.setAttribute("data-testid", "attribution-indicator");
-            return icon;
-        });
+            const icon = document.createElement('div')
+            icon.innerHTML = ShieldIcon
+            icon.classList.add(styles.attributionIcon, this.iconClass)
+            icon.setAttribute('data-testid', 'attribution-indicator')
+            return icon
+        })
         this.status = this.findOrAppend(this.statusClass, () => {
-            const status = document.createElement("div");
-            status.classList.add(styles.status, this.statusClass);
-            return status;
-        });
+            const status = document.createElement('div')
+            status.classList.add(styles.status, this.statusClass)
+            return status
+        })
     }
 
     public setPending() {
-        this.container.title = "Guard Rails: Running Code Attribution Check…";
-        this.status.innerHTML = this.statusSpinning;
+        this.container.title = 'Guard Rails: Running Code Attribution Check…'
+        this.status.innerHTML = this.statusSpinning
     }
 
     public setSuccess() {
-        this.container.title = "Guard Rails Check Passed";
-        this.status.innerHTML = this.statusPass;
+        this.container.title = 'Guard Rails Check Passed'
+        this.status.innerHTML = this.statusPass
     }
 
     public setFailure(repos: string[], limitHit: boolean) {
-        this.container.classList.add(styles.attributionIconFound);
-        this.container.title = this.tooltip(repos, limitHit);
-        this.status.innerHTML = this.statusFailed;
+        this.container.classList.add(styles.attributionIconFound)
+        this.container.title = this.tooltip(repos, limitHit)
+        this.status.innerHTML = this.statusFailed
     }
 
     public setUnavailable() {
-        this.container.classList.add(styles.attributionIconUnavailable);
-        this.container.title = "Attribution search unavailable.";
-        this.status.innerHTML = this.statusUnavailable;
+        this.container.classList.add(styles.attributionIconUnavailable)
+        this.container.title = 'Attribution search unavailable.'
+        this.status.innerHTML = this.statusUnavailable
     }
 
-    private findOrAppend(
-        className: string,
-        make: () => HTMLElement
-    ): HTMLElement {
-        const elements = this.container.getElementsByClassName(className);
+    private findOrAppend(className: string, make: () => HTMLElement): HTMLElement {
+        const elements = this.container.getElementsByClassName(className)
         if (elements.length > 0) {
-            return elements[0] as HTMLElement;
+            return elements[0] as HTMLElement
         }
-        const newElement = make();
-        this.container.append(newElement);
-        return newElement;
+        const newElement = make()
+        this.container.append(newElement)
+        return newElement
     }
 
     private tooltip(repos: string[], limitHit: boolean) {
-        const prefix = "Guard Rails Check Failed. Code found in";
+        const prefix = 'Guard Rails Check Failed. Code found in'
         if (repos.length === 1) {
-            return `${prefix} ${repos[0]}.`;
+            return `${prefix} ${repos[0]}.`
         }
-        const tooltip = `${prefix} ${repos.length} repositories: ${repos.join(
-            ", "
-        )}`;
-        return limitHit ? `${tooltip} or more...` : `${tooltip}.`;
+        const tooltip = `${prefix} ${repos.length} repositories: ${repos.join(', ')}`
+        return limitHit ? `${tooltip} or more...` : `${tooltip}.`
     }
 }
 
@@ -237,21 +232,21 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
         metadata,
         guardrails,
     }) {
-        const rootRef = useRef<HTMLDivElement>(null);
+        const rootRef = useRef<HTMLDivElement>(null)
 
         useEffect(() => {
-            const preElements = rootRef.current?.querySelectorAll("pre");
+            const preElements = rootRef.current?.querySelectorAll('pre')
             if (!preElements?.length || !copyButtonOnSubmit) {
-                return;
+                return
             }
 
             for (const preElement of preElements) {
-                const preText = preElement.textContent;
+                const preText = preElement.textContent
                 if (preText?.trim() && preElement.parentNode) {
                     const eventMetadata = {
                         requestID: metadata?.requestID,
                         source: metadata?.source,
-                    };
+                    }
                     const buttons = createButtons(
                         preText,
                         copyButtonClassName,
@@ -259,54 +254,43 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                         insertButtonClassName,
                         insertButtonOnSubmit,
                         eventMetadata
-                    );
+                    )
                     if (guardrails) {
-                        const flexFiller = document.createElement("div");
-                        flexFiller.classList.add(styles.flexFiller);
-                        buttons.append(flexFiller);
-                        const g = new GuardrailsStatusController(buttons);
-                        g.setPending();
+                        const flexFiller = document.createElement('div')
+                        flexFiller.classList.add(styles.flexFiller)
+                        buttons.append(flexFiller)
+                        const g = new GuardrailsStatusController(buttons)
+                        g.setPending()
 
                         guardrails
                             .searchAttribution(preText)
-                            .then((attribution) => {
+                            .then(attribution => {
                                 if (isError(attribution)) {
-                                    g.setUnavailable();
-                                } else if (
-                                    attribution.repositories.length === 0
-                                ) {
-                                    g.setSuccess();
+                                    g.setUnavailable()
+                                } else if (attribution.repositories.length === 0) {
+                                    g.setSuccess()
                                 } else {
                                     g.setFailure(
-                                        attribution.repositories.map(
-                                            (r) => r.name
-                                        ),
+                                        attribution.repositories.map(r => r.name),
                                         attribution.limitHit
-                                    );
+                                    )
                                 }
                             })
                             .catch(() => {
-                                g.setUnavailable();
-                                return;
-                            });
+                                g.setUnavailable()
+                                return
+                            })
                     }
 
                     // Insert the buttons after the pre using insertBefore() because there is no insertAfter()
-                    preElement.parentNode.insertBefore(
-                        buttons,
-                        preElement.nextSibling
-                    );
+                    preElement.parentNode.insertBefore(buttons, preElement.nextSibling)
 
                     // capture copy events (right click or keydown) on code block
-                    preElement.addEventListener("copy", () => {
+                    preElement.addEventListener('copy', () => {
                         if (copyButtonOnSubmit) {
-                            copyButtonOnSubmit(
-                                preText,
-                                "Keydown",
-                                eventMetadata
-                            );
+                            copyButtonOnSubmit(preText, 'Keydown', eventMetadata)
                         }
-                    });
+                    })
                 }
             }
         }, [
@@ -317,7 +301,7 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
             metadata?.requestID,
             metadata?.source,
             guardrails,
-        ]);
+        ])
 
         return useMemo(
             () => (
@@ -330,6 +314,6 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                 />
             ),
             [displayText]
-        );
+        )
     }
-);
+)

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -155,59 +155,51 @@ function createCodeBlockActionButton(
 }
 
 class GuardrailsStatusController {
-    readonly iconClass = "guardrails-icon";
-    readonly spinnerClass = "guardrails-spinner";
+    readonly statusSpinning = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`;
+    readonly statusPass = '<i class="codicon codicon-pass"></i>';
+    readonly statusFailed = "Guard Rails Check Failed";
+    readonly statusUnavailable = "Guard Rails API Error";
 
-    private icon: HTMLElement;
-    private spinner: HTMLElement;
+    readonly iconClass = "guardrails-icon";
+    readonly statusClass = "guardrails-status";
+
+    private status: HTMLElement;
 
     constructor(public container: HTMLElement) {
-        this.icon = this.findOrAppend(this.iconClass, () => this.makeIcon());
-        this.spinner = this.findOrAppend(this.spinnerClass, () => {
-            const spinner = this.makeSpinner();
-            this.hide(spinner);
-            return spinner;
+        this.findOrAppend(this.iconClass, () => {
+            const icon = document.createElement("div");
+            icon.innerHTML = ShieldIcon;
+            icon.classList.add(styles.attributionIcon, this.iconClass);
+            icon.setAttribute("data-testid", "attribution-indicator");
+            return icon;
+        });
+        this.status = this.findOrAppend(this.statusClass, () => {
+            const status = document.createElement("div");
+            status.classList.add(styles.status, this.statusClass);
+            return status;
         });
     }
 
     public setPending() {
-        this.spinner.innerHTML = `<i class="codicon codicon-loading ${styles.codiconLoading}"></i>`;
-        this.show(this.spinner);
         this.container.title = "Guard Rails: Running Code Attribution Check…";
+        this.status.innerHTML = this.statusSpinning;
     }
 
     public setSuccess() {
-        this.spinner.innerHTML = '<i class="codicon codicon-pass></i>';
-        this.show(this.spinner);
-        this.icon.classList.add(styles.attributionIconNotFound);
         this.container.title = "Guard Rails Check Passed";
+        this.status.innerHTML = this.statusPass;
     }
 
     public setFailure(repos: string[], limitHit: boolean) {
-        this.icon.classList.add(styles.attributionIconFound);
-        this.hide(this.spinner);
+        this.container.classList.add(styles.attributionIconFound);
         this.container.title = this.tooltip(repos, limitHit);
+        this.status.innerHTML = this.statusFailed;
     }
 
     public setUnavailable() {
-        this.icon.classList.add(styles.attributionIconUnavailable);
-        this.icon.title = "Attribution search unavailable.";
-        this.hide(this.spinner);
-    }
-
-    private makeIcon(): HTMLElement {
-        const icon = document.createElement("div");
-        icon.innerHTML = ShieldIcon;
-        icon.classList.add(styles.attributionIcon, this.iconClass);
-        icon.title = "Attribution search running...";
-        icon.setAttribute("data-testid", "attribution-indicator");
-        return icon;
-    }
-
-    private makeSpinner(): HTMLElement {
-        const spinner = document.createElement("div");
-        spinner.classList.add(styles.spinner, this.spinnerClass);
-        return spinner;
+        this.container.classList.add(styles.attributionIconUnavailable);
+        this.container.title = "Attribution search unavailable.";
+        this.status.innerHTML = this.statusUnavailable;
     }
 
     private findOrAppend(
@@ -215,20 +207,12 @@ class GuardrailsStatusController {
         make: () => HTMLElement
     ): HTMLElement {
         const elements = this.container.getElementsByClassName(className);
-        if (elements.length === 0) {
-            const newElement = make();
-            this.container.append(newElement);
-            return newElement;
+        if (elements.length > 0) {
+            return elements[0] as HTMLElement;
         }
-        return elements[0] as HTMLElement;
-    }
-
-    private hide(element: HTMLElement) {
-        element.style.visibility = "hidden";
-    }
-
-    private show(element: HTMLElement) {
-        element.style.visibility = "visible";
+        const newElement = make();
+        this.container.append(newElement);
+        return newElement;
     }
 
     private tooltip(repos: string[], limitHit: boolean) {


### PR DESCRIPTION
Closes sourcegraph/sourcegraph#59294

[Figma](https://www.figma.com/file/H0k85e9AGWqSkiaExKVdyL/Guard-Rails-in-Cody-for-VS-Code?type=design&node-id=23-592&mode=design&t=pnlU3Q8qbm7N2Tq8-0)

[Long Loom showing demo local sg start](https://www.loom.com/share/c8cdef930af144e78584cc01e2882a7f?sid=00eac153-c720-4928-bae7-d44ec0567330)

Pass:
<img width="430" alt="pass" src="https://github.com/sourcegraph/cody/assets/153410/64fde9a5-245e-421f-a93f-e2dd24598fb0">

Fail:
<img width="428" alt="fail" src="https://github.com/sourcegraph/cody/assets/153410/03220f38-bb86-414f-98fc-30ad985816d9">

Unavailable ([caveat](https://github.com/sourcegraph/sourcegraph/issues/59294#issuecomment-1910151871)):
<img width="436" alt="unavailable-orange" src="https://github.com/sourcegraph/cody/assets/153410/035f7cac-432f-47f6-a621-ce8b4da78dd9">


## Test plan

- [x] Manual test
- [ ] Update automatic tests

For testing you got to enable `attribution.enabled` in your local site config as well as an experimental setting in VS Code:
<img width="484" alt="Screenshot 2024-01-25 at 3 08 12 PM" src="https://github.com/sourcegraph/cody/assets/153410/4f6f879c-3787-4aa6-8b1e-8499877715dc">

