### PR TITLE
Autocomplete: Add button to quickly expose Autocomplete options to status bar items

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - [Internal] Command: Added new code lenses for generating additional unit tests. [pull/2959](https://github.com/sourcegraph/cody/pull/2959)
 - Edit: Added Cody Pro support for models: GPT-4, GPT-3.5, Claude 2.1 and Claude Instant. [pull/2951](https://github.com/sourcegraph/cody/pull/2951)
 - Edit: Added a multi-model selector to the Edit input, allowing quick access to change the Edit LLM. [pull/2951](https://github.com/sourcegraph/cody/pull/2951)
+- Autocomplete: Added a shortcut to go to the Autocomplete settings from the Cody Settings overlay. [pull/3048(https://github.com/sourcegraph/cody/pull/3048)
 
 ### Fixed
 

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -189,10 +189,6 @@ export function createStatusBar(): CodyStatusBar {
             item?.button?.onClick?.()
             quickPick.hide()
         })
-
-        // if (option && 'onSelect' in option) {
-        //     option.onSelect().catch(console.error)
-        // }
     })
 
     // Reference counting to ensure loading states are handled consistently across different

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -31,6 +31,10 @@ const ONE_HOUR = 60 * 60 * 1000
 
 type StatusBarErrorName = 'auth' | 'RateLimitError' | 'AutoCompleteDisabledByAdmin'
 
+interface StatusBarItem extends vscode.QuickPickItem {
+    onSelect: () => Promise<void>
+}
+
 export function createStatusBar(): CodyStatusBar {
     const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right)
     statusBarItem.text = DEFAULT_TEXT
@@ -48,8 +52,9 @@ export function createStatusBar(): CodyStatusBar {
             detail: string,
             setting: string,
             getValue: (config: Configuration) => boolean,
-            requiresReload = false
-        ): vscode.QuickPickItem & { onSelect: () => Promise<void> } {
+            requiresReload = false,
+            buttons: readonly vscode.QuickInputButton[] | undefined = undefined
+        ): StatusBarItem {
             const isEnabled = getValue(config)
             return {
                 label:
@@ -69,6 +74,7 @@ export function createStatusBar(): CodyStatusBar {
                         await vscode.commands.executeCommand('workbench.action.reloadWindow')
                     }
                 },
+                buttons,
             }
         }
 
@@ -76,96 +82,117 @@ export function createStatusBar(): CodyStatusBar {
             errors.map(error => error.error.onShow?.())
         }
 
-        const option = await vscode.window.showQuickPick(
+        const quickPick = vscode.window.createQuickPick()
+        quickPick.items = [
             // These description should stay in sync with the settings in package.json
-            [
-                ...(errors.length > 0
-                    ? [
-                          { label: 'notice', kind: vscode.QuickPickItemKind.Separator },
-                          ...errors.map(error => ({
-                              label: `$(alert) ${error.error.title}`,
-                              description: '',
-                              detail: QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX + error.error.description,
-                              onSelect(): Promise<void> {
-                                  error.error.onSelect?.()
-                                  const index = errors.indexOf(error)
-                                  errors.splice(index)
-                                  rerender()
-                                  return Promise.resolve()
-                              },
-                          })),
-                      ]
-                    : []),
-                { label: 'enable/disable features', kind: vscode.QuickPickItemKind.Separator },
-                createFeatureToggle(
-                    'Code Autocomplete',
-                    undefined,
-                    'Enable Cody-powered code autocompletions',
-                    'cody.autocomplete.enabled',
-                    c => c.autocomplete
-                ),
-                createFeatureToggle(
-                    'Code Actions',
-                    undefined,
-                    'Enable Cody fix and explain options in the Quick Fix menu',
-                    'cody.codeActions.enabled',
-                    c => c.codeActions
-                ),
-                createFeatureToggle(
-                    'Editor Title Icon',
-                    undefined,
-                    'Enable Cody to appear in editor title menu for quick access to Cody commands',
-                    'cody.editorTitleCommandIcon',
-                    c => c.editorTitleCommandIcon
-                ),
-                createFeatureToggle(
-                    'Code Lenses',
-                    undefined,
-                    'Enable Code Lenses in documents for quick access to Cody commands',
-                    'cody.commandCodeLenses',
-                    c => c.commandCodeLenses
-                ),
-                createFeatureToggle(
-                    'Command Hints',
-                    undefined,
-                    'Enable hints for Edit and Chat shortcuts, displayed alongside editor selections',
-                    'cody.commandHints.enabled',
-                    c => c.commandHints
-                ),
-                createFeatureToggle(
-                    'Search Context',
-                    'Beta',
-                    'Enable using the natural language search index as an Enhanced Context chat source',
-                    'cody.experimental.symfContext',
-                    c => c.experimentalSymfContext,
-                    false
-                ),
-                { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
-                {
-                    label: '$(gear) Cody Extension Settings',
-                    async onSelect(): Promise<void> {
-                        await vscode.commands.executeCommand('cody.settings.extension')
-                    },
-                },
-                {
-                    label: '$(symbol-namespace) Custom Commands Settings',
-                    async onSelect(): Promise<void> {
-                        await vscode.commands.executeCommand('cody.menu.commands-settings')
-                    },
-                },
-                { label: 'feedback & support', kind: vscode.QuickPickItemKind.Separator },
-                ...FeedbackOptionItems,
-            ],
+            ...(errors.length > 0
+                ? [
+                      { label: 'notice', kind: vscode.QuickPickItemKind.Separator },
+                      ...errors.map(error => ({
+                          label: `$(alert) ${error.error.title}`,
+                          description: '',
+                          detail: QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX + error.error.description,
+                          onSelect(): Promise<void> {
+                              error.error.onSelect?.()
+                              const index = errors.indexOf(error)
+                              errors.splice(index)
+                              rerender()
+                              return Promise.resolve()
+                          },
+                      })),
+                  ]
+                : []),
+            { label: 'enable/disable features', kind: vscode.QuickPickItemKind.Separator },
+            createFeatureToggle(
+                'Code Autocomplete',
+                undefined,
+                'Enable Cody-powered code autocompletions',
+                'cody.autocomplete.enabled',
+                c => c.autocomplete,
+                false,
+                [
+                    {
+                        iconPath: new vscode.ThemeIcon('settings-more-action'),
+                        tooltip: 'Autocomplete Settings',
+                        onClick: () =>
+                            vscode.commands.executeCommand('workbench.action.openSettings', {
+                                query: '@ext:sourcegraph.cody-ai autocomplete',
+                            }),
+                    } as vscode.QuickInputButton,
+                ]
+            ),
+            createFeatureToggle(
+                'Code Actions',
+                undefined,
+                'Enable Cody fix and explain options in the Quick Fix menu',
+                'cody.codeActions.enabled',
+                c => c.codeActions
+            ),
+            createFeatureToggle(
+                'Editor Title Icon',
+                undefined,
+                'Enable Cody to appear in editor title menu for quick access to Cody commands',
+                'cody.editorTitleCommandIcon',
+                c => c.editorTitleCommandIcon
+            ),
+            createFeatureToggle(
+                'Code Lenses',
+                undefined,
+                'Enable Code Lenses in documents for quick access to Cody commands',
+                'cody.commandCodeLenses',
+                c => c.commandCodeLenses
+            ),
+            createFeatureToggle(
+                'Command Hints',
+                undefined,
+                'Enable hints for Edit and Chat shortcuts, displayed alongside editor selections',
+                'cody.commandHints.enabled',
+                c => c.commandHints
+            ),
+            createFeatureToggle(
+                'Search Context',
+                'Beta',
+                'Enable using the natural language search index as an Enhanced Context chat source',
+                'cody.experimental.symfContext',
+                c => c.experimentalSymfContext,
+                false
+            ),
+            { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
             {
-                title: 'Cody Settings',
-                placeHolder: 'Choose an option',
-                matchOnDescription: true,
+                label: '$(gear) Cody Extension Settings',
+                async onSelect(): Promise<void> {
+                    await vscode.commands.executeCommand('cody.settings.extension')
+                },
+            },
+            {
+                label: '$(symbol-namespace) Custom Commands Settings',
+                async onSelect(): Promise<void> {
+                    await vscode.commands.executeCommand('cody.menu.commands-settings')
+                },
+            },
+            { label: 'feedback & support', kind: vscode.QuickPickItemKind.Separator },
+            ...FeedbackOptionItems,
+        ]
+        quickPick.title = 'Cody Settings'
+        quickPick.placeholder = 'Choose an option'
+        quickPick.matchOnDescription = true
+        quickPick.show()
+        quickPick.onDidAccept(() => {
+            const option = quickPick.activeItems[0] as StatusBarItem
+            if (option && 'onSelect' in option) {
+                option.onSelect().catch(console.error)
             }
-        )
+            quickPick.hide()
+        })
+        quickPick.onDidTriggerItemButton(item => {
+            // @ts-ignore: onClick is a custom extension to the QuickInputButton
+            item?.button?.onClick?.()
+            quickPick.hide()
+        })
 
-        if (option && 'onSelect' in option) {
-            option.onSelect().catch(console.error)
-        }
+        // if (option && 'onSelect' in option) {
+        //     option.onSelect().catch(console.error)
+        // }
     })
 
     // Reference counting to ensure loading states are handled consistently across different


### PR DESCRIPTION
c.f.: https://sourcegraph.slack.com/archives/C05AGQYD528/p1707217245795609?thread_ts=1707216986.020879&cid=C05AGQYD528

Needs a quick change from to `window.showQuickPick` to `window.createQuickPick`.

## Test plan

https://github.com/sourcegraph/cody/assets/458591/b8d5ec4e-5c2e-49c5-92f8-c80ba9f70acb



<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
