### PR TITLE
Don't add duplicate workspace folders

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -158,11 +158,17 @@ let workspaceDocuments: WorkspaceDocuments | undefined
 export function setWorkspaceDocuments(newWorkspaceDocuments: WorkspaceDocuments): void {
     workspaceDocuments = newWorkspaceDocuments
     if (newWorkspaceDocuments.workspaceRootUri) {
-        workspaceFolders.push({
-            name: 'Workspace Root',
-            uri: newWorkspaceDocuments.workspaceRootUri,
-            index: 0,
-        })
+        if (
+            !workspaceFolders
+                .map(wf => wf.uri.toString())
+                .includes(newWorkspaceDocuments.workspaceRootUri.toString())
+        ) {
+            workspaceFolders.push({
+                name: 'Workspace Root',
+                uri: newWorkspaceDocuments.workspaceRootUri,
+                index: 0,
+            })
+        }
     }
 }
 


### PR DESCRIPTION
When we receive the initialization message from the client, only add the workspace folders if they don't already exist. Previously, when the agent service lived past the client lifespan, a subsequent client could add a duplicate workspace folder. (Currently, I think we only hit this in the dev environment if the agent is run separately.)

## Test plan

- [ ] Run the IntelliJ plugin against this version of the agent