### PR TITLE
exclude build/ and .class files from user context files

### DIFF
--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -24,7 +24,8 @@ const findWorkspaceFiles = async (
     // TODO(toolmantim): Add support for the search.exclude option, e.g.
     // Object.keys(vscode.workspace.getConfiguration().get('search.exclude',
     // {}))
-    const fileExcludesPattern = '**/{*.env,.git,out/,dist/,snap,node_modules,__pycache__}**'
+    const fileExcludesPattern =
+        '**/{*.env,.git,.class,out/,dist/,build/,snap,node_modules,__pycache__}**'
     // TODO(toolmantim): Check this performs with remote workspaces (do we need a UI spinner etc?)
     return vscode.workspace.findFiles('', fileExcludesPattern, undefined, cancellationToken)
 }


### PR DESCRIPTION
## Test plan

- [ ] Run locally and try to include a .class file (e.g., in `sourcegraph/jetbrains`)
- [ ] Run locally and try to include a regular source file (should still succeed)