### PR TITLE
fix: do not display non-chat view in panel

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -21,6 +21,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Commands: Fixed an issue where Cody failed to register additional instructions followed by the command key when submitted from the command menu. [pull/2789](https://github.com/sourcegraph/cody/pull/2789)
 - Chat: The title for the chat panel is now reset correctly on "Restart Chat Session"/"New Chat Session" button click. [pull/2786](https://github.com/sourcegraph/cody/pull/2786)
 - Chat: Fixed an issue where Ctrl+Enter on Windows would not work (did not send a follow-on chat). [pull/2823](https://github.com/sourcegraph/cody/pull/2823)
+- Chat: Fixed an issue where the user authentication view appeared in the chat panel. [pull/2904](https://github.com/sourcegraph/cody/pull/2904)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -109,6 +109,12 @@ export class ChatManager implements vscode.Disposable {
     }
 
     public async setWebviewView(view: View): Promise<void> {
+        // Chat panel is only used for chat view
+        // Request to open chat panel for login view/unAuth users, will be sent to sidebar view
+        if (!this.options.authProvider.getAuthStatus()?.isLoggedIn || view !== 'chat') {
+            return vscode.commands.executeCommand('cody.focus')
+        }
+
         const chatProvider = await this.getChatProvider()
         await chatProvider?.setWebviewView(view)
     }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1109,6 +1109,15 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     public async setWebviewView(view: View): Promise<void> {
+        if (view !== 'chat') {
+            // Only chat view is supported in the webview panel.
+            // When a different view is requested,
+            // Set context to notifiy the webview panel to close.
+            // This should close the webview panel and open the login view in the sidebar.
+            await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, false)
+            await vscode.commands.executeCommand('setContext', 'cody.activated', false)
+            return
+        }
         if (!this.webviewPanel) {
             await this.createWebviewPanel()
         }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -561,7 +561,8 @@ const register = async (
                 errorType: 'auth',
                 description: 'You need to sign in to use Cody.',
                 onSelect: () => {
-                    void chatManager.setWebviewView('chat')
+                    // Bring up the sidebar view
+                    void vscode.commands.executeCommand('cody.focus')
                 },
             })
         }

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -35,5 +35,18 @@ test('requires a valid auth token and allows logouts', async ({ page, sidebar })
     await expect(
         sidebarFrame.getByRole('button', { name: 'Sign In to Your Enterprise Instance' })
     ).toBeVisible()
+
+    // Click on Cody at the bottom menu to open the Cody Settings Menu and click on Sign In.
+    await page.getByRole('button', { name: 'cody-logo-heavy, Sign In to Use Cody' }).click()
+    await page
+        .getByLabel('alert  Sign In to Use Cody, You need to sign in to use Cody., notice')
+        .locator('a')
+        .first()
+        .click()
+    // Makes sure the sign in page is loaded in the sidebar view with Cody: Chat as the heading
+    // instead of the chat panel.
+    await expect(page.getByRole('heading', { name: 'Cody: Chat' })).toBeVisible()
+    await page.getByRole('heading', { name: 'Cody: Chat' }).click()
+
     await assertEvents(loggedEvents, expectedEvents)
 })

--- a/vscode/webviews/NavBar.tsx
+++ b/vscode/webviews/NavBar.tsx
@@ -1,1 +1,1 @@
-export type View = 'chat' | 'login' | 'history'
+export type View = 'chat' | 'login'


### PR DESCRIPTION
Reported by https://sourcegraph.slack.com/archives/C05AGQYD528/p1706206513677179

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Provided by cezary on slack:
- User is signed out of Cody (I just Cmd+Shift+P > Sign out'd)
- I click on the yellow Cody icon in the bottom
- Signup screen appears on the right hand side in a pane
- Clicking sign into enterprise instance seems to have no effect.

After this change: sidebar will be opened with auth view instead of chat panel

https://github.com/sourcegraph/cody/assets/68532117/5a9a8e15-7318-402f-bf66-8e741928f3c8

