### PR TITLE
Adding temp fix for the race condition involved in reading auth token

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -599,8 +599,6 @@ const register = async (
 
     promises.push(showSetupNotification(initialConfig))
 
-    await Promise.all(promises)
-
     // Register a serializer for reviving the chat panel on reload
     if (vscode.window.registerWebviewPanelSerializer) {
         vscode.window.registerWebviewPanelSerializer(CodyChatPanelViewType, {


### PR DESCRIPTION
Fixes the race condition in the auth token issue highlighted in https://github.com/sourcegraph/cody/issues/2940 thanks to Kevin and Kalan for raising this.


The original bug came in this cool cleanup PR https://github.com/sourcegraph/cody/pull/2782 on this [commit](https://github.com/sourcegraph/cody/commit/058b8ad9542ce15fc3f95bc87f3c0d440699b708) CC @olafurpg 

## What is the bug?
In the latest version of Cody if you install it in VS code then it will ask you to reload and then you can't login(Coz it can't read auth token)

NOTE: 
1. This bug very likely has nothing to Tabnine, it was just a coincidence
2. The actual error of token not found is [here](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/services/SecretStorageProvider.ts?L15)

## Test plan

- Run the debugger
- Logout of Cody
- Log in to cody
- Everything should work


To verify the failure case do the same testing on main branch and you will see problems highlighted in the original issue. 