### PR TITLE
Agent: add ability to disable network requests to sourcegraph.com

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -63,7 +63,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:50 GMT
+            value: Fri, 26 Jan 2024 14:31:06 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -92,7 +92,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:49.054Z
+      startedDateTime: 2024-01-26T14:31:04.612Z
       time: 0
       timings:
         blocked: -1
@@ -588,7 +588,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:36:38 GMT
+            value: Fri, 26 Jan 2024 14:31:10 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -617,7 +617,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:36:34.786Z
+      startedDateTime: 2024-01-26T14:31:07.185Z
       time: 0
       timings:
         blocked: -1
@@ -695,7 +695,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:49 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -726,7 +726,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.827Z
+      startedDateTime: 2024-01-26T14:31:04.382Z
       time: 0
       timings:
         blocked: -1
@@ -806,7 +806,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:47 GMT
+            value: Fri, 26 Jan 2024 14:31:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -837,7 +837,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:47.474Z
+      startedDateTime: 2024-01-26T14:31:03.016Z
       time: 0
       timings:
         blocked: -1
@@ -915,7 +915,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:47 GMT
+            value: Fri, 26 Jan 2024 14:31:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -946,7 +946,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:47.476Z
+      startedDateTime: 2024-01-26T14:31:03.018Z
       time: 0
       timings:
         blocked: -1
@@ -1026,7 +1026,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1057,7 +1057,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.206Z
+      startedDateTime: 2024-01-26T14:31:03.755Z
       time: 0
       timings:
         blocked: -1
@@ -1081,6 +1081,9 @@ log:
             name: user-agent
             value: enterpriseClient / v1
           - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseClientabcde1234
+          - _fromType: array
             name: accept
             value: "*/*"
           - _fromType: array
@@ -1094,7 +1097,7 @@ log:
             value: close
           - name: host
             value: demo.sourcegraph.com
-        headersSize: 273
+        headersSize: 335
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -1122,7 +1125,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:32:56 GMT
+            value: Fri, 26 Jan 2024 14:31:02 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -1150,7 +1153,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-01-26T13:32:56.194Z
+      startedDateTime: 2024-01-26T14:31:02.561Z
       time: 0
       timings:
         blocked: -1
@@ -1174,6 +1177,9 @@ log:
             name: user-agent
             value: enterpriseClient / v1
           - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseClientabcde1234
+          - _fromType: array
             name: accept
             value: "*/*"
           - _fromType: array
@@ -1187,7 +1193,7 @@ log:
             value: close
           - name: host
             value: demo.sourcegraph.com
-        headersSize: 273
+        headersSize: 335
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -1215,7 +1221,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:32:56 GMT
+            value: Fri, 26 Jan 2024 14:31:03 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -1243,7 +1249,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-01-26T13:32:56.484Z
+      startedDateTime: 2024-01-26T14:31:02.793Z
       time: 0
       timings:
         blocked: -1
@@ -1311,7 +1317,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -1340,7 +1346,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.497Z
+      startedDateTime: 2024-01-26T14:31:04.059Z
       time: 0
       timings:
         blocked: -1
@@ -1408,7 +1414,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -1437,7 +1443,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.499Z
+      startedDateTime: 2024-01-26T14:31:04.062Z
       time: 0
       timings:
         blocked: -1
@@ -1505,7 +1511,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -1534,7 +1540,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.501Z
+      startedDateTime: 2024-01-26T14:31:04.064Z
       time: 0
       timings:
         blocked: -1
@@ -1602,7 +1608,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -1631,7 +1637,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.502Z
+      startedDateTime: 2024-01-26T14:31:04.065Z
       time: 0
       timings:
         blocked: -1
@@ -1699,7 +1705,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -1728,7 +1734,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.503Z
+      startedDateTime: 2024-01-26T14:31:04.066Z
       time: 0
       timings:
         blocked: -1
@@ -1752,6 +1758,9 @@ log:
             name: user-agent
             value: enterpriseClient / v1
           - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseClientabcde1234
+          - _fromType: array
             name: accept
             value: "*/*"
           - _fromType: array
@@ -1765,7 +1774,7 @@ log:
             value: close
           - name: host
             value: demo.sourcegraph.com
-        headersSize: 266
+        headersSize: 328
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -1795,7 +1804,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:32:56 GMT
+            value: Fri, 26 Jan 2024 14:31:02 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -1823,7 +1832,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-01-26T13:32:56.190Z
+      startedDateTime: 2024-01-26T14:31:02.558Z
       time: 0
       timings:
         blocked: -1
