### PR TITLE
add e2e test for /edit

### DIFF
--- a/vscode/test/e2e/command-edit.test.ts
+++ b/vscode/test/e2e/command-edit.test.ts
@@ -1,0 +1,106 @@
+import { expect } from '@playwright/test'
+
+import { loggedEvents, resetLoggedEvents } from '../fixtures/mock-server'
+
+import { sidebarExplorer, sidebarSignin } from './common'
+import { assertEvents, test } from './helpers'
+
+test.beforeEach(() => {
+    resetLoggedEvents()
+})
+
+test('code lenses for edit (fixup) task', async ({ page, sidebar }) => {
+    // Sign into Cody
+    await sidebarSignin(page, sidebar)
+
+    // Open the Explorer view from the sidebar
+    await sidebarExplorer(page).click()
+    // Open the index.html file from the tree view
+    await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
+    // Wait for index.html to fully open
+    await page.getByRole('tab', { name: 'index.html' }).hover()
+
+    // Find the text hello cody, and then highlight the text
+    await page.getByText('<title>Hello Cody</title>').click()
+    await page.keyboard.down('Shift')
+    await page.keyboard.press('ArrowDown')
+
+    // Enter instruction in the command palette via clicking on the Cody Icon
+    await page.getByRole('button', { name: 'Commands' }).click()
+    await page.getByRole('option', { name: 'Edit code' }).click()
+
+    const inputBox = page.getByPlaceholder(/^Enter edit instructions \(type @ to include code/)
+    const instruction = 'replace hello with goodbye'
+    const inputTitle = 'Edit index.html:7:8 with Cody'
+    const showDiffLens = page.getByRole('button', { name: 'A Show Diff' })
+    const acceptLens = page.getByRole('button', { name: 'Accept' })
+    const retryLens = page.getByRole('button', { name: 'Retry' })
+    const undoLens = page.getByRole('button', { name: 'Undo' })
+
+    // Wait for the input box to appear with the document name in title
+    await expect(page.getByText(inputTitle)).toBeVisible()
+    await inputBox.focus()
+    await inputBox.fill(instruction)
+    await page
+        .locator('a')
+        .filter({ hasText: /^Submit$/ })
+        .click() // Submit via Submit button
+
+    // Code Lenses should appear
+    await expect(showDiffLens).toBeVisible()
+    await expect(acceptLens).toBeVisible()
+    await expect(retryLens).toBeVisible()
+    await expect(undoLens).toBeVisible()
+
+    // The text in the doc should be replaced
+    await expect(page.getByText('>Hello Cody</')).not.toBeVisible()
+    await expect(page.getByText('>Goodbye Cody</')).toBeVisible()
+
+    // Show Diff: Create a new editor with diff view
+    // The code lenses should stay after moving from diff view back to index.html
+    await showDiffLens.click()
+    await expect(page.getByText(/^Cody Edit Diff View -/)).toBeVisible()
+    await page.getByText(/^Cody Edit Diff View -/).click()
+    await page.getByRole('tab', { name: 'index.html', exact: true }).click()
+    await expect(showDiffLens).toBeVisible()
+    await expect(acceptLens).toBeVisible()
+    await expect(retryLens).toBeVisible()
+    await expect(undoLens).toBeVisible()
+
+    // Undo: remove all the changes made by edit
+    await undoLens.click()
+    await expect(page.getByText('>Hello Cody</')).toBeVisible()
+    await expect(page.getByText('>Goodbye Cody</')).not.toBeVisible()
+
+    // create another edit from the sidebar Edit button
+    await page.getByText('7', { exact: true }).click()
+    await page.click('.badge[aria-label="Cody"]')
+    await page.getByText('Edit code with instructions').click()
+    await expect(page.getByText('Edit index.html:2:11 with Cody')).toBeVisible()
+    await inputBox.focus()
+    await inputBox.fill(instruction)
+    await page.keyboard.press('Enter')
+    await expect(page.getByText('>Hello Cody</')).not.toBeVisible()
+    await expect(page.getByText('>Goodbye Cody</')).toBeVisible()
+
+    // Retry: show the command palette with the previous instruction
+    await expect(retryLens).toBeVisible()
+    await retryLens.click()
+    await expect(page.getByText('Edit index.html:2 with Cody')).toBeVisible()
+    await expect(inputBox).toHaveValue(instruction)
+    await inputBox.press('Escape')
+
+    // Undo: revert document to previous state
+    await undoLens.click()
+    await expect(page.getByText('>Hello Cody</')).toBeVisible()
+    await expect(page.getByText('>Goodbye Cody</')).not.toBeVisible()
+
+    const expectedEvents = [
+        'CodyVSCodeExtension:command:edit:executed',
+        'CodyVSCodeExtension:fixupResponse:hasCode',
+        'CodyVSCodeExtension:fixup:codeLens:clicked', // each code lens clicked
+        'CodyVSCodeExtension:fixup:applied', // after clicking 'Accept'
+        'CodyVSCodeExtension:fixup:reverted', // after clicking 'Undo'
+    ]
+    await assertEvents(loggedEvents, expectedEvents)
+})

--- a/vscode/test/e2e/command-edit.test.ts
+++ b/vscode/test/e2e/command-edit.test.ts
@@ -31,7 +31,7 @@ test('code lenses for edit (fixup) task', async ({ page, sidebar }) => {
 
     const inputBox = page.getByPlaceholder(/^Enter edit instructions \(type @ to include code/)
     const instruction = 'replace hello with goodbye'
-    const inputTitle = 'Edit index.html:7:8 with Cody'
+    const inputTitle = /^Edit index.html:(\d+).* with Cody$/
     const showDiffLens = page.getByRole('button', { name: 'A Show Diff' })
     const acceptLens = page.getByRole('button', { name: 'Accept' })
     const retryLens = page.getByRole('button', { name: 'Retry' })
@@ -76,7 +76,7 @@ test('code lenses for edit (fixup) task', async ({ page, sidebar }) => {
     await page.getByText('7', { exact: true }).click()
     await page.click('.badge[aria-label="Cody"]')
     await page.getByText('Edit code with instructions').click()
-    await expect(page.getByText('Edit index.html:2:11 with Cody')).toBeVisible()
+    await expect(page.getByText(inputTitle)).toBeVisible()
     await inputBox.focus()
     await inputBox.fill(instruction)
     await page.keyboard.press('Enter')
@@ -86,7 +86,7 @@ test('code lenses for edit (fixup) task', async ({ page, sidebar }) => {
     // Retry: show the command palette with the previous instruction
     await expect(retryLens).toBeVisible()
     await retryLens.click()
-    await expect(page.getByText('Edit index.html:2 with Cody')).toBeVisible()
+    await expect(page.getByText(inputTitle)).toBeVisible()
     await expect(inputBox).toHaveValue(instruction)
     await inputBox.press('Escape')
 


### PR DESCRIPTION
Adding a new e2e test for `/edit` command, specifically for testing the code lenses to view diff, accept, retry, and undo edit instructions provided by Cody. 

Code Lenses should appear after submitting or retrying an edit instruction, and allow quick access to view the diff, accept the change, retry the instruction, or undo the edit.

The new test cover the following features used by /edit
- [x] Edit Menu invokable from the Cody Command Menu
- [x] Edit Menu invokable from Sidebar Commands panel
- [x] Edit Menu includes current doc name with line number in title
- [x] Code lenses action for Show Diff
- [x] Code lenses action for Accept
- [x] Code lenses action for Retry
- [x] Code lenses action for Undo

A separate test should be created for testing other options on the Edit Menu.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

CI should be green with the newly added test