### PR TITLE
Edit: Remove usage of codebase context

### DIFF
--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -7,7 +7,6 @@ import {
     MAX_CURRENT_FILE_TOKENS,
     Transcript,
     truncateText,
-    type CodebaseContext,
     type CompletionParameters,
     type Message,
 } from '@sourcegraph/cody-shared'
@@ -50,7 +49,6 @@ interface BuildInteractionOptions {
     model: SupportedModels
     task: FixupTask
     editor: VSCodeEditor
-    context: CodebaseContext
 }
 
 interface BuiltInteraction extends Pick<CompletionParameters, 'stopSequences'> {
@@ -63,7 +61,6 @@ export const buildInteraction = async ({
     model,
     task,
     editor,
-    context,
 }: BuildInteractionOptions): Promise<BuiltInteraction> => {
     const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
     const precedingText = document.getText(
@@ -102,7 +99,6 @@ export const buildInteraction = async ({
             selectionRange: task.selectionRange,
             userContextFiles: task.userContextFiles,
             contextMessages: task.contextMessages,
-            context,
             editor,
             followingText,
             precedingText,

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -42,7 +42,6 @@ export class EditProvider {
             model,
             task: this.config.task,
             editor: this.config.editor,
-            context: this.config.contextProvider.context,
         })
 
         const multiplexer = new BotResponseMultiplexer()


### PR DESCRIPTION
## Description

Remove codebase context as:
- We now support user provided context, which will generally be much more accurate for the user
- This context is very rarely useful and adds latency to every request. Related code is unlikely to be useful for edits. It's possible we could use codebase context for code related to the instructions, but this is unlikely to work well given most instructions are short. We should revisit a mechanism to manually trigger codebase context.

## Test plan

1. Run edits
2. Check they output as normally


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
