### PR TITLE
Add config feature gating for chat and commands

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -530,10 +530,10 @@ describe('Agent', () => {
                 command: 'cody.search.index-update',
             })
             await client.openFile(ignoredUri)
-            const id = await client.request('commands/explain', null)
-            const lastMessage = await client.firstNonEmptyTranscript(id)
-            // Ignored file should not be used as context files even when selected
-            expect(lastMessage.messages[0]?.contextFiles).toHaveLength(0)
+            // Cannot execute commands in an ignored files, so this should throw error
+            await client.request('commands/explain', null).catch(err => {
+                expect(err).toBeDefined()
+            })
         }, 30_000)
 
         it('inline edit on an ignored file', async () => {

--- a/vscode/src/commands/execute/ask.ts
+++ b/vscode/src/commands/execute/ask.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode'
 import type { ChatSession } from '../../chat/chat-view/SimpleChatPanelProvider'
 import type { WebviewSubmitMessage } from '../../chat/protocol'
-import type { ChatEventSource } from '@sourcegraph/cody-shared'
+import { ConfigFeaturesSingleton, type ChatEventSource } from '@sourcegraph/cody-shared'
+import { isDefaultChatCommand } from '.'
 
 export interface ExecuteChatArguments extends WebviewSubmitMessage {
     source?: ChatEventSource
@@ -11,5 +12,14 @@ export interface ExecuteChatArguments extends WebviewSubmitMessage {
  * Wrapper around the `cody.action.chat` command that can be used anywhere but with better type-safety.
  */
 export const executeChat = async (args: ExecuteChatArguments): Promise<ChatSession | undefined> => {
+    const { chat, commands } = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
+    const isCommand = isDefaultChatCommand(args.source || '')
+    if ((!isCommand && !chat) || (isCommand && !commands)) {
+        void vscode.window.showErrorMessage(
+            'This feature has been disabled by your Sourcegraph site admin.'
+        )
+        return undefined
+    }
+
     return vscode.commands.executeCommand<ChatSession | undefined>('cody.action.chat', args)
 }

--- a/vscode/src/commands/execute/ask.ts
+++ b/vscode/src/commands/execute/ask.ts
@@ -3,6 +3,7 @@ import type { ChatSession } from '../../chat/chat-view/SimpleChatPanelProvider'
 import type { WebviewSubmitMessage } from '../../chat/protocol'
 import { ConfigFeaturesSingleton, type ChatEventSource } from '@sourcegraph/cody-shared'
 import { isDefaultChatCommand } from '.'
+import { getEditor } from '../../editor/active-editor'
 
 export interface ExecuteChatArguments extends WebviewSubmitMessage {
     source?: ChatEventSource
@@ -10,6 +11,7 @@ export interface ExecuteChatArguments extends WebviewSubmitMessage {
 
 /**
  * Wrapper around the `cody.action.chat` command that can be used anywhere but with better type-safety.
+ * This is also called by all the default chat commands (e.g. /explain, /smell).
  */
 export const executeChat = async (args: ExecuteChatArguments): Promise<ChatSession | undefined> => {
     const { chat, commands } = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
@@ -18,6 +20,11 @@ export const executeChat = async (args: ExecuteChatArguments): Promise<ChatSessi
         void vscode.window.showErrorMessage(
             'This feature has been disabled by your Sourcegraph site admin.'
         )
+        return undefined
+    }
+
+    if (isCommand && getEditor()?.ignored) {
+        void vscode.window.showErrorMessage('Cannot execute a command in an ignored file.')
         return undefined
     }
 

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -57,12 +57,10 @@ test('chat and command do not work in .cody/ignore file', async ({ page, sidebar
     /* TEST: Command - Ignored file do not show up with context */
     await page.getByText('Explain code').hover()
     await page.getByText('Explain code').click()
-    // Assistant should response to your command,
-    // but the current file is excluded (ignoredByCody.css) and not on the context list
-    await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
-    // TODO bee update current behavior to following:
+    // Assistant should not response to your command, so you should still see the old message.
+    await expect(chatPanel.getByText('Ignore me')).toBeVisible()
     // A system message shows up to notify users that the file is ignored
-    // await expect(page.getByText(/^Current file is ignored/)).toBeVisible()
+    await expect(page.getByText(/^Cannot execute a command in an ignored file./)).toBeVisible()
 })
 
 function withPlatformSlashes(input: string) {


### PR DESCRIPTION
This commit adds a check for the chat and commands config features before executing the chat command. If either feature is disabled by the site admin, an error message is shown and the command is not executed. This gates usage of the chat and commands behind the config features.

Also updated behavior where running a command in an ignored file will returns an error.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

connect to an instance that has chat or command disabled, and check if the error message shows up correctly.