### PR TITLE
Add analytics to settings & support items

### DIFF
--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -19,7 +19,6 @@ import type { MessageProviderOptions } from './chat/MessageProvider'
 import {
     ACCOUNT_LIMITS_INFO_URL,
     ACCOUNT_UPGRADE_URL,
-    ACCOUNT_USAGE_URL,
     CODY_FEEDBACK_URL,
     type AuthStatus,
 } from './chat/protocol'
@@ -60,6 +59,7 @@ import {
     executeDocCommand,
     executeUnitTestCommand,
 } from './commands/execute'
+import { registerSidebarCommands } from './services/SidebarCommands'
 
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
@@ -392,24 +392,7 @@ const register = async (
         ),
 
         // Account links
-        vscode.commands.registerCommand('cody.show-page', (page: string) => {
-            let url: URL
-            switch (page) {
-                case 'upgrade':
-                    url = ACCOUNT_UPGRADE_URL
-                    break
-                case 'usage':
-                    url = ACCOUNT_USAGE_URL
-                    break
-                case 'rate-limits':
-                    url = ACCOUNT_LIMITS_INFO_URL
-                    break
-                default:
-                    console.warn(`Unable to show unknown page: "${page}"`)
-                    return
-            }
-            void vscode.env.openExternal(vscode.Uri.parse(url.toString()))
-        }),
+        ...registerSidebarCommands(),
 
         // Account links
         vscode.commands.registerCommand(

--- a/vscode/src/services/SidebarCommands.ts
+++ b/vscode/src/services/SidebarCommands.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode'
+
+import {
+    ACCOUNT_LIMITS_INFO_URL,
+    ACCOUNT_UPGRADE_URL,
+    ACCOUNT_USAGE_URL,
+    CODY_DOC_URL,
+    CODY_FEEDBACK_URL,
+    DISCORD_URL,
+} from '../chat/protocol'
+import { telemetryService } from '../services/telemetry'
+import { telemetryRecorder } from '../services/telemetry-v2'
+import { releaseNotesURL } from '../release'
+import { version } from '../version'
+
+export function registerSidebarCommands(): vscode.Disposable[] {
+    function logSidebarClick(feature: string) {
+        telemetryService.log(`CodyVSCodeExtension:sidebar:${feature}:clicked`, undefined, {
+            hasV2Event: true,
+        })
+        telemetryRecorder.recordEvent(`cody.sidebar.${feature}`, 'clicked')
+    }
+
+    return [
+        vscode.commands.registerCommand('cody.show-page', (page: string) => {
+            logSidebarClick(page)
+            let url: URL
+            switch (page) {
+                case 'upgrade':
+                    url = ACCOUNT_UPGRADE_URL
+                    break
+                case 'usage':
+                    url = ACCOUNT_USAGE_URL
+                    break
+                case 'rate-limits':
+                    url = ACCOUNT_LIMITS_INFO_URL
+                    break
+                default:
+                    console.warn(`Unable to show unknown page: "${page}"`)
+                    return
+            }
+            void vscode.env.openExternal(vscode.Uri.parse(url.toString()))
+        }),
+        vscode.commands.registerCommand('cody.sidebar.settings', () => {
+            logSidebarClick('settings')
+            void vscode.commands.executeCommand('cody.status-bar.interacted')
+        }),
+        vscode.commands.registerCommand('cody.sidebar.keyboardShortcuts', () => {
+            logSidebarClick('keyboardShortcuts')
+            void vscode.commands.executeCommand(
+                'workbench.action.openGlobalKeybindings',
+                '@ext:sourcegraph.cody-ai'
+            )
+        }),
+        vscode.commands.registerCommand('cody.sidebar.releaseNotes', () => {
+            logSidebarClick('releaseNotes')
+            void vscode.commands.executeCommand('vscode.open', releaseNotesURL(version))
+        }),
+        vscode.commands.registerCommand('cody.sidebar.documentation', () => {
+            logSidebarClick('documentation')
+            void vscode.commands.executeCommand('vscode.open', CODY_DOC_URL.href)
+        }),
+        vscode.commands.registerCommand('cody.sidebar.feedback', () => {
+            logSidebarClick('feedback')
+            void vscode.commands.executeCommand('vscode.open', CODY_FEEDBACK_URL.href)
+        }),
+        vscode.commands.registerCommand('cody.sidebar.discord', () => {
+            logSidebarClick('discord')
+            void vscode.commands.executeCommand('vscode.open', DISCORD_URL.href)
+        }),
+        vscode.commands.registerCommand('cody.sidebar.account', () => {
+            logSidebarClick('account')
+            void vscode.commands.executeCommand('cody.auth.account')
+        }),
+    ]
+}

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -55,44 +55,38 @@ const supportItems: CodySidebarTreeItem[] = [
     {
         title: 'Settings',
         icon: 'settings-gear',
-        command: { command: 'cody.status-bar.interacted' },
+        command: { command: 'cody.sidebar.settings' },
     },
     {
         title: 'Keyboard Shortcuts',
         icon: 'keyboard',
-        command: {
-            command: 'workbench.action.openGlobalKeybindings',
-            args: ['@ext:sourcegraph.cody-ai'],
-        },
+        command: { command: 'cody.sidebar.keyboardShortcuts' },
     },
     {
         title: `${releaseType(version) === 'stable' ? 'Release' : 'Pre-Release'} Notes`,
         description: `v${version}`,
         icon: 'github',
-        command: {
-            command: 'vscode.open',
-            args: [releaseNotesURL(version)],
-        },
+        command: { command: 'cody.sidebar.releaseNotes' },
     },
     {
         title: 'Documentation',
         icon: 'book',
-        command: { command: 'vscode.open', args: [CODY_DOC_URL.href] },
+        command: { command: 'cody.sidebar.documentation' },
     },
     {
         title: 'Feedback',
         icon: 'feedback',
-        command: { command: 'vscode.open', args: [CODY_FEEDBACK_URL.href] },
+        command: { command: 'cody.sidebar.feedback' },
     },
     {
         title: 'Discord',
         icon: 'organization',
-        command: { command: 'vscode.open', args: [DISCORD_URL.href] },
+        command: { command: 'cody.sidebar.discord' },
     },
     {
         title: 'Account',
         icon: 'account',
-        command: { command: 'cody.auth.account' },
+        command: { command: 'cody.sidebar.account' },
     },
 ]
 

--- a/vscode/src/services/treeViewItems.ts
+++ b/vscode/src/services/treeViewItems.ts
@@ -1,7 +1,6 @@
 import type { FeatureFlag } from '@sourcegraph/cody-shared'
 
-import { CODY_DOC_URL, CODY_FEEDBACK_URL, DISCORD_URL } from '../chat/protocol'
-import { releaseNotesURL, releaseType } from '../release'
+import { releaseType } from '../release'
 import { version } from '../version'
 
 export type CodyTreeItemType = 'command' | 'support' | 'search' | 'chat'


### PR DESCRIPTION
Fixes #2365

@chenkc805 The only difference from your link is that instead of `CodyVSCodeExtension:sidebar:preReleaseNotes:clicked` I called the event `CodyVSCodeExtension:sidebar:releaseNotes:clicked` (since it will be the same for both stable and insider releases)

## Test plan

https://github.com/sourcegraph/cody/assets/458591/3e67daef-236c-49ce-96cb-36c2330b7cb4


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
