### PR TITLE
add: display cody icon in chat panel title

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Chat: Display Cody icon in the editor title of the chat panels when `cody.editorTitleCommandIcon` is enabled. [pull/2937](https://github.com/sourcegraph/cody/pull/2937)
+
 ### Fixed
 
 - Chat: Updated Chat input tips as commands are no longer executable from chat. [pull/2934](https://github.com/sourcegraph/cody/pull/2934)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -694,7 +694,7 @@
       "editor/title": [
         {
           "command": "cody.menu.commands",
-          "when": "cody.activated && config.cody.editorTitleCommandIcon && !editorReadonly",
+          "when": "cody.activated && config.cody.editorTitleCommandIcon && !editorReadonly && (resourceScheme == file || activeWebviewPanelId == cody.chatPanel)",
           "group": "navigation",
           "visibility": "visible"
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -694,7 +694,7 @@
       "editor/title": [
         {
           "command": "cody.menu.commands",
-          "when": "cody.activated && config.cody.editorTitleCommandIcon && resourceScheme == file && !editorReadonly",
+          "when": "cody.activated && config.cody.editorTitleCommandIcon && !editorReadonly",
           "group": "navigation",
           "visibility": "visible"
         },


### PR DESCRIPTION
This commit updates the package.json for the VS Code extension by removing the condition that required the resourceScheme to be file for the cody.menu.commands to be visible in the editor title. This change allows the command to be visible regardless of the resource scheme, as long as cody.activated is true, config.cody.editorTitleCommandIcon is set, and the editor is not in readonly mode. This enhances the command's visibility and usability in various contexts within VS Code, and shows up in the chat panels.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->


### Before

cody icon doesn't show up in chat panel

![image](https://github.com/sourcegraph/cody/assets/68532117/c10012db-71bb-4f58-a815-88d6e1c4f564)


### After

![image](https://github.com/sourcegraph/cody/assets/68532117/9fac8b12-1020-41ad-9162-7e0cc7e19141)
