### PR TITLE
Add support for integration tests using a multi-root workspace

### DIFF
--- a/vscode/test/fixtures/multi-root.code-workspace
+++ b/vscode/test/fixtures/multi-root.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "workspace"
+		},
+		{
+			"path": "workspace2"
+		}
+	]
+}

--- a/vscode/test/fixtures/workspace2/README.md
+++ b/vscode/test/fixtures/workspace2/README.md
@@ -1,0 +1,2 @@
+This is a second workspace folder included in `multi-root.code-workspace` used by integration
+tests in `test/integration/multi-root` for testing in multi-root workspaces.

--- a/vscode/test/integration/main.ts
+++ b/vscode/test/integration/main.ts
@@ -16,36 +16,38 @@ async function main(): Promise<void> {
     // __dirname is derived from that path, not this file's source path.
     const vscodeCodyRoot = path.resolve(__dirname, '..', '..', '..', '..')
 
-    // The test workspace is not copied to out/ during the TypeScript build, so we need to refer to
-    // it in the src/ dir.
-    const testWorkspacePath = path.resolve(vscodeCodyRoot, 'test', 'fixtures', 'workspace')
-
     // The directory containing the extension's package.json, passed to --extensionDevelopmentPath.
     const extensionDevelopmentPath = vscodeCodyRoot
 
-    // The path to the test runner script, passed to --extensionTestsPath.
-    const extensionTestsPath = path.resolve(
-        vscodeCodyRoot,
-        'dist',
-        'tsc',
-        'test',
-        'integration',
-        'index'
-    )
+    // The root folder for all integration test workspaces in the src/ dir.
+    const testFixturesPath = path.resolve(vscodeCodyRoot, 'test', 'fixtures')
+
+    /// The root folder containing the sets of integration tests to run.
+    const integrationTestsPath = path.resolve(vscodeCodyRoot, 'dist', 'tsc', 'test', 'integration')
+
+    // The set of tests and the workspaces they operate on.
+    const testConfigs = [
+        { testsFolder: 'single-root', workspace: 'workspace' },
+        { testsFolder: 'multi-root', workspace: 'multi-root.code-workspace' },
+    ]
 
     try {
         // Download VS Code, unzip it, and run the integration test.
-        await MockServer.run(() =>
-            runTests({
-                version: '1.81.1',
-                extensionDevelopmentPath,
-                extensionTestsPath,
-                launchArgs: [
-                    testWorkspacePath,
-                    '--disable-extensions', // disable other extensions
-                ],
-            })
-        )
+        await MockServer.run(async () => {
+            for (const testConfig of testConfigs) {
+                await runTests({
+                    version: '1.81.1',
+                    extensionDevelopmentPath,
+                    extensionTestsPath: path.normalize(
+                        path.resolve(integrationTestsPath, testConfig.testsFolder, 'index')
+                    ),
+                    launchArgs: [
+                        path.normalize(path.resolve(testFixturesPath, testConfig.workspace)),
+                        '--disable-extensions', // disable other extensions
+                    ],
+                })
+            }
+        })
     } catch (error) {
         console.error('Failed to run tests:', error)
         process.exit(1)

--- a/vscode/test/integration/multi-root/index.ts
+++ b/vscode/test/integration/multi-root/index.ts
@@ -1,0 +1,5 @@
+import * as runner from '../runner'
+
+export function run(): Promise<void> {
+    return runner.run(__dirname)
+}

--- a/vscode/test/integration/multi-root/workspace.test.ts
+++ b/vscode/test/integration/multi-root/workspace.test.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import * as path from 'node:path'
+
+suite('Multi-root Workspace', () => {
+    test('was correctly loaded', async () => {
+        const workspaceFolderNames = vscode.workspace.workspaceFolders?.map(wf =>
+            path.basename(wf.uri.fsPath)
+        )
+        assert.deepStrictEqual(workspaceFolderNames, ['workspace', 'workspace2'])
+    })
+})

--- a/vscode/test/integration/runner.ts
+++ b/vscode/test/integration/runner.ts
@@ -3,15 +3,13 @@ import * as path from 'path'
 import glob from 'glob'
 import Mocha from 'mocha'
 
-export function run(): Promise<void> {
+export function run(testsRoot: string): Promise<void> {
     const mocha = new Mocha({
         ui: 'tdd',
         color: true,
         timeout: 15000,
         grep: process.env.TEST_PATTERN ? new RegExp(process.env.TEST_PATTERN, 'i') : undefined,
     })
-
-    const testsRoot = __dirname
 
     return new Promise((resolve, reject) => {
         glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {

--- a/vscode/test/integration/single-root/api.test.ts
+++ b/vscode/test/integration/single-root/api.test.ts
@@ -2,9 +2,9 @@ import * as assert from 'assert'
 
 import * as vscode from 'vscode'
 
-import { VSCodeDocumentHistory } from '../../src/completions/context/retrievers/jaccard-similarity/history'
+import { VSCodeDocumentHistory } from '../../../src/completions/context/retrievers/jaccard-similarity/history'
 
-import { testFileUri } from './helpers'
+import { testFileUri } from '../helpers'
 
 suite('API tests', () => {
     test('Cody registers some commands', async () => {

--- a/vscode/test/integration/single-root/chat.test.ts
+++ b/vscode/test/integration/single-root/chat.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert'
 
 import * as vscode from 'vscode'
 
-import type { SimpleChatPanelProvider } from '../../src/chat/chat-view/SimpleChatPanelProvider'
+import type { SimpleChatPanelProvider } from '../../../src/chat/chat-view/SimpleChatPanelProvider'
 
 import {
     afterIntegrationTest,
@@ -11,7 +11,7 @@ import {
     getTextEditorWithSelection,
     getTranscript,
     waitUntil,
-} from './helpers'
+} from '../helpers'
 
 async function getChatViewProvider(): Promise<SimpleChatPanelProvider> {
     const chatViewProvider = await getExtensionAPI().exports.testing?.chatPanelProvider.get()

--- a/vscode/test/integration/single-root/commands.test.ts
+++ b/vscode/test/integration/single-root/commands.test.ts
@@ -9,7 +9,7 @@ import {
     getTextEditorWithSelection,
     getTranscript,
     waitUntil,
-} from './helpers'
+} from '../helpers'
 
 // This checks the chat messages after submitting a command to make sure it contains
 // display text which includes command name and file name

--- a/vscode/test/integration/single-root/index.ts
+++ b/vscode/test/integration/single-root/index.ts
@@ -1,0 +1,5 @@
+import * as runner from '../runner'
+
+export function run(): Promise<void> {
+    return runner.run(__dirname)
+}

--- a/vscode/test/integration/single-root/workspace.test.ts
+++ b/vscode/test/integration/single-root/workspace.test.ts
@@ -1,0 +1,12 @@
+import * as assert from 'assert'
+import * as vscode from 'vscode'
+import * as path from 'node:path'
+
+suite('Single-root Workspace', () => {
+    test('was correctly loaded', async () => {
+        const workspaceFolderNames = vscode.workspace.workspaceFolders?.map(wf =>
+            path.basename(wf.uri.fsPath)
+        )
+        assert.deepStrictEqual(workspaceFolderNames, ['workspace'])
+    })
+})

--- a/vscode/test/integration/tsconfig.json
+++ b/vscode/test/integration/tsconfig.json
@@ -7,6 +7,6 @@
     "types": ["mocha", "node"],
   },
   "references": [{ "path": "../../" }],
-  "include": ["*.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["testdata"],
 }


### PR DESCRIPTION
This moves the existing integration tests into a `single-root` folder and adds a `multi-root` folder. Because we can't change between single/multi-root while tests are running (it causes an extension host restart), these are separate invocations (`vscode/test/integration/main.ts` was updated to have a set of test folders / workspaces).

This is work towards https://github.com/sourcegraph/cody/issues/3003, which is to have integration tests that open a multi-root workspace and ensure ignores are handled correctly for each (I have some basic tests for this but they're failing and need some debugging).

## Test plan

- Check bot results
- Ensure results include both:
  - the original single-root integration tests (including the new "Single-root Workspace was correctly loaded" test) [result](https://github.com/sourcegraph/cody/actions/runs/7756639403/job/21154351783?pr=3014#step:8:392)
  - the new multi-root integration tests (currently just a single "Multi-root Workspace was correctly loaded" test) [result](https://github.com/sourcegraph/cody/actions/runs/7756639403/job/21154351783?pr=3014#step:8:415)




