### PR TITLE
Cosmetic changelog script improvements

### DIFF
--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -116,9 +116,13 @@ async function main(): Promise<void> {
     const { changes, previousVersion } = extractSection(changelogBody, currentVersion)
 
     const minor = currentVersion.split('.').slice(0, 2).join('.')
+    const previousMinor = extractPreviousMinor(minor)
 
     const intro = dedent`
-        ✨ See the [What’s new in v${minor}](https://about.sourcegraph.com/blog/cody-vscode-${minor}.0-release) blog post for what’s new in this release since v${minor} ✨
+        ✨ See the [What’s new in v${minor}](https://about.sourcegraph.com/blog/cody-vscode-${minor.replaceAll(
+            '.',
+            '-'
+        )}-0-release) blog post for what’s new in this release since v${previousMinor} ✨
 
         ## v${currentVersion} Changes
     `
@@ -155,3 +159,8 @@ async function main(): Promise<void> {
 }
 
 main().catch(console.error)
+
+function extractPreviousMinor(majorAndMinor: string): string {
+    const [major, minor] = majorAndMinor.split('.')
+    return `${major}.${parseInt(minor) - 1}`
+}


### PR DESCRIPTION
We aligned on using dashes for the release posts and change the `since v{version}` code to be correct (well, more correct, it doesn't support major version bumps but these don't happen often anyways (and would need quite a bit of code to work as we would need to know the last minor version that we released on the prev. major).

## Test plan

```
pnpm -C vscode run github-changelog && cat vscode/GITHUB_CHANGELOG.md

> cody-ai@1.2.2 github-changelog /Users/philipp/dev/cody/vscode
> ts-node-transpile-only ./scripts/github-changelog.ts

✨ See the [What’s new in v1.2](https://about.sourcegraph.com/blog/cody-vscode-1-2-0-release) blog post for what’s new in this release since v1.1 ✨

## v1.2.2 Changes

- Fixed an issue where the natural language search panel would disappear instead of showing results by @sqs in https://github.com/sourcegraph/cody/pull/2981

**Full Changelog**: https://github.com/sourcegraph/cody/compare/vscode-v1.2.1...vscode-v1.2.2
```

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
