### PR TITLE
fix: ignore non file in status bar

### DIFF
--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -209,6 +209,9 @@ export function createStatusBar(): CodyStatusBar {
     // If ignored, adds 'Ignored' to the status bar text.
     // Otherwise, rerenders the status bar.
     const verifyActiveEditor = (uri?: vscode.Uri) => {
+        // NOTE: Non-file URIs are not supported by the .cody/ignore files and
+        // are ignored by default. As they are files that a user would not expect to
+        // be used by Cody, we will not display them with the "warning".
         if (uri?.scheme === 'file' && isCodyIgnoredFile(uri)) {
             statusBarItem.tooltip = 'Current file is ignored by Cody'
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -209,7 +209,7 @@ export function createStatusBar(): CodyStatusBar {
     // If ignored, adds 'Ignored' to the status bar text.
     // Otherwise, rerenders the status bar.
     const verifyActiveEditor = (uri?: vscode.Uri) => {
-        if (uri && isCodyIgnoredFile(uri)) {
+        if (uri?.scheme === 'file' && isCodyIgnoredFile(uri)) {
             statusBarItem.tooltip = 'Current file is ignored by Cody'
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
         } else {


### PR DESCRIPTION
fix: check scheme before ignoring file in status bar

The status bar logic was ignoring files without checking the URI scheme first. This fixes it to only ignore files with the 'file' scheme, preventing incorrect ignoring of other URI types.

Note: this is only available behind the unstable feature flag.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

in your editor, create an untitled file

before: the cody icon will light up as we mark all the non-files as ignored

<img width="835" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/767e9bd4-bfa8-4bf7-b67d-060b634de297">


after: cody status bar does not light up

<img width="904" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/a9a7835d-10d7-44e1-b8a3-44a02cb15906">


