### PR TITLE
cody: change auth endpoint to handle SAMS redirect

### DIFF
--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -40,7 +40,6 @@ async function openExternalAuthUrl(provider: AuthMethod): Promise<boolean> {
     const gitLabLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=gitlab&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=${postSignUpSurveyUrl}`
     const googleLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=google&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=${postSignUpSurveyUrl}`
 
-
     let uriSpec: string
     switch (provider) {
         case 'github':

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -36,9 +36,10 @@ async function openExternalAuthUrl(provider: AuthMethod): Promise<boolean> {
     const site = DOTCOM_URL.toString() // Note, ends with the path /
 
     const genericLoginUrl = `${site}sign-in?returnTo=${postSignUpSurveyUrl}`
-    const gitHubLoginUrl = `${site}.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F%3A%3Ae917b2b7fa9040e1edd4&redirect=${postSignUpSurveyUrl}`
-    const gitLabLoginUrl = `${site}.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3Ab45ecb474e92c069567822400cf73db6e39917635bf682f062c57aca68a1e41c&redirect=${postSignUpSurveyUrl}`
-    const googleLoginUrl = `${site}.auth/openidconnect/login?pc=google&redirect=${postSignUpSurveyUrl}`
+    const gitHubLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=github&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=${postSignUpSurveyUrl}`
+    const gitLabLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=gitlab&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=${postSignUpSurveyUrl}`
+    const googleLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=google&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=${postSignUpSurveyUrl}`
+
 
     let uriSpec: string
     switch (provider) {


### PR DESCRIPTION
Part of the accounts migration from sourcegraph.com to accounts.sourcegraph.com (SAMS). Using this new auth url that enables us to redirect to SAMS and back to dotcom. 

I wasn't able to test the GitLab login properly as my account is too new, could someone help with this? 

For more context, see [Joe's explanation](https://sourcegraph.slack.com/archives/C05AGQYD528/p1706593310231579?thread_ts=1706585008.158329&cid=C05AGQYD528)

## Test plan
Pull the branch, **make sure you are logged out of sourcegraph.com AND accounts.sourcegraph.com**. Head to the editor, log out of Cody, confirm that each login has the right url and try logging in.

See each scenario below:

GitHub

https://github.com/sourcegraph/cody/assets/51868853/6390ac11-d228-4c2c-8960-edc85d7ef558

GitLab

https://github.com/sourcegraph/cody/assets/51868853/fb18441e-fb42-463d-9f31-439a1d48a36c

Google

https://github.com/sourcegraph/cody/assets/51868853/25af627c-717f-49ef-abd6-cade32ab1489



<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
