### PR TITLE
fix: remove sparkle from context list without enhanced context

### DIFF
--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -97,7 +97,7 @@ export const TranscriptItem: React.FunctionComponent<
     // TODO (bee) can be removed once we support editing command prompts.
     // A boolean indicating whether the current message is a known command input.
     const isCommandInput =
-        message?.displayText?.startsWith('/') || isDefaultCommandPrompts(message?.displayText || '')
+        message?.displayText?.startsWith('/') || isDefaultCommandPrompts(message?.displayText)
 
     return (
         <div
@@ -183,6 +183,7 @@ export const TranscriptItem: React.FunctionComponent<
                             contextFiles={message.contextFiles}
                             fileLinkComponent={fileLinkComponent}
                             className={transcriptActionClassName}
+                            isCommand={isCommandInput}
                         />
                     ) : (
                         inProgress && <LoadingContext />
@@ -219,6 +220,9 @@ const commandPrompts = {
     smell: `Please review and analyze the selected code and identify potential areas for improvement related to code smells, readability, maintainability, performance, security, etc. Do not list issues already addressed in the given code. Focus on providing up to 5 constructive suggestions that could make the code more robust, efficient, or align with best practices. For each suggestion, provide a brief explanation of the potential benefits. After listing any recommendations, summarize if you found notable opportunities to enhance the code quality overall or if the code generally follows sound design principles. If no issues found, reply 'There are no errors'`,
 }
 
-export function isDefaultCommandPrompts(text: string): boolean {
+export function isDefaultCommandPrompts(text?: string): boolean {
+    if (!text) {
+        return false
+    }
     return Object.values(commandPrompts).includes(text)
 }

--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -25,7 +25,13 @@ export const EnhancedContext: React.FunctionComponent<{
     contextFiles: ContextFile[]
     fileLinkComponent: React.FunctionComponent<FileLinkProps>
     className?: string
-}> = React.memo(function ContextFilesContent({ contextFiles, fileLinkComponent: FileLink, className }) {
+    isCommand: boolean
+}> = React.memo(function ContextFilesContent({
+    contextFiles,
+    fileLinkComponent: FileLink,
+    className,
+    isCommand,
+}) {
     if (!contextFiles.length) {
         return
     }
@@ -44,7 +50,14 @@ export const EnhancedContext: React.FunctionComponent<{
         return
     }
 
-    const prefix = '✨ Context: '
+    // Enhanced Context are context added by one of Cody's context fetchers.
+    // NOTE: sparkle should only be added to messages that use enhanced context.
+    // NOTE: Core chat commands (e.g. /explain and /smell) use local context only.
+    // Check if the filteredFiles only contain local context (non-enhanced context).
+    const localContextType = ['user', 'selection', 'terminal', 'editor']
+    const localContextOnly = filteredFiles.every(file => localContextType.includes(file.type))
+    const sparkle = localContextOnly || isCommand ? '' : '✨ '
+    const prefix = sparkle + 'Context: '
     // It checks if file.range exists first before accessing start and end.
     // If range doesn't exist, it adds 0 lines for that file.
     const lineCount = filteredFiles.reduce(

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,7 +14,10 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Add a new experimental fast-path mode for Cody community users that directly connections to our inference services. [pull/2927](https://github.com/sourcegraph/cody/pull/2927)
 - Command: The `Generate Unit Tests` command now functions as an inline edit command. When executed, the new tests will be automatically appended to the test file. If no existing test file is found, a temporary one will be created. [pull/2959](https://github.com/sourcegraph/cody/pull/2959)
 - [Internal] Command: Added new code lenses for generating additional unit tests. [pull/2959](https://github.com/sourcegraph/cody/pull/2959)
+
 ### Fixed
+
+- Chat: Messages without enhanced context should not include the sparkle emoji in context list.
 
 ### Changed
 

--- a/vscode/test/e2e/core-commands.test.ts
+++ b/vscode/test/e2e/core-commands.test.ts
@@ -27,7 +27,8 @@ test('Explain Command & Smell Command & Chat from Command Menu', async ({ page, 
     // Check if the command shows the current file as context with the correct number of lines
     // When no selection is made, we will try to create smart selection from the cursor position
     // If there is no cursor position, we will use the visible content of the editor
-    await chatPanel.getByText('✨ Context: 12 lines from 1 file').click()
+    // NOTE: Core commands context should not start with ✨
+    await chatPanel.getByText('Context: 12 lines from 1 file').click()
 
     // Check if assistant responsed
     await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
@@ -44,7 +45,7 @@ test('Explain Command & Smell Command & Chat from Command Menu', async ({ page, 
     await page.getByText('<title>Hello Cody</title>').click()
     await expect(page.getByText('Explain code')).toBeVisible()
     await page.getByText('Explain code').click()
-    await chatPanel.getByText('✨ Context: 9 lines from 1 file').click()
+    await chatPanel.getByText('Context: 9 lines from 1 file').click()
     const disabledEditButtons = chatPanel.getByTitle('Cannot Edit Command').locator('i')
     const editLastMessageButton = chatPanel.getByRole('button', { name: /^Edit Last Message / })
     // Edit button should shows as disabled for all command messages.
@@ -56,7 +57,8 @@ test('Explain Command & Smell Command & Chat from Command Menu', async ({ page, 
     // Running a command again should reuse the current cursor position
     await expect(page.getByText('Identify code smells')).toBeVisible()
     await page.getByText('Identify code smells').click()
-    await chatPanel.getByText('✨ Context: 9 lines from 1 file').click()
+    await chatPanel.getByText('Context: 9 lines from 1 file').hover()
+    await chatPanel.getByText('Context: 9 lines from 1 file').click()
     await expect(disabledEditButtons).toHaveCount(1)
     await expect(editLastMessageButton).not.toBeVisible()
 


### PR DESCRIPTION
Do not display sparkle emoji in Context list if no enhanced context was used, aka messages from the core commands.

`/smell`

![image](https://github.com/sourcegraph/cody/assets/68532117/d9f17916-8816-474a-b7eb-c44c5d0d62fe)

`/explain`

![image](https://github.com/sourcegraph/cody/assets/68532117/5a464266-b606-48f0-86cd-f679d685d9c9)

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

updated e2e tests to reflect this change.
