### PR TITLE
add e2e test for custom command openTabs context

### DIFF
--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -165,7 +165,9 @@ test('execute custom commands with context defined in cody.json', async ({ page,
     await expect(chatPanel.getByText('✨ Context: 14 lines from 2 files')).toBeVisible()
     await chatPanel.getByText('✨ Context: 14 lines from 2 files').click()
     await expect(chatPanel.getByRole('button', { name: '@index.html:1-10' })).toBeVisible()
-    await expect(chatPanel.getByRole('button', { name: '@lib/batches/env/var.go:1-0' })).toBeVisible()
+    await expect(
+        chatPanel.getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1-0') })
+    ).toBeVisible()
 })
 
 test('open and delete cody.json from the custom command menu', async ({ page, sidebar }) => {

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -85,13 +85,12 @@ test('create a new user command via the custom commands menu', async ({ page, si
     await expect(chatPanel.getByText(prompt)).toBeVisible()
 })
 
-test('execute a custom command defined in workspace cody.json', async ({ page, sidebar }) => {
+test('execute custom commands with context defined in cody.json', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 
     // Open the File Explorer view from the sidebar
     await sidebarExplorer(page).click()
-    // Open the index.html file from the tree view
     await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
     // Wait for index.html to fully open
     await page.getByRole('tab', { name: 'index.html' }).hover()
@@ -109,7 +108,7 @@ test('execute a custom command defined in workspace cody.json', async ({ page, s
     await page.getByLabel('Settings & Support Section').click()
     await page.getByLabel('Chats Section').click()
 
-    // Test: context.currentDir with /currentDir command
+    /* Test: context.currentDir with /currentDir command */
     await page.getByLabel('Custom Custom commands').locator('a').click()
     await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
     await page.getByPlaceholder('Search command to run...').fill('currentDir')
@@ -127,7 +126,7 @@ test('execute a custom command defined in workspace cody.json', async ({ page, s
     await expect(chatPanel.locator('span').filter({ hasText: '@buzz.ts:1-15' })).toBeVisible()
     await expect(chatPanel.locator('span').filter({ hasText: '@index.html:1-11' })).toBeVisible()
 
-    // Test: context.filePath with /filePath command
+    /* Test: context.filePath with /filePath command */
     await page.getByLabel('Custom Custom commands').locator('a').click()
     await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
     await page.getByPlaceholder('Search command to run...').click()
@@ -137,7 +136,7 @@ test('execute a custom command defined in workspace cody.json', async ({ page, s
     // Should show 2 files with current file added as context
     await expect(chatPanel.getByText('✨ Context: 14 lines from 2 files')).toBeVisible()
 
-    // Test: context.directory with /directory command
+    /* Test: context.directory with /directory command */
     await page.getByLabel('Custom Custom commands').locator('a').click()
     await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
     await page.getByPlaceholder('Search command to run...').click()
@@ -149,11 +148,24 @@ test('execute a custom command defined in workspace cody.json', async ({ page, s
     await expect(
         chatPanel.locator('span').filter({ hasText: withPlatformSlashes('@lib/batches/env/var.go:1-1') })
     ).toBeVisible()
-    // Click on the file link should open the file in the editor
+    // Click on the file link should open the 'var.go file in the editor
     await chatPanel
         .getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1-1') })
         .click()
-    await expect(page.getByRole('tab', { name: 'index.html' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'var.go' })).toBeVisible()
+
+    /* Test: context.openTabs with /openTabs command */
+    await page.getByLabel('Custom Custom commands').locator('a').click()
+    await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
+    await page.getByPlaceholder('Search command to run...').click()
+    await page.getByPlaceholder('Search command to run...').fill('/openTabs')
+    await page.keyboard.press('Enter')
+    await expect(chatPanel.getByText('Open tabs as context.')).toBeVisible()
+    // The files from the open tabs should be added as context
+    await expect(chatPanel.getByText('✨ Context: 14 lines from 2 files')).toBeVisible()
+    await chatPanel.getByText('✨ Context: 14 lines from 2 files').click()
+    await expect(chatPanel.getByRole('button', { name: '@index.html:1-10' })).toBeVisible()
+    await expect(chatPanel.getByRole('button', { name: '@lib/batches/env/var.go:1-0' })).toBeVisible()
 })
 
 test('open and delete cody.json from the custom command menu', async ({ page, sidebar }) => {

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -70,8 +70,9 @@ test.only('create a new user command via the custom commands menu', async ({ pag
     await page.getByRole('treeitem', { name: '.vscode' }).locator('a').click()
     await page.getByRole('treeitem', { name: 'cody.json' }).locator('a').dblclick()
     await page.getByRole('tab', { name: 'cody.json' }).hover()
-    // Scroll to the buttom
-    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
+    // Click on minimap to scroll to the buttom
+    await page.locator('canvas').nth(2).click()
+    await page.getByText(commandName).hover()
     await expect(page.getByText(commandName)).toBeVisible()
     await page.getByText('index.html').first().click()
 

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -9,7 +9,7 @@ test.beforeEach(() => {
     resetLoggedEvents()
 })
 
-test.only('create a new user command via the custom commands menu', async ({ page, sidebar }) => {
+test('create a new user command via the custom commands menu', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -9,7 +9,7 @@ test.beforeEach(() => {
     resetLoggedEvents()
 })
 
-test('create a new user command via the custom commands menu', async ({ page, sidebar }) => {
+test.only('create a new user command via the custom commands menu', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 
@@ -70,6 +70,8 @@ test('create a new user command via the custom commands menu', async ({ page, si
     await page.getByRole('treeitem', { name: '.vscode' }).locator('a').click()
     await page.getByRole('treeitem', { name: 'cody.json' }).locator('a').dblclick()
     await page.getByRole('tab', { name: 'cody.json' }).hover()
+    // Scroll to the buttom
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))
     await expect(page.getByText(commandName)).toBeVisible()
     await page.getByText('index.html').first().click()
 

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -265,6 +265,14 @@ async function buildCodyJson(workspaceDirectory: string): Promise<void> {
                 directoryPath: 'lib/batches/env',
             },
         },
+        openTabs: {
+            description: 'Get files from open tabs.',
+            prompt: 'Open tabs as context.',
+            context: {
+                selection: false,
+                openTabs: true,
+            },
+        },
     }
 
     // add file to the .vscode directory created in the buildWorkSpaceSettings step


### PR DESCRIPTION
This commit updates the custom command e2e tests. It adds a new test to cover custom commands that are using `openTabs` as context. 

These tests ensure custom commands are executed correctly, added the context accordingly, and provide the expected results.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

The newly added e2e test case should pass with all the existing ones.