### PR TITLE
Add integration tests for Ignores in multi-root VS Code workspaces

### DIFF
--- a/agent/src/vscode-shim.test.ts
+++ b/agent/src/vscode-shim.test.ts
@@ -212,6 +212,21 @@ describe('vscode.workspace.findFiles', () => {
         `)
     })
 
+    it('findFiles(RelativePattern(workspaceFolder, "**.sh"))', async () => {
+        // TODO(dantup): add tests for multiple WorkspaceFolders to ensure the
+        //  filter actually works if/when we support multiple workspace folders.
+        const files = await vscode.workspace.findFiles(
+            new vscode.RelativePattern(vscode.workspaceFolders[0], '**/*.sh'),
+            undefined,
+            undefined
+        )
+        expect(files.map(relativize)).toMatchInlineSnapshot(`
+          [
+            "scripts/hello.sh",
+          ]
+        `)
+    })
+
     it('findFiles(exclude="**.sh")', async () => {
         const files = await vscode.workspace.findFiles('', '**/*.sh', undefined)
         expect(files.map(relativize).sort()).toMatchInlineSnapshot(`

--- a/vscode/src/repository/repositoryHelpers.ts
+++ b/vscode/src/repository/repositoryHelpers.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode'
 
-import { convertGitCloneURLToCodebaseName } from '@sourcegraph/cody-shared'
+import { convertGitCloneURLToCodebaseName, ignores } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 import { setUpCodyIgnore } from '../services/cody-ignore'
 
 import type { API, GitExtension, Repository } from './builtinGitExtension'
+import { TestSupport } from '../test-support'
 
 export function gitDirectoryUri(uri: vscode.Uri): vscode.Uri | undefined {
     return gitAPI()?.getRepository(uri)?.rootUri
@@ -39,6 +40,9 @@ export async function gitAPIinit(): Promise<vscode.Disposable | undefined> {
     function init(): void {
         if (!vscodeGitAPI && extension?.isActive) {
             setUpCodyIgnore()
+            if (TestSupport.instance) {
+                TestSupport.instance.ignoreHelper.set(ignores)
+            }
             // This throws error if the git extension is disabled
             vscodeGitAPI = extension.exports?.getAPI(1)
         }

--- a/vscode/src/services/cody-ignore.ts
+++ b/vscode/src/services/cody-ignore.ts
@@ -65,11 +65,8 @@ async function refresh(uri: vscode.Uri): Promise<void> {
 
     // Get the codebase name from the git clone URL on each refresh
     // NOTE: This is needed because the ignore rules are mapped to workspace addresses at creation time, we will need to map the name of the codebase to each workspace for us to map the embedding results returned for a specific codebase by the search API to the correct workspace later.
-    const ignoreFilePattern = new vscode.RelativePattern(wf.uri, CODY_IGNORE_POSIX_GLOB).pattern
-    const ignoreFiles = await vscode.workspace.findFiles(
-        // UseRelativePattern to restrict the search to this WorkspaceFolder
-        new vscode.RelativePattern(wf, ignoreFilePattern)
-    )
+    const ignoreFilePattern = new vscode.RelativePattern(wf.uri, CODY_IGNORE_POSIX_GLOB)
+    const ignoreFiles = await vscode.workspace.findFiles(ignoreFilePattern)
     const filesWithContent: IgnoreFileContent[] = await Promise.all(
         ignoreFiles.map(async fileUri => ({
             uri: fileUri,

--- a/vscode/src/services/cody-ignore.ts
+++ b/vscode/src/services/cody-ignore.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode'
 import { CODY_IGNORE_POSIX_GLOB, ignores, type IgnoreFileContent } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
-import { TestSupport } from '../test-support'
 
 const utf8 = new TextDecoder('utf-8')
 
@@ -14,9 +13,6 @@ const utf8 = new TextDecoder('utf-8')
  * NOTE: This is only called once at git extension start up time (gitAPIinit)
  */
 export function setUpCodyIgnore(): vscode.Disposable {
-    if (TestSupport.instance) {
-        TestSupport.instance.ignoreHelper.set(ignores)
-    }
     onConfigChange()
 
     // Refresh ignore rules when any ignore file in the workspace changes.

--- a/vscode/src/test-support.ts
+++ b/vscode/src/test-support.ts
@@ -1,6 +1,7 @@
 import type { ChatMessage } from '@sourcegraph/cody-shared'
 
 import type { SimpleChatPanelProvider } from './chat/chat-view/SimpleChatPanelProvider'
+import type { IgnoreHelper } from '@sourcegraph/cody-shared/src/cody-ignore/ignore-helper'
 
 // A one-slot channel which lets readers block on a value being
 // available from a writer. Tests use this to wait for the
@@ -36,6 +37,7 @@ class Rendezvous<T> {
 export class TestSupport {
     public static instance: TestSupport | undefined
     public chatPanelProvider = new Rendezvous<SimpleChatPanelProvider>()
+    public ignoreHelper = new Rendezvous<IgnoreHelper>()
 
     public async chatMessages(): Promise<ChatMessage[]> {
         return (await this.chatPanelProvider.get()).getViewTranscript()

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -229,12 +229,18 @@ export class TreeItem {
 }
 
 export class RelativePattern implements vscode_types.RelativePattern {
-    public baseUri = Uri.parse('file:///foobar')
+    public baseUri: Uri
     public base: string
     constructor(
         _base: vscode_types.WorkspaceFolder | vscode_types.Uri | string,
         public readonly pattern: string
     ) {
+        this.baseUri =
+            typeof _base === 'string'
+                ? Uri.file(_base)
+                : 'uri' in _base
+                  ? Uri.from(_base.uri)
+                  : Uri.from(_base)
         this.base = _base.toString()
     }
 }

--- a/vscode/src/testutils/uri.ts
+++ b/vscode/src/testutils/uri.ts
@@ -31,7 +31,7 @@ export class Uri {
         return new Uri(URI.parse(value, strict))
     }
 
-    public static file(path: string): URI {
+    public static file(path: string): Uri {
         return new Uri(URI.file(path))
     }
 

--- a/vscode/test/fixtures/multi-root.code-workspace
+++ b/vscode/test/fixtures/multi-root.code-workspace
@@ -1,10 +1,19 @@
 {
-	"folders": [
-		{
-			"path": "workspace"
-		},
-		{
-			"path": "workspace2"
-		}
-	]
+    "folders": [
+        {
+            "path": "workspace"
+        },
+        {
+            "path": "workspace2"
+        }
+    ],
+    "settings": {
+        // Settings that should also apply to the single-root workspace tests should also be
+        // included in fixtures\workspace\.vscode\settings.json!
+        "cody.serverEndpoint": "http://localhost:49300",
+        "cody.commandCodeLenses": true,
+        "cody.editorTitleCommandIcon": true,
+        "cody.experimental.symfContext": false,
+        "cody.internal.unstable": true
+    }
 }

--- a/vscode/test/fixtures/workspace/.cody/ignore
+++ b/vscode/test/fixtures/workspace/.cody/ignore
@@ -1,3 +1,4 @@
 # NOTE: USED FOR AUTOMATED TEST CODY IGNORE
 # All .css files will be excluded from Cody context
 *.css
+**/*.ws1 # Used by ignore integration tests

--- a/vscode/test/fixtures/workspace/ignoreTests/ignoreTest.ws1
+++ b/vscode/test/fixtures/workspace/ignoreTests/ignoreTest.ws1
@@ -1,0 +1,4 @@
+This file should be ignored.
+
+.ws1 files are ignored only in the "workspace" folder
+.ws2 files are ignored only in the "workspace2" folder

--- a/vscode/test/fixtures/workspace/ignoreTests/ignoreTest.ws2
+++ b/vscode/test/fixtures/workspace/ignoreTests/ignoreTest.ws2
@@ -1,0 +1,4 @@
+This file should NOT be ignored.
+
+.ws1 files are ignored only in the "workspace" folder
+.ws2 files are ignored only in the "workspace2" folder

--- a/vscode/test/fixtures/workspace2/.cody/ignore
+++ b/vscode/test/fixtures/workspace2/.cody/ignore
@@ -1,0 +1,2 @@
+# NOTE: USED FOR AUTOMATED TEST CODY IGNORE
+**/*.ws2 # Used by ignore integration tests

--- a/vscode/test/fixtures/workspace2/ignoreTests/ignoreTest.ws1
+++ b/vscode/test/fixtures/workspace2/ignoreTests/ignoreTest.ws1
@@ -1,0 +1,4 @@
+This file should NOT be ignored.
+
+.ws1 files are ignored only in the "workspace" folder
+.ws2 files are ignored only in the "workspace2" folder

--- a/vscode/test/fixtures/workspace2/ignoreTests/ignoreTest.ws2
+++ b/vscode/test/fixtures/workspace2/ignoreTests/ignoreTest.ws2
@@ -1,0 +1,4 @@
+This file should be ignored.
+
+.ws1 files are ignored only in the "workspace" folder
+.ws2 files are ignored only in the "workspace2" folder

--- a/vscode/test/integration/multi-root/ignore.test.ts
+++ b/vscode/test/integration/multi-root/ignore.test.ts
@@ -1,0 +1,42 @@
+import assert from 'assert'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+import { URI } from 'vscode-uri'
+import { getExtensionAPI } from '../helpers'
+
+suite('Ignores in multi-root workspace', () => {
+    const workspace1Path = vscode.workspace.workspaceFolders![0].uri.fsPath
+    const workspace2Path = vscode.workspace.workspaceFolders![1].uri.fsPath
+
+    async function checkIgnore(fullPath: string, expectIgnored: boolean) {
+        const ignoreHelper = await (await getExtensionAPI().activate()).testing!.ignoreHelper.get()
+
+        await new Promise(resolve => setTimeout(resolve, 1000))
+
+        fullPath = path.normalize(fullPath)
+        const fileUri = URI.file(fullPath)
+
+        // Verify the file exists to ensure the parts are correct.
+        assert.ok(fs.existsSync(fullPath))
+
+        // Verify ignore status.
+        assert.equal(
+            ignoreHelper.isIgnored(fileUri),
+            expectIgnored,
+            `Wrong ignore status for ${fileUri}`
+        )
+    }
+
+    test('ignores ws1 files in workspace1', () =>
+        checkIgnore(`${workspace1Path}/ignoreTests/ignoreTest.ws1`, true))
+
+    test('does not ignore ws2 files in workspace1', () =>
+        checkIgnore(`${workspace1Path}/ignoreTests/ignoreTest.ws2`, false))
+
+    test('does not ignore ws1 files in workspace2', () =>
+        checkIgnore(`${workspace2Path}/ignoreTests/ignoreTest.ws1`, false))
+
+    test('ignores ws2 files in workspace2', () =>
+        checkIgnore(`${workspace2Path}/ignoreTests/ignoreTest.ws2`, true))
+})


### PR DESCRIPTION
This adds some integration tests that in an active multi-root workspace in VS Code, the ignore files are set up and applied correctly.

Also includes some tweaks to the shim `findFiles()` to support `RelativePattern` which fixes an issue where we could add ignore rules from the "wrong" workspace folders (not in a breaking way, but it was confusing to debug and slower because we ran a search across all workspace folders for each workspace folder).

Fixes https://github.com/sourcegraph/cody/issues/3003

## Test plan

- Check bot results for the new tests, or:
- Open the `multi-root.code-workspace` workspace from `fixtures` and verify that the `.ws1` is ignored only in workspace1 and that `.ws2` file is ignored only in workspace2.
