### PR TITLE
Autocomplete: fix actual position calculation for hot-streak completions

### DIFF
--- a/vscode/src/completions/get-current-doc-context.test.ts
+++ b/vscode/src/completions/get-current-doc-context.test.ts
@@ -408,9 +408,11 @@ describe('insertCompletionIntoDocContext', () => {
             dynamicMultilineCompletions: false,
         })
 
+        const insertText = "console.log('hello')\n    console.log('world')"
+
         const updatedDocContext = insertIntoDocContext({
             docContext,
-            insertText: "console.log('hello')\n    console.log('world')",
+            insertText,
             languageId: document.languageId,
             dynamicMultilineCompletions: false,
         })
@@ -423,12 +425,14 @@ describe('insertCompletionIntoDocContext', () => {
             suffix: '\n}',
             currentLinePrefix: "    console.log('world')",
             currentLineSuffix: '',
+            injectedCompletionText: insertText,
             prevNonEmptyLine: "    console.log('hello')",
             nextNonEmptyLine: '}',
             multilineTrigger: null,
             multilineTriggerPosition: null,
             injectedPrefix: null,
             position: { character: 24, line: 2 },
+            positionWithoutInjectedCompletionText: docContext.position,
         })
     })
 
@@ -448,9 +452,10 @@ describe('insertCompletionIntoDocContext', () => {
             dynamicMultilineCompletions: false,
         })
 
+        const insertText = "'hello', 'world')"
         const updatedDocContext = insertIntoDocContext({
             docContext,
-            insertText: "'hello', 'world')",
+            insertText,
             languageId: document.languageId,
             dynamicMultilineCompletions: false,
         })
@@ -462,6 +467,7 @@ describe('insertCompletionIntoDocContext', () => {
             suffix: '\n}',
             currentLinePrefix: "    console.log('hello', 'world')",
             currentLineSuffix: '',
+            injectedCompletionText: insertText,
             prevNonEmptyLine: 'function helloWorld() {',
             nextNonEmptyLine: '}',
             multilineTrigger: null,
@@ -469,6 +475,7 @@ describe('insertCompletionIntoDocContext', () => {
             injectedPrefix: null,
             // Note: The position is always moved at the end of the line that the text was inserted
             position: { character: "    console.log('hello', 'world')".length, line: 1 },
+            positionWithoutInjectedCompletionText: docContext.position,
         })
     })
 
@@ -488,9 +495,10 @@ describe('insertCompletionIntoDocContext', () => {
             dynamicMultilineCompletions: false,
         })
 
+        const insertText = '\n        propA: foo,\n        propB: bar,\n    }, 2)'
         const updatedDocContext = insertIntoDocContext({
             docContext,
-            insertText: '\n        propA: foo,\n        propB: bar,\n    }, 2)',
+            insertText,
             languageId: document.languageId,
             dynamicMultilineCompletions: false,
         })
@@ -506,6 +514,7 @@ describe('insertCompletionIntoDocContext', () => {
             suffix: '\n}',
             currentLinePrefix: '    }, 2)',
             currentLineSuffix: '',
+            injectedCompletionText: insertText,
             prevNonEmptyLine: '        propB: bar,',
             nextNonEmptyLine: '}',
             multilineTrigger: null,
@@ -513,6 +522,7 @@ describe('insertCompletionIntoDocContext', () => {
             injectedPrefix: null,
             // Note: The position is always moved at the end of the line that the text was inserted
             position: { character: '    }, 2)'.length, line: 4 },
+            positionWithoutInjectedCompletionText: docContext.position,
         })
     })
 })

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -29,6 +29,7 @@ export interface DocumentContext extends DocumentDependentContext, LinesContext 
      * on every completion update or new virtual completion creation.
      */
     injectedCompletionText?: string
+    positionWithoutInjectedCompletionText?: vscode.Position
 }
 
 export interface DocumentDependentContext {

--- a/vscode/src/completions/get-current-doc-context.ts
+++ b/vscode/src/completions/get-current-doc-context.ts
@@ -211,7 +211,7 @@ export function insertIntoDocContext(params: InsertIntoDocContextParams): Docume
         text: insertText,
     })
 
