### PR TITLE
Autocomplete: update BFG snippets structure to match the format expected on the client

### DIFF
--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -197,7 +197,24 @@ export class BfgRetriever implements ContextRetriever {
                 return []
             }
 
-            return [...(responses?.symbols || []), ...(responses?.files || [])]
+            const mergedContextSnippets = [...(responses.symbols || []), ...(responses?.files || [])]
+
+            // Convert BFG snippets to match the format expected on the client.
+            const symbols = mergedContextSnippets.map(contextSnippet => ({
+                ...contextSnippet,
+                uri: vscode.Uri.from({ scheme: 'file', path: contextSnippet.fileName }),
+            })) satisfies Omit<ContextSnippet, 'startLine' | 'endLine'>[]
+
+            logDebug(
+                'CodyEngine',
+                'bfg/contextAtPosition',
+                `returning ${mergedContextSnippets.length} results`
+            )
+
+            // TODO: add `startLine` and `endLine` to `responses` or explicitly add
+            // another context snippet type to the client.
+            // @ts-ignore
+            return symbols
         } catch (error) {
             logDebug('CodyEngine:error', `${error}`)
             return []

--- a/vscode/src/jsonrpc/bfg-protocol.ts
+++ b/vscode/src/jsonrpc/bfg-protocol.ts
@@ -2,14 +2,22 @@
  * This file declares the protocol for communicating between Cody and BFG (Blazingly Fast Graph), a Rust implementation
  * of the "Graph Context" feature flag.
  */
-import type { FileContextSnippet, SymbolContextSnippet } from '../completions/types'
-
 import type { Position, Range } from './agent-protocol'
+
+export interface BFGFileContextSnippet {
+    fileName: string
+    content: string
+}
+
+export interface BFGSymbolContextSnippet extends BFGFileContextSnippet {
+    symbol: string
+}
+
 export type Requests = {
     'bfg/initialize': [{ clientName: string }, { serverVersion: string }]
     'bfg/contextAtPosition': [
         { uri: string; content: string; position: Position; maxChars: number; contextRange?: Range },
-        { symbols?: SymbolContextSnippet[]; files?: FileContextSnippet[] },
+        { symbols?: BFGSymbolContextSnippet[]; files?: BFGFileContextSnippet[] },
     ]
     // biome-ignore lint/suspicious/noConfusingVoidType: this models a function returning void
     'bfg/gitRevision/didChange': [{ gitDirectoryUri: string }, void]


### PR DESCRIPTION
## Context

- I started testing BFG locally and bumped into a runtime error. The context mixer [logic](https://github.com/sourcegraph/cody/blob/7106a4fc2c8d088961f66de2336217a87805136f/vscode/src/completions/context/context-mixer.ts#L110) expects context snippets to have the `uri` field. This field [was added](https://github.com/sourcegraph/cody/pull/2749) relatively recently, but neither the BFG implementation nor the client retriever was updated accordingly. 
- This PR fixes the issue on the client side and adds additional types that would prevent the problem from happening. AFAIU, this solution is similar to the approach `LocalEmbeddingsController` uses, where local embeddings snippet types returned by Cody engine [are defined separately](https://github.com/sourcegraph/cody/blob/main/vscode/src/jsonrpc/embeddings-protocol.ts#L21) from [global types](https://github.com/sourcegraph/cody/blob/main/vscode/src/completions/types.ts#L32) used by context mixer.

## Test plan

CI