@@ -1900,7 +1909,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1931,165 +1940,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.506Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: aee3ab7913330cb0f865102042d59d00
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 735
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "735"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 341
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: >-
-              
-              query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $textResultsCount: Int!) {
-              	getCodyContext(repos: $repos, query: $query, codeResultsCount: $codeResultsCount, textResultsCount: $textResultsCount) {
-                      ...on FileChunkContext {
-                          blob {
-                              path
-                              repository {
-                                id
-                                name
-                              }
-                              commit {
-                                oid
-                              }
-                              url
-                            }
-                            startLine
-                            endLine
-                            chunkContent
-                      }
-                  }
-              }
-            variables:
-              codeResultsCount: 15
-              query: What is Squirrel?
-              repos:
-                - UmVwb3NpdG9yeTozMTA=
-              textResultsCount: 5
-        queryString:
-          - name: GetCodyContext
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?GetCodyContext
-      response:
-        bodySize: 2514
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 2514
-          text: "[\"H4sIAAAAAAAA/+xZ+27bOPZ+FUK/nzG21xYd+TKJFgWm0zhtgabTJu7speo4FHksEZFIl\
-            Tyy43YC7LPso+2TLCg7rew4l25n//L+45AidUh933cuZD57giHzws9eAvhM\",\"i+U\
-            zrRCu0Avff/biTMduqGCYeqHHMwkK6QJiag2noBBMYaQFaqDQtf4ZFNrZYVKBOdMlgv\
-            XRXnkdz020ErVZOrtSeKH3Lv91EfdfF+L50RIm+tPp5OkTr+MploMXeonEtIx9rnNqd\
-            Wk4JIYVab3tXXc8rvNcojOpK5tMcDg6CAaD/iEbDYeD/rB3NIDBjyPx42jYEwejXszi\
-            fjxw75Ym80KPPrzQT4+1SrvUIUe/G6/rjmeRGXwlFXjhcNjxQIl158eOx9NSXVZ8KfR\
-            CjxBCrjuR+hAp77pziz0Bc2ogA2ah2s667aPdN17uQWIT8YPBBuYHg29H/UYDMhOcGV\
-            Gtl2Q6ZlnX4jIDS59XvfOqc+4YoCfa5CcSMvErM5IptLef7LM7/Teg3OK9H9Rp7w92s\
-            h6VvV6fUyHnVQsi1dqtgUT7uRb7Rtf6qzeRHR30asiODoJbyEZoZWL9y0PrS00tmpJj\
-            aUB0czAJdIWczeh8QOYDP/D7hFIilZAGON4J/1o3sWFKwEo2FpjhabeUVKqiRApXBRi\
-            Zg0KWUVsmCViUWtnxFYKyUqs9jJJ/FGxbAhj16wIYDXe6lgEsjSIWGYI/c97arJk/d4\
-            8rH25F6vr+uAtx184hQ7iUuAr2VXql733fd3Q+cT8G5h9oc84yKQzMW7TJtYAW/VPGl\
-            rrE/eX+TvQaw5+38GsMj2kjOLzBsBEcua7D0TVrSG7VNEcb4WB3dn2I5Psk+jOz8EwL\
-            OJXGaPO2BLN86Qb2OIH+x3BtUhcM66E8GN4O5TVPLi2cQq6bzRZ5ssqWZLV0ZX08B4U\
-            vmBIZGOtLJbE+MV0PtDrk/Yd7PD4XFK6Al6gNla62ViyjC20uwVBTKpQ50MsyBqPAFd\
-            iJ3jv+vx2hrbroYKMuOrhdF0W4JnyWo39eGKlw1ow8i1D4NcsNEXkdl7nh6m5CXZluE\
-            8oldXAyJfaQsp0YbJJyeFjj5Ki3gxJ3PLkD4y8qcJHadTJqQaFUkH1ViEVtgOrYgpmz\
-            WGYSl3tIxfdAtZX06l403OVEd6e8LytpHecyMcxVRFTohUoMEzBFsLjP5DwAy3Y862/\
-            Es9vF6H1UuHA6M9VUQattf8xixi9d9yv4U4QrnK6S3bSKeHtIz/dAtVV1jOrOE4wenY\
-            JM+FvD/v9PDUtwWUA4k5krQTLguGpX64VaZUtSMHRqmrh5BhK4Kshvr3+ZdF++Ph7/d\
-            Xwcuty1eu6/LTXCKSBrmqoc9l+zHJqtVocY39VZPL07v33RrJNpppn40thDhdwPxpbb\
-            upj51W2Ho7s1oK1/BrmeQ9Ma/ggqSsvcKZOhrcJ8qi1O3eA6ouwzMY+AZpumjcvTHXe\
-            nO1314uTlq8n4jDT/8mJ8NiYNS54QXhoDCqcNS56+PibMJGUOCrvri7fq94eG/cHNbt\
-            jWRYcUYKQWX//evOKqzupYc2JYsnrgSNp49PCtwt1XkNUxqpsYXRa+5XZvbw6+AaEt1\
-            QSjumqCw53HylgbAaYba0SddzOYYdcwIUsbkt6f783YdpnHOrPUfiylMZDRs/HT49Ox\
-            n+/dBe0DaGzSUj/r3865/0fO1wYiFambNpGWMEVeTCZviCuIwZCZNmTGLBKmBCkMcGm\
-            BZJqzjLigQqq6OpMJKA6ktFIlBA1A10qXkv1HFGK1RIIOrcJoUXK0ZWy5kUVVF2aSg7\
-            JgpyLe14L5D8FsUyKD3oZIervu9lmJOtGZ8MdXBXBsRl4UqadEwYKsFyALZgk3wBAEi\
-            Zek3a5EU9/L+j8vKWJhQ1qHYQWRROgykUu19T20bsTSg6A/+N39rPJHGEUqitS//vFP\
-            0n613sscjJVatQ==\",\"Q3IQ9G8Gx1eFXOU80nw3edZqh+QEYhIMOiToBX0ShIPDIi\
-            fvJs9Is+/3iGBLSwzkTCqpktYuM28mt6yMwsEhy8mb88nNC+8sGMJ1qbAdkt72VpElt\
-            h2Si4ubgXOWgZ1pw2ETvJfH7ZCU6lLphdoxVxeFNlgqicvV1DvBDnpBz89kkqL7Lr96\
-            vSLgyzNq6C9fzdH1onQuYfH7zQ5WGbyC/gyKbEkWElPCSMiKwug5iKlFlhchWaSgCKb\
-            SVmFlPXjrrUUqEaY8BX45zZm5rL+XMktiAEXcuZ2gJpgC4aVFnYNxW/Ba/vhjybImdk\
-            gO1hU891xPaU5XKuNazWRCFxCnWl9aqktMtINk/3LK40D59owfeXrhFDWNGfJ0ylOmE\
-            phKEXkhiby3+Unvb0F6zJ6flH8P3o1OJ/xT5D1c7bMS008uOsylAGNpAaZS8So1cqYK\
-            oxE42v0tEr4Lq62LyuH9F5XV/9S9dpvGzAKdaX2joYzFkFnabjtOCflQEev7fqQuLi7\
-            +R/FeUPzh+vrfAQAA//9FNuwjqyYAAA==\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 26 Jan 2024 13:34:51 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: content-encoding
-            value: gzip
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1233
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-01-26T13:34:50.557Z
+      startedDateTime: 2024-01-26T14:31:04.070Z
       time: 0
       timings:
         blocked: -1
@@ -2217,7 +2068,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:36:34 GMT
+            value: Fri, 26 Jan 2024 14:31:07 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2248,7 +2099,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:36:33.980Z
+      startedDateTime: 2024-01-26T14:31:06.353Z
       time: 0
       timings:
         blocked: -1
@@ -2332,7 +2183,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -2361,7 +2212,243 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.504Z
+      startedDateTime: 2024-01-26T14:31:04.068Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: e4ae9b3ce4528acef8067a179ece8244
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 342
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "342"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 348
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: connected
+                  feature: cody.auth
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.1.3
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 112
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv\
+            8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 26 Jan 2024 14:31:04 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1233
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-26T14:31:04.296Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 6b3a541ad7e0f5d4628adb5da3a38c6d
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 350
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "350"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 348
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: executed
+                  feature: cody.chat-question
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.1.3
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 112
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv\
+            8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 26 Jan 2024 14:31:04 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1233
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-01-26T14:31:04.610Z
       time: 0
       timings:
         blocked: -1
@@ -2439,7 +2526,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:50 GMT
+            value: Fri, 26 Jan 2024 14:31:06 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2470,7 +2557,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:50.338Z
+      startedDateTime: 2024-01-26T14:31:06.083Z
       time: 0
       timings:
         blocked: -1
@@ -2494,6 +2581,9 @@ log:
             name: user-agent
             value: enterpriseClient / v1
           - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseClientabcde1234
+          - _fromType: array
             name: accept
             value: "*/*"
           - _fromType: array
@@ -2507,7 +2597,7 @@ log:
             value: close
           - name: host
             value: demo.sourcegraph.com
-        headersSize: 264
+        headersSize: 326
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -2537,7 +2627,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:32:56 GMT
+            value: Fri, 26 Jan 2024 14:31:02 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -2565,7 +2655,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-01-26T13:32:56.192Z
+      startedDateTime: 2024-01-26T14:31:02.560Z
       time: 0
       timings:
         blocked: -1
@@ -2641,7 +2731,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:49 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2672,7 +2762,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.826Z
+      startedDateTime: 2024-01-26T14:31:04.381Z
       time: 0
       timings:
         blocked: -1
@@ -2753,7 +2843,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2784,7 +2874,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:47.700Z
+      startedDateTime: 2024-01-26T14:31:03.259Z
       time: 0
       timings:
         blocked: -1
@@ -2853,7 +2943,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:03 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -2882,7 +2972,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:47.970Z
+      startedDateTime: 2024-01-26T14:31:03.482Z
       time: 0
       timings:
         blocked: -1
@@ -2953,7 +3043,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:32:56 GMT
+            value: Fri, 26 Jan 2024 14:31:02 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -2981,7 +3071,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-01-26T13:32:56.170Z
+      startedDateTime: 2024-01-26T14:31:02.537Z
       time: 0
       timings:
         blocked: -1
