### PR TITLE
fix: handle ask and edit commands from menu

### DIFF
--- a/lib/shared/src/commands/types.ts
+++ b/lib/shared/src/commands/types.ts
@@ -3,7 +3,6 @@ export type DefaultCodyCommands = DefaultChatCommands | DefaultEditCommands
 
 // Default Cody Commands that runs as a Chat request
 export enum DefaultChatCommands {
-    Ask = 'chat', // Submit a question in chat
     Explain = 'explain', // Explain code
     Test = 'test', // Generate unit tests in Chat
     Smell = 'smell', // Generate code smell report in Chat
@@ -11,7 +10,6 @@ export enum DefaultChatCommands {
 
 // Default Cody Commands that runs as an Inline Edit command
 export enum DefaultEditCommands {
-    Edit = 'edit', // Inline edit request
     Unit = 'unit', // Generate unit tests with inline edit
     Doc = 'doc', // Generate documentation with inline edit
 }

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -38,10 +38,7 @@ class CommandsController implements vscode.Disposable {
 
         // Process default commands
         if (isDefaultChatCommand(commandKey) || isDefaultEditCommand(commandKey)) {
-            // we want the edit command to pass through as it has additional arguments
-            if (commandKey !== '/edit') {
-                return executeDefaultCommand(commandKey)
-            }
+            return executeDefaultCommand(commandKey)
         }
 
         if (!command) {

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -36,9 +36,15 @@ class CommandsController implements vscode.Disposable {
         const commandKey = commandSplit?.shift() || text
         const command = this.provider?.get(commandKey)
 
+        // Additional instruction that will be added to end of prompt in the custom command prompt
+        // It's added at execution time to allow dynamic arguments
+        // E.g. if the command is `/edit replace dash with period`,
+        // the additionalInput is `replace dash with period`
+        const additionalInstruction = commandKey === text ? '' : commandSplit.slice(1).join(' ')
+
         // Process default commands
         if (isDefaultChatCommand(commandKey) || isDefaultEditCommand(commandKey)) {
-            return executeDefaultCommand(commandKey)
+            return executeDefaultCommand(commandKey, additionalInstruction)
         }
 
         if (!command) {
@@ -46,12 +52,7 @@ class CommandsController implements vscode.Disposable {
             return undefined
         }
 
-        // Additional instruction that will be added to end of prompt in the custom command prompt
-        // It's added at execution time to allow dynamic arguments
-        // E.g. if the command is `/edit replace dash with period`,
-        // the additionalInput is `replace dash with period`
-        const additionalArgs = commandKey === text ? '' : commandSplit.slice(1).join(' ')
-        command.prompt = [command.prompt, additionalArgs].join(' ')?.trim()
+        command.prompt = [command.prompt, additionalInstruction].join(' ')?.trim()
 
         // Add shell output as context if any before passing to the runner
         const shell = command.context?.command

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -38,7 +38,10 @@ class CommandsController implements vscode.Disposable {
 
         // Process default commands
         if (isDefaultChatCommand(commandKey) || isDefaultEditCommand(commandKey)) {
-            return executeDefaultCommand(commandKey)
+            // we want the edit command to pass through as it has additional arguments
+            if (commandKey !== '/edit') {
+                return executeDefaultCommand(commandKey)
+            }
         }
 
         if (!command) {

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -31,9 +31,9 @@ class CommandsController implements vscode.Disposable {
      * Handles prompt building and context fetching for commands.
      */
     public async execute(text: string, args: CodyCommandArgs): Promise<CommandResult | undefined> {
-        const commandSplit = text.split(' ')
+        const commandSplit = text?.trim().split(' ')
         // The unique key for the command. e.g. /test
-        const commandKey = commandSplit.shift() || text
+        const commandKey = commandSplit?.shift() || text
         const command = this.provider?.get(commandKey)
 
         // Process default commands
@@ -50,7 +50,7 @@ class CommandsController implements vscode.Disposable {
         // It's added at execution time to allow dynamic arguments
         // E.g. if the command is `/edit replace dash with period`,
         // the additionalInput is `replace dash with period`
-        const additionalArgs = commandKey === text ? '' : commandSplit.join(' ')
+        const additionalArgs = commandKey === text ? '' : commandSplit.slice(1).join(' ')
         command.prompt = [command.prompt, additionalArgs].join(' ')?.trim()
 
         // Add shell output as context if any before passing to the runner

--- a/vscode/src/commands/default/doc.ts
+++ b/vscode/src/commands/default/doc.ts
@@ -16,7 +16,11 @@ export async function executeDocCommand(
     args?: Partial<CodyCommandArgs>
 ): Promise<EditCommandResult | undefined> {
     logDebug('executeDocCommand', 'executing', { args })
-    const prompt = defaultCommands.doc.prompt
+    let prompt = defaultCommands.doc.prompt
+
+    if (args?.additionalInstruction) {
+        prompt = `${prompt} ${args.additionalInstruction}`
+    }
 
     const editor = getEditor()?.active
     const document = editor?.document

--- a/vscode/src/commands/default/explain.ts
+++ b/vscode/src/commands/default/explain.ts
@@ -12,9 +12,13 @@ import type { CodyCommandArgs } from '../types'
  *
  * Context: Current selection and current file
  */
-export async function explainCommand(): Promise<ExecuteChatArguments> {
+export async function explainCommand(args?: Partial<CodyCommandArgs>): Promise<ExecuteChatArguments> {
     const addEnhancedContext = false
-    const prompt = defaultCommands.explain.prompt
+    let prompt = defaultCommands.explain.prompt
+
+    if (args?.additionalInstruction) {
+        prompt = `${prompt} ${args.additionalInstruction}`
+    }
 
     // fetches the context file from the current cursor position using getContextFileFromCursor().
     const contextFiles: ContextFile[] = []
@@ -43,6 +47,6 @@ export async function executeExplainCommand(
     logDebug('executeDocCommand', 'executing', { args })
     return {
         type: 'chat',
-        session: await executeChat(await explainCommand()),
+        session: await executeChat(await explainCommand(args)),
     }
 }

--- a/vscode/src/commands/default/index.ts
+++ b/vscode/src/commands/default/index.ts
@@ -42,20 +42,21 @@ export function isDefaultEditCommand(id: string): DefaultEditCommands | undefine
  * Returns the command result if a matched command is found, otherwise returns undefined.
  */
 export async function executeDefaultCommand(
-    id: DefaultCodyCommands | string
+    id: DefaultCodyCommands | string,
+    additionalInstruction?: string
 ): Promise<CommandResult | undefined> {
     const key = id.replace(/^\//, '').trim() as DefaultCodyCommands
     switch (key) {
         case DefaultChatCommands.Explain:
-            return executeExplainCommand()
+            return executeExplainCommand({ additionalInstruction })
         case DefaultChatCommands.Smell:
-            return executeSmellCommand()
+            return executeSmellCommand({ additionalInstruction })
         case DefaultChatCommands.Test:
-            return executeTestCommand()
+            return executeTestCommand({ additionalInstruction })
         case DefaultEditCommands.Unit:
-            return executeUnitTestCommand()
+            return executeUnitTestCommand({ additionalInstruction })
         case DefaultEditCommands.Doc:
-            return executeDocCommand()
+            return executeDocCommand({ additionalInstruction })
         default:
             console.log('not a default command')
             return undefined

--- a/vscode/src/commands/default/smell.ts
+++ b/vscode/src/commands/default/smell.ts
@@ -11,9 +11,13 @@ import type { CodyCommandArgs } from '../types'
  *
  * Context: Current selection
  */
-export async function smellCommand(): Promise<ExecuteChatArguments> {
+export async function smellCommand(args?: Partial<CodyCommandArgs>): Promise<ExecuteChatArguments> {
     const addEnhancedContext = false
-    const prompt = defaultCommands.smell.prompt
+    let prompt = defaultCommands.smell.prompt
+
+    if (args?.additionalInstruction) {
+        prompt = `${prompt} ${args.additionalInstruction}`
+    }
 
     const contextFiles: ContextFile[] = []
     const currentSelection = await getContextFileFromCursor()
@@ -37,6 +41,6 @@ export async function executeSmellCommand(
     logDebug('executeDocCommand', 'executing', { args })
     return {
         type: 'chat',
-        session: await executeChat(await smellCommand()),
+        session: await executeChat(await smellCommand(args)),
     }
 }

--- a/vscode/src/commands/default/test.ts
+++ b/vscode/src/commands/default/test.ts
@@ -11,8 +11,12 @@ import { getContextFilesForTestCommand } from '../context/test-command'
  *
  * Context: Test files, current selection, and current file
  */
-async function testCommand(): Promise<ExecuteChatArguments> {
-    const prompt = defaultCommands.test.prompt
+async function testCommand(args?: Partial<CodyCommandArgs>): Promise<ExecuteChatArguments> {
+    let prompt = defaultCommands.test.prompt
+
+    if (args?.additionalInstruction) {
+        prompt = `${prompt} ${args.additionalInstruction}`
+    }
 
     const editor = getEditor()?.active
     const document = editor?.document
@@ -47,6 +51,6 @@ export async function executeTestCommand(
     logDebug('executeTestCommand', 'executing', { args })
     return {
         type: 'chat',
-        session: await executeChat(await testCommand()),
+        session: await executeChat(await testCommand(args)),
     }
 }

--- a/vscode/src/commands/default/unit.ts
+++ b/vscode/src/commands/default/unit.ts
@@ -18,7 +18,11 @@ import { getContextFilesForUnitTestCommand } from '../context/unit-test-command'
 export async function executeUnitTestCommand(
     args?: Partial<CodyCommandArgs>
 ): Promise<EditCommandResult | undefined> {
-    const prompt = defaultCommands.unit.prompt
+    let prompt = defaultCommands.unit.prompt
+
+    if (args?.additionalInstruction) {
+        prompt = `${prompt} ${args.additionalInstruction}`
+    }
 
     const editor = getEditor()?.active
     const document = editor?.document

--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -42,7 +42,12 @@ export async function showCommandMenu(
         }
 
         // Extra options
-        items.push(CommandMenuSeperator.settings, configOption, addOption)
+        items.push(CommandMenuSeperator.settings, configOption)
+
+        // The Create New Command option should show up in custom command menu only
+        if (type === 'custom') {
+            items.push(addOption)
+        }
     }
 
     const options = CommandMenuTitleItem[type]

--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -129,23 +129,27 @@ export async function showCommandMenu(
                 return openCustomCommandDocsLink()
             }
 
+            // Check if it's an ask command
             if (selected.startsWith('/ask')) {
-                if (!value) {
+                const inputValue = value.replace(/^\/ask/, '').trim()
+                // show input box if no value
+                if (!inputValue) {
                     void showChatInputBox()
                 } else {
-                    void executeChat({ text: value, submitType: 'user-newchat', source: 'menu' })
+                    void executeChat({ text: inputValue, submitType: 'user-newchat', source: 'menu' })
                 }
                 quickPick.hide()
                 return
             }
 
+            // Check if it's an edit command
             if (selected.startsWith('/edit')) {
                 void executeEdit({ instruction: value }, 'menu')
                 quickPick.hide()
                 return
             }
 
-            // Else, process the selection as a command
+            // Else, process the selection as custom command
             if (selected.startsWith('/')) {
                 void commands.executeCommand('cody.action.command', selected + ' ' + value)
             }

--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -59,7 +59,6 @@ export async function showCommandMenu(
         quickPick.placeholder = options.placeHolder
         quickPick.matchOnDescription = true
         quickPick.buttons = CommandMenuTitleItem[type].buttons
-        quickPick.matchOnDescription = true
 
         quickPick.onDidTriggerButton(async item => {
             // On gear icon click
@@ -83,6 +82,16 @@ export async function showCommandMenu(
         })
 
         quickPick.onDidChangeValue(value => {
+            if (value?.startsWith('/')) {
+                const commandKey = value.split(' ')[0]
+                const isCommand = items.find(item => item.label === commandKey)
+                if (commandKey && isCommand) {
+                    isCommand.alwaysShow = true
+                    quickPick.items = [isCommand]
+                    return
+                }
+            }
+
             if (value && !value.startsWith('/')) {
                 quickPick.items = [CommandMenuOption.edit, CommandMenuOption.chat, ...items]
             } else {

--- a/vscode/src/commands/menus/items/options.ts
+++ b/vscode/src/commands/menus/items/options.ts
@@ -3,6 +3,7 @@ import type { CommandMenuItem } from '../types'
 export const ASK_QUESTION_COMMAND = {
     description: 'Ask a question',
     slashCommand: '/ask',
+    require,
 }
 
 export const EDIT_COMMAND = {

--- a/vscode/src/commands/menus/items/options.ts
+++ b/vscode/src/commands/menus/items/options.ts
@@ -3,7 +3,6 @@ import type { CommandMenuItem } from '../types'
 export const ASK_QUESTION_COMMAND = {
     description: 'Ask a question',
     slashCommand: '/ask',
-    require,
 }
 
 export const EDIT_COMMAND = {

--- a/vscode/src/commands/types.ts
+++ b/vscode/src/commands/types.ts
@@ -31,4 +31,5 @@ export interface CodyCommandArgs {
     runInChatMode?: boolean
     // current context to add on top of the command context
     userContextFiles?: ContextFile[]
+    additionalInstruction?: string
 }

--- a/vscode/test/e2e/command.test.ts
+++ b/vscode/test/e2e/command.test.ts
@@ -47,4 +47,11 @@ test('execute command from sidebar', async ({ page, sidebar }) => {
     const editButtons = chatPanelFrame.locator('.codicon-edit')
     await expect(editButtons).toHaveCount(1)
     await expect(chatPanelFrame.getByTitle('Edit Your Message').locator('i')).toBeVisible()
+
+    // You can submit a chat question via command menu using /ask
+    await page.getByRole('button', { name: /Commands .*/ }).click()
+    await page.getByPlaceholder('Search for a command or enter your question here...').fill('hello cody')
+    await page.getByLabel('/ask, Ask a question').locator('a').click()
+    // the question should show up in the chat panel on submit
+    await chatPanelFrame.getByText('hello cody').click()
 })


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/2939

This enables /ask and /edit from menu to work again.

Also added e2e test to cover submitting question via /ask in command menu.



## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Start an ask/ edit command from the command menu to confirm it works. 


https://github.com/sourcegraph/cody/assets/68532117/c3ca3077-fdf5-46ea-a5b6-0cded45c0c2a


"Create Custom Command" option should only show up in custom command menu

![image](https://github.com/sourcegraph/cody/assets/68532117/4d91e692-55c1-478b-9ec5-92c3d7817895)