### PR TITLE
display .cody/ignore status in status bar

### DIFF
--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -44,7 +44,8 @@ export function createStatusBar(): CodyStatusBar {
     // Otherwise, rerenders the status bar.
     const onDocumentChange = vscode.window.onDidChangeActiveTextEditor(e => {
         if (e && isCodyIgnoredFile(e?.document.uri)) {
-            statusBarItem.text = DEFAULT_TEXT + ' Ignored'
+            statusBarItem.tooltip = 'Current file is ignored by Cody'
+            statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
         } else {
             rerender()
         }

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -20,6 +20,13 @@ test('chat and command do not work in .cody/ignore file', async ({ page, sidebar
     await page.getByRole('treeitem', { name: 'ignoredByCody.css' }).locator('a').dblclick()
     await page.getByRole('tab', { name: 'ignoredByCody.css' }).hover()
 
+    // Cody icon in the status bar should shows that the file is being ignored
+    const statusBarButton = page.getByRole('button', {
+        name: 'cody-logo-heavy, Current file is ignored by Cody',
+    })
+    await statusBarButton.hover()
+    await expect(statusBarButton).toBeVisible()
+
     // Open Cody sidebar to start a new chat
     await page.click('.badge[aria-label="Cody"]')
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()


### PR DESCRIPTION
Update status bar background color on ignored files (behind unstable flag)

- Added functionality to the status bar in StatusBar.ts to display whether the current file is ignored by Cody or not by switching the background color of the status bar item.

This feature allows users and devs to easily identify if the current file is being ignored by Cody directly from the editor.

This feature is behind the unstable feature flag. When unstable flag is not enabled, the background will not be updated based on ignore file.

Note: I found it hard to tell if cody ignore is active or not during development and testing. We can remove it when this is out of unstable state. 


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Go to a Cody ignored file
2. Check if the status bar item update accordingly

### Updated

As discussed with Tim, we willl update the background color to indicates if the current file is ignored by Cody or not instead of adding Ignore next to Cody icon

![image](https://github.com/sourcegraph/cody/assets/68532117/2edb356f-201b-46b5-852a-1bf21a6cf2bd)

### Outdated

![image](https://github.com/sourcegraph/cody/assets/68532117/2294b1ba-3cc1-485c-b159-1bdf78916df7)
