### PR TITLE
Edit: Add command hint filters against non-file selections and multiple selections

### DIFF
--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -74,6 +74,18 @@ export class GhostHintDecorator implements vscode.Disposable {
                 (event: vscode.TextEditorSelectionChangeEvent) => {
                     const editor = event.textEditor
 
+                    if (editor.document.uri.scheme !== 'file') {
+                        // Selection changed on a non-file document, e.g. (an output pane)
+                        // Edit's aren't possible here, so do nothing
+                        return
+                    }
+
+                    if (event.selections.length > 1) {
+                        // Multiple selections, it will be confusing to show the ghost text on all of them, or just the first
+                        // Clear existing text and avoid showing anything.
+                        return this.clearGhostText(editor)
+                    }
+
                     const selection = event.selections[0]
                     if (isEmptyOrIncompleteSelection(editor.document, selection)) {
                         // Empty or incomplete selection, we can technically do an edit/generate here but it is unlikely the user will want to do so.


### PR DESCRIPTION
## Description

Non-file selections:
- E.g. the "Cody by Sourcegraph" output log. --> Edit isn't possible here
- Multiple selections -> Edit is technically possible on the first selection, but this is confusing if a user has multiple selections, so we just hide the text for now.
   - Idea for the future: Trigger the same edits for each selection ?

## Test plan

1. Make selections in above condiitons
2. Check no command hints are shown

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
