### PR TITLE
Fix ignore patterns that have trailing comments

### DIFF
--- a/lib/shared/src/cody-ignore/ignore-helper.test.ts
+++ b/lib/shared/src/cody-ignore/ignore-helper.test.ts
@@ -139,9 +139,15 @@ describe('IgnoreHelper', () => {
     })
 
     it('handles comments and blank lines in the ignore file', () => {
-        setWorkspace1Ignores(['#.foo', '', 'bar'])
+        setWorkspace1Ignores([
+            '# header comment',
+            '#.foo',
+            '',
+            '.bar # an explanatory reason that .bar is ignored',
+        ])
         expect(ignore.isIgnored(Utils.joinPath(workspace1Root, '.env'))).toBe(true)
         expect(ignore.isIgnored(Utils.joinPath(workspace1Root, '.foo'))).toBe(false)
+        expect(ignore.isIgnored(Utils.joinPath(workspace1Root, '.bar'))).toBe(true)
     })
 
     describe('returns the correct value for a sample of rules', () => {

--- a/lib/shared/src/cody-ignore/ignore-helper.ts
+++ b/lib/shared/src/cody-ignore/ignore-helper.ts
@@ -75,10 +75,12 @@ export class IgnoreHelper {
 
             // Build the ignore rule with the relative folder path applied to the start of each rule.
             for (let ignoreLine of ignoreFile.content.split('\n')) {
-                // Skip blanks/ comments
-                ignoreLine = ignoreLine.trim()
+                // Trim off any trailing comments.
+                ignoreLine = ignoreLine.split('#')[0]
 
-                if (!ignoreLine.length || ignoreLine.startsWith('#')) {
+                // Skip any lines that are now empty.
+                ignoreLine = ignoreLine.trim()
+                if (!ignoreLine.length) {
                     continue
                 }
 


### PR DESCRIPTION
The `ignore` library doesn't appear to handle comments itself. When the ignore file contained comments on a line like:

```
.foo # comment
```

This would not match `.foo` files. We now strip comments from the end of lines before processing.

## Test plan

- `run pnpm test:unit ignore` and ensure the new test that contains comments passes
