### PR TITLE
fix: handle missing prompts in custom commands

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -18,6 +18,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: Messages without enhanced context should not include the sparkle emoji in context list. [pull/3006](https://github.com/sourcegraph/cody/pull/3006)
+- Custom Command: Fixed an issue where custom commands could fail to load due to an invalid entry (e.g. missing prompt). [pull/3012](https://github.com/sourcegraph/cody/pull/3012)
 
 ### Changed
 

--- a/vscode/src/commands/utils/get-commands.test.ts
+++ b/vscode/src/commands/utils/get-commands.test.ts
@@ -17,6 +17,10 @@ describe('buildCodyCommandMap', () => {
                 slashCommand: 'bye',
                 prompt: 'Bye!',
             },
+            missing: {
+                description: 'Missing prompt',
+                type: 'user',
+            },
         }
         // Turn file into Record<string, unknown>
 
@@ -35,6 +39,9 @@ describe('buildCodyCommandMap', () => {
         expect(commandMap.get('bye')?.type).toBe(undefined)
         // Command type set up by user should be replaced on build
         expect(commandMap.get('/bye')?.type).toBe('workspace')
+        // the /missing command will not be available due to the missing prompt
+        // but it shouldn't break the map building process.
+        expect(commandMap.get('/missing')?.type).toBe(undefined)
     })
 
     it('sets edit mode for edit commands correctly', () => {

--- a/vscode/src/commands/utils/get-commands.ts
+++ b/vscode/src/commands/utils/get-commands.ts
@@ -40,11 +40,15 @@ export function buildCodyCommandMap(
     // If it doesn't, use the root as the root
     const commands = parsed.commands ?? parsed
     for (const key in commands) {
-        const command = commands[key] as CodyCommand
+        const command = commands[key] as Partial<CodyCommand>
+        // Skip adding the command if it doesn't have a prompt
+        if (!command.prompt) {
+            continue
+        }
         command.type = type
         command.slashCommand = toSlashCommand(key)
         // Set default mode to ask unless it's an edit command
-        command.mode = command.mode ?? (command.prompt.startsWith('/edit ') ? 'edit' : 'ask')
+        command.mode = command.mode ?? (command.prompt?.startsWith('/edit ') ? 'edit' : 'ask')
         map.set(command.slashCommand, command as CodyCommand)
     }
 

--- a/vscode/src/commands/utils/get-commands.ts
+++ b/vscode/src/commands/utils/get-commands.ts
@@ -48,7 +48,7 @@ export function buildCodyCommandMap(
         command.type = type
         command.slashCommand = toSlashCommand(key)
         // Set default mode to ask unless it's an edit command
-        command.mode = command.mode ?? (command.prompt?.startsWith('/edit ') ? 'edit' : 'ask')
+        command.mode = command.mode ?? (command.prompt.startsWith('/edit ') ? 'edit' : 'ask')
         map.set(command.slashCommand, command as CodyCommand)
     }
 

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -88,6 +88,8 @@ test('create a new user command via the custom commands menu', async ({ page, si
     await expect(chatPanel.getByText(prompt)).toBeVisible()
 })
 
+// NOTE: If no custom commands are showing up in the command menu, it might
+// indicate a breaking change during the custom command building step.
 test('execute custom commands with context defined in cody.json', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
@@ -207,7 +209,9 @@ test('open and delete cody.json from the custom command menu', async ({ page, si
         .getByLabel('Configure Custom Commands..., Manage your custom reusable commands, settings')
         .locator('a')
         .click()
+    await page.locator('a').filter({ hasText: 'Open Workspace Settings (JSON)' }).hover()
+    await page.getByRole('button', { name: 'Delete Settings File' }).hover()
     await page.getByRole('button', { name: 'Delete Settings File' }).click()
-    await sidebarExplorer(page).click()
-    await expect(page.getByRole('treeitem', { name: 'cody.json' }).locator('a')).toBeVisible()
+    // The opened cody.json file should be shown as "Deleted"
+    await expect(page.getByRole('list').getByLabel(/.vscode\/cody.json • Deleted$/)).toBeVisible()
 })

--- a/vscode/test/e2e/custom-command.test.ts
+++ b/vscode/test/e2e/custom-command.test.ts
@@ -213,5 +213,5 @@ test('open and delete cody.json from the custom command menu', async ({ page, si
     await page.getByRole('button', { name: 'Delete Settings File' }).hover()
     await page.getByRole('button', { name: 'Delete Settings File' }).click()
     // The opened cody.json file should be shown as "Deleted"
-    await expect(page.getByRole('list').getByLabel(/.vscode\/cody.json • Deleted$/)).toBeVisible()
+    await expect(page.getByRole('list').getByLabel(/cody.json(.*)Deleted$/)).toBeVisible()
 })

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -279,6 +279,10 @@ async function buildCodyJson(workspaceDirectory: string): Promise<void> {
                 openTabs: true,
             },
         },
+        invalid: {
+            description: 'Command without prompt should not break the custom command menu.',
+            note: 'This is used for validating the custom command UI to avoid cases where an invalid command entry prevents all custom commands from showing up in the menu.',
+        },
     }
 
     // add file to the .vscode directory created in the buildWorkSpaceSettings step


### PR DESCRIPTION
context: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1706656724966049

fix: handle commands missing prompts when building map

Issue: Currently, an invalid entry in the cody.json will cause custom commands not showing up in the command menu.

Fix: Updated the get-commands utility to skip adding commands to the map if they don't contain a prompt property. It updates the command type and adds null checking before accessing the prompt property.

This prevents crashes when building the custom command map if a command is missing the expected prompt field.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Updated both the unit test and e2e test to ensure an invalid custom command entry would not break the custom command at build time.

Create a custom command entry without adding a prompt in your cody.json.

Before: all your custom command from that file will not show up in the custom command menu.

After: only the invalid ones will not show up in the menu, while the valid ones do.