### PR TITLE
Workspace settings: Disable codeActionsOnSave

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,9 +18,5 @@
   "typescript.tsc.autoDetect": "off",
   "typescript.tsdk": "node_modules/typescript/lib",
   "task.allowAutomaticTasks": "on",
-  "editor.codeActionsOnSave": {
-    "quickfix.biome": "explicit",
-    "source.organizeImports.biome": "explicit"
-  },
   "editor.defaultFormatter": "biomejs.biome"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,6 @@
   "task.allowAutomaticTasks": "on",
   "editor.codeActionsOnSave": {
     "quickfix.biome": "explicit",
-    "source.fixAll": "explicit",
     "source.organizeImports.biome": "explicit"
   },
   "editor.defaultFormatter": "biomejs.biome"


### PR DESCRIPTION
## Desc

Takes precedence over user setting and causes annoying behaviour: https://sourcegraph.slack.com/archives/C05AGQYD528/p1706194762920939

(We can still enable these in user settings if people want them)

## Test plan

N/A - Dev setting only

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
