### PR TITLE
Autocomplete: Remove obvious prompt-continuations

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,7 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Autocomplete: Improved the new jaccard similarity retriever and context mixing experiments. [pull/2898](https://github.com/sourcegraph/cody/pull/2898)
-- Autocomplete: Remove obvious prompt-continuations. [pull/]()
+- Autocomplete: Remove obvious prompt-continuations. [pull/2974](https://github.com/sourcegraph/cody/pull/2974)
 
 ## [1.2.1]
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Autocomplete: Improved the new jaccard similarity retriever and context mixing experiments. [pull/2898](https://github.com/sourcegraph/cody/pull/2898)
+- Autocomplete: Remove obvious prompt-continuations. [pull/]()
 
 ## [1.2.1]
 

--- a/vscode/src/completions/get-inline-completions-tests/post-processing.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/post-processing.test.ts
@@ -129,6 +129,27 @@ for (const isTreeSitterEnabled of cases) {
             ).toEqual([])
         })
 
+        // c.f. https://github.com/sourcegraph/cody/issues/2912
+        it('removes prompt-continuations', async () => {
+            expect(
+                await getInlineCompletionsInsertText(
+                    params(
+                        dedent`
+                        function it() {
+                            █
+                    `,
+                        [
+                            // Anthropic-style prompts
+                            completion`\nHuman: Here is some more context code to provide`,
+                            // StarCoder style context snippet
+                            completion`// Path: foo.ts`,
+                            completion`# Path: foo.ts`,
+                        ]
+                    )
+                )
+            ).toEqual([])
+        })
+
         it('removes appends the injected prefix to the completion response since this is not sent to the LLM', async () => {
             expect(
                 await getInlineCompletionsInsertText(

--- a/vscode/src/completions/text-processing/process-inline-completions.ts
+++ b/vscode/src/completions/text-processing/process-inline-completions.ts
@@ -213,10 +213,17 @@ function rankCompletions(completions: ParsedCompletion[]): ParsedCompletion[] {
     })
 }
 
+const PROMPT_CONTINUATIONS = [
+    // Anthropic style prompt continuation
+    /^(\n){0,2}Human:\ /,
+    // StarCoder style code example
+    /^(\/\/|\#) Path:\ /,
+]
 function removeLowQualityCompletions(completions: InlineCompletionItem[]): InlineCompletionItem[] {
-    return (
-        completions
-            // Filter out empty or single character completions.
-            .filter(c => c.insertText.trim().length > 1)
-    )
+    return completions.filter(c => {
+        const isEmptyOrSingleCharacterCompletion = c.insertText.trim().length <= 1
+        const isPromptContinuation = PROMPT_CONTINUATIONS.some(regex => c.insertText.match(regex))
+
+        return !isEmptyOrSingleCharacterCompletion && !isPromptContinuation
+    })
 }


### PR DESCRIPTION
Closes #2912

If the completion is very obviously a prompt continuation, we should not show it. I noticed this too a bunch of time with `// Path: ...` style completions in StarCoder.

## Test plan

- Added unit tests

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
