### PR TITLE
cody: update auth endpoint for SAMS redirect

### DIFF
--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -36,9 +36,9 @@ async function openExternalAuthUrl(provider: AuthMethod): Promise<boolean> {
     const site = DOTCOM_URL.toString() // Note, ends with the path /
 
     const genericLoginUrl = `${site}sign-in?returnTo=${postSignUpSurveyUrl}`
-    const gitHubLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=github&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=${postSignUpSurveyUrl}`
-    const gitLabLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=gitlab&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=${postSignUpSurveyUrl}`
-    const googleLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=google&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=${postSignUpSurveyUrl}`
+    const gitHubLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=${postSignUpSurveyUrl}`
+    const gitLabLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=${postSignUpSurveyUrl}`
+    const googleLoginUrl = `${site}.auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=${postSignUpSurveyUrl}`
 
     let uriSpec: string
     switch (provider) {


### PR DESCRIPTION
This is a follow-up improvement to https://github.com/sourcegraph/cody/pull/2957. TIL we can configure auth provider in Sourcegraph to have a static `pc` to reference to. This is strictly better than relying on the brittle sha256 of current provider config.

## Test plan

Manually tested

and

![CleanShot 2024-02-05 at 14 55 27@2x](https://github.com/sourcegraph/cody/assets/2946214/6633b293-fe68-494a-8c9e-f9bcafcaab19)

