### PR TITLE
Autocomplete: add `deepseek-coder:6.7b` support

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Chat: Display Cody icon in the editor title of the chat panels when `cody.editorTitleCommandIcon` is enabled. [pull/2937](https://github.com/sourcegraph/cody/pull/2937)
+- Autocomplete: local inference support with [deepseek-coder](https://ollama.ai/library/deepseek-coder) powered by ollama. [pull/2966](https://github.com/sourcegraph/cody/pull/2966)
 
 ### Fixed
 

--- a/vscode/doc/ollama.md
+++ b/vscode/doc/ollama.md
@@ -3,6 +3,8 @@
 ## How to use
 
 1. Install and run [Ollama](https://ollama.ai/)
-2. Download Code Llama 7b: `ollama pull codellama:7b-code` or [other codellama verison](https://ollama.ai/library/codellama/tags) you prefer to use locally.
+2. Download one of the support local models:
+  - `ollama pull deepseek-coder:6.7b-base-q4_K_M` for [deepseek-coder](https://ollama.ai/library/deepseek-coder)
+  - `ollama pull codellama:7b-code` for [codellama](https://ollama.ai/library/codellama)
 3. Update Cody's VS Code settings to use the `unstable-ollama` autocomplete provider.
 4. Confirm Cody uses Ollama by looking at the Cody output channel or the autocomplete trace view (in the command palette).

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -980,7 +980,7 @@
           "markdownDescription": "Options for the [Ollama](https://ollama.ai/) experimental autocomplete provider.",
           "default": {
             "url": "http://localhost:11434",
-            "model": "codellama:7b-code"
+            "model": "deepseek-coder:6.7b-base-q4_K_M"
           },
           "properties": {
             "url": {
@@ -990,10 +990,11 @@
             },
             "model": {
               "type": "string",
-              "default": "codellama:7b-code",
+              "default": "deepseek-coder:6.7b-base-q4_K_M",
               "examples": [
                 "codellama:7b-code",
-                "codellama:13b-code"
+                "codellama:13b-code",
+                "deepseek-coder:6.7b-base-q4_K_M"
               ]
             },
             "parameters": {

--- a/vscode/src/completions/providers/fetch-and-process-completions.ts
+++ b/vscode/src/completions/providers/fetch-and-process-completions.ts
@@ -50,7 +50,7 @@ export async function* fetchAndProcessDynamicMultilineCompletions(
         const { completedCompletion, rawCompletion, isFullResponse } = stopParams
         addAutocompleteDebugEvent('stopStreamingAndUsePartialResponse', {
             isFullResponse,
-            text: rawCompletion,
+            text: completedCompletion.insertText,
         })
 
         yield {

--- a/vscode/src/completions/providers/ollama-models.ts
+++ b/vscode/src/completions/providers/ollama-models.ts
@@ -1,0 +1,142 @@
+import type * as vscode from 'vscode'
+
+import type { OllamaGenerateParameters } from '@sourcegraph/cody-shared'
+
+interface OllamaPromptContext {
+    snippets: { uri: vscode.Uri; content: string }[]
+    context: string
+    currentFileNameComment: string
+    isInfill: boolean
+
+    uri: vscode.Uri
+    prefix: string
+    suffix: string
+
+    languageId: string
+}
+
+const EOT_TOKEN = '<EOT>'
+const SHARED_STOP_SEQUENCES = [
+    '// Path:',
+    '\u001E',
+    '\u001C',
+    EOT_TOKEN,
+
+    // Tokens that reduce the quality of multi-line completions but improve performance.
+    '; ',
+    ';\t',
+]
+const SINGLE_LINE_STOP_SEQUENCES = ['\n', ...SHARED_STOP_SEQUENCES]
+// TODO(valery): find the balance between using less stop tokens to get more multiline completions and keeping a good perf.
+// `SHARED_STOP_SEQUENCES` are not included because the number of multiline completions goes down significantly
+// leaving an impression that Ollama provider support only singleline completions.
+const MULTI_LINE_STOP_SEQUENCES: string[] = ['\n\n', EOT_TOKEN /* ...SHARED_STOP_SEQUENCES */]
+
+export interface OllamaModel {
+    getPrompt(ollamaPrompt: OllamaPromptContext): string
+    getRequestOptions(isMultiline: boolean, isDynamicMultiline: boolean): OllamaGenerateParameters
+}
+
+class DefaultOllamaModel implements OllamaModel {
+    getPrompt(ollamaPrompt: OllamaPromptContext): string {
+        const { context, currentFileNameComment, prefix } = ollamaPrompt
+        return context + currentFileNameComment + prefix
+    }
+
+    getRequestOptions(isMultiline: boolean, isDynamicMultiline: boolean): OllamaGenerateParameters {
+        const params = {
+            stop: SINGLE_LINE_STOP_SEQUENCES,
+            temperature: 0.2,
+            top_k: -1,
+            top_p: -1,
+            num_predict: 30,
+        }
+
+        if (isMultiline) {
+            Object.assign(params, {
+                num_predict: 256,
+                stop: MULTI_LINE_STOP_SEQUENCES,
+            })
+        }
+
+        if (isDynamicMultiline) {
+            params.stop = []
+        }
+
+        return params
+    }
+}
+
+class DeepseekCoder extends DefaultOllamaModel {
+    getPrompt(ollamaPrompt: OllamaPromptContext): string {
+        const { context, currentFileNameComment, prefix, suffix } = ollamaPrompt
+
+        const infillPrefix = context + currentFileNameComment + prefix
+
+        return `<｜fim▁begin｜>${infillPrefix}<｜fim▁hole｜>${suffix}<｜fim▁end｜>`
+    }
+
+    getRequestOptions(isMultiline: boolean, isDynamicMultiline: boolean): OllamaGenerateParameters {
+        const params = {
+            stop: SINGLE_LINE_STOP_SEQUENCES,
+            temperature: 0.6,
+            top_k: 30,
+            top_p: 0.2,
+            num_predict: 30,
+            num_gpu: 99,
+            repeat_penalty: 1.1,
+        }
+
+        if (isMultiline) {
+            Object.assign(params, {
+                num_predict: -1,
+                stop: MULTI_LINE_STOP_SEQUENCES,
+            })
+        }
+
+        if (isDynamicMultiline) {
+            Object.assign(params, {
+                num_predict: -1,
+                stop: [],
+            })
+        }
+
+        return params
+    }
+}
+
+class CodeLlama extends DefaultOllamaModel {
+    getPrompt(ollamaPrompt: OllamaPromptContext): string {
+        const { context, currentFileNameComment, prefix, suffix, isInfill } = ollamaPrompt
+
+        if (isInfill) {
+            const infillPrefix = context + currentFileNameComment + prefix
+
+            /**
+             * The infill prompt for Code Llama.
+             * Source: https://github.com/facebookresearch/codellama/blob/e66609cfbd73503ef25e597fd82c59084836155d/llama/generation.py#L418
+             *
+             * Why are there spaces left and right?
+             * > For instance, the model expects this format: `<PRE> {pre} <SUF>{suf} <MID>`.
+             * But you won’t get infilling if the last space isn’t added such as in `<PRE> {pre} <SUF>{suf}<MID>`
+             *
+             * Source: https://blog.fireworks.ai/simplifying-code-infilling-with-code-llama-and-fireworks-ai-92c9bb06e29c
+             */
+            return `<PRE> ${infillPrefix} <SUF>${suffix} <MID>`
+        }
+
+        return context + currentFileNameComment + prefix
+    }
+}
+
+export function getModelHelpers(model: string) {
+    if (model.includes('codellama')) {
+        return new CodeLlama()
+    }
+
+    if (model.includes('deepseek-coder')) {
+        return new DeepseekCoder()
+    }
+
+    return new DefaultOllamaModel()
+}


### PR DESCRIPTION
## Context

- Adds autocomplete support for local inference with [deepseek-coder:6.7b-base-q4_K_M](https://ollama.ai/library/deepseek-coder:6.7b-base-q4_K_M) powered by ollama.
- Adds a bit of abstraction to simplify further addition of new ollama models.
- Sets `deepseek-coder:6.7` as a default model for the ollama provider.
- Should be tested with the follow-up perf improvements https://github.com/sourcegraph/cody/pull/2967

## Test plan

1. Install and run [Ollama](https://ollama.ai/)
2. Download one of the support local models:
    - `ollama pull deepseek-coder:6.7b-base-q4_K_M` for [deepseek-coder](https://ollama.ai/library/deepseek-coder)
    - `ollama pull codellama:7b-code` for [codellama](https://ollama.ai/library/codellama)
3. Update Cody's VS Code settings to use the `unstable-ollama` autocomplete provider.
4. Confirm Cody uses Ollama by looking at the Cody output channel or the autocomplete trace view (in the command palette).
