### PR TITLE
feat(errors): add ServerError class to handle server-side aborts

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -79,6 +79,31 @@ export class NetworkError extends Error {
     }
 }
 
+/*
+ * Error for incompleted requests aborted by the server side error
+ * E.g. context deadline exceeded, request timeout, etc.
+ */
+export class ServerError extends Error {
+    public static readonly errorName = 'ServerError'
+    public readonly name = ServerError.errorName
+
+    /**
+     * Checks if the given error message indicates a request that was aborted by the server,
+     * such as from a context deadline exceeded.
+     *
+     * @param message The error message to check
+     * @returns True if the message matches a known incompleted error, false otherwise
+     */
+    public static isServerError(message: string): boolean {
+        const knownErrors = ['context deadline exceeded']
+        return knownErrors.includes(message)
+    }
+
+    constructor(public readonly message: string) {
+        super(message)
+    }
+}
+
 export function isNetworkError(error: Error): error is NetworkError {
     return error instanceof NetworkError
 }

--- a/lib/ui/src/chat/ErrorItem.tsx
+++ b/lib/ui/src/chat/ErrorItem.tsx
@@ -5,6 +5,7 @@ import { RateLimitError, type ChatError } from '@sourcegraph/cody-shared'
 import type { ApiPostMessage, ChatButtonProps, UserAccountInfo } from '../Chat'
 
 import styles from './ErrorItem.module.css'
+import { ServerError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 /**
  * An error message shown in the chat.
@@ -24,6 +25,12 @@ export const ErrorItem: React.FunctionComponent<{
                 postMessage={postMessage}
             />
         )
+    }
+
+    // Skip errors that should not be user-facing
+    if (typeof error !== 'string' && error.name === ServerError.errorName) {
+        // TODO (bee) display helpful tips in chat
+        return null
     }
 
     return <RequestErrorItem error={error.message} />

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -84,6 +84,7 @@ import {
     type ContextItem,
     type MessageWithContext,
 } from './SimpleChatModel'
+import { ServerError } from '@sourcegraph/cody-shared/src/sourcegraph-api/errors'
 
 interface SimpleChatPanelProviderOptions {
     config: ChatPanelConfig
@@ -814,7 +815,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 this.addBotMessage(requestID, content)
             },
             error: (partialResponse, error) => {
-                if (!isAbortError(error)) {
+                if (ServerError.isServerError(error.message)) {
+                    this.postError(new ServerError(error.message), 'transcript')
+                } else if (!isAbortError(error)) {
                     this.postError(error, 'transcript')
                 }
                 try {


### PR DESCRIPTION
Context: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1706116514736789

feat(errors): add ServerError class to handle server-side aborts

- Implement a new ServerError class to identify errors like 'context deadline exceeded'.
- Add logic to skip user-facing display of `ServerError` instances in chat components.
- Handle ServerError in SimpleChatPanelProvider to post relevant errors to the transcript.

Follow-up:
- Add helpful tips to explain follow-up actions when a server error is encountered. For example, type `ask Cody to continue if your request was cut off`, or display a button for the user to press `continue` etc 
- Increase deadline to 2 minutes on the server side

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Switch to ChatGPT 4.0 as your chat model
- Use the /test command in a large method to ask Cody to generate Unit Test, as long as the response takes longer than 1 minute, your answer should be cut off
- Confirm the previous error message is not showing up 

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/b1927f03-9364-4641-a02a-f56c7ea8cdd6)

### After

Message is cut off:

![image](https://github.com/sourcegraph/cody/assets/68532117/c9949e4e-b19a-4061-98c2-f33a2ed47117)

With no error message display that caused confusion:

![image](https://github.com/sourcegraph/cody/assets/68532117/d43ce6b9-5745-4058-bad1-29af79db40e3)
