### PR TITLE
Agent: use more helpful assertion in squirrel test

### DIFF
--- a/agent/src/cli/jsonrpc.ts
+++ b/agent/src/cli/jsonrpc.ts
@@ -116,6 +116,12 @@ export const jsonrpcCommand = new Command('jsonrpc')
             // Automatically pass through requests to GitHub because we
             // don't want to record huge binary downloads.
             polly.server.get('https://github.com/*path').passthrough()
+            // Uncomment below if you want to intercept network requests to, for
+            // example, fail github.com downloads. This can be helpful to reproduce
+            // situations where users are running Cody on airgapped computers.
+            // polly.server.get('https://github.com/*path').intercept((_req, res) => {
+            //     res.sendStatus(400)
+            // })
             polly.server.get('https://objects.githubusercontent.com/*path').passthrough()
         } else if (options.recordingMode) {
             console.error('CODY_RECORDING_DIRECTORY is required when CODY_RECORDING_MODE is set.')

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -771,8 +771,8 @@ describe('Agent', () => {
                 await client.sendSingleMessageToNewChatWithFullTranscript('What is Squirrel?', {
                     addEnhancedContext: true,
                 })
-            expect(lastMessage?.text?.toLocaleLowerCase().includes('code nav')).toBeTruthy()
-            expect(lastMessage?.text?.toLocaleLowerCase().includes('sourcegraph')).toBeTruthy()
+            expect(lastMessage?.text?.toLocaleLowerCase() ?? '').includes('code nav')
+            expect(lastMessage?.text?.toLocaleLowerCase() ?? '').includes('sourcegraph')
             decodeURIs(transcript)
             const contextFiles = transcript.messages.flatMap(m => m.contextFiles ?? [])
             expect(contextFiles).not.toHaveLength(0)


### PR DESCRIPTION
The error message is clearer now if the test fails. I've also added an example on how to reproduce network errors when failing to download, for example, the symf binary.

The error now includes the string of the reply, instead of just saying "value is not truthy"

<img width="1285" alt="CleanShot 2024-01-25 at 14 17 46@2x" src="https://github.com/sourcegraph/cody/assets/1408093/e9814fb9-1678-4ce2-bc41-82a38cc34e9b">

## Test plan

Green CI

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
