### PR TITLE
add /ask to command menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: Updated Chat input tips as commands are no longer executable from chat. [pull/2934](https://github.com/sourcegraph/cody/pull/2934)
 - Custom Command: Removed codebase as context option from the custom command menu. [pull/2932](https://github.com/sourcegraph/cody/pull/2932)
+- Command: Add `/ask` back to the Cody command menu, which was removed by accident. [pull/2939](https://github.com/sourcegraph/cody/pull/2939)
 
 ### Changed
 

--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -1,13 +1,19 @@
 import type { CodyCommand, ContextFile } from '@sourcegraph/cody-shared'
 
 import * as vscode from 'vscode'
-import { EDIT_COMMAND } from '../menus/items'
+import { ASK_QUESTION_COMMAND, EDIT_COMMAND } from '../menus/items'
 import { CustomCommandsManager } from './custom-commands'
 import { showCommandMenu } from '../menus'
 import { getContextFileFromShell } from '../context/shell'
 import { getDefaultCommandsMap } from '../utils/get-commands'
 
 const editorCommands: CodyCommand[] = [
+    {
+        description: ASK_QUESTION_COMMAND.description,
+        prompt: ASK_QUESTION_COMMAND.slashCommand,
+        slashCommand: ASK_QUESTION_COMMAND.slashCommand,
+        mode: 'ask',
+    },
     {
         description: EDIT_COMMAND.description,
         prompt: EDIT_COMMAND.slashCommand,


### PR DESCRIPTION
Add the missing /ask command back to command menu.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

![image](https://github.com/sourcegraph/cody/assets/68532117/a161e8c9-094b-4a75-8970-df63f7602f07)
