### PR TITLE
Autocomplete: add more stop-reason values to autocomplete responses

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -106,7 +106,7 @@ export { GuardrailsPost, summariseAttribution } from './guardrails'
 export type { Attribution, Guardrails } from './guardrails'
 export { SourcegraphGuardrailsClient } from './guardrails/client'
 export {
-    STOP_REASON_STREAMING_CHUNK,
+    CompletionStopReason,
     type CodeCompletionsClient,
     type CodeCompletionsParams,
     type CompletionResponseGenerator,

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -7,9 +7,11 @@ import type { CompletionParameters, CompletionResponse } from '../sourcegraph-ap
  * TODO: migrate to union of multiple `CompletionResponse` types to explicitly document
  * all possible response types.
  */
-export const STOP_REASON_STREAMING_CHUNK = 'cody-streaming-chunk'
-export const STOP_REASON_REQUEST_ABORTED = 'cody-request-aborted'
-export const STOP_REASON_REQUEST_FINISHED = 'cody-request-finished'
+export enum CompletionStopReason {
+    StreamingChunk = 'cody-streaming-chunk',
+    RequestAborted = 'cody-request-aborted',
+    RequestFinished = 'cody-request-finished',
+}
 
 export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'> & { timeoutMs: number }
 export type CompletionResponseGenerator = AsyncGenerator<CompletionResponse>

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -8,6 +8,11 @@ import type { CompletionParameters, CompletionResponse } from '../sourcegraph-ap
  * all possible response types.
  */
 export enum CompletionStopReason {
+    /**
+     * Used to signal to the completion processing code that we're still streaming.
+     * Can be removed if we make `CompletionResponse.stopReason` optional. Then
+     * `{ stopReason: undefined }` can be used instead.
+     */
     StreamingChunk = 'cody-streaming-chunk',
     RequestAborted = 'cody-request-aborted',
     RequestFinished = 'cody-request-finished',

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -8,6 +8,8 @@ import type { CompletionParameters, CompletionResponse } from '../sourcegraph-ap
  * all possible response types.
  */
 export const STOP_REASON_STREAMING_CHUNK = 'cody-streaming-chunk'
+export const STOP_REASON_REQUEST_ABORTED = 'cody-request-aborted'
+export const STOP_REASON_REQUEST_FINISHED = 'cody-request-finished'
 
 export type CodeCompletionsParams = Omit<CompletionParameters, 'fast'> & { timeoutMs: number }
 export type CompletionResponseGenerator = AsyncGenerator<CompletionResponse>

--- a/lib/shared/src/ollama/ollama-client.ts
+++ b/lib/shared/src/ollama/ollama-client.ts
@@ -1,11 +1,9 @@
 import { isDefined } from '../common'
 import type { OllamaGenerateParameters, OllamaOptions } from '../configuration'
 import {
-    STOP_REASON_STREAMING_CHUNK,
+    CompletionStopReason,
     type CodeCompletionsClient,
     type CompletionResponseGenerator,
-    STOP_REASON_REQUEST_ABORTED,
-    STOP_REASON_REQUEST_FINISHED,
 } from '../inferenceClient/misc'
 import type { CompletionLogger } from '../sourcegraph-api/completions/client'
 import type { CompletionResponse } from '../sourcegraph-api/completions/types'
@@ -92,7 +90,7 @@ export function createOllamaClient(
 
             for await (const chunk of iterableBody) {
                 if (signal.aborted) {
-                    stopReason = STOP_REASON_REQUEST_ABORTED
+                    stopReason = CompletionStopReason.RequestAborted
                     break
                 }
 
@@ -101,7 +99,7 @@ export function createOllamaClient(
 
                     if (line.response) {
                         insertText += line.response
-                        yield { completion: insertText, stopReason: STOP_REASON_STREAMING_CHUNK }
+                        yield { completion: insertText, stopReason: CompletionStopReason.StreamingChunk }
                     }
 
                     if (line.done && line.total_duration) {
@@ -114,7 +112,7 @@ export function createOllamaClient(
 
             const completionResponse: CompletionResponse = {
                 completion: insertText,
-                stopReason: stopReason || STOP_REASON_REQUEST_FINISHED,
+                stopReason: stopReason || CompletionStopReason.RequestFinished,
             }
 
             log?.onComplete(completionResponse)

--- a/lib/shared/src/sourcegraph-api/completions/types.ts
+++ b/lib/shared/src/sourcegraph-api/completions/types.ts
@@ -47,7 +47,7 @@ export interface CompletionCallbacks {
  *   since the last `change` value.
  * - `complete`: Only called when a stream successfully completes. If an error is encountered, this
  *   is never called.
- * - `error`: Only called when a stream fails or encounteres an error. This should be assumed to be
+ * - `error`: Only called when a stream fails or encounters an error. This should be assumed to be
  *   a "complete" event, and no other callbacks will be called afterwards.
  */
 export type CompletionGeneratorValue =

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -173,11 +173,9 @@ export function createClient(
                 throw error
             }
 
-            /**
-             * In case of the abort error and non-empty completion response, we can
-             * consider the completion partially completed and want to log it to
-             * the Cody output channel via `log.onComplete()` instead of erroring.
-             */
+            // In case of the abort error and non-empty completion response, we can
+            // consider the completion partially completed and want to log it to
+            // the Cody output channel via `log.onComplete()` instead of erroring.
             if (isAbortError(error as Error) && completionResponse) {
                 completionResponse.stopReason = CompletionStopReason.RequestAborted
             } else {

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -2,7 +2,7 @@ import {
     FeatureFlag,
     NetworkError,
     RateLimitError,
-    STOP_REASON_STREAMING_CHUNK,
+    CompletionStopReason,
     TracedError,
     addTraceparent,
     featureFlagProvider,
@@ -19,10 +19,6 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { fetch } from '../fetch'
-import {
-    STOP_REASON_REQUEST_ABORTED,
-    STOP_REASON_REQUEST_FINISHED,
-} from '@sourcegraph/cody-shared/src/inferenceClient/misc'
 
 /**
  * Access the code completion LLM APIs via a Sourcegraph server instance.
@@ -127,7 +123,7 @@ export function createClient(
 
                     if (signal.aborted) {
                         if (completionResponse) {
-                            completionResponse.stopReason = STOP_REASON_REQUEST_ABORTED
+                            completionResponse.stopReason = CompletionStopReason.RequestAborted
                         }
 
                         break
@@ -138,7 +134,7 @@ export function createClient(
 
                         yield {
                             completion: completionResponse.completion,
-                            stopReason: completionResponse.stopReason || STOP_REASON_STREAMING_CHUNK,
+                            stopReason: completionResponse.stopReason || CompletionStopReason.StreamingChunk,
                         }
                     }
 
@@ -150,7 +146,7 @@ export function createClient(
                 }
 
                 if (!completionResponse.stopReason) {
-                    completionResponse.stopReason = STOP_REASON_REQUEST_FINISHED
+                    completionResponse.stopReason = CompletionStopReason.RequestFinished
                 }
 
                 log?.onComplete(completionResponse)

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -134,7 +134,8 @@ export function createClient(
 
                         yield {
                             completion: completionResponse.completion,
-                            stopReason: completionResponse.stopReason || CompletionStopReason.StreamingChunk,
+                            stopReason:
+                                completionResponse.stopReason || CompletionStopReason.StreamingChunk,
                         }
                     }
 

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -3,7 +3,7 @@ import { isEqual } from 'lodash'
 import { expect } from 'vitest'
 
 import {
-    STOP_REASON_STREAMING_CHUNK,
+    CompletionStopReason,
     testFileUri,
     type CodeCompletionsClient,
     type CompletionParameters,
@@ -94,7 +94,7 @@ export function params(
 
             if (completionResponseGenerator) {
                 for await (const response of completionResponseGenerator(completeParams)) {
-                    yield { ...response, stopReason: STOP_REASON_STREAMING_CHUNK }
+                    yield { ...response, stopReason: CompletionStopReason.StreamingChunk }
                 }
 
                 // Signal to tests that all streaming chunks are processed.
@@ -234,7 +234,7 @@ export function paramsWithInlinedCompletion(
                 lastResponse += completionChunk
                 yield {
                     completion: lastResponse,
-                    stopReason: STOP_REASON_STREAMING_CHUNK,
+                    stopReason: CompletionStopReason.StreamingChunk,
                 }
 
                 if (delayBetweenChunks) {

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -196,7 +196,11 @@ export class InlineCompletionItemProvider
         return wrapInActiveSpan('autocomplete.provideInlineCompletionItems', async () => {
             // Update the last request
             const lastCompletionRequest = this.lastCompletionRequest
-            const completionRequest: CompletionRequest = { document, position, context }
+            const completionRequest: CompletionRequest = {
+                document,
+                position,
+                context,
+            }
             this.lastCompletionRequest = completionRequest
 
             const configFeatures = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -1,4 +1,4 @@
-import { STOP_REASON_STREAMING_CHUNK, type CompletionResponseGenerator } from '@sourcegraph/cody-shared'
+import { CompletionStopReason, type CompletionResponseGenerator } from '@sourcegraph/cody-shared'
 
 import { addAutocompleteDebugEvent } from '../../services/open-telemetry/debug-utils'
 import { canUsePartialCompletion } from '../can-use-partial-completion'
@@ -79,7 +79,7 @@ export async function* fetchAndProcessDynamicMultilineCompletions(
     for await (const { completion, stopReason } of completionResponseGenerator) {
         const isFirstCompletionTimeoutElapsed =
             performance.now() - generatorStartTime >= firstCompletionTimeout
-        const isFullResponse = stopReason !== STOP_REASON_STREAMING_CHUNK
+        const isFullResponse = stopReason !== CompletionStopReason.StreamingChunk
         const shouldYieldFirstCompletion = isFullResponse || isFirstCompletionTimeoutElapsed
 
         const extractCompletion = shouldYieldFirstCompletion
@@ -235,7 +235,7 @@ export async function* fetchAndProcessCompletions(
             completion,
         })
 
-        const isFullResponse = stopReason !== STOP_REASON_STREAMING_CHUNK
+        const isFullResponse = stopReason !== CompletionStopReason.StreamingChunk
         const rawCompletion = providerSpecificPostProcess(completion)
 
         if (hotStreakExtractor) {


### PR DESCRIPTION
## Context

- Adds `STOP_REASON_REQUEST_ABORTED` and `STOP_REASON_REQUEST_FINISHED` to completion responses to enable better observability locally and improve our analytics events analysis capabilities.
- Adds early exit for aborted requests to ollama HTTP client.

## Test plan

CI
