### PR TITLE
Fix git clone URL converstion for dots in repo names

### DIFF
--- a/lib/shared/src/utils.test.ts
+++ b/lib/shared/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
     convertGitCloneURLToCodebaseName,
@@ -7,7 +7,7 @@ import {
 } from './utils'
 
 describe('convertGitCloneURLToCodebaseName', () => {
-    test('converst Azure DevOps URL', () => {
+    it('converts Azure DevOps URL', () => {
         expect(
             convertGitCloneURLToCodebaseName(
                 'https://dev.azure.com/organization/project/_git/repository'
@@ -15,37 +15,37 @@ describe('convertGitCloneURLToCodebaseName', () => {
         ).toEqual('dev.azure.com/organization/project/repository')
     })
 
-    test('converts GitHub SSH URL', () => {
+    it('converts GitHub SSH URL', () => {
         expect(convertGitCloneURLToCodebaseName('git@github.com:sourcegraph/sourcegraph.git')).toEqual(
             'github.com/sourcegraph/sourcegraph'
         )
     })
 
-    test('converts GitHub SSH URL with different user', () => {
+    it('converts GitHub SSH URL with different user', () => {
         expect(
             convertGitCloneURLToCodebaseName('jdsbcnuqwew@github.com:sourcegraph/sourcegraph.git')
         ).toEqual('github.com/sourcegraph/sourcegraph')
     })
 
-    test('converts GitHub SSH URL with the port number', () => {
+    it('converts GitHub SSH URL with the port number', () => {
         expect(
             convertGitCloneURLToCodebaseName('ssh://git@gitlab-my-company.net:20022/path/repo.git')
         ).toEqual('gitlab-my-company.net/path/repo')
     })
 
-    test('converts GitHub SSH URL no trailing .git', () => {
+    it('converts GitHub SSH URL no trailing .git', () => {
         expect(convertGitCloneURLToCodebaseName('git@github.com:sourcegraph/sourcegraph')).toEqual(
             'github.com/sourcegraph/sourcegraph'
         )
     })
 
-    test('converts GitHub HTTPS URL', () => {
+    it('converts GitHub HTTPS URL', () => {
         expect(convertGitCloneURLToCodebaseName('https://github.com/sourcegraph/sourcegraph')).toEqual(
             'github.com/sourcegraph/sourcegraph'
         )
     })
 
-    test('converts Bitbucket HTTPS URL', () => {
+    it('converts Bitbucket HTTPS URL', () => {
         expect(
             convertGitCloneURLToCodebaseName(
                 'https://username@bitbucket.org/sourcegraph/sourcegraph.git'
@@ -53,43 +53,49 @@ describe('convertGitCloneURLToCodebaseName', () => {
         ).toEqual('bitbucket.org/sourcegraph/sourcegraph')
     })
 
-    test('converts Bitbucket SSH URL', () => {
+    it('converts Bitbucket SSH URL', () => {
         expect(
             convertGitCloneURLToCodebaseName('git@bitbucket.sgdev.org:sourcegraph/sourcegraph.git')
         ).toEqual('bitbucket.sgdev.org/sourcegraph/sourcegraph')
     })
 
-    test('converts GitLab SSH URL', () => {
+    it('converts GitLab SSH URL', () => {
         expect(convertGitCloneURLToCodebaseName('git@gitlab.com:sourcegraph/sourcegraph.git')).toEqual(
             'gitlab.com/sourcegraph/sourcegraph'
         )
     })
 
-    test('converts GitLab HTTPS URL', () => {
+    it('converts GitLab HTTPS URL', () => {
         expect(
             convertGitCloneURLToCodebaseName('https://gitlab.com/sourcegraph/sourcegraph.git')
         ).toEqual('gitlab.com/sourcegraph/sourcegraph')
     })
 
-    test('converts GitHub SSH URL with Git', () => {
+    it('converts GitHub SSH URL with Git', () => {
         expect(convertGitCloneURLToCodebaseName('git@github.com:sourcegraph/sourcegraph.git')).toEqual(
             'github.com/sourcegraph/sourcegraph'
         )
     })
 
-    test('converts Eriks SSH Alias URL', () => {
+    it('converts Eriks SSH Alias URL', () => {
         expect(convertGitCloneURLToCodebaseName('github:sourcegraph/sourcegraph')).toEqual(
             'github.com/sourcegraph/sourcegraph'
         )
     })
 
-    test('converts HTTP URL', () => {
+    it('converts HTTP URL', () => {
         expect(convertGitCloneURLToCodebaseName('http://github.com/sourcegraph/sourcegraph')).toEqual(
             'github.com/sourcegraph/sourcegraph'
         )
     })
 
-    test('returns null for invalid URL', () => {
+    it('returns null for invalid URL', () => {
         expect(isError(convertGitCloneURLToCodebaseNameOrError('invalid'))).toBe(true)
+    })
+
+    it('converts URLs with dots in the repo name', () => {
+        expect(
+            convertGitCloneURLToCodebaseName('git@github.com:philipp-spiess/philippspiess.com.git')
+        ).toEqual('github.com/philipp-spiess/philippspiess.com')
     })
 })

--- a/lib/shared/src/utils.ts
+++ b/lib/shared/src/utils.ts
@@ -32,11 +32,11 @@ export function convertGitCloneURLToCodebaseNameOrError(cloneURL: string): strin
     }
     try {
         // Handle common Git SSH URL format
-        const match = cloneURL.match(/^[\w-]+@([^:]+):([\w-]+)\/([\w-]+)(\.git)?$/)
+        const match = cloneURL.match(/^[\w-]+@([^:]+):([\w-]+)\/([\w-\.]+)$/)
         if (match) {
             const host = match[1]
             const owner = match[2]
-            const repo = match[3]
+            const repo = match[3].replace(/\.git$/, '')
             return `${host}/${owner}/${repo}`
         }
         const uri = new URL(cloneURL)

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -21,6 +21,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Commands: Fixed an issue where Cody failed to register additional instructions followed by the command key when submitted from the command menu. [pull/2789](https://github.com/sourcegraph/cody/pull/2789)
 - Chat: The title for the chat panel is now reset correctly on "Restart Chat Session"/"New Chat Session" button click. [pull/2786](https://github.com/sourcegraph/cody/pull/2786)
 - Chat: Fixed an issue where Ctrl+Enter on Windows would not work (did not send a follow-on chat). [pull/2823](https://github.com/sourcegraph/cody/pull/2823)
+- Fixes an issue where the codebase URL was not properly inferred for a git repo when the repo name contains dots. [pull/2901](https://github.com/sourcegraph/cody/pull/2901)
 
 ### Changed
 


### PR DESCRIPTION
I noticed that the `convertGitCloneURLToCodebaseName` logic doesn't work for repos with dots in the name (my console was littered with errors). We can't fix this in the regex alone (since regexes are greedy and when I allow the repo group to have dots, it will match the `.git` part), so we now have a second regex to replace the `.git` replacement.

## Test plan

- Added a unit test  

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
