### PR TITLE
fix: update chat input placeholder

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-Update Chat input tips as commands are no longer executable from chat.
+Update Chat input tips as commands are no longer executable from chat. [pull/2934](https://github.com/sourcegraph/cody/pull/2934)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+Update Chat input tips as commands are no longer executable from chat.
+
 ### Changed
 
 ## [1.2.0]
@@ -15,7 +17,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Chat: Add a history quick in the editor panel for chats grouped by last interaction timestamp. [pull/2250](https://github.com/sourcegraph/cody/pull/2250)
-- Commands: Custom edit commands are now executable from the Chat panel. [pull/2789](https://github.com/sourcegraph/cody/pull/2789)
 - Added support for the new `fireworks/starcoder` virtual model name when used in combination with an Enterprise instance. [pull/2714](https://github.com/sourcegraph/cody/pull/2714)
 - Chat: Added support for editing any non-command chat messages. [pull/2826](https://github.com/sourcegraph/cody/pull/2826)
 - Chat: New action buttons added above the chat input area for easy keyboard access. [pull/2826](https://github.com/sourcegraph/cody/pull/2826)
@@ -50,6 +51,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Cleaned up chat editor title buttons & history separators. [pull/2895](https://github.com/sourcegraph/cody/pull/2895)
 - Context: Embeddings search by sourcegraph.com have been removed. For the moment, remote embeddings may still affect results for Sourcegraph Enterprise users through the new multi-repo search feature described above. Local embeddings are not affected by this change. [pull/2879](https://github.com/sourcegraph/cody/pull/2879)
 - [Internal] New generate unit test available behind `cody.internal.unstable`. [pull/2646](https://github.com/sourcegraph/cody/pull/2646)
+- Commands: Slash commands are no longer supported in chat panel. [pull/2869](https://github.com/sourcegraph/cody/pull/2869)
+- Commands: The underlying prompt for the default chat commands will be displayed in the chat panel. [pull/2869](https://github.com/sourcegraph/cody/pull/2869)
 
 ## [1.1.3]
 

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -6,6 +6,7 @@ import type { CodyCommandArgs } from './types'
 import { CommandRunner } from './services/runner'
 import type { CommandsProvider } from './services/provider'
 import type { CommandResult } from '../main'
+import { executeDefaultCommand, isDefaultChatCommand, isDefaultEditCommand } from './default'
 
 /**
  * Handles commands execution with commands from CommandsProvider
@@ -34,6 +35,12 @@ class CommandsController implements vscode.Disposable {
         // The unique key for the command. e.g. /test
         const commandKey = commandSplit.shift() || text
         const command = this.provider?.get(commandKey)
+
+        // Process default commands
+        if (isDefaultChatCommand(commandKey) || isDefaultEditCommand(commandKey)) {
+            return executeDefaultCommand(commandKey)
+        }
+
         if (!command) {
             logDebug('CommandsController:execute', 'command not found', { verbose: { commandKey } })
             return undefined

--- a/vscode/src/commands/default/index.ts
+++ b/vscode/src/commands/default/index.ts
@@ -8,8 +8,15 @@ import { executeExplainCommand } from './explain'
 import { executeTestCommand } from './test'
 import { executeDocCommand } from './doc'
 import type { CommandResult } from '../../main'
+import { executeUnitTestCommand } from './unit'
 
 export { commands as defaultCommands } from './cody.json'
+
+export { executeSmellCommand } from './smell'
+export { executeExplainCommand } from './explain'
+export { executeTestCommand } from './test'
+export { executeDocCommand } from './doc'
+export { executeUnitTestCommand } from './unit'
 
 export function isDefaultChatCommand(id: string): DefaultChatCommands | undefined {
     // Remove leading slash if any
@@ -37,7 +44,8 @@ export function isDefaultEditCommand(id: string): DefaultEditCommands | undefine
 export async function executeDefaultCommand(
     id: DefaultCodyCommands | string
 ): Promise<CommandResult | undefined> {
-    switch (id) {
+    const key = id.replace(/^\//, '').trim() as DefaultCodyCommands
+    switch (key) {
         case DefaultChatCommands.Explain:
             return executeExplainCommand()
         case DefaultChatCommands.Smell:
@@ -45,7 +53,7 @@ export async function executeDefaultCommand(
         case DefaultChatCommands.Test:
             return executeTestCommand()
         case DefaultEditCommands.Unit:
-            return executeTestCommand()
+            return executeUnitTestCommand()
         case DefaultEditCommands.Doc:
             return executeDocCommand()
         default:

--- a/vscode/src/commands/default/unit.ts
+++ b/vscode/src/commands/default/unit.ts
@@ -15,7 +15,7 @@ import { getContextFilesForUnitTestCommand } from '../context/unit-test-command'
  *
  * Context: Test files, current selection, and current file
  */
-export async function executeNewTestCommand(
+export async function executeUnitTestCommand(
     args?: Partial<CodyCommandArgs>
 ): Promise<EditCommandResult | undefined> {
     const prompt = defaultCommands.unit.prompt

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -48,16 +48,18 @@ import { createOrUpdateEventLogger, telemetryService } from './services/telemetr
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
 import { onTextDocumentChange } from './services/utils/codeblock-action-tracker'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
-import { executeNewTestCommand } from './commands/default/unit'
 import { executeCodyCommand, setCommandController } from './commands/CommandsController'
 import { newCodyCommandArgs } from './commands/utils/get-commands'
 import type { DefaultCodyCommands } from '@sourcegraph/cody-shared/src/commands/types'
 import type { FixupTask } from './non-stop/FixupTask'
-import { executeExplainCommand } from './commands/default/explain'
-import { executeTestCommand } from './commands/default/test'
-import { executeSmellCommand } from './commands/default/smell'
-import { executeDocCommand } from './commands/default/doc'
 import { EnterpriseContextFactory } from './context/enterprise-context-factory'
+import {
+    executeExplainCommand,
+    executeTestCommand,
+    executeSmellCommand,
+    executeDocCommand,
+    executeUnitTestCommand,
+} from './commands/default'
 
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
@@ -341,7 +343,7 @@ const register = async (
         vscode.commands.registerCommand('cody.command.generate-tests', a => executeTestCommand(a)),
         vscode.commands.registerCommand('cody.command.smell-code', a => executeSmellCommand(a)),
         vscode.commands.registerCommand('cody.command.document-code', a => executeDocCommand(a)),
-        vscode.commands.registerCommand('cody.command.unit-tests', a => executeNewTestCommand(a)) // behind unstable flag
+        vscode.commands.registerCommand('cody.command.unit-tests', a => executeUnitTestCommand(a)) // behind unstable flag
     )
 
     const statusBar = createStatusBar()

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -293,7 +293,7 @@ const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
     isNewChat,
 }) => {
     const inputRef = useRef<HTMLTextAreaElement>(null)
-    const tips = '(@ to include code, / for commands)'
+    const tips = '(@ to include code)'
     const placeholder = isNewChat ? `Message ${tips}` : `Follow-Up Message ${tips}`
     const disabledPlaceHolder = 'Chat has been disabled by your Enterprise instance site administrator'
 


### PR DESCRIPTION
Cleaned up imports for commands. Removed mention of `/ for command` from the chat input placeholder.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/ffce1b18-10e9-4c66-a8ae-873882413de5)


### After

![image](https://github.com/sourcegraph/cody/assets/68532117/c4dfc484-4e6b-4c55-b20a-a77183a8d94c)
