### PR TITLE
Edit: Fix chat/edit shortcuts

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -490,7 +490,7 @@
             {
                 "command": "cody.chat.panel.new",
                 "key": "alt+l",
-                "when": "cody.activated && config.cody.internal.unstable"
+                "when": "cody.activated"
             },
             {
                 "command": "cody.command.edit-code",
@@ -501,7 +501,7 @@
             {
                 "command": "cody.command.edit-code",
                 "key": "alt+k",
-                "when": "cody.activated && !editorReadonly && config.cody.internal.unstable"
+                "when": "cody.activated && !editorReadonly"
             },
             {
                 "command": "cody.menu.commands",


### PR DESCRIPTION
## Description

These shortcuts were accidentally not enabled everywhere as part of https://github.com/sourcegraph/cody/pull/2865

We can enable these shortcuts fully now, even when the command hint setting is off

## Test plan

1. Check the `unstable` flag is off
2. Check shortcuts show normally

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
