### PR TITLE
add log default chat commands

### DIFF
--- a/vscode/src/commands/default/explain.ts
+++ b/vscode/src/commands/default/explain.ts
@@ -6,6 +6,8 @@ import { DefaultChatCommands } from '@sourcegraph/cody-shared/src/commands/types
 import { defaultCommands } from '.'
 import type { ChatCommandResult } from '../../main'
 import type { CodyCommandArgs } from '../types'
+import { telemetryService } from '../../services/telemetry'
+import { telemetryRecorder } from '../../services/telemetry-v2'
 
 /**
  * Generates the prompt and context files with arguments for the 'explain' command.
@@ -45,6 +47,22 @@ export async function executeExplainCommand(
     args?: Partial<CodyCommandArgs>
 ): Promise<ChatCommandResult | undefined> {
     logDebug('executeDocCommand', 'executing', { args })
+    telemetryService.log('CodyVSCodeExtension:command:explain:executed', {
+        useCodebaseContex: false,
+        requestID: args?.requestID,
+        source: args?.source,
+    })
+    telemetryRecorder.recordEvent('cody.command.explain', 'executed', {
+        metadata: {
+            useCodebaseContex: 0,
+        },
+        interactionID: args?.requestID,
+        privateMetadata: {
+            requestID: args?.requestID,
+            source: args?.source,
+        },
+    })
+
     return {
         type: 'chat',
         session: await executeChat(await explainCommand(args)),

--- a/vscode/src/commands/default/explain.ts
+++ b/vscode/src/commands/default/explain.ts
@@ -46,7 +46,7 @@ export async function explainCommand(args?: Partial<CodyCommandArgs>): Promise<E
 export async function executeExplainCommand(
     args?: Partial<CodyCommandArgs>
 ): Promise<ChatCommandResult | undefined> {
-    logDebug('executeDocCommand', 'executing', { args })
+    logDebug('executeExplainCommand', 'executing', { args })
     telemetryService.log('CodyVSCodeExtension:command:explain:executed', {
         useCodebaseContex: false,
         requestID: args?.requestID,

--- a/vscode/src/commands/default/smell.ts
+++ b/vscode/src/commands/default/smell.ts
@@ -5,6 +5,8 @@ import { DefaultChatCommands } from '@sourcegraph/cody-shared/src/commands/types
 import { defaultCommands } from '.'
 import type { ChatCommandResult } from '../../main'
 import type { CodyCommandArgs } from '../types'
+import { telemetryService } from '../../services/telemetry'
+import { telemetryRecorder } from '../../services/telemetry-v2'
 
 /**
  * Generates the prompt and context files with arguments for the 'smell' command.
@@ -38,7 +40,23 @@ export async function smellCommand(args?: Partial<CodyCommandArgs>): Promise<Exe
 export async function executeSmellCommand(
     args?: Partial<CodyCommandArgs>
 ): Promise<ChatCommandResult | undefined> {
-    logDebug('executeDocCommand', 'executing', { args })
+    logDebug('executeSmellCommand', 'executing', { args })
+    telemetryService.log('CodyVSCodeExtension:command:smell:executed', {
+        useCodebaseContex: false,
+        requestID: args?.requestID,
+        source: args?.source,
+    })
+    telemetryRecorder.recordEvent('cody.command.smell', 'executed', {
+        metadata: {
+            useCodebaseContex: 0,
+        },
+        interactionID: args?.requestID,
+        privateMetadata: {
+            requestID: args?.requestID,
+            source: args?.source,
+        },
+    })
+
     return {
         type: 'chat',
         session: await executeChat(await smellCommand(args)),

--- a/vscode/src/commands/default/test.ts
+++ b/vscode/src/commands/default/test.ts
@@ -6,6 +6,8 @@ import { type ExecuteChatArguments, executeChat } from './ask'
 import { defaultCommands } from '.'
 import type { ChatCommandResult } from '../../main'
 import { getContextFilesForTestCommand } from '../context/test-command'
+import { telemetryService } from '../../services/telemetry'
+import { telemetryRecorder } from '../../services/telemetry-v2'
 /**
  * Generates the prompt and context files with arguments for the 'test' command.
  *
@@ -49,6 +51,22 @@ export async function executeTestCommand(
     args?: Partial<CodyCommandArgs>
 ): Promise<ChatCommandResult | undefined> {
     logDebug('executeTestCommand', 'executing', { args })
+    telemetryService.log('CodyVSCodeExtension:command:test:executed', {
+        useCodebaseContex: false,
+        requestID: args?.requestID,
+        source: args?.source,
+    })
+    telemetryRecorder.recordEvent('cody.command.test', 'executed', {
+        metadata: {
+            useCodebaseContex: 0,
+        },
+        interactionID: args?.requestID,
+        privateMetadata: {
+            requestID: args?.requestID,
+            source: args?.source,
+        },
+    })
+
     return {
         type: 'chat',
         session: await executeChat(await testCommand(args)),

--- a/vscode/test/e2e/command.test.ts
+++ b/vscode/test/e2e/command.test.ts
@@ -1,7 +1,10 @@
 import { expect } from '@playwright/test'
 
 import { sidebarExplorer, sidebarSignin } from './common'
-import { test } from './helpers'
+import { assertEvents, test } from './helpers'
+import { loggedEvents } from '../fixtures/mock-server'
+
+const expectedEvents = ['CodyVSCodeExtension:command:explain:executed']
 
 test('execute command from sidebar', async ({ page, sidebar }) => {
     // Sign into Cody
@@ -54,4 +57,6 @@ test('execute command from sidebar', async ({ page, sidebar }) => {
     await page.getByLabel('/ask, Ask a question').locator('a').click()
     // the question should show up in the chat panel on submit
     await chatPanelFrame.getByText('hello cody').click()
+
+    await assertEvents(loggedEvents, expectedEvents)
 })

--- a/vscode/test/e2e/unit-test-command.test.ts
+++ b/vscode/test/e2e/unit-test-command.test.ts
@@ -1,9 +1,12 @@
 import { expect } from '@playwright/test'
 
 import { sidebarExplorer, sidebarSignin } from './common'
-import { test } from './helpers'
+import { assertEvents, test } from './helpers'
+import { loggedEvents } from '../fixtures/mock-server'
 
-test('unit test commands with context fetching', async ({ page, sidebar }) => {
+const expectedEvents = ['CodyVSCodeExtension:command:test:executed']
+
+test.only('unit test commands with context fetching', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 
@@ -36,4 +39,6 @@ test('unit test commands with context fetching', async ({ page, sidebar }) => {
 
     // Check if assistant responsed
     await expect(chatPanelFrame.getByText('hello from the assistant')).toBeVisible()
+
+    await assertEvents(loggedEvents, expectedEvents)
 })

--- a/vscode/test/e2e/unit-test-command.test.ts
+++ b/vscode/test/e2e/unit-test-command.test.ts
@@ -6,7 +6,7 @@ import { loggedEvents } from '../fixtures/mock-server'
 
 const expectedEvents = ['CodyVSCodeExtension:command:test:executed']
 
-test.only('unit test commands with context fetching', async ({ page, sidebar }) => {
+test('unit test commands with context fetching', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 


### PR DESCRIPTION
current not logging the default chat commands after the command refactoring.

This adds the logging back for them

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

execute a command and chat the output channel to make sure the commands are logged correctly.