### PR TITLE
Autocomplete: add `single-multiline-request` feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -26,6 +26,8 @@ export enum FeatureFlag {
     // Continue generations after a single-line completion and use the response to see the next line
     // if the first completion is accepted.
     CodyAutocompleteHotStreak = 'cody-autocomplete-hot-streak',
+    // Trigger only one request for every multiline completion instead of three.
+    CodyAutocompleteSingleMultilineRequest = 'cody-autocomplete-single-multiline-request',
 
     // Enable Cody PLG features on JetBrains
     CodyProJetBrains = 'cody-pro-jetbrains',
@@ -51,7 +53,10 @@ export class FeatureFlagProvider {
 
     constructor(private apiClient: SourcegraphGraphQLAPIClient) {}
 
-    private getFromCache(flagName: FeatureFlag, endpoint: string): boolean | undefined {
+    public getFromCache(
+        flagName: FeatureFlag,
+        endpoint: string = this.apiClient.endpoint
+    ): boolean | undefined {
         const now = Date.now()
         if (now - this.lastUpdated > ONE_HOUR) {
             // Cache expired, refresh

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -1,0 +1,104 @@
+import { type Configuration, FeatureFlag, type FeatureFlagProvider } from '@sourcegraph/cody-shared'
+import type { ContextStrategy } from './context/context-strategy'
+
+class CompletionProviderConfig {
+    private _config?: Configuration
+
+    /**
+     * Use the injected feature flag provider to make testing easier.
+     */
+    private featureFlagProvider?: FeatureFlagProvider
+
+    private flagsToResolve: FeatureFlag[] = [
+        FeatureFlag.CodyAutocompleteContextBfgMixed,
+        FeatureFlag.CodyAutocompleteContextNewJaccardSimilarity,
+        FeatureFlag.CodyAutocompleteDynamicMultilineCompletions,
+        FeatureFlag.CodyAutocompleteHotStreak,
+        FeatureFlag.CodyAutocompleteSingleMultilineRequest,
+    ]
+
+    private get config() {
+        if (!this._config) {
+            throw new Error('CompletionProviderConfig is not initialized')
+        }
+
+        return this._config
+    }
+
+    /**
+     * Should be called before `InlineCompletionItemProvider` instance is created, so that the singleton
+     * with resolved values is ready for downstream use.
+     */
+    public async init(config: Configuration, featureFlagProvider: FeatureFlagProvider): Promise<void> {
+        this._config = config
+        this.featureFlagProvider = featureFlagProvider
+
+        await Promise.all(this.flagsToResolve.map(flag => featureFlagProvider.evaluateFeatureFlag(flag)))
+    }
+
+    public setConfig(config: Configuration) {
+        this._config = config
+    }
+
+    public getPrefetchedFlag(flag: FeatureFlag | `${FeatureFlag}`): boolean {
+        if (!this.featureFlagProvider) {
+            throw new Error('CompletionProviderConfig is not initialized')
+        }
+
+        return Boolean(this.featureFlagProvider.getFromCache(flag as FeatureFlag))
+    }
+
+    public get dynamicMultilineCompletions(): boolean {
+        return (
+            this.config.autocompleteExperimentalDynamicMultilineCompletions ||
+            this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteDynamicMultilineCompletions)
+        )
+    }
+
+    public get hotStreak(): boolean {
+        return (
+            this.config.autocompleteExperimentalHotStreak ||
+            this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteHotStreak)
+        )
+    }
+
+    public get contextStrategy(): ContextStrategy {
+        const { config } = this
+
+        const bfgMixedContextFlag = this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteContextBfgMixed)
+        const newJaccardSimilarityContextFlag = this.getPrefetchedFlag(
+            FeatureFlag.CodyAutocompleteContextNewJaccardSimilarity
+        )
+
+        const contextStrategy: ContextStrategy =
+            config.autocompleteExperimentalGraphContext === 'bfg'
+                ? 'bfg'
+                : config.autocompleteExperimentalGraphContext === 'bfg-mixed'
+                  ? 'bfg-mixed'
+                  : config.autocompleteExperimentalGraphContext === 'local-mixed'
+                      ? 'local-mixed'
+                      : config.autocompleteExperimentalGraphContext === 'jaccard-similarity'
+                          ? 'jaccard-similarity'
+                          : config.autocompleteExperimentalGraphContext === 'new-jaccard-similarity'
+                              ? 'new-jaccard-similarity'
+                              : bfgMixedContextFlag
+                                  ? 'bfg-mixed'
+                                  : newJaccardSimilarityContextFlag
+                                      ? 'new-jaccard-similarity'
+                                      : 'jaccard-similarity'
+
+        return contextStrategy
+    }
+}
+
+/**
+ * A singleton store for completion provider configuration values which allows us to
+ * avoid propagating every feature flag and config value through completion provider
+ * internal calls. It guarantees that `flagsToResolve` are resolved on `CompletionProvider`
+ * creation and along with `Configuration`.
+ *
+ * A subset of relevant config values and feature flags is moved here from the existing
+ * params waterfall. Ideally, we rely on this singleton as a source of truth for config values
+ * and collapse function calls nested in `InlineCompletionItemProvider.generateCompletions()`.
+ */
+export const completionProviderConfig = new CompletionProviderConfig()

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -1,22 +1,21 @@
 import * as vscode from 'vscode'
 
 import {
-    FeatureFlag,
-    featureFlagProvider,
     isDotCom,
     type CodeCompletionsClient,
     type Configuration,
+    featureFlagProvider,
 } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 import type { AuthProvider } from '../services/AuthProvider'
 import type { CodyStatusBar } from '../services/StatusBar'
 
-import type { ContextStrategy } from './context/context-strategy'
 import type { BfgRetriever } from './context/retrievers/bfg/bfg-retriever'
 import { InlineCompletionItemProvider } from './inline-completion-item-provider'
 import { createProviderConfig } from './providers/create-provider'
 import { registerAutocompleteTraceView } from './tracer/traceView'
+import { completionProviderConfig } from './completion-provider-config'
 
 interface InlineCompletionItemProviderArgs {
     config: Configuration
@@ -71,41 +70,12 @@ export async function createInlineCompletionItemProvider({
 
     const disposables: vscode.Disposable[] = []
 
-    const [
-        providerConfig,
-        bfgMixedContextFlag,
-        newJaccardSimilarityContextFlag,
-        dynamicMultilineCompletionsFlag,
-        hotStreakFlag,
-    ] = await Promise.all([
+    const [providerConfig] = await Promise.all([
         createProviderConfig(config, client, authProvider.getAuthStatus().configOverwrites),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteContextBfgMixed),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteContextNewJaccardSimilarity),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteDynamicMultilineCompletions),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteHotStreak),
+        completionProviderConfig.init(config, featureFlagProvider),
     ])
+
     if (providerConfig) {
-        const contextStrategy: ContextStrategy =
-            config.autocompleteExperimentalGraphContext === 'bfg'
-                ? 'bfg'
-                : config.autocompleteExperimentalGraphContext === 'bfg-mixed'
-                  ? 'bfg-mixed'
-                  : config.autocompleteExperimentalGraphContext === 'local-mixed'
-                      ? 'local-mixed'
-                      : config.autocompleteExperimentalGraphContext === 'jaccard-similarity'
-                          ? 'jaccard-similarity'
-                          : config.autocompleteExperimentalGraphContext === 'new-jaccard-similarity'
-                              ? 'new-jaccard-similarity'
-                              : bfgMixedContextFlag
-                                  ? 'bfg-mixed'
-                                  : newJaccardSimilarityContextFlag
-                                      ? 'new-jaccard-similarity'
-                                      : 'jaccard-similarity'
-
-        const dynamicMultilineCompletions =
-            config.autocompleteExperimentalDynamicMultilineCompletions || dynamicMultilineCompletionsFlag
-        const hotStreak = config.autocompleteExperimentalHotStreak || hotStreakFlag
-
         const authStatus = authProvider.getAuthStatus()
         const completionsProvider = new InlineCompletionItemProvider({
             authStatus: authProvider.getAuthStatus(),
@@ -115,10 +85,7 @@ export async function createInlineCompletionItemProvider({
             formatOnAccept: config.autocompleteFormatOnAccept,
             triggerNotice,
             isRunningInsideAgent: config.isRunningInsideAgent,
-            contextStrategy,
             createBfgRetriever,
-            dynamicMultilineCompletions,
-            hotStreak,
             isDotComUser: isDotCom(authStatus.endpoint || ''),
         })
 

--- a/vscode/src/completions/get-inline-completions-tests/dynamic-multiline.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/dynamic-multiline.test.ts
@@ -25,7 +25,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
             console.log(5)█`,
             {
                 delayBetweenChunks: 50,
-                dynamicMultilineCompletions: true,
+                configuration: { autocompleteExperimentalDynamicMultilineCompletions: true },
             }
         )
 
@@ -49,7 +49,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
                 return value█
             }`,
             {
-                dynamicMultilineCompletions: true,
+                configuration: { autocompleteExperimentalDynamicMultilineCompletions: true },
             }
         )
 
@@ -71,7 +71,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
             const compeltion = new InlineCompletion(result)█
             console.log(completion)`,
             {
-                dynamicMultilineCompletions: true,
+                configuration: { autocompleteExperimentalDynamicMultilineCompletions: true },
             }
         )
 
@@ -96,7 +96,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
 
             console.log(oddNumbers)`,
             {
-                dynamicMultilineCompletions: true,
+                configuration: { autocompleteExperimentalDynamicMultilineCompletions: true },
             }
         )
 
@@ -123,7 +123,7 @@ describe('[getInlineCompletions] dynamic multiline', () => {
             }
             console.log(5)█`,
             {
-                dynamicMultilineCompletions: true,
+                configuration: { autocompleteExperimentalDynamicMultilineCompletions: true },
             }
         )
 

--- a/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/hot-streak.test.ts
@@ -26,7 +26,7 @@ describe('[getInlineCompletions] hot streak', () => {
                     █
                 }`,
                 {
-                    hotStreak: true,
+                    configuration: { autocompleteExperimentalHotStreak: true },
                     delayBetweenChunks: 50,
                 }
             )
@@ -54,7 +54,7 @@ describe('[getInlineCompletions] hot streak', () => {
                     console.log(4)
                     █
                 }`,
-                { hotStreak: true }
+                { configuration: { autocompleteExperimentalHotStreak: true } }
             )
 
             expect(request.items[0].insertText).toEqual('console.log(2)')
@@ -79,9 +79,7 @@ describe('[getInlineCompletions] hot streak', () => {
                     console.log(4)
                     return foo█
                 }`,
-                {
-                    hotStreak: true,
-                }
+                { configuration: { autocompleteExperimentalHotStreak: true } }
             )
 
             await request.completionResponseGeneratorPromise
@@ -129,8 +127,10 @@ describe('[getInlineCompletions] hot streak', () => {
                     }█
                 }`,
                 {
-                    dynamicMultilineCompletions: true,
-                    hotStreak: true,
+                    configuration: {
+                        autocompleteExperimentalDynamicMultilineCompletions: true,
+                        autocompleteExperimentalHotStreak: true,
+                    },
                 }
             )
 
@@ -158,8 +158,10 @@ describe('[getInlineCompletions] hot streak', () => {
                 █
                 const`,
                 {
-                    dynamicMultilineCompletions: true,
-                    hotStreak: true,
+                    configuration: {
+                        autocompleteExperimentalDynamicMultilineCompletions: true,
+                        autocompleteExperimentalHotStreak: true,
+                    },
                     delayBetweenChunks: 20,
                     providerOptions: {
                         firstCompletionTimeout: 10,

--- a/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
@@ -726,7 +726,7 @@ for (const isTreeSitterEnabled of cases) {
                             }
                             console.log(5)┤`
                         },
-                        dynamicMultilineCompletions: true,
+                        configuration: { autocompleteExperimentalDynamicMultilineCompletions: true },
                     })
 
                     const [insertText] = await getInlineCompletionsInsertText(requestParams)

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -22,6 +22,7 @@ import type { AutocompleteItem } from './suggested-autocomplete-items-cache'
 import type { InlineCompletionItemWithAnalytics } from './text-processing/process-inline-completions'
 import type { ProvideInlineCompletionsItemTraceData } from './tracer'
 import { isValidTestFile } from '../commands/utils/test-commands'
+import { completionProviderConfig } from './completion-provider-config'
 
 export interface InlineCompletionsParams {
     // Context
@@ -53,8 +54,6 @@ export interface InlineCompletionsParams {
 
     // Feature flags
     completeSuggestWidgetSelection?: boolean
-    dynamicMultilineCompletions?: boolean
-    hotStreak?: boolean
 
     // Callbacks to accept completions
     handleDidAcceptCompletionItem?: (
@@ -188,8 +187,6 @@ async function doGetInlineCompletions(
         handleDidPartiallyAcceptCompletionItem,
         artificialDelay,
         completionIntent,
-        dynamicMultilineCompletions,
-        hotStreak,
         lastAcceptedCompletionItem,
         isDotComUser,
     } = params
@@ -319,8 +316,6 @@ async function doGetInlineCompletions(
         triggerKind,
         providerConfig,
         docContext,
-        dynamicMultilineCompletions,
-        hotStreak,
     })
 
     tracer?.({
@@ -361,35 +356,19 @@ async function doGetInlineCompletions(
 }
 
 interface GetCompletionProvidersParams
-    extends Pick<
-        InlineCompletionsParams,
-        | 'document'
-        | 'position'
-        | 'triggerKind'
-        | 'providerConfig'
-        | 'dynamicMultilineCompletions'
-        | 'hotStreak'
-    > {
+    extends Pick<InlineCompletionsParams, 'document' | 'position' | 'triggerKind' | 'providerConfig'> {
     docContext: DocumentContext
 }
 
 function getCompletionProvider(params: GetCompletionProvidersParams): Provider {
-    const {
-        document,
-        position,
-        triggerKind,
-        providerConfig,
-        docContext,
-        dynamicMultilineCompletions,
-        hotStreak,
-    } = params
+    const { document, position, triggerKind, providerConfig, docContext } = params
 
     const sharedProviderOptions: Omit<ProviderOptions, 'id' | 'n' | 'multiline'> = {
         docContext,
         document,
         position,
-        dynamicMultilineCompletions,
-        hotStreak,
+        dynamicMultilineCompletions: completionProviderConfig.dynamicMultilineCompletions,
+        hotStreak: completionProviderConfig.hotStreak,
         // For the now the value is static and based on the average multiline completion latency.
         firstCompletionTimeout: 1900,
     }
@@ -398,7 +377,9 @@ function getCompletionProvider(params: GetCompletionProvidersParams): Provider {
         return providerConfig.create({
             id: 'multiline',
             ...sharedProviderOptions,
-            n: 3, // 3 vs. 1 does not meaningfully affect perf
+            n: completionProviderConfig.getPrefetchedFlag('cody-autocomplete-single-multiline-request')
+                ? 1
+                : 3, // 3 vs. 1 does not meaningfully affect perf
             multiline: true,
         })
     }

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -1,5 +1,5 @@
 import dedent from 'dedent'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as vscode from 'vscode'
 
 import { graphqlClient, RateLimitError, type GraphQLAPIClientConfig } from '@sourcegraph/cody-shared'
@@ -16,6 +16,7 @@ import * as CompletionLogger from './logger'
 import { createProviderConfig } from './providers/anthropic'
 import { documentAndPosition } from './test-helpers'
 import type { InlineCompletionItem } from './types'
+import { initCompletionProviderConfig } from './get-inline-completions-tests/helpers'
 
 vi.mock('vscode', () => ({
     ...vsCodeMocks,
@@ -68,7 +69,6 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
                 client: null as any,
             }),
             triggerNotice: null,
-            contextStrategy: 'none',
             authStatus: DUMMY_AUTH_STATUS,
             ...superArgs,
         })
@@ -79,6 +79,10 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
 }
 
 describe('InlineCompletionItemProvider', () => {
+    beforeAll(async () => {
+        await initCompletionProviderConfig({})
+    })
+
     it('returns results that span the whole line', async () => {
         const { document, position } = documentAndPosition('const foo = █', 'typescript')
         const fn = vi.fn(getInlineCompletions).mockResolvedValue({

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -17,7 +17,7 @@ import { telemetryService } from '../services/telemetry'
 
 import { getArtificialDelay, resetArtificialDelay, type LatencyFeatureFlags } from './artificial-delay'
 import { ContextMixer } from './context/context-mixer'
-import { DefaultContextStrategyFactory, type ContextStrategy } from './context/context-strategy'
+import { DefaultContextStrategyFactory } from './context/context-strategy'
 import type { BfgRetriever } from './context/retrievers/bfg/bfg-retriever'
 import { getCompletionIntent } from './doc-context-getters'
 import { FirstCompletionDecorationHandler } from './first-completion-decoration-handler'
@@ -44,6 +44,7 @@ import {
     type AutocompleteItem,
 } from './suggested-autocomplete-items-cache'
 import type { ProvideInlineCompletionItemsTracer, ProvideInlineCompletionsItemTraceData } from './tracer'
+import { completionProviderConfig } from './completion-provider-config'
 
 interface AutocompleteResult extends vscode.InlineCompletionList {
     logId: CompletionLogID
@@ -62,7 +63,6 @@ export interface CodyCompletionItemProviderConfig {
     authStatus: AuthStatus
     isDotComUser?: boolean
 
-    contextStrategy: ContextStrategy
     createBfgRetriever?: () => BfgRetriever
 
     // Settings
@@ -70,8 +70,6 @@ export interface CodyCompletionItemProviderConfig {
 
     // Feature flags
     completeSuggestWidgetSelection?: boolean
-    dynamicMultilineCompletions?: boolean
-    hotStreak?: boolean
 }
 
 interface CompletionRequest {
@@ -114,8 +112,6 @@ export class InlineCompletionItemProvider
     constructor({
         completeSuggestWidgetSelection = true,
         formatOnAccept = true,
-        dynamicMultilineCompletions = false,
-        hotStreak = false,
         tracer = null,
         createBfgRetriever,
         ...config
@@ -124,8 +120,6 @@ export class InlineCompletionItemProvider
             ...config,
             completeSuggestWidgetSelection,
             formatOnAccept,
-            dynamicMultilineCompletions,
-            hotStreak,
             tracer,
             isRunningInsideAgent: config.isRunningInsideAgent ?? false,
             isDotComUser: config.isDotComUser ?? false,
@@ -152,7 +146,10 @@ export class InlineCompletionItemProvider
 
         this.requestManager = new RequestManager()
         this.contextMixer = new ContextMixer(
-            new DefaultContextStrategyFactory(config.contextStrategy, createBfgRetriever)
+            new DefaultContextStrategyFactory(
+                completionProviderConfig.contextStrategy,
+                createBfgRetriever
+            )
         )
 
         const chatHistory = localStorage.getChatHistory(this.config.authStatus)?.chat
@@ -285,7 +282,7 @@ export class InlineCompletionItemProvider
                 maxSuffixLength: this.config.providerConfig.contextSizeHints.suffixChars,
                 // We ignore the current context selection if completeSuggestWidgetSelection is not enabled
                 context: takeSuggestWidgetSelectionIntoAccount ? context : undefined,
-                dynamicMultilineCompletions: this.config.dynamicMultilineCompletions,
+                dynamicMultilineCompletions: completionProviderConfig.dynamicMultilineCompletions,
             })
 
             const completionIntent = getCompletionIntent({
@@ -329,8 +326,6 @@ export class InlineCompletionItemProvider
                     completeSuggestWidgetSelection: takeSuggestWidgetSelectionIntoAccount,
                     artificialDelay,
                     completionIntent,
-                    dynamicMultilineCompletions: this.config.dynamicMultilineCompletions,
-                    hotStreak: this.config.hotStreak,
                     lastAcceptedCompletionItem: this.lastAcceptedCompletionItem,
                     isDotComUser: this.config.isDotComUser,
                 })

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -777,6 +777,11 @@ export class MockFeatureFlagProvider extends FeatureFlagProvider {
     public evaluateFeatureFlag(flag: FeatureFlag): Promise<boolean> {
         return Promise.resolve(this.enabledFlags.has(flag))
     }
+
+    public getFromCache(flag: FeatureFlag): boolean {
+        return this.enabledFlags.has(flag)
+    }
+
     public syncAuthStatus(): Promise<void> {
         return Promise.resolve()
     }


### PR DESCRIPTION
## Context

- Adds `cody-autocomplete-single-multiline-request` feature flag to reduce the number of requests for multiline completions from three to one.
- Adds `CompletionProviderConfig` singleton that prefetches completion provider feature flags and stores the latest configuration object to reduce the "prop-drilling" of completion provider options.

## Test plan

CI