-    return getDerivedDocContext({
+    const updatedDocContext = getDerivedDocContext({
         languageId,
         position: updatedPosition,
         dynamicMultilineCompletions,
@@ -223,6 +223,12 @@ export function insertIntoDocContext(params: InsertIntoDocContextParams): Docume
             injectedPrefix: null,
         },
     })
+
+    updatedDocContext.positionWithoutInjectedCompletionText =
+        updatedDocContext.positionWithoutInjectedCompletionText || docContext.position
+    updatedDocContext.injectedCompletionText = (docContext.injectedCompletionText || '') + insertText
+
+    return updatedDocContext
 }
 
 export interface LinesContext {

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -230,6 +230,11 @@ export async function* fetchAndProcessCompletions(
     let hotStreakExtractor: undefined | HotStreakExtractor
 
     for await (const { stopReason, completion } of completionResponseGenerator) {
+        addAutocompleteDebugEvent('fetchAndProcessCompletions', {
+            stopReason,
+            completion,
+        })
+
         const isFullResponse = stopReason !== STOP_REASON_STREAMING_CHUNK
         const rawCompletion = providerSpecificPostProcess(completion)
 

--- a/vscode/src/completions/providers/hot-streak.ts
+++ b/vscode/src/completions/providers/hot-streak.ts
@@ -71,13 +71,9 @@ function insertCompletionAndPressEnter(
         dynamicMultilineCompletions,
     })
 
-    updatedDocContext.positionWithoutInjectedCompletionText =
-        updatedDocContext.positionWithoutInjectedCompletionText || docContext.position
-    updatedDocContext.injectedCompletionText =
-        (docContext.injectedCompletionText || '') + insertTextWithPressedEnter
-
     return updatedDocContext
 }
+
 export function createHotStreakExtractor(params: HotStreakExtractorParams): HotStreakExtractor {
     const { completedCompletion, providerOptions } = params
     const {

--- a/vscode/src/completions/providers/hot-streak.ts
+++ b/vscode/src/completions/providers/hot-streak.ts
@@ -29,6 +29,20 @@ export interface HotStreakExtractor {
     extract(rawCompletion: string, isRequestEnd: boolean): Generator<FetchCompletionResult>
 }
 
+export function pressEnterAndGetIndentString(
+    insertText: string,
+    currentLine: string,
+    document: TextDocument
+): string {
+    const { languageId, uri } = document
+
+    const startsNewBlock = Boolean(endsWithBlockStart(insertText, languageId))
+    const newBlockIndent = startsNewBlock ? getEditorIndentString(uri) : ''
+    const currentIndentReference = insertText.includes('\n') ? getLastLine(insertText) : currentLine
+
+    return '\n' + detectIndent(currentIndentReference).indent + newBlockIndent
+}
+
 /**
  * For a hot streak, we require the completion to be inserted followed by an enter key
  * Enter will usually insert a line break followed by the same indentation that the
@@ -41,30 +55,24 @@ function insertCompletionAndPressEnter(
     dynamicMultilineCompletions: boolean
 ): DocumentContext {
     const { insertText } = completion
-    const { languageId, uri } = document
 
-    const startsNewBlock = Boolean(endsWithBlockStart(insertText, languageId))
-    const newBlockIndent = startsNewBlock ? getEditorIndentString(uri) : ''
-    const currentIndentReference = insertText.includes('\n')
-        ? getLastLine(insertText)
-        : docContext.currentLinePrefix
-
-    const indentString = '\n' + detectIndent(currentIndentReference).indent + newBlockIndent
+    const indentString = pressEnterAndGetIndentString(insertText, docContext.currentLinePrefix, document)
     const insertTextWithPressedEnter = insertText + indentString
 
     addAutocompleteDebugEvent('insertCompletionAndPressEnter', {
         currentLinePrefix: docContext.currentLinePrefix,
-        startsNewBlock,
         text: insertTextWithPressedEnter,
     })
 
     const updatedDocContext = insertIntoDocContext({
         docContext,
-        languageId,
+        languageId: document.languageId,
         insertText: insertTextWithPressedEnter,
         dynamicMultilineCompletions,
     })
 
+    updatedDocContext.positionWithoutInjectedCompletionText =
+        updatedDocContext.positionWithoutInjectedCompletionText || docContext.position
     updatedDocContext.injectedCompletionText =
         (docContext.injectedCompletionText || '') + insertTextWithPressedEnter
 

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -5,7 +5,7 @@ import { getLanguageConfig } from '../../tree-sitter/language'
 import { logCompletionBookkeepingEvent } from '../logger'
 
 import { isAlmostTheSameString } from './string-comparator'
-import { Position } from 'vscode'
+import type { Position } from 'vscode'
 
 export const OPENING_CODE_TAG = '<CODE5711>'
 export const CLOSING_CODE_TAG = '</CODE5711>'
@@ -397,21 +397,6 @@ export function lastNLines(text: string, n: number): string {
 export function removeIndentation(text: string): string {
     const lines = text.split('\n')
     return lines.map(line => line.replace(INDENTATION_REGEX, '')).join('\n')
-}
-
-export function getPositionAfterTextDeletion(position: Position, text?: string): Position {
-    if (!text || text.length === 0) {
-        return position
-    }
-
-    const insertedLines = lines(text)
-
-    const updatedPosition =
-        insertedLines.length <= 1
-            ? position.translate(0, Math.min(-insertedLines[0].length, 0))
-            : new Position(position.line - (insertedLines.length - 1), insertedLines.at(-1)!.length)
-
-    return updatedPosition
 }
 
 export function getPositionAfterTextInsertion(position: Position, text?: string): Position {


### PR DESCRIPTION
## Context

- As a follow-up to https://github.com/sourcegraph/cody/pull/2881, I started adding more tests. I bumped into the issue that I had created with the last-minute fix in the PR where I removed the `actualPosition` from `docContext` and switched to computing it manually on the spot. The math was incorrect in some cases: we need to know the length of the string at the target line number to calculate the correct position. This PR reverts back to having this field to avoid the complexity of handling edge cases where the injected completion overwrites `currentLineSuffix`.
- It also adds a helper function `acceptFirstCompletionAndPressEnter`, to the return value of `getInlineCompletionsWithInlinedChunks`, making hot-streak tests even more compact and easier to read. 

## Test plan

CI
