### PR TITLE
fix build in bash

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -12,7 +12,7 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build:root": "cd .. && pnpm build && cd agent",
+    "build:root": "cd .. && pnpm build && cd $(pwd)/agent",
     "build:agent": "node src/esbuild.mjs",
     "build": "pnpm run build:root && pnpm run build:agent",
     "build-minify": "pnpm run build --minify",


### PR DESCRIPTION
Makes `pnpm test:unit` work with bash on macOS

## Test plan

Test-only