### PR TITLE
update: remove codebase item from custom command menu

### DIFF
--- a/vscode/src/commands/menus/items/index.ts
+++ b/vscode/src/commands/menus/items/index.ts
@@ -71,12 +71,6 @@ export const customPromptsContextOptions: ContextOption[] = [
         picked: true,
     },
     {
-        id: 'codebase',
-        label: 'Codebase',
-        detail: 'Code snippets retrieved from the available source for codebase context (embeddings or local keyword search).',
-        picked: false,
-    },
-    {
         id: 'currentDir',
         label: 'Current Directory',
         detail: 'First 10 text files in the current directory. If the prompt includes the words "test" or "tests", only test files will be included.',


### PR DESCRIPTION
We have removed codebase context as a context option from `Custom Command`, but it is still showing up as an option in the `New Custom Command` menu.

This PR removes it from the option list.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Check if the codebase option still shows up in New Custom Command menu.

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/86478691-16ef-460e-85c7-f1d5a775b191)


### After

![image](https://github.com/sourcegraph/cody/assets/68532117/e34b9755-c00d-4536-a576-95cd4b14a98d)
