### PR TITLE
Autocomplete: truncate the last completion line if it matches suffix

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
@@ -581,33 +581,60 @@ for (const isTreeSitterEnabled of cases) {
             if (isTreeSitterEnabled) {
                 it('stops when the next non-empty line of the suffix matches', async () => {
                     expect(
-                        await getInlineCompletionsInsertText(
-                            params(
-                                dedent`
+                        (
+                            await getInlineCompletionsInsertText(
+                                params(
+                                    dedent`
                                 function myFunction() {
                                     █
                                 }
                         `,
-                                [
-                                    completion`
+                                    [
+                                        completion`
                                 ├function nestedFunction() {
                                     console.log('one')
                                 }
 
                                 nestedFunction()
                                 }┤`,
-                                ]
+                                    ]
+                                )
                             )
-                        )
+                        )[0]
                     ).toMatchInlineSnapshot(`
-                  [
-                    "function nestedFunction() {
-                      console.log('one')
-                  }
+                      "function nestedFunction() {
+                          console.log('one')
+                      }
 
-                  nestedFunction()",
-                  ]
-                `)
+                      nestedFunction()"
+                    `)
+                })
+
+                it('stops when the next non-empty line of the suffix starts with the last completion line', async () => {
+                    expect(
+                        (
+                            await getInlineCompletionsInsertText(
+                                params(
+                                    dedent`
+                                    const controller = {
+                                        set(value) {
+                                            █
+                                        },
+                                        get() {
+                                            return 1
+                                        }
+                                    }`,
+                                    [
+                                        completion`
+                                            ├this.value = value
+                                        },
+                                        whatever() ┤
+                                    ┴┴┴┴`,
+                                    ]
+                                )
+                            )
+                        )[0]
+                    ).toBe('this.value = value')
                 })
 
                 it('truncates multiline completions with inconsistent indentation', async () => {

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -178,6 +178,10 @@ export function trimUntilSuffix(
     for (let i = insertionLines.length - 1; i >= 0; i--) {
         let line = insertionLines[i]
 
+        if (line.length === 0) {
+            continue
+        }
+
         // Include the current indentation of the prefix in the first line
         if (i === 0) {
             line = prefixIndentationWithFirstCompletionLine + line
@@ -197,7 +201,11 @@ export function trimUntilSuffix(
             break
         }
 
-        if (isSameIndentation && isAlmostTheSameString(line, firstNonEmptySuffixLine)) {
+        if (
+            isSameIndentation &&
+            (isAlmostTheSameString(line, firstNonEmptySuffixLine) ||
+                firstNonEmptySuffixLine.startsWith(line))
+        ) {
             cutOffIndex = i
             break
         }


### PR DESCRIPTION
## Context 

- If the last completion line starts the next-non-empty-suffix line, we didn't truncate it, which caused completions to be suggested with redundant closing brackets:

    ![CleanShot 2024-01-19 at 12 14 34@2x](https://github.com/sourcegraph/cody/assets/3846380/7eaa3a4b-a18a-41ed-82a1-4e02ac900b0b)

- This PR fixes the issues and adds a unit test to cover this case.
- [Slack report](https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1705662932035059)

## Test plan

CI
