### PR TITLE
Clarify asdf setup instructions

### DIFF
--- a/doc/dev/index.md
+++ b/doc/dev/index.md
@@ -3,6 +3,7 @@
 ### Setup
 
 1. Install [asdf](https://asdf-vm.com/)
+2. Install pnpm using asdf
 1. Run `asdf install` (if needed, run `asdf plugin add NAME` for any missing plugins)
 1. Run `pnpm install && pnpm build`
 


### PR DESCRIPTION
You need to have at least one asdf plugin installed for it to give you a meaningful error message on which plugins are missing. Otherwise, it just says "Install plugins first to be able to install tools" which is not actionable.