### PR TITLE
Add set model endpoint to agent protocol

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -730,6 +730,13 @@ export class Agent extends MessageHandler {
             return { models: panel.models ?? [] }
         })
 
+        this.registerAuthenticatedRequest('chat/setModel', async ({id, model}) => {
+            await this.receiveWebviewMessage(id, {
+                command: 'chatModel', model: model
+            })
+            return true
+        })
+
         this.registerAuthenticatedRequest('chat/remoteRepos', async ({ id }) => {
             const panel = this.webPanels.getPanelOrError(id)
             await this.receiveWebviewMessage(id, { command: 'context/get-remote-search-repos' })

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -49,6 +49,7 @@ export type Requests = {
     'chat/restore': [{ modelID: string; messages: ChatMessage[]; chatID: string }, string]
 
     'chat/models': [{ id: string }, { models: ModelProvider[] }]
+    'chat/setModel': [{id: string; model: string}, boolean]
     'chat/remoteRepos': [{ id: string }, { remoteRepos?: Repo[] }]
 
     // High-level wrapper around webview/receiveMessage and webview/postMessage


### PR DESCRIPTION
It is part of https://github.com/sourcegraph/jetbrains/issues/221 
We need to add possibility to set specific llm model per chat.
## Test plan
Test api from JetBrains plugin
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
