### PR TITLE
VSCode UI: Add an e2e smoke test for the multi-repo picker

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -116,7 +116,7 @@ interface CodyLLMSiteConfigurationProviderResponse {
     site: { codyLLMConfiguration: Pick<CodyLLMSiteConfiguration, 'provider'> | null } | null
 }
 
-interface RepoListResponse {
+export interface RepoListResponse {
     repositories: {
         nodes: { name: string; id: string }[]
         pageInfo: {

--- a/vscode/test/e2e/context-settings.test.ts
+++ b/vscode/test/e2e/context-settings.test.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test'
 
 import { sidebarSignin } from './common'
 import { newChat, test } from './helpers'
+import type { RepoListResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
 
 test('enhanced context selector is keyboard accessible', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
@@ -27,4 +28,82 @@ test('enhanced context selector is keyboard accessible', async ({ page, sidebar 
     await expect(enhancedContextCheckbox).not.toBeVisible()
     // ... and focus the button which re-opens it.
     await expect(contextSettingsButton.and(page.locator(':focus'))).toBeVisible()
+})
+
+test('enterprise context selector does not dismiss when picking repos', async ({
+    page,
+    sidebar,
+    server,
+}) => {
+    const repos1: RepoListResponse = {
+        repositories: {
+            nodes: [
+                {
+                    id: 'WOOZL',
+                    name: 'repo/foo',
+                },
+            ],
+            pageInfo: {
+                endCursor: 'WOOZL',
+            },
+        },
+    }
+    const repos2: RepoListResponse = {
+        repositories: {
+            nodes: [
+                {
+                    id: 'WUZLE',
+                    name: 'repo/bar',
+                },
+            ],
+            pageInfo: {
+                endCursor: null,
+            },
+        },
+    }
+    server.onGraphQl('Repositories').replyJson({ data: repos1 }).next().replyJson({ data: repos2 })
+
+    await sidebarSignin(page, sidebar)
+    const chatFrame = await newChat(page)
+
+    // Because there are no repositories in the workspace, none should be selected by default.
+    await chatFrame.getByTitle('Configure Enhanced Context').click()
+    await expect(chatFrame.getByText('No repositories selected')).toBeVisible()
+
+    // Choosing a repository should open the repository picker.
+    const chooseReposButton = chatFrame.getByRole('button', { name: 'Choose Repositories' })
+    await chooseReposButton.click()
+    const repoPicker = page.getByText(/Choose up to \d+ more repositories/)
+    await expect(repoPicker).toBeVisible()
+
+    // Opening the picker should not close the enhanced context status widget.
+    await expect(chooseReposButton).toBeVisible()
+
+    // Repositories listed on the remote should be present in the picker.
+    const repoFoo = page.getByText('repo/foo')
+    const repoBar = page.getByText('repo/bar')
+    await expect(repoFoo).toBeVisible()
+    await expect(repoBar).toBeVisible()
+
+    // Typing should filter the list of repositories.
+    await page.keyboard.type('o/f')
+    await expect(repoBar).not.toBeVisible()
+
+    // Choosing should dismiss the repo picker, but not the enhanced context
+    // settings widget.
+    await repoFoo.click()
+    await page.keyboard.type('\n')
+    await expect(repoPicker).not.toBeVisible()
+    await expect(chooseReposButton).toBeVisible()
+    // We need a delay here because the enhanced context settings widget was
+    // dismissing after a rerender.
+    await new Promise(resolve => setTimeout(resolve, 250))
+
+    // TODO: When https://github.com/sourcegraph/cody/issues/2938 is fixed,
+    // expect the choose repos button to be visible.
+    await expect(chooseReposButton).not.toBeVisible()
+    await chatFrame.getByTitle('Configure Enhanced Context').click()
+
+    // The chosen repo should appear in the picker.
+    await expect(chatFrame.getByTitle('repo/foo').getByText(/^foo$/)).toBeVisible()
 })

--- a/vscode/test/e2e/context-settings.test.ts
+++ b/vscode/test/e2e/context-settings.test.ts
@@ -30,11 +30,7 @@ test('enhanced context selector is keyboard accessible', async ({ page, sidebar 
     await expect(contextSettingsButton.and(page.locator(':focus'))).toBeVisible()
 })
 
-test('enterprise context selector does not dismiss when picking repos', async ({
-    page,
-    sidebar,
-    server,
-}) => {
+test('enterprise context selector can pick repos', async ({ page, sidebar, server }) => {
     const repos1: RepoListResponse = {
         repositories: {
             nodes: [

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -7,7 +7,7 @@ import { test as base, expect, type Frame, type FrameLocator, type Page } from '
 import { _electron as electron } from 'playwright'
 import * as uuid from 'uuid'
 
-import { resetLoggedEvents, run, sendTestInfo } from '../fixtures/mock-server'
+import { MockServer, resetLoggedEvents, sendTestInfo } from '../fixtures/mock-server'
 
 import { installVsCode } from './install-deps'
 
@@ -53,9 +53,17 @@ export const test = base
     .extend<DotcomUrlOverride>({
         dotcomUrl: undefined,
     })
+    .extend<{ server: MockServer }>({
+        // biome-ignore lint/correctness/noEmptyPattern: Playwright ascribes meaning to the empty pattern: No dependencies.
+        server: async ({}, use) => {
+            MockServer.run(async server => {
+                await use(server)
+            })
+        },
+    })
     .extend({
         page: async (
-            { page: _page, workspaceDirectory, extraWorkspaceSettings, dotcomUrl },
+            { page: _page, workspaceDirectory, extraWorkspaceSettings, dotcomUrl, server: MockServer },
             use,
             testInfo
         ) => {
@@ -124,15 +132,13 @@ export const test = base
             // the signed-in and signed-out cases
             await new Promise(resolve => setTimeout(resolve, 500))
 
-            await run(async () => {
-                // Ensure we're signed out.
-                if (await page.isVisible('[aria-label="User Settings"]')) {
-                    await signOut(page)
-                }
+            // Ensure we're signed out.
+            if (await page.isVisible('[aria-label="User Settings"]')) {
+                await signOut(page)
+            }
 
-                resetLoggedEvents()
-                await use(page)
-            })
+            resetLoggedEvents()
+            await use(page)
 
             await app.close()
 

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -63,275 +63,374 @@ const topicPublisher = pubSubClient.topic(
     publishOptions
 )
 
-// Runs a stub Cody service for testing.
-export async function run<T>(around: () => Promise<T>): Promise<T> {
-    const app = express()
-    app.use(express.json())
+//#region GraphQL Mocks
 
-    // endpoint which will accept the data that you want to send in that you will add your pubsub code
-    app.post('/.api/testLogging', (req, res) => {
-        void logTestingData('legacy', req.body)
-        storeLoggedEvents(req.body)
-        res.status(200)
-    })
+// This is a primitive system for injecting GraphQL responses per-test, instead
+// of adding every possible GraphQL response to the mock server directly.
 
-    // matches @sourcegraph/cody-shared't work, so hardcode it here.
-    app.post('/.api/mockEventRecording', (req, res) => {
-        const events = req.body as TelemetryEventInput[]
-        for (const event of events) {
-            void logTestingData('new', JSON.stringify(event))
-            if (
-                ![
-                    'cody.extension', // extension setup events can behave differently in test environments
-                ].includes(event.feature)
-            ) {
-                loggedV2Events.push(`${event.feature}/${event.action}`)
-            }
-        }
-        res.status(200)
-    })
+type GraphQlMockResponse =
+    | {
+          kind: 'json'
+          json: string
+      }
+    | {
+          kind: 'status'
+          status: number
+          message: string | undefined
+      }
 
-    /** Whether to simulate that rate limits have been hit */
-    let chatRateLimited = false
-    /** Whether the user is Pro (true), Free (false) or not a dotCom user (undefined) */
-    let chatRateLimitPro: boolean | undefined
-    app.post('/.api/completions/stream', (req, res) => {
-        if (chatRateLimited) {
-            res.setHeader('retry-after', new Date().toString())
-            res.setHeader('x-ratelimit-limit', '12345')
-            if (chatRateLimitPro !== undefined) {
-                res.setHeader('x-is-cody-pro-user', `${chatRateLimitPro}`)
-            }
-            res.sendStatus(429)
-            return
-        }
-
-        // TODO: Filter streaming response
-        // TODO: Handle multiple messages
-        // Ideas from Dom - see if we could put something in the test request itself where we tell it what to respond with
-        // or have a method on the server to send a set response the next time it sees a trigger word in the request.
-        const request = req as MockRequest
-        const lastHumanMessageIndex = request.body.messages.length - 2
-        let response = responses.chat
-        if (
-            request.body.messages[lastHumanMessageIndex].text.includes(FIXUP_PROMPT_TAG) ||
-            request.body.messages[lastHumanMessageIndex].text.includes(NON_STOP_FIXUP_PROMPT_TAG)
-        ) {
-            response = responses.fixup
-        }
-        if (request.body.messages[lastHumanMessageIndex].text.includes('show me a code snippet')) {
-            response = responses.chatWithSnippet
-        }
-        res.send(
-            `event: completion\ndata: {"completion": ${JSON.stringify(
-                response
-            )}}\n\nevent: done\ndata: {}\n\n`
-        )
-    })
-    app.post('/.test/completions/triggerRateLimit', (req, res) => {
-        chatRateLimited = true
-        chatRateLimitPro = undefined
-        res.sendStatus(200)
-    })
-    app.post('/.test/completions/triggerRateLimit/free', (req, res) => {
-        chatRateLimited = true
-        chatRateLimitPro = false
-        res.sendStatus(200)
-    })
-    app.post('/.test/completions/triggerRateLimit/pro', (req, res) => {
-        chatRateLimited = true
-        chatRateLimitPro = true
-        res.sendStatus(200)
-    })
-    app.post('/.test/completions/triggerRateLimit/enterprise', (req, res) => {
-        chatRateLimited = true
-        chatRateLimitPro = undefined
-        res.sendStatus(200)
-    })
-
-    app.post('/.api/completions/code', (req, res) => {
-        const OPENING_CODE_TAG = '<CODE5711>'
-        const request = req as MockRequest
-
-        // Extract the code from the last message.
-        let completionPrefix = request.body.messages.at(-1)?.text
-        if (!completionPrefix?.startsWith(OPENING_CODE_TAG)) {
-            throw new Error(
-                `Last completion message did not contain code starting with ${OPENING_CODE_TAG}`
-            )
-        }
-        completionPrefix = completionPrefix.slice(OPENING_CODE_TAG.length)
-
-        // Trim to the last word since our mock responses are just completing words. If the
-        // request has a trailing space, we won't provide anything since the user hasn't
-        // started typing a word.
-        completionPrefix = completionPrefix?.split(/\s/g).at(-1)
-
-        // Find a matching mock response that is longer than what we've already
-        // typed.
-        const completion =
-            responses.code.mockResponses
-                .find(
-                    candidate =>
-                        completionPrefix?.length &&
-                        candidate.startsWith(completionPrefix) &&
-                        candidate.length > completionPrefix.length
-                )
-                ?.slice(completionPrefix?.length) ?? ''
-
-        const response = { ...responses.code.template, completion }
-        res.send(JSON.stringify(response))
-    })
-
-    let attribution = false
-    app.post('/.api/graphql', (req, res) => {
-        if (req.headers.authorization !== `token ${VALID_TOKEN}`) {
-            res.sendStatus(401)
-            return
-        }
-
-        const operation = new URL(req.url, 'https://example.com').search.replace(/^\?/, '')
-        switch (operation) {
-            case 'CurrentUser':
-                res.send(
-                    JSON.stringify({
-                        data: {
-                            currentUser: {
-                                id: 'u',
-                                hasVerifiedEmail: true,
-                                displayName: 'Person',
-                                username: 'person',
-                                avatarURL: '',
-                                primaryEmail: {
-                                    email: 'person@company.comp',
-                                },
-                            },
-                        },
-                    })
-                )
-                break
-            case 'CurrentUserCodyProEnabled':
-                res.send(
-                    JSON.stringify({
-                        data: {
-                            currentUser: {
-                                codyProEnabled: false,
-                            },
-                        },
-                    })
-                )
-                break
-            case 'IsContextRequiredForChatQuery':
-                res.send(
-                    JSON.stringify({
-                        data: { isContextRequiredForChatQuery: false },
-                    })
-                )
-                break
-            case 'SiteIdentification':
-                res.send(
-                    JSON.stringify({
-                        data: {
-                            site: {
-                                siteID: 'test-site-id',
-                                productSubscription: {
-                                    license: { hashedKey: 'mmm,hashedkey' },
-                                },
-                            },
-                        },
-                    })
-                )
-                break
-            case 'SiteProductVersion':
-                res.send(
-                    JSON.stringify({
-                        data: { site: { productVersion: 'dev' } },
-                    })
-                )
-                break
-            case 'SiteGraphQLFields':
-                res.send(
-                    JSON.stringify({
-                        data: {
-                            __type: {
-                                fields: [{ name: 'id' }, { name: 'isCodyEnabled' }],
-                            },
-                        },
-                    })
-                )
-                break
-            case 'SiteHasCodyEnabled':
-                res.send(JSON.stringify({ data: { site: { isCodyEnabled: true } } }))
-                break
-            case 'CurrentSiteCodyLlmConfiguration': {
-                res.send(
-                    JSON.stringify({
-                        data: {
-                            site: {
-                                codyLLMConfiguration: {
-                                    chatModel: 'test-chat-default-model',
-                                    provider: 'sourcegraph',
-                                },
-                            },
-                        },
-                    })
-                )
-                break
-            }
-            case 'CodyConfigFeaturesResponse': {
-                res.send(
-                    JSON.stringify({
-                        data: {
-                            site: {
-                                codyConfigFeatures: {
-                                    chat: true,
-                                    autoComplete: true,
-                                    commands: true,
-                                    attribution,
-                                },
-                            },
-                        },
-                    })
-                )
-                break
-            }
-            default:
-                res.sendStatus(400)
-                break
-        }
-    })
-
-    app.post('/.test/attribution/enable', (req, res) => {
-        attribution = true
-        res.sendStatus(200)
-    })
-    app.post('/.test/attribution/disable', (req, res) => {
-        attribution = false
-        res.sendStatus(200)
-    })
-
-    const server = app.listen(SERVER_PORT)
-
-    // Calling close() on the server only stops accepting new connections
-    // and does not terminate existing connections. This can result in
-    // tests reusing the previous tests server unless they are explicitly
-    // closed, so track connections as they open.
-    const sockets = new Set<Socket>()
-    server.on('connection', socket => sockets.add(socket))
-
-    const result = await around()
-
-    // Tell the server to stop accepting connections. The server won't shut down
-    // and the callback won't be fired until all existing clients are closed.
-    const serverClosed = new Promise(resolve => server.close(resolve))
-
-    // Close all the existing connections and wait for the server shutdown.
-    for (const socket of sockets) {
-        socket.destroy()
+export class GraphQlMock {
+    private response: GraphQlMockResponse = {
+        kind: 'status',
+        status: 400,
+        message: 'unhandled GraphQL operation',
     }
-    await serverClosed
+    private nextMock: GraphQlMock | undefined = undefined
 
-    return result
+    constructor(
+        private readonly container: MockServer,
+        private readonly operation: string
+    ) {}
+
+    public replyJson(json: any): GraphQlMock {
+        this.response = {
+            kind: 'json',
+            json: JSON.stringify(json),
+        }
+        return this
+    }
+
+    public replyStatus(code: number, message?: string): GraphQlMock {
+        this.response = {
+            kind: 'status',
+            status: code,
+            message,
+        }
+        return this
+    }
+
+    public next(): GraphQlMock {
+        this.nextMock = new GraphQlMock(this.container, this.operation)
+        return this.nextMock
+    }
+
+    handleRequest(res: express.Response): void {
+        switch (this.response.kind) {
+            case 'json':
+                res.send(this.response.json)
+                break
+            case 'status':
+                res.status(this.response.status)
+                if (this.response.message) {
+                    res.statusMessage = this.response.message
+                }
+                break
+        }
+        if (this.nextMock) {
+            this.container.graphQlMocks.set(this.operation, this.nextMock)
+        }
+    }
+}
+
+//#endregion
+
+// Lets the test change the behavior of the mock server.
+export class MockServer {
+    graphQlMocks: Map<string, GraphQlMock> = new Map()
+
+    constructor(public readonly express: express.Express) {}
+
+    public onGraphQl(operation: string): GraphQlMock {
+        let mock = this.graphQlMocks.get(operation)
+        if (!mock) {
+            mock = new GraphQlMock(this, operation)
+            this.graphQlMocks.set(operation, mock)
+        }
+        return mock
+    }
+
+    // Runs a stub Cody service for testing.
+    public static async run<T>(around: (server: MockServer) => Promise<T>): Promise<T> {
+        const app = express()
+        const controller = new MockServer(app)
+
+        app.use(express.json())
+
+        // endpoint which will accept the data that you want to send in that you will add your pubsub code
+        app.post('/.api/testLogging', (req, res) => {
+            void logTestingData('legacy', req.body)
+            storeLoggedEvents(req.body)
+            res.status(200)
+        })
+
+        // matches @sourcegraph/cody-shared't work, so hardcode it here.
+        app.post('/.api/mockEventRecording', (req, res) => {
+            const events = req.body as TelemetryEventInput[]
+            for (const event of events) {
+                void logTestingData('new', JSON.stringify(event))
+                if (
+                    ![
+                        'cody.extension', // extension setup events can behave differently in test environments
+                    ].includes(event.feature)
+                ) {
+                    loggedV2Events.push(`${event.feature}/${event.action}`)
+                }
+            }
+            res.status(200)
+        })
+
+        /** Whether to simulate that rate limits have been hit */
+        let chatRateLimited = false
+        /** Whether the user is Pro (true), Free (false) or not a dotCom user (undefined) */
+        let chatRateLimitPro: boolean | undefined
+        app.post('/.api/completions/stream', (req, res) => {
+            if (chatRateLimited) {
+                res.setHeader('retry-after', new Date().toString())
+                res.setHeader('x-ratelimit-limit', '12345')
+                if (chatRateLimitPro !== undefined) {
+                    res.setHeader('x-is-cody-pro-user', `${chatRateLimitPro}`)
+                }
+                res.sendStatus(429)
+                return
+            }
+
+            // TODO: Filter streaming response
+            // TODO: Handle multiple messages
+            // Ideas from Dom - see if we could put something in the test request itself where we tell it what to respond with
+            // or have a method on the server to send a set response the next time it sees a trigger word in the request.
+            const request = req as MockRequest
+            const lastHumanMessageIndex = request.body.messages.length - 2
+            let response = responses.chat
+            if (
+                request.body.messages[lastHumanMessageIndex].text.includes(FIXUP_PROMPT_TAG) ||
+                request.body.messages[lastHumanMessageIndex].text.includes(NON_STOP_FIXUP_PROMPT_TAG)
+            ) {
+                response = responses.fixup
+            }
+            if (request.body.messages[lastHumanMessageIndex].text.includes('show me a code snippet')) {
+                response = responses.chatWithSnippet
+            }
+            res.send(
+                `event: completion\ndata: {"completion": ${JSON.stringify(
+                    response
+                )}}\n\nevent: done\ndata: {}\n\n`
+            )
+        })
+        app.post('/.test/completions/triggerRateLimit', (req, res) => {
+            chatRateLimited = true
+            chatRateLimitPro = undefined
+            res.sendStatus(200)
+        })
+        app.post('/.test/completions/triggerRateLimit/free', (req, res) => {
+            chatRateLimited = true
+            chatRateLimitPro = false
+            res.sendStatus(200)
+        })
+        app.post('/.test/completions/triggerRateLimit/pro', (req, res) => {
+            chatRateLimited = true
+            chatRateLimitPro = true
+            res.sendStatus(200)
+        })
+        app.post('/.test/completions/triggerRateLimit/enterprise', (req, res) => {
+            chatRateLimited = true
+            chatRateLimitPro = undefined
+            res.sendStatus(200)
+        })
+
+        app.post('/.api/completions/code', (req, res) => {
+            const OPENING_CODE_TAG = '<CODE5711>'
+            const request = req as MockRequest
+
+            // Extract the code from the last message.
+            let completionPrefix = request.body.messages.at(-1)?.text
+            if (!completionPrefix?.startsWith(OPENING_CODE_TAG)) {
+                throw new Error(
+                    `Last completion message did not contain code starting with ${OPENING_CODE_TAG}`
+                )
+            }
+            completionPrefix = completionPrefix.slice(OPENING_CODE_TAG.length)
+
+            // Trim to the last word since our mock responses are just completing words. If the
+            // request has a trailing space, we won't provide anything since the user hasn't
+            // started typing a word.
+            completionPrefix = completionPrefix?.split(/\s/g).at(-1)
+
+            // Find a matching mock response that is longer than what we've already
+            // typed.
+            const completion =
+                responses.code.mockResponses
+                    .find(
+                        candidate =>
+                            completionPrefix?.length &&
+                            candidate.startsWith(completionPrefix) &&
+                            candidate.length > completionPrefix.length
+                    )
+                    ?.slice(completionPrefix?.length) ?? ''
+
+            const response = { ...responses.code.template, completion }
+            res.send(JSON.stringify(response))
+        })
+
+        let attribution = false
+        app.post('/.api/graphql', (req, res) => {
+            if (req.headers.authorization !== `token ${VALID_TOKEN}`) {
+                res.sendStatus(401)
+                return
+            }
+
+            const operation = new URL(req.url, 'https://example.com').search.replace(/^\?/, '')
+            if (controller.graphQlMocks.has(operation)) {
+                try {
+                    controller.onGraphQl(operation).handleRequest(res)
+                } catch (error) {
+                    res.sendStatus(500)
+                    res.statusMessage = (error as Error).message
+                }
+            } else {
+                switch (operation) {
+                    case 'CurrentUser':
+                        res.send(
+                            JSON.stringify({
+                                data: {
+                                    currentUser: {
+                                        id: 'u',
+                                        hasVerifiedEmail: true,
+                                        displayName: 'Person',
+                                        username: 'person',
+                                        avatarURL: '',
+                                        primaryEmail: {
+                                            email: 'person@company.comp',
+                                        },
+                                    },
+                                },
+                            })
+                        )
+                        break
+                    case 'CurrentUserCodyProEnabled':
+                        res.send(
+                            JSON.stringify({
+                                data: {
+                                    currentUser: {
+                                        codyProEnabled: false,
+                                    },
+                                },
+                            })
+                        )
+                        break
+                    case 'IsContextRequiredForChatQuery':
+                        res.send(
+                            JSON.stringify({
+                                data: { isContextRequiredForChatQuery: false },
+                            })
+                        )
+                        break
+                    case 'SiteIdentification':
+                        res.send(
+                            JSON.stringify({
+                                data: {
+                                    site: {
+                                        siteID: 'test-site-id',
+                                        productSubscription: {
+                                            license: { hashedKey: 'mmm,hashedkey' },
+                                        },
+                                    },
+                                },
+                            })
+                        )
+                        break
+                    case 'SiteProductVersion':
+                        res.send(
+                            JSON.stringify({
+                                data: { site: { productVersion: 'dev' } },
+                            })
+                        )
+                        break
+                    case 'SiteGraphQLFields':
+                        res.send(
+                            JSON.stringify({
+                                data: {
+                                    __type: {
+                                        fields: [{ name: 'id' }, { name: 'isCodyEnabled' }],
+                                    },
+                                },
+                            })
+                        )
+                        break
+                    case 'SiteHasCodyEnabled':
+                        res.send(JSON.stringify({ data: { site: { isCodyEnabled: true } } }))
+                        break
+                    case 'CurrentSiteCodyLlmConfiguration': {
+                        res.send(
+                            JSON.stringify({
+                                data: {
+                                    site: {
+                                        codyLLMConfiguration: {
+                                            chatModel: 'test-chat-default-model',
+                                            provider: 'sourcegraph',
+                                        },
+                                    },
+                                },
+                            })
+                        )
+                        break
+                    }
+                    case 'CodyConfigFeaturesResponse': {
+                        res.send(
+                            JSON.stringify({
+                                data: {
+                                    site: {
+                                        codyConfigFeatures: {
+                                            chat: true,
+                                            autoComplete: true,
+                                            commands: true,
+                                            attribution,
+                                        },
+                                    },
+                                },
+                            })
+                        )
+                        break
+                    }
+                    default:
+                        res.sendStatus(400)
+                        res.statusMessage = `unhandled GraphQL operation ${operation}`
+                        break
+                }
+            }
+        })
+
+        app.post('/.test/attribution/enable', (req, res) => {
+            attribution = true
+            res.sendStatus(200)
+        })
+        app.post('/.test/attribution/disable', (req, res) => {
+            attribution = false
+            res.sendStatus(200)
+        })
+
+        const server = app.listen(SERVER_PORT)
+
+        // Calling close() on the server only stops accepting new connections
+        // and does not terminate existing connections. This can result in
+        // tests reusing the previous tests server unless they are explicitly
+        // closed, so track connections as they open.
+        const sockets = new Set<Socket>()
+        server.on('connection', socket => sockets.add(socket))
+
+        const result = await around(controller)
+
+        // Tell the server to stop accepting connections. The server won't shut down
+        // and the callback won't be fired until all existing clients are closed.
+        const serverClosed = new Promise(resolve => server.close(resolve))
+
+        // Close all the existing connections and wait for the server shutdown.
+        for (const socket of sockets) {
+            socket.destroy()
+        }
+        await serverClosed
+
+        return result
+    }
 }
 
 async function logTestingData(type: 'legacy' | 'new', data: string): Promise<void> {

--- a/vscode/test/integration/main.ts
+++ b/vscode/test/integration/main.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 
 import { runTests } from '@vscode/test-electron'
 
-import * as mockServer from '../fixtures/mock-server'
+import { MockServer } from '../fixtures/mock-server'
 
 async function main(): Promise<void> {
     // Set this environment variable so the extension exposes hooks to the test runner.
@@ -35,7 +35,7 @@ async function main(): Promise<void> {
 
     try {
         // Download VS Code, unzip it, and run the integration test.
-        await mockServer.run(() =>
+        await MockServer.run(() =>
             runTests({
                 version: '1.81.1',
                 extensionDevelopmentPath,


### PR DESCRIPTION
Most interesting thing here: Adds the ability to mock GraphQL responses at a fine granularity, instead of having everyone dump them into the mock server.

## Test plan

```
cd vscode
pnpm test:e2e -- context-settings.test.ts
```