@@ -3059,7 +3149,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
+            value: Fri, 26 Jan 2024 14:31:04 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3090,7 +3180,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.499Z
+      startedDateTime: 2024-01-26T14:31:04.061Z
       time: 0
       timings:
         blocked: -1
@@ -3159,7 +3249,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 26 Jan 2024 13:34:47 GMT
+            value: Fri, 26 Jan 2024 14:31:03 GMT
           - name: content-type
             value: application/json
           - name: content-length
@@ -3188,116 +3278,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-01-26T13:34:47.455Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 5f31715a87b272fef48c9fcf093c2cfb
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 699
-        cookies: []
-        headers:
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: content-type
-            value: text/plain;charset=UTF-8
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "699"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.com
-        headersSize: 253
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: text/plain;charset=UTF-8
-          params: []
-          textJSON:
-            query: >-
-              
-              mutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {
-                  logEvent(
-              		event: $event
-              		userCookieID: $userCookieID
-              		url: $url
-              		source: $source
-              		argument: $argument
-              		publicArgument: $publicArgument
-              		client: $client
-              		connectedSiteID: $connectedSiteID
-              		hashedLicenseKey: $hashedLicenseKey
-                  ) {
-              		alwaysNil
-              	}
-              }
-            variables:
-              client: VSCODE_CODY_EXTENSION
-              event: CodyVSCodeExtension:Auth:connected
-              source: IDEEXTENSION
-              url: ""
-              userCookieID: ANONYMOUS_USER_COOKIE_ID
-        queryString:
-          - name: LogEventMutation
-            value: null
-        url: https://sourcegraph.com/.api/graphql?LogEventMutation
-      response:
-        bodySize: 26
-        content:
-          mimeType: application/json
-          size: 26
-          text: "{\"data\":{\"logEvent\":null}}"
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 26 Jan 2024 13:34:48 GMT
-          - name: content-type
-            value: application/json
-          - name: content-length
-            value: "26"
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1286
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-01-26T13:34:48.505Z
+      startedDateTime: 2024-01-26T14:31:03.014Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -1,0 +1,484 @@
+import assert from 'assert'
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process'
+import fspromises from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import * as vscode from 'vscode'
+import { Uri } from 'vscode'
+import { logError, type ChatMessage, type ContextFile } from '@sourcegraph/cody-shared'
+import type { ExtensionMessage, ExtensionTranscriptMessage } from '../../vscode/src/chat/protocol'
+import { AgentTextDocument } from './AgentTextDocument'
+import { MessageHandler, type NotificationMethodName } from './jsonrpc-alias'
+import type {
+    ClientInfo,
+    EditTask,
+    ExtensionConfiguration,
+    ProgressReportParams,
+    ProgressStartParams,
+    ProtocolCodeLens,
+    ServerInfo,
+    WebviewPostMessageParams,
+} from './protocol-alias'
+import { CodyTaskState } from '../../vscode/src/non-stop/utils'
+import { AgentWorkspaceDocuments } from './AgentWorkspaceDocuments'
+import { ProtocolTextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
+import { applyPatch } from 'fast-myers-diff'
+type ProgressMessage = ProgressStartMessage | ProgressReportMessage | ProgressEndMessage
+
+interface ProgressStartMessage {
+    method: 'progress/start'
+    id: string
+    message: ProgressStartParams
+}
+interface ProgressReportMessage {
+    method: 'progress/report'
+    id: string
+    message: ProgressReportParams
+}
+interface ProgressEndMessage {
+    method: 'progress/end'
+    id: string
+    message: Record<string, never>
+}
+
+export class TestClient extends MessageHandler {
+    public info: ClientInfo
+    public agentProcess?: ChildProcessWithoutNullStreams
+    // Array of all raw `progress/*` notification. Typed as `any` because
+    // start/end/report have different types.
+    public progressMessages: ProgressMessage[] = []
+    public progressIDs = new Map<string, number>()
+    public progressStartEvents = new vscode.EventEmitter<ProgressStartParams>()
+    public readonly name: string
+    public readonly serverEndpoint: string
+    public readonly accessToken?: string
+    public workspace = new AgentWorkspaceDocuments()
+
+    constructor(
+        private readonly params: {
+            readonly name: string
+            readonly accessToken?: string
+            serverEndpoint?: string
+            telemetryExporter?: 'testing' | 'graphql' // defaults to testing, which doesn't send telemetry
+            logEventMode?: 'connected-instance-only' | 'all' | 'dotcom-only'
+        }
+    ) {
+        super()
+        this.serverEndpoint = params.serverEndpoint ?? 'https://sourcegraph.com'
+
+        this.name = params.name
+        this.accessToken = params.accessToken
+        this.info = this.getClientInfo()
+
+        this.registerNotification('progress/start', message => {
+            this.progressStartEvents.fire(message)
+            message.id = this.progressID(message.id)
+            this.progressMessages.push({
+                method: 'progress/start',
+                id: message.id,
+                message,
+            })
+        })
+        this.registerNotification('progress/report', message => {
+            message.id = this.progressID(message.id)
+            this.progressMessages.push({
+                method: 'progress/report',
+                id: message.id,
+                message,
+            })
+        })
+        this.registerNotification('progress/end', ({ id }) => {
+            this.progressMessages.push({
+                method: 'progress/end',
+                id: this.progressID(id),
+                message: {},
+            })
+        })
+        this.registerNotification('codeLenses/display', async params => {
+            this.codeLenses.set(params.uri, params.codeLenses)
+        })
+        this.registerRequest('textDocument/edit', async params => {
+            const document = this.workspace.getDocument(vscode.Uri.parse(params.uri))
+            if (!document) {
+                logError('textDocument/edit: document not found', params.uri)
+                return false
+            }
+            const patches = params.edits.map<[number, number, string]>(edit => {
+                switch (edit.type) {
+                    case 'delete':
+                        return [
+                            document.offsetAt(edit.range.start),
+                            document.offsetAt(edit.range.end),
+                            '',
+                        ]
+                    case 'insert':
+                        return [
+                            document.offsetAt(edit.position),
+                            document.offsetAt(edit.position),
+                            edit.value,
+                        ]
+                    case 'replace':
+                        return [
+                            document.offsetAt(edit.range.start),
+                            document.offsetAt(edit.range.end),
+                            edit.value,
+                        ]
+                }
+            })
+            const updatedContent = [...applyPatch(document.content, patches)].join('')
+            this.workspace.addDocument(
+                ProtocolTextDocumentWithUri.from(document.uri, { content: updatedContent })
+            )
+            return true
+        })
+        this.registerNotification('debug/message', message => {
+            // Uncomment below to see `logDebug` messages.
+            // console.log(`${message.channel}: ${message.message}`)
+        })
+    }
+
+    public openFile(
+        uri: Uri,
+        params?: { selectionName?: string; removeCursor?: boolean }
+    ): Promise<void> {
+        return this.textDocumentEvent(uri, 'textDocument/didOpen', params)
+    }
+    public changeFile(
+        uri: Uri,
+        params?: { selectionName?: string; removeCursor?: boolean }
+    ): Promise<void> {
+        return this.textDocumentEvent(uri, 'textDocument/didChange', params)
+    }
+
+    public async textDocumentEvent(
+        uri: Uri,
+        method: NotificationMethodName,
+        params?: { selectionName?: string; removeCursor?: boolean }
+    ): Promise<void> {
+        const selectionName = params?.selectionName ?? 'SELECTION'
+        let content = await fspromises.readFile(uri.fsPath, 'utf8')
+        const selectionStartMarker = `/* ${selectionName}_START */`
+        const selectionStart = content.indexOf(selectionStartMarker)
+        const selectionEnd = content.indexOf(`/* ${selectionName}_END */`)
+        const cursor = content.indexOf('/* CURSOR */')
+        if (selectionStart < 0 && selectionEnd < 0 && params?.selectionName) {
+            throw new Error(`No selection found for name ${params.selectionName}`)
+        }
+        if (params?.removeCursor ?? true) {
+            content = content.replace('/* CURSOR */', '')
+        }
+
+        const document = AgentTextDocument.from(uri, content)
+        const start =
+            cursor >= 0
+                ? document.positionAt(cursor)
+                : selectionStart >= 0
+                  ? document.positionAt(selectionStart + selectionStartMarker.length)
+                  : undefined
+        const end =
+            cursor >= 0 ? start : selectionEnd >= 0 ? document.positionAt(selectionEnd) : undefined
+        const protocolDocument = {
+            uri: uri.toString(),
+            content,
+            selection: start && end ? { start, end } : undefined,
+        }
+        this.workspace.addDocument(ProtocolTextDocumentWithUri.fromDocument(protocolDocument))
+        this.notify(method, protocolDocument)
+    }
+
+    private progressID(id: string): string {
+        const fromCache = this.progressIDs.get(id)
+        if (fromCache !== undefined) {
+            return `ID_${fromCache}`
+        }
+        const freshID = this.progressIDs.size
+        this.progressIDs.set(id, freshID)
+        return `ID_${freshID}`
+    }
+
+    /**
+     * Promise that resolves when the provided task has reached the 'applied' state.
+     */
+    public taskHasReachedAppliedPhase(params: EditTask): Promise<void> {
+        switch (params.state) {
+            case CodyTaskState.applied:
+                return Promise.resolve()
+            case CodyTaskState.finished:
+            case CodyTaskState.error:
+                return Promise.reject(
+                    new Error(`Task reached terminal state before being applied ${params}`)
+                )
+        }
+
+        let disposable: vscode.Disposable
+        return new Promise<void>((resolve, reject) => {
+            disposable = this.onDidChangeTaskState(({ id, state }) => {
+                if (id === params.id) {
+                    switch (state) {
+                        case CodyTaskState.applied:
+                            return resolve()
+                        case CodyTaskState.error:
+                        case CodyTaskState.finished:
+                            return reject(
+                                new Error(
+                                    `Task reached terminal state before being applied ${{ id, state }}`
+                                )
+                            )
+                    }
+                }
+            })
+        }).finally(() => disposable.dispose())
+    }
+
+    public codeLenses = new Map<string, ProtocolCodeLens[]>()
+    public newTaskState = new vscode.EventEmitter<EditTask>()
+    public onDidChangeTaskState = this.newTaskState.event
+    public webviewMessages: WebviewPostMessageParams[] = []
+    public webviewMessagesEmitter = new vscode.EventEmitter<WebviewPostMessageParams>()
+
+    /**
+     * Returns a promise of the first `type: 'transcript'` message where
+     * `isMessageInProgress: false` and messages is non-empty. This is a helper
+     * function you may need to re-implement if you are writing a Cody client to
+     * write tests. The tricky bit is that we don't have full control over when
+     * the server starts streaming messages to the client, it may start before
+     * chat/new or commands/* requests respond with the ID of the chat session.
+     * Therefore, the only way to correctly identify the first reply in the chat session
+     * is by 1) recording all `webview/postMessage` for unknown IDs and 2)
+     * implement a similar helper that deals with both cases where the first message
+     * has already been sent and when it hasn't been sent.
+     */
+    public firstNonEmptyTranscript(id: string): Promise<ExtensionTranscriptMessage> {
+        const disposables: vscode.Disposable[] = []
+        return new Promise<ExtensionTranscriptMessage>((resolve, reject) => {
+            const onMessage = (message: WebviewPostMessageParams): void => {
+                if (message.id !== id) {
+                    return
+                }
+                if (
+                    message.message.type === 'transcript' &&
+                    message.message.messages.length > 0 &&
+                    !message.message.isMessageInProgress
+                ) {
+                    resolve(message.message)
+                } else if (message.message.type === 'errors') {
+                    reject(new Error(`expected transcript, obtained ${JSON.stringify(message.message)}`))
+                }
+            }
+
+            for (const message of this.webviewMessages) {
+                onMessage(message)
+            }
+            disposables.push(this.webviewMessagesEmitter.event(params => onMessage(params)))
+        }).finally(() => vscode.Disposable.from(...disposables).dispose())
+    }
+
+    public async initialize(additionalConfig?: Partial<ExtensionConfiguration>): Promise<ServerInfo> {
+        this.agentProcess = this.spawnAgentProcess()
+
+        this.connectProcess(this.agentProcess, error => {
+            console.error(error)
+        })
+        this.registerNotification('editTaskState/didChange', params => {
+            this.newTaskState.fire(params)
+        })
+
+        this.registerNotification('webview/postMessage', params => {
+            this.webviewMessages.push(params)
+            this.webviewMessagesEmitter.fire(params)
+        })
+
+        try {
+            const serverInfo = await this.handshake(this.info, additionalConfig)
+            assert.deepStrictEqual(serverInfo.name, 'cody-agent', 'Agent should be cody-agent')
+            return serverInfo
+        } catch (error) {
+            if (error === undefined) {
+                throw new Error('Agent failed to initialize, error is undefined')
+            }
+            if (error instanceof Error) {
+                throw error
+            }
+            throw new TypeError(`Agent failed to initialize, error is ${JSON.stringify(error)}`, {
+                cause: error,
+            })
+        }
+    }
+
+    public async setChatModel(id: string, model: string): Promise<void> {
+        await this.request('webview/receiveMessage', {
+            id,
+            message: { command: 'chatModel', model },
+        })
+    }
+
+    public async reset(id: string): Promise<void> {
+        await this.request('webview/receiveMessage', {
+            id,
+            message: { command: 'reset' },
+        })
+    }
+
+    public async editMessage(
+        id: string,
+        text: string,
+        params?: { addEnhancedContext?: boolean; contextFiles?: ContextFile[]; index?: number }
+    ): Promise<ChatMessage | undefined> {
+        const reply = asTranscriptMessage(
+            await this.request('chat/editMessage', {
+                id,
+                message: {
+                    command: 'edit',
+                    text,
+                    index: params?.index,
+                    contextFiles: params?.contextFiles ?? [],
+                    addEnhancedContext: params?.addEnhancedContext ?? false,
+                },
+            })
+        )
+        return reply.messages.at(-1)
+    }
+
+    public async sendMessage(
+        id: string,
+        text: string,
+        params?: { addEnhancedContext?: boolean; contextFiles?: ContextFile[] }
+    ): Promise<ChatMessage | undefined> {
+        return (await this.sendSingleMessageToNewChatWithFullTranscript(text, { ...params, id }))
+            ?.lastMessage
+    }
+
+    public async sendSingleMessageToNewChat(
+        text: string,
+        params?: { addEnhancedContext?: boolean; contextFiles?: ContextFile[] }
+    ): Promise<ChatMessage | undefined> {
+        return (await this.sendSingleMessageToNewChatWithFullTranscript(text, params))?.lastMessage
+    }
+
+    public async sendSingleMessageToNewChatWithFullTranscript(
+        text: string,
+        params?: { addEnhancedContext?: boolean; contextFiles?: ContextFile[]; id?: string }
+    ): Promise<{ lastMessage?: ChatMessage; panelID: string; transcript: ExtensionTranscriptMessage }> {
+        const id = params?.id ?? (await this.request('chat/new', null))
+        const reply = asTranscriptMessage(
+            await this.request('chat/submitMessage', {
+                id,
+                message: {
+                    command: 'submit',
+                    text,
+                    submitType: 'user',
+                    addEnhancedContext: params?.addEnhancedContext ?? false,
+                    contextFiles: params?.contextFiles,
+                },
+            })
+        )
+        return { panelID: id, transcript: reply, lastMessage: reply.messages.at(-1) }
+    }
+
+    public async shutdownAndExit() {
+        if (this.isAlive()) {
+            await this.request('shutdown', null)
+            this.notify('exit', null)
+        } else {
+            console.log('Agent has already exited')
+        }
+    }
+
+    public getAgentDir(): string {
+        const cwd = process.cwd()
+        return path.basename(cwd) === 'agent' ? cwd : path.join(cwd, 'agent')
+    }
+
+    private async handshake(
+        clientInfo: ClientInfo,
+        additionalConfig?: Partial<ExtensionConfiguration>
+    ): Promise<ServerInfo> {
+        return new Promise((resolve, reject) => {
+            setTimeout(
+                () =>
+                    reject(
+                        new Error(
+                            "Agent didn't initialize within 10 seconds, something is most likely wrong." +
+                                " If you think it's normal for the agent to use more than 10 seconds to initialize," +
+                                ' increase this timeout.'
+                        )
+                    ),
+                10000
+            )
+            this.request('initialize', {
+                ...clientInfo,
+                extensionConfiguration: {
+                    serverEndpoint: 'https://invalid',
+                    accessToken: 'invalid',
+                    customHeaders: {},
+                    ...clientInfo.extensionConfiguration,
+                    ...additionalConfig,
+                },
+            }).then(
+                info => {
+                    this.notify('initialized', null)
+                    resolve(info)
+                },
+                error => reject(error)
+            )
+        })
+    }
+
+    private spawnAgentProcess() {
+        const agentDir = this.getAgentDir()
+        const recordingDirectory = path.join(agentDir, 'recordings')
+        const agentScript = path.join(agentDir, 'dist', 'index.js')
+
+        return spawn('node', ['--enable-source-maps', agentScript, 'jsonrpc'], {
+            stdio: 'pipe',
+            cwd: agentDir,
+            env: {
+                CODY_SHIM_TESTING: 'true',
+                CODY_TEMPERATURE_ZERO: 'true',
+                CODY_RECORDING_MODE: 'replay', // can be overwritten with process.env.CODY_RECORDING_MODE
+                CODY_RECORDING_DIRECTORY: recordingDirectory,
+                CODY_RECORDING_NAME: this.name,
+                SRC_ACCESS_TOKEN: this.accessToken,
+                CODY_TELEMETRY_EXPORTER: this.params.telemetryExporter ?? 'testing',
+                CODY_LOG_EVENT_MODE: this.params.logEventMode,
+                ...process.env,
+            },
+        })
+    }
+
+    private getClientInfo(): ClientInfo {
+        const workspaceRootUri = Uri.file(path.join(os.tmpdir(), 'cody-vscode-shim-test'))
+
+        return {
+            name: this.name,
+            version: 'v1',
+            workspaceRootUri: workspaceRootUri.toString(),
+            workspaceRootPath: workspaceRootUri.fsPath,
+            capabilities: {
+                progressBars: 'enabled',
+                edit: 'enabled',
+                codeLenses: 'enabled',
+            },
+            extensionConfiguration: {
+                anonymousUserID: `${this.name}abcde1234`,
+                accessToken: this.accessToken ?? 'sgp_RRRRRRRREEEEEEEDDDDDDAAACCCCCTEEEEEEEDDD',
+                serverEndpoint: this.serverEndpoint,
+                customHeaders: {},
+                autocompleteAdvancedProvider: 'anthropic',
+                customConfiguration: {
+                    'cody.autocomplete.experimental.graphContext': null,
+                },
+                debug: false,
+                verboseDebug: false,
+                codebase: 'github.com/sourcegraph/cody',
+            },
+        }
+    }
+}
+
+export function asTranscriptMessage(reply: ExtensionMessage): ExtensionTranscriptMessage {
+    if (reply.type === 'transcript') {
+        return reply
+    }
+    throw new Error(`expected transcript, got: ${JSON.stringify(reply)}`)
+}

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -1,478 +1,19 @@
 import assert from 'assert'
-import { execSync, spawn, type ChildProcessWithoutNullStreams } from 'child_process'
+import { execSync } from 'child_process'
 import fspromises from 'fs/promises'
 import os from 'os'
 import path from 'path'
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
-import * as vscode from 'vscode'
 import { Uri } from 'vscode'
 
-import { logError, type ChatMessage, type ContextFile, isWindows } from '@sourcegraph/cody-shared'
+import { isWindows } from '@sourcegraph/cody-shared'
 
-import type { ExtensionMessage, ExtensionTranscriptMessage } from '../../vscode/src/chat/protocol'
+import type { ExtensionTranscriptMessage } from '../../vscode/src/chat/protocol'
 
-import { AgentTextDocument } from './AgentTextDocument'
-import { MessageHandler, type NotificationMethodName } from './jsonrpc-alias'
-import type {
-    ClientInfo,
-    EditTask,
-    ExtensionConfiguration,
-    ProgressReportParams,
-    ProgressStartParams,
-    ProtocolCodeLens,
-    ServerInfo,
-    WebviewPostMessageParams,
-} from './protocol-alias'
 import { URI } from 'vscode-uri'
-import { CodyTaskState } from '../../vscode/src/non-stop/utils'
-import { AgentWorkspaceDocuments } from './AgentWorkspaceDocuments'
-import { ProtocolTextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
-import { applyPatch } from 'fast-myers-diff'
 import { isNode16 } from './isNode16'
-
-type ProgressMessage = ProgressStartMessage | ProgressReportMessage | ProgressEndMessage
-interface ProgressStartMessage {
-    method: 'progress/start'
-    id: string
-    message: ProgressStartParams
-}
-interface ProgressReportMessage {
-    method: 'progress/report'
-    id: string
-    message: ProgressReportParams
-}
-interface ProgressEndMessage {
-    method: 'progress/end'
-    id: string
-    message: Record<string, never>
-}
-
-export class TestClient extends MessageHandler {
-    public info: ClientInfo
-    public agentProcess?: ChildProcessWithoutNullStreams
-    // Array of all raw `progress/*` notification. Typed as `any` because
-    // start/end/report have different types.
-    public progressMessages: ProgressMessage[] = []
-    public progressIDs = new Map<string, number>()
-    public progressStartEvents = new vscode.EventEmitter<ProgressStartParams>()
-    public readonly serverEndpoint: string
-    public workspace = new AgentWorkspaceDocuments()
-
-    constructor(
-        public readonly name: string,
-        public readonly accessToken?: string,
-        serverEndpoint?: string
-    ) {
-        super()
-        this.serverEndpoint = serverEndpoint ?? 'https://sourcegraph.com'
-
-        this.name = name
-        this.info = this.getClientInfo()
-
-        this.registerNotification('progress/start', message => {
-            this.progressStartEvents.fire(message)
-            message.id = this.progressID(message.id)
-            this.progressMessages.push({
-                method: 'progress/start',
-                id: message.id,
-                message,
-            })
-        })
-        this.registerNotification('progress/report', message => {
-            message.id = this.progressID(message.id)
-            this.progressMessages.push({
-                method: 'progress/report',
-                id: message.id,
-                message,
-            })
-        })
-        this.registerNotification('progress/end', ({ id }) => {
-            this.progressMessages.push({
-                method: 'progress/end',
-                id: this.progressID(id),
-                message: {},
-            })
-        })
-        this.registerNotification('codeLenses/display', async params => {
-            this.codeLenses.set(params.uri, params.codeLenses)
-        })
-        this.registerRequest('textDocument/edit', async params => {
-            const document = this.workspace.getDocument(vscode.Uri.parse(params.uri))
-            if (!document) {
-                logError('textDocument/edit: document not found', params.uri)
-                return false
-            }
-            const patches = params.edits.map<[number, number, string]>(edit => {
-                switch (edit.type) {
-                    case 'delete':
-                        return [
-                            document.offsetAt(edit.range.start),
-                            document.offsetAt(edit.range.end),
-                            '',
-                        ]
-                    case 'insert':
-                        return [
-                            document.offsetAt(edit.position),
-                            document.offsetAt(edit.position),
-                            edit.value,
-                        ]
-                    case 'replace':
-                        return [
-                            document.offsetAt(edit.range.start),
-                            document.offsetAt(edit.range.end),
-                            edit.value,
-                        ]
-                }
-            })
-            const updatedContent = [...applyPatch(document.content, patches)].join('')
-            this.workspace.addDocument(
-                ProtocolTextDocumentWithUri.from(document.uri, { content: updatedContent })
-            )
-            return true
-        })
-        this.registerNotification('debug/message', message => {
-            // Uncomment below to see `logDebug` messages.
-            // console.log(`${message.channel}: ${message.message}`)
-        })
-    }
-
-    public openFile(
-        uri: Uri,
-        params?: { selectionName?: string; removeCursor?: boolean }
-    ): Promise<void> {
-        return this.textDocumentEvent(uri, 'textDocument/didOpen', params)
-    }
-    public changeFile(
-        uri: Uri,
-        params?: { selectionName?: string; removeCursor?: boolean }
-    ): Promise<void> {
-        return this.textDocumentEvent(uri, 'textDocument/didChange', params)
-    }
-
-    public async textDocumentEvent(
-        uri: Uri,
-        method: NotificationMethodName,
-        params?: { selectionName?: string; removeCursor?: boolean }
-    ): Promise<void> {
-        const selectionName = params?.selectionName ?? 'SELECTION'
-        let content = await fspromises.readFile(uri.fsPath, 'utf8')
-        const selectionStartMarker = `/* ${selectionName}_START */`
-        const selectionStart = content.indexOf(selectionStartMarker)
-        const selectionEnd = content.indexOf(`/* ${selectionName}_END */`)
-        const cursor = content.indexOf('/* CURSOR */')
-        if (selectionStart < 0 && selectionEnd < 0 && params?.selectionName) {
-            throw new Error(`No selection found for name ${params.selectionName}`)
-        }
-        if (params?.removeCursor ?? true) {
-            content = content.replace('/* CURSOR */', '')
-        }
-
-        const document = AgentTextDocument.from(uri, content)
-        const start =
-            cursor >= 0
-                ? document.positionAt(cursor)
-                : selectionStart >= 0
-                  ? document.positionAt(selectionStart + selectionStartMarker.length)
-                  : undefined
-        const end =
-            cursor >= 0 ? start : selectionEnd >= 0 ? document.positionAt(selectionEnd) : undefined
-        const protocolDocument = {
-            uri: uri.toString(),
-            content,
-            selection: start && end ? { start, end } : undefined,
-        }
-        this.workspace.addDocument(ProtocolTextDocumentWithUri.fromDocument(protocolDocument))
-        this.notify(method, protocolDocument)
-    }
-
-    private progressID(id: string): string {
-        const fromCache = this.progressIDs.get(id)
-        if (fromCache !== undefined) {
-            return `ID_${fromCache}`
-        }
-        const freshID = this.progressIDs.size
-        this.progressIDs.set(id, freshID)
-        return `ID_${freshID}`
-    }
-
-    /**
-     * Promise that resolves when the provided task has reached the 'applied' state.
-     */
-    public taskHasReachedAppliedPhase(params: EditTask): Promise<void> {
-        switch (params.state) {
-            case CodyTaskState.applied:
-                return Promise.resolve()
-            case CodyTaskState.finished:
-            case CodyTaskState.error:
-                return Promise.reject(
-                    new Error(`Task reached terminal state before being applied ${params}`)
-                )
-        }
-
-        let disposable: vscode.Disposable
-        return new Promise<void>((resolve, reject) => {
-            disposable = this.onDidChangeTaskState(({ id, state }) => {
-                if (id === params.id) {
-                    switch (state) {
-                        case CodyTaskState.applied:
-                            return resolve()
-                        case CodyTaskState.error:
-                        case CodyTaskState.finished:
-                            return reject(
-                                new Error(
-                                    `Task reached terminal state before being applied ${{ id, state }}`
-                                )
-                            )
-                    }
-                }
-            })
-        }).finally(() => disposable.dispose())
-    }
-
-    public codeLenses = new Map<string, ProtocolCodeLens[]>()
-    public newTaskState = new vscode.EventEmitter<EditTask>()
-    public onDidChangeTaskState = this.newTaskState.event
-    public webviewMessages: WebviewPostMessageParams[] = []
-    public webviewMessagesEmitter = new vscode.EventEmitter<WebviewPostMessageParams>()
-
-    /**
-     * Returns a promise of the first `type: 'transcript'` message where
-     * `isMessageInProgress: false` and messages is non-empty. This is a helper
-     * function you may need to re-implement if you are writing a Cody client to
-     * write tests. The tricky bit is that we don't have full control over when
-     * the server starts streaming messages to the client, it may start before
-     * chat/new or commands/* requests respond with the ID of the chat session.
-     * Therefore, the only way to correctly identify the first reply in the chat session
-     * is by 1) recording all `webview/postMessage` for unknown IDs and 2)
-     * implement a similar helper that deals with both cases where the first message
-     * has already been sent and when it hasn't been sent.
-     */
-    public firstNonEmptyTranscript(id: string): Promise<ExtensionTranscriptMessage> {
-        const disposables: vscode.Disposable[] = []
-        return new Promise<ExtensionTranscriptMessage>((resolve, reject) => {
-            const onMessage = (message: WebviewPostMessageParams): void => {
-                if (message.id !== id) {
-                    return
-                }
-                if (
-                    message.message.type === 'transcript' &&
-                    message.message.messages.length > 0 &&
-                    !message.message.isMessageInProgress
-                ) {
-                    resolve(message.message)
-                } else if (message.message.type === 'errors') {
-                    reject(new Error(`expected transcript, obtained ${JSON.stringify(message.message)}`))
-                }
-            }
-
-            for (const message of this.webviewMessages) {
-                onMessage(message)
-            }
-            disposables.push(this.webviewMessagesEmitter.event(params => onMessage(params)))
-        }).finally(() => vscode.Disposable.from(...disposables).dispose())
-    }
-
-    public async initialize(additionalConfig?: Partial<ExtensionConfiguration>): Promise<ServerInfo> {
-        this.agentProcess = this.spawnAgentProcess()
-
-        this.connectProcess(this.agentProcess, error => {
-            console.error(error)
-        })
-        this.registerNotification('editTaskState/didChange', params => {
-            this.newTaskState.fire(params)
-        })
-
-        this.registerNotification('webview/postMessage', params => {
-            this.webviewMessages.push(params)
-            this.webviewMessagesEmitter.fire(params)
-        })
-
-        try {
-            const serverInfo = await this.handshake(this.info, additionalConfig)
-            assert.deepStrictEqual(serverInfo.name, 'cody-agent', 'Agent should be cody-agent')
-            return serverInfo
-        } catch (error) {
-            if (error === undefined) {
-                throw new Error('Agent failed to initialize, error is undefined')
-            }
-            if (error instanceof Error) {
-                throw error
-            }
-            throw new TypeError(`Agent failed to initialize, error is ${JSON.stringify(error)}`, {
-                cause: error,
-            })
-        }
-    }
-
-    public async setChatModel(id: string, model: string): Promise<void> {
-        await this.request('webview/receiveMessage', {
-            id,
-            message: { command: 'chatModel', model },
-        })
-    }
-
-    public async reset(id: string): Promise<void> {
-        await this.request('webview/receiveMessage', {
-            id,
-            message: { command: 'reset' },
-        })
-    }
-
-    public async editMessage(
-        id: string,
-        text: string,
-        params?: { addEnhancedContext?: boolean; contextFiles?: ContextFile[]; index?: number }
-    ): Promise<ChatMessage | undefined> {
-        const reply = asTranscriptMessage(
-            await this.request('chat/editMessage', {
-                id,
-                message: {
-                    command: 'edit',
-                    text,
-                    index: params?.index,
-                    contextFiles: params?.contextFiles ?? [],
-                    addEnhancedContext: params?.addEnhancedContext ?? false,
-                },
-            })
-        )
-        return reply.messages.at(-1)
-    }
-
-    public async sendMessage(
-        id: string,
-        text: string,
-        params?: { addEnhancedContext?: boolean; contextFiles?: ContextFile[] }
-    ): Promise<ChatMessage | undefined> {
-        return (await this.sendSingleMessageToNewChatWithFullTranscript(text, { ...params, id }))
-            ?.lastMessage
-    }
-
-    public async sendSingleMessageToNewChat(
-        text: string,
-        params?: { addEnhancedContext?: boolean; contextFiles?: ContextFile[] }
-    ): Promise<ChatMessage | undefined> {
-        return (await this.sendSingleMessageToNewChatWithFullTranscript(text, params))?.lastMessage
-    }
-
-    public async sendSingleMessageToNewChatWithFullTranscript(
-        text: string,
-        params?: { addEnhancedContext?: boolean; contextFiles?: ContextFile[]; id?: string }
-    ): Promise<{ lastMessage?: ChatMessage; panelID: string; transcript: ExtensionTranscriptMessage }> {
-        const id = params?.id ?? (await this.request('chat/new', null))
-        const reply = asTranscriptMessage(
-            await this.request('chat/submitMessage', {
-                id,
-                message: {
-                    command: 'submit',
-                    text,
-                    submitType: 'user',
-                    addEnhancedContext: params?.addEnhancedContext ?? false,
-                    contextFiles: params?.contextFiles,
-                },
-            })
-        )
-        return { panelID: id, transcript: reply, lastMessage: reply.messages.at(-1) }
-    }
-
-    public async shutdownAndExit() {
-        if (this.isAlive()) {
-            await this.request('shutdown', null)
-            this.notify('exit', null)
-        } else {
-            console.log('Agent has already exited')
-        }
-    }
-
-    public getAgentDir(): string {
-        const cwd = process.cwd()
-        return path.basename(cwd) === 'agent' ? cwd : path.join(cwd, 'agent')
-    }
-
-    private async handshake(
-        clientInfo: ClientInfo,
-        additionalConfig?: Partial<ExtensionConfiguration>
-    ): Promise<ServerInfo> {
-        return new Promise((resolve, reject) => {
-            setTimeout(
-                () =>
-                    reject(
-                        new Error(
-                            "Agent didn't initialize within 10 seconds, something is most likely wrong." +
-                                " If you think it's normal for the agent to use more than 10 seconds to initialize," +
-                                ' increase this timeout.'
-                        )
-                    ),
-                10_000
-            )
-            this.request('initialize', {
-                ...clientInfo,
-                extensionConfiguration: {
-                    serverEndpoint: 'https://invalid',
-                    accessToken: 'invalid',
-                    customHeaders: {},
-                    ...clientInfo.extensionConfiguration,
-                    ...additionalConfig,
-                },
-            }).then(
-                info => {
-                    this.notify('initialized', null)
-                    resolve(info)
-                },
-                error => reject(error)
-            )
-        })
-    }
-
-    private spawnAgentProcess() {
-        const agentDir = this.getAgentDir()
-        const recordingDirectory = path.join(agentDir, 'recordings')
-        const agentScript = path.join(agentDir, 'dist', 'index.js')
-
-        return spawn('node', ['--enable-source-maps', agentScript, 'jsonrpc'], {
-            stdio: 'pipe',
-            cwd: agentDir,
-            env: {
-                CODY_SHIM_TESTING: 'true',
-                CODY_TEMPERATURE_ZERO: 'true',
-                CODY_RECORDING_MODE: 'replay', // can be overwritten with process.env.CODY_RECORDING_MODE
-                CODY_RECORDING_DIRECTORY: recordingDirectory,
-                CODY_RECORDING_NAME: this.name,
-                SRC_ACCESS_TOKEN: this.accessToken,
-                ...process.env,
-            },
-        })
-    }
-
-    private getClientInfo(): ClientInfo {
-        const workspaceRootUri = Uri.file(path.join(os.tmpdir(), 'cody-vscode-shim-test'))
-
-        return {
-            name: this.name,
-            version: 'v1',
-            workspaceRootUri: workspaceRootUri.toString(),
-            workspaceRootPath: workspaceRootUri.fsPath,
-            capabilities: {
-                progressBars: 'enabled',
-                edit: 'enabled',
-                codeLenses: 'enabled',
-            },
-            extensionConfiguration: {
-                anonymousUserID: `${this.name}abcde1234`,
-                accessToken: this.accessToken ?? 'sgp_RRRRRRRREEEEEEEDDDDDDAAACCCCCTEEEEEEEDDD',
-                serverEndpoint: this.serverEndpoint,
-                customHeaders: {},
-                autocompleteAdvancedProvider: 'anthropic',
-                customConfiguration: {
-                    'cody.autocomplete.experimental.graphContext': null,
-                },
-                debug: false,
-                verboseDebug: false,
-                codebase: 'github.com/sourcegraph/cody',
-            },
-        }
-    }
-}
+import { TestClient, asTranscriptMessage } from './TestClient'
 
 const explainPollyError = `
 
@@ -517,15 +58,16 @@ describe('Agent', () => {
         return
     }
 
-    const client = new TestClient(
-        'defaultClient',
+    const client = new TestClient({
+        name: 'defaultClient',
         // The redacted ID below is copy-pasted from the recording file and
         // needs to be updated whenever we change the underlying access token.
         // We can't return a random string here because then Polly won't be able
         // to associate the HTTP requests between record mode and replay mode.
-        process.env.SRC_ACCESS_TOKEN ??
-            'REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3'
-    )
+        accessToken:
+            process.env.SRC_ACCESS_TOKEN ??
+            'REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3',
+    })
 
     // Bundle the agent. When running `pnpm run test`, vitest doesn't re-run this step.
     //
@@ -1303,12 +845,13 @@ describe('Agent', () => {
     })
 
     describe('RateLimitedAgent', () => {
-        const rateLimitedClient = new TestClient(
-            'rateLimitedClient',
-            process.env.SRC_ACCESS_TOKEN_WITH_RATE_LIMIT ??
+        const rateLimitedClient = new TestClient({
+            name: 'rateLimitedClient',
+            accessToken:
+                process.env.SRC_ACCESS_TOKEN_WITH_RATE_LIMIT ??
                 // See comment above `const client =` about how this value is derived.
-                'REDACTED_8c77b24d9f3d0e679509263c553887f2887d67d33c4e3544039c1889484644f5'
-        )
+                'REDACTED_8c77b24d9f3d0e679509263c553887f2887d67d33c4e3544039c1889484644f5',
+        })
         // Initialize inside beforeAll so that subsequent tests are skipped if initialization fails.
         beforeAll(async () => {
             const serverInfo = await rateLimitedClient.initialize()
@@ -1331,13 +874,16 @@ describe('Agent', () => {
     })
 
     describe('Enterprise', () => {
-        const enterpriseClient = new TestClient(
-            'enterpriseClient',
-            process.env.SRC_ENTERPRISE_ACCESS_TOKEN ??
+        const enterpriseClient = new TestClient({
+            name: 'enterpriseClient',
+            accessToken:
+                process.env.SRC_ENTERPRISE_ACCESS_TOKEN ??
                 // See comment above `const client =` about how this value is derived.
                 'REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69',
-            'https://demo.sourcegraph.com'
-        )
+            serverEndpoint: 'https://demo.sourcegraph.com',
+            telemetryExporter: 'graphql',
+            logEventMode: 'connected-instance-only',
+        })
         // Initialize inside beforeAll so that subsequent tests are skipped if initialization fails.
         beforeAll(async () => {
             const serverInfo = await enterpriseClient.initialize()
@@ -1399,6 +945,11 @@ describe('Agent', () => {
         )
 
         afterAll(async () => {
+            const { requests } = await enterpriseClient.request('testing/networkRequests', null)
+            const nonServerInstanceRequests = requests
+                .filter(({ url }) => !url.startsWith(enterpriseClient.serverEndpoint))
+                .map(({ url }) => url)
+            expect(JSON.stringify(nonServerInstanceRequests)).toStrictEqual('[]')
             await enterpriseClient.shutdownAndExit()
             // Long timeout because to allow Polly.js to persist HTTP recordings
         }, 30_000)
@@ -1422,11 +973,4 @@ function trimEndOfLine(text: string | undefined): string {
         .split('\n')
         .map(line => line.trimEnd())
         .join('\n')
-}
-
-function asTranscriptMessage(reply: ExtensionMessage): ExtensionTranscriptMessage {
-    if (reply.type === 'transcript') {
-        return reply
-    }
-    throw new Error(`expected transcript, got: ${JSON.stringify(reply)}`)
 }

--- a/agent/src/telemetry/index.ts
+++ b/agent/src/telemetry/index.ts
@@ -29,7 +29,7 @@ export class AgentHandlerTelemetryRecorderProvider extends TelemetryRecorderProv
                 client: clientInfo.name,
                 clientVersion: clientInfo.version,
             },
-            process.env.CODY_SHIM_TESTING === 'true'
+            process.env.CODY_TELEMETRY_EXPORTER === 'testing'
                 ? new TestTelemetryExporter()
                 : new GraphQLTelemetryExporter(
                       graphqlClient,

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -5,7 +5,7 @@ import { URI } from 'vscode-uri'
 import type { TelemetryEventInput } from '@sourcegraph/telemetry'
 
 import type { ConfigurationWithAccessToken } from '../../configuration'
-import { logError } from '../../logger'
+import { logDebug, logError } from '../../logger'
 import { addTraceparent, wrapInActiveSpan } from '../../tracing'
 import { isError } from '../../utils'
 import { DOTCOM_URL, isDotCom } from '../environments'
@@ -559,6 +559,26 @@ export class SourcegraphGraphQLAPIClient {
          */
         if (this.isDotCom()) {
             return this.sendEventLogRequestToAPI(event)
+        }
+
+        switch (process.env.CODY_LOG_EVENT_MODE) {
+            case 'connected-instance-only':
+                mode = 'connected-instance-only'
+                break
+            case 'dotcom-only':
+                mode = 'dotcom-only'
+                break
+            case 'all':
+                mode = 'all'
+                break
+            default:
+                if (process.env.CODY_LOG_EVENT_MODE) {
+                    logDebug(
+                        'SourcegraphGraphQLAPIClient.logEvent',
+                        'unknown mode',
+                        process.env.CODY_LOG_EVENT_MODE
+                    )
+                }
         }
 
         switch (mode) {

--- a/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.ts
+++ b/lib/shared/src/sourcegraph-api/telemetry/GraphQLTelemetryExporter.ts
@@ -98,6 +98,7 @@ export class GraphQLTelemetryExporter implements TelemetryExporter {
          * if setLegacyEventsStateOnce determines we need to do so.
          */
         if (this.exportMode === 'legacy') {
+            console.log({ legacyBackcompatLogEventMode: this.legacyBackcompatLogEventMode })
             const resultOrError = await Promise.all(
                 events.map(event =>
                     this.client.logEvent(

--- a/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
+++ b/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
@@ -52,7 +52,7 @@ export class TelemetryRecorderProvider extends BaseTelemetryRecorderProvider<
                 }`,
                 clientVersion: extensionDetails.version,
             },
-            process.env.CODY_SHIM_TESTING === 'true'
+            process.env.CODY_TELEMETRY_EXPORTER === 'testing'
                 ? new TestTelemetryExporter()
                 : new GraphQLTelemetryExporter(client, anonymousUserID, legacyBackcompatLogEventMode),
             [

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -110,6 +110,7 @@ export type Requests = {
     // for dealing with progress bars then you can send a request to this
     // endpoint to emulate the scenario where the server creates a progress bar.
     'testing/progress': [{ title: string }, { result: string }]
+    'testing/networkRequests': [null, { requests: NetworkRequest[] }]
 
     // Only used for testing purposes. This operation runs indefinitely unless
     // the client sends progress/cancel.
@@ -505,4 +506,8 @@ export interface ProtocolCommand {
     command: string
     tooltip?: string
     arguments?: any[]
+}
+
+export interface NetworkRequest {
+    url: string
 }


### PR DESCRIPTION
Previously, the agent sent log events to sourcegraph.com for enterprise accounts even if any of the following things were true:

- `cody.serverEndpoint` was set to the enterprise URL.
- `cody.telemetry.level` was set to `off`. This setting is, in fact, entirely ignored by the agent.

The root problem was that the v1 event logger was still logging one event to sourcegraph.com without any option to route this request only to the connected instance. This was problematic because some enterprise instances are airgapped and this request ended up timing out.

This PR fixes the problem by adding support to exclusively send logging events to the connected instance. This behavior can only be enabled by setting the environment variable `CODY_LOG_EVENT_MODE` to the value `'connected-instance-only'`. Previously, it defaulted to the value `'dotcom-only'` or `'all'` without any workaround. We are using an environment variable because that is enough to unblock JetBrains. It probably makes sense to add a similar setting for the VSC extension.


Paired with @chwarwick on this PR
## Test plan

See updated enterprise test case that adds an assertion that we don't send any requests to other URLs than the connected instance.

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
