### PR TITLE
fix issue where natural language search panel disappears instead of showing results

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,8 +12,10 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Edit/Chat: Added "ghost" text alongside code to showcase Edit and Chat commands. Enable it by setting `cody.commandHints.enabled` to true. [pull/2865](https://github.com/sourcegraph/cody/pull/2865)
 - Autocomplete: local inference support with [deepseek-coder](https://ollama.ai/library/deepseek-coder) powered by ollama. [pull/2966](https://github.com/sourcegraph/cody/pull/2966)
 - Autocomplete: Add a new experimental fast-path mode for Cody community users that directly connections to our inference services. [pull/2927](https://github.com/sourcegraph/cody/pull/2927)
-- 
+
 ### Fixed
+
+- Fixed an issue where the natural language search panel would disappear instead of showing results. [pull/2981](https://github.com/sourcegraph/cody/pull/2981)
 
 ### Changed
 

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -119,6 +119,10 @@ export type ExtensionMessage =
           authStatus: AuthStatus
           workspaceFolderUris: string[]
       }
+    | {
+          type: 'search:config'
+          workspaceFolderUris: string[]
+      }
     | { type: 'history'; messages: UserLocalHistory | null }
     | ({ type: 'transcript' } & ExtensionTranscriptMessage)
     | { type: 'view'; messages: View }

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -11,7 +11,7 @@ import {
     type SearchPanelSnippet,
 } from '@sourcegraph/cody-shared'
 
-import type { WebviewMessage } from '../chat/protocol'
+import type { ExtensionMessage, WebviewMessage } from '../chat/protocol'
 import { getEditor } from '../editor/active-editor'
 import type { IndexStartEvent, SymfRunner } from '../local-context/symf'
 
@@ -292,6 +292,14 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
         if (cancellationToken.isCancellationRequested) {
             return
         }
+
+        // Update the config. We could do this on a smarter schedule, but this suffices for when the
+        // webview needs it for now.
+        this.webview?.postMessage({
+            type: 'search:config',
+            workspaceFolderUris:
+                vscode.workspace.workspaceFolders?.map(folder => folder.uri.toString()) ?? [],
+        } satisfies ExtensionMessage)
 
         await vscode.window.withProgress({ location: { viewId: 'cody.search' } }, async () => {
             const cumulativeResults: SearchPanelFile[] = []

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -12,6 +12,7 @@ import { displayPathBasename, displayPathDirname, type SearchPanelFile } from '@
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 import styles from './SearchPanel.module.css'
+import { updateDisplayPathEnvInfoForWebview } from './utils/displayPathEnvInfo'
 
 const SEARCH_DEBOUNCE_MS = 400
 
@@ -107,6 +108,9 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
                     resultsCache.clear()
                     break
                 }
+                case 'search:config':
+                    updateDisplayPathEnvInfoForWebview(message.workspaceFolderUris)
+                    break
             }
         })
     }, [vscodeAPI, resultsCache, query])


### PR DESCRIPTION
It was not initializing its environment with the VS Code workspace root folders to generate accurate workspace-relative paths. I forgot to add that to the search webview entrypoint (only added it to the chat webview entrypoint).

Confirmed working:

![image](https://github.com/sourcegraph/cody/assets/1976/64b79d46-8b85-49c7-a4b4-1bdb3eb70d36)


## Test plan

Run a natural language search and confirm you see results instead of the webview disappearing.