### PR TITLE
feat: ask Cody about terminal output

### DIFF
--- a/lib/shared/src/commands/types.ts
+++ b/lib/shared/src/commands/types.ts
@@ -6,6 +6,7 @@ export enum DefaultChatCommands {
     Explain = 'explain', // Explain code
     Unit = 'unit', // Generate unit tests in Chat
     Smell = 'smell', // Generate code smell report in Chat
+    Terminal = 'terminal', // Explain terminal output
 }
 
 // Default Cody Commands that runs as an Inline Edit command

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -262,11 +262,10 @@
                 "icon": "$(feedback)"
             },
             {
-              "command": "cody.command.explain-output",
-              "title": "Ask Cody",
-              "category": "Cody Command",
-              "when": "cody.activated",
-              "icon": "$(cody-logo)"
+                "command": "cody.command.explain-output",
+                "title": "Ask Cody",
+                "category": "Cody Command",
+                "icon": "$(cody-logo)"
             },
             {
                 "command": "cody.command.edit-code",
@@ -710,11 +709,11 @@
                 }
             ],
             "terminal/context": [
-              {
-                "command": "cody.command.explain-output",
-                "group": "0_cody",
-                "when": "terminalFocus && cody.activated"
-              }
+                {
+                    "command": "cody.command.explain-output",
+                    "group": "0_cody",
+                    "when": "cody.activated"
+                }
             ]
         },
         "configuration": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -263,7 +263,7 @@
             },
             {
                 "command": "cody.command.explain-output",
-                "title": "Ask Cody",
+                "title": "Ask Cody to Explain",
                 "category": "Cody Command",
                 "icon": "$(cody-logo)"
             },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -262,6 +262,13 @@
                 "icon": "$(feedback)"
             },
             {
+              "command": "cody.command.explain-output",
+              "title": "Ask Cody",
+              "category": "Cody Command",
+              "when": "cody.activated",
+              "icon": "$(cody-logo)"
+            },
+            {
                 "command": "cody.command.edit-code",
                 "category": "Cody Command",
                 "title": "Edit Code",
@@ -701,6 +708,13 @@
                     "when": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory && viewItem == cody.chats",
                     "group": "inline@2"
                 }
+            ],
+            "terminal/context": [
+              {
+                "command": "cody.command.explain-output",
+                "group": "0_cody",
+                "when": "terminalFocus && cody.activated"
+              }
             ]
         },
         "configuration": {

--- a/vscode/src/commands/execute/index.ts
+++ b/vscode/src/commands/execute/index.ts
@@ -18,6 +18,7 @@ export { executeTestChatCommand } from './test-chat'
 export { executeDocCommand } from './doc'
 export { executeTestEditCommand } from './test-edit'
 export { executeTestCaseEditCommand } from './test-case'
+export { executeExplainOutput } from './terminal'
 
 export function isDefaultChatCommand(id: string): DefaultChatCommands | undefined {
     // Remove leading slash if any

--- a/vscode/src/commands/execute/terminal.ts
+++ b/vscode/src/commands/execute/terminal.ts
@@ -1,0 +1,72 @@
+import { DefaultChatCommands, logDebug } from '@sourcegraph/cody-shared'
+import { executeChat } from './ask'
+import type { ChatCommandResult } from '../../main'
+import { telemetryService } from '../../services/telemetry'
+import { telemetryRecorder } from '../../services/telemetry-v2'
+
+import * as uuid from 'uuid'
+export interface TerminalOutputArguments {
+    name: string
+    selection?: string
+    creationOptions?: { shellPath?: string; shellArgs?: string[] }
+}
+
+/**
+ * Executes a chat command to explain the given terminal output.
+ * Can be invoked from the VS Code terminal.
+ *
+ * NOTE: The terminal output arguments is returned by the user's
+ * selection through context menu (right click).
+ */
+export async function executeExplainOutput(
+    args: TerminalOutputArguments
+): Promise<ChatCommandResult | undefined> {
+    logDebug('executeExplainOutput', 'executing', { args })
+    const requestID = uuid.v4()
+    const addEnhancedContext = false
+    const source = DefaultChatCommands.Terminal
+    telemetryService.log('CodyVSCodeExtension:command:terminal:executed', {
+        useCodebaseContex: false,
+        requestID,
+        source,
+    })
+    telemetryRecorder.recordEvent('cody.command.terminal', 'executed', {
+        metadata: {
+            useCodebaseContex: 0,
+        },
+        interactionID: requestID,
+        privateMetadata: {
+            requestID,
+            source,
+        },
+    })
+
+    const output = args.selection?.trim()
+    if (!output) {
+        return undefined
+    }
+
+    let prompt = template.replace('{{PROCESS}}', args.name).replace('{{OUTPUT}}', output)
+    const options = JSON.stringify(args.creationOptions ?? {})
+    if (options) {
+        prompt += `\nProcess options: ${options}`
+    }
+
+    return {
+        type: 'chat',
+        session: await executeChat({
+            text: prompt,
+            submitType: 'user-newchat',
+            contextFiles: [],
+            addEnhancedContext,
+            source,
+        }),
+    }
+}
+
+const template = `
+Review and analyze this terminal output from the \`{{PROCESS}}\` process and summarize the key information. If this indicates an error, provide step-by-step instructions on how I can resolve this:
+\n\`\`\`
+\n{{OUTPUT}}
+\n\`\`\`
+`

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -59,9 +59,9 @@ import {
     executeDocCommand,
     executeTestChatCommand,
     executeTestCaseEditCommand,
+    executeExplainOutput,
 } from './commands/execute'
 import { registerSidebarCommands } from './services/SidebarCommands'
-import { executeExplainOutput } from './commands/execute/terminal'
 
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
@@ -348,9 +348,7 @@ const register = async (
         vscode.commands.registerCommand('cody.command.generate-tests', a => executeTestChatCommand(a)),
         vscode.commands.registerCommand('cody.command.unit-tests', a => executeTestEditCommand(a)),
         vscode.commands.registerCommand('cody.command.tests-cases', a => executeTestCaseEditCommand(a)),
-        vscode.commands.registerCommand('cody.command.explain-output', a =>
-            executeExplainOutput(a)
-        )
+        vscode.commands.registerCommand('cody.command.explain-output', a => executeExplainOutput(a))
     )
 
     const statusBar = createStatusBar()

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -61,6 +61,7 @@ import {
     executeTestCaseEditCommand,
 } from './commands/execute'
 import { registerSidebarCommands } from './services/SidebarCommands'
+import { executeExplainOutput } from './commands/execute/terminal'
 
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
@@ -346,7 +347,10 @@ const register = async (
         vscode.commands.registerCommand('cody.command.document-code', a => executeDocCommand(a)),
         vscode.commands.registerCommand('cody.command.generate-tests', a => executeTestChatCommand(a)),
         vscode.commands.registerCommand('cody.command.unit-tests', a => executeTestEditCommand(a)),
-        vscode.commands.registerCommand('cody.command.tests-cases', a => executeTestCaseEditCommand(a))
+        vscode.commands.registerCommand('cody.command.tests-cases', a => executeTestCaseEditCommand(a)),
+        vscode.commands.registerCommand('cody.command.explain-output', a =>
+            executeExplainOutput(a)
+        )
     )
 
     const statusBar = createStatusBar()


### PR DESCRIPTION
Every time I encounter an error in the terminal, I need to copy and paste the error message into the chat and ask Cody to explain or debug it for me. I just discovered that there is an API to add a contribution point to the right-click menu in the VS Code terminal. I am proposing adding an option to 'Ask Cody' directly from the terminal output window.

<img width="1984" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/01e2560c-0e24-43f2-a069-3dbea6ea09d1">

This PR adds a new "Ask Cody" option to the terminal right-click menu that allows users to `Ask Cody` to explain the selection from their terminal output:
- The terminal output will be sent to chat view with a predefined prompt that they can easily edit with the edit button.
- Register a new command called `cody.command.explain-output` and bind it to the terminal view context menu.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Select text in your terminal and right click to `Ask Cody`: 

https://github.com/sourcegraph/cody/assets/68532117/fb33ab59-83af-449f-801d-7895da856c8c

