### PR TITLE
remove retry lens from /test

### DIFF
--- a/vscode/src/non-stop/codelenses.ts
+++ b/vscode/src/non-stop/codelenses.ts
@@ -38,7 +38,7 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
             const retry = getRetryLens(codeLensRange, task.id)
             const undo = getUndoLens(codeLensRange, task.id)
             if (isTest) {
-                return [accept, retry, undo]
+                return [accept, undo]
             }
             return [title, accept, retry, undo]
         }


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C05AGQYD528/p1706865888514999

the retry button doesn't work on untitled file it seems, and since we have disabled the "edit" button for the core commands in chat, will remove the retry code lens from the /test command as well until it is fixed.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

the current e2e test for the /test command should still pass as it only looks for "undo" and "Accept" in the test 😎 