### PR TITLE
move /test behind flag

### DIFF
--- a/vscode/src/commands/execute/test-edit.ts
+++ b/vscode/src/commands/execute/test-edit.ts
@@ -6,7 +6,6 @@ import { defaultCommands, executeTestChatCommand } from '.'
 import type { ChatCommandResult, EditCommandResult } from '../../main'
 import type { CodyCommandArgs } from '../types'
 import { getContextFilesForUnitTestCommand } from '../context/unit-test-file'
-import * as uuid from 'uuid'
 import type { URI } from 'vscode-uri'
 import { isTestFileForOriginal } from '../utils/test-commands'
 import { workspace } from 'vscode'
@@ -19,10 +18,10 @@ import { workspace } from 'vscode'
 export async function executeTestEditCommand(
     args?: Partial<CodyCommandArgs>
 ): Promise<EditCommandResult | ChatCommandResult | undefined> {
-    // TODO: remove after 1.2.3 patch
-    // Exclude from patch release using a random placeholder config value
+    // NOTE: Move behind 'internal.unstable' for 1.2.3 patch release
+    // TODO remove after the patch releases for 1.3 release
     const config = workspace.getConfiguration('cody')
-    if (!config.get(uuid.v4())) {
+    if (!config.get('internal.unstable')) {
         return executeTestChatCommand(args)
     }
 

--- a/vscode/src/commands/execute/test-edit.ts
+++ b/vscode/src/commands/execute/test-edit.ts
@@ -2,14 +2,14 @@ import { logError, type ContextFile } from '@sourcegraph/cody-shared'
 import { getEditor } from '../../editor/active-editor'
 import { type ExecuteEditArguments, executeEdit } from '../../edit/execute'
 import { DefaultEditCommands } from '@sourcegraph/cody-shared/src/commands/types'
-import { defaultCommands } from '.'
-import type { EditCommandResult } from '../../main'
+import { defaultCommands, executeTestChatCommand } from '.'
+import type { ChatCommandResult, EditCommandResult } from '../../main'
 import type { CodyCommandArgs } from '../types'
 import { getContextFilesForUnitTestCommand } from '../context/unit-test-file'
-
+import * as uuid from 'uuid'
 import type { URI } from 'vscode-uri'
 import { isTestFileForOriginal } from '../utils/test-commands'
-
+import { workspace } from 'vscode'
 /**
  * Command that generates a new test file for the selected code with unit tests added.
  * When calls, the command will be executed as an inline-edit command.
@@ -18,7 +18,14 @@ import { isTestFileForOriginal } from '../utils/test-commands'
  */
 export async function executeTestEditCommand(
     args?: Partial<CodyCommandArgs>
-): Promise<EditCommandResult | undefined> {
+): Promise<EditCommandResult | ChatCommandResult | undefined> {
+    // TODO: remove after 1.2.3 patch
+    // Exclude from patch release using a random placeholder config value
+    const config = workspace.getConfiguration('cody')
+    if (!config.get(uuid.v4())) {
+        return executeTestChatCommand(args)
+    }
+
     // The prompt for generating tests in a new test file
     const newTestFilePrompt = defaultCommands.test.prompt
     // The prompt for adding new test suite to an existing test file

--- a/vscode/src/commands/services/code-lenses.ts
+++ b/vscode/src/commands/services/code-lenses.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode'
-import * as uuid from 'uuid'
 import { getEditor } from '../../editor/active-editor'
 import { isValidTestFile } from '../utils/test-commands'
 import { getDocumentSections } from '../../editor/utils/document-sections'
@@ -110,10 +109,10 @@ export class CommandCodeLenses implements vscode.CodeLensProvider {
     }
 
     private async provideCodeLensesForSymbols(doc: vscode.Uri): Promise<vscode.CodeLens[]> {
-        // TODO: remove after 1.2.3 patch
-        // Exclude from patch release using a random placeholder config value
+        // NOTE: Move behind 'internal.unstable' for 1.2.3 patch release
+        // TODO remove after the patch releases for 1.3 release
         const config = vscode.workspace.getConfiguration('cody')
-        if (!config.get(uuid.v4())) {
+        if (!config.get('internal.unstable')) {
             return []
         }
 

--- a/vscode/src/commands/services/code-lenses.ts
+++ b/vscode/src/commands/services/code-lenses.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode'
+import * as uuid from 'uuid'
 import { getEditor } from '../../editor/active-editor'
 import { isValidTestFile } from '../utils/test-commands'
 import { getDocumentSections } from '../../editor/utils/document-sections'
@@ -109,6 +110,13 @@ export class CommandCodeLenses implements vscode.CodeLensProvider {
     }
 
     private async provideCodeLensesForSymbols(doc: vscode.Uri): Promise<vscode.CodeLens[]> {
+        // TODO: remove after 1.2.3 patch
+        // Exclude from patch release using a random placeholder config value
+        const config = vscode.workspace.getConfiguration('cody')
+        if (!config.get(uuid.v4())) {
+            return []
+        }
+
         const codeLenses = []
         const linesWithLenses = new Set()
 


### PR DESCRIPTION
Exclude new `/test` from patch release by moving it behind unstable flag

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Disable the 'cody.internal.unstable' config
- Run the /test command
- The unit tests should be generated in chat view instead of inline