### PR TITLE
Add test case to reproduce crash that only happens with Enterprise accounts

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -627,6 +627,413 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 282c1ec78b202e69765ae92eb9d210ff
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3164
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - name: user-agent
+            value: enterpriseClient / v1
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 265
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >+
+                  Codebase context from file path src/example.test.ts: Use the
+                  following code snippet from file: src/example.test.ts:
+
+                  import { expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  - You are an AI programming assistant who is an expert in
+                  updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+
+
+                  This is part of the file: src/example.test.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>describe('test block', () => {
+                      it('does 1', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does 2', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does something else', () => {
+                          // This line will error due to incorrect usage of `performance.now`
+                          const startTime = performance.now(/* CURSOR */)
+                      })
+                  })
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to geneerate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: |
+                  <CODE5711>
+            model: anthropic/claude-2.0
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://demo.sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 8260
+        content:
+          mimeType: text/event-stream
+          size: 8260
+          text: >+
+            event: completion
+
+            data: {"completion":"/**","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vit","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to call","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to call performance","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to call performance.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to call performance.now","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to call performance.now incorrectly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to call performance.now incorrectly\n */","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to call performance.now incorrectly\n */\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Defines a test block with 3 test cases using Vitest:\n * - does 1 - asserts true equals true \n * - does 2 - asserts true equals true\n * - does something else - attempts to call performance.now incorrectly\n */\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 08 Feb 2024 10:57:24 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1204
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-08T10:57:20.992Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 402b7b5009f7d08b7aa1506bda51149c
       _order: 0
       cache: {}
@@ -1772,6 +2179,478 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-02-07T17:48:32.942Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 93bd8e087f46f900e4262dbb66d707e8
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 348
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "348"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 348
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: executed
+                  feature: cody.command.doc
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.4.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 112
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv\
+            8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 08 Feb 2024 10:57:21 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1233
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-08T10:57:20.974Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 3dc83765f706a23fed578b410f93df2e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 350
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "350"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 348
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: hasCode
+                  feature: cody.fixup.response
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.4.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 112
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv\
+            8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 08 Feb 2024 10:57:46 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1233
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-08T10:57:46.341Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 7e6d4b25e918f96e05dabe653c71ac78
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 349
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "349"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 348
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: succeeded
+                  feature: cody.fixup.apply
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.4.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 112
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv\
+            8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 08 Feb 2024 10:57:46 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1233
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-08T10:57:46.363Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: adf3d545a399500b58c4d318c29816e0
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 349
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "349"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 348
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: accept
+                  feature: cody.fixup.codeLens
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.4.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 112
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv\
+            8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 08 Feb 2024 10:57:46 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1233
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-08T10:57:46.365Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -615,29 +615,33 @@ describe('Agent', () => {
         filename: string,
         assertion: (obtained: string) => void
     ): void {
-        it(name, async () => {
-            await documentClient.request('command/execute', {
-                command: 'cody.search.index-update',
-            })
-            const uri = vscode.Uri.file(path.join(workspaceRootPath, 'src', filename))
-            await documentClient.openFile(uri, { removeCursor: false })
-            const task = await documentClient.request('commands/document', null)
-            await documentClient.taskHasReachedAppliedPhase(task)
-            const lenses = documentClient.codeLenses.get(uri.toString()) ?? []
-            expect(lenses).toHaveLength(4) // Show diff, accept, retry , undo
-            const acceptCommand = lenses.find(
-                ({ command }) => command?.command === 'cody.fixup.codelens.accept'
-            )
-            if (acceptCommand === undefined || acceptCommand.command === undefined) {
-                throw new Error(
-                    `Expected accept command, found none. Lenses ${JSON.stringify(lenses, null, 2)}`
+        it(
+            name,
+            async () => {
+                await documentClient.request('command/execute', {
+                    command: 'cody.search.index-update',
+                })
+                const uri = vscode.Uri.file(path.join(workspaceRootPath, 'src', filename))
+                await documentClient.openFile(uri, { removeCursor: false })
+                const task = await documentClient.request('commands/document', null)
+                await documentClient.taskHasReachedAppliedPhase(task)
+                const lenses = documentClient.codeLenses.get(uri.toString()) ?? []
+                expect(lenses).toHaveLength(4) // Show diff, accept, retry , undo
+                const acceptCommand = lenses.find(
+                    ({ command }) => command?.command === 'cody.fixup.codelens.accept'
                 )
-            }
-            await documentClient.request('command/execute', acceptCommand.command)
-            expect(documentClient.codeLenses.get(uri.toString()) ?? []).toHaveLength(0)
-            const newContent = documentClient.workspace.getDocument(uri)?.content
-            assertion(trimEndOfLine(newContent))
-        })
+                if (acceptCommand === undefined || acceptCommand.command === undefined) {
+                    throw new Error(
+                        `Expected accept command, found none. Lenses ${JSON.stringify(lenses, null, 2)}`
+                    )
+                }
+                await documentClient.request('command/execute', acceptCommand.command)
+                expect(documentClient.codeLenses.get(uri.toString()) ?? []).toHaveLength(0)
+                const newContent = documentClient.workspace.getDocument(uri)?.content
+                assertion(trimEndOfLine(newContent))
+            },
+            20_000
+        )
     }
 
     describe('Commands', () => {
@@ -1117,11 +1121,11 @@ describe('Agent', () => {
                   import { describe } from 'vitest'
 
                   /**
-                   * Test block that contains 3 test cases:
-                   * - Does test 1
-                   * - Does test 2
-                   * - Does another test that has a bug
-                  */
+                   * Defines a test block with 3 test cases using Vitest:
+                   * - does 1 - asserts true equals true
+                   * - does 2 - asserts true equals true
+                   * - does something else - attempts to call performance.now incorrectly
+                   */
                   describe('test block', () => {
                       it('does 1', () => {
                           expect(true).toBe(true)


### PR DESCRIPTION
When triggering the "Document code" command in JetBrains with an Enterprise account, we hit on the following error
```
InternalError: Cannot read properties of undefined (reading 'model')

TypeError: Cannot read properties of undefined (reading 'model')
    at getModel (/Users/olafurpg/dev/sourcegraph/cody/vscode/src/models/index.ts:24:26)
    at Object.get (/Users/olafurpg/dev/sourcegraph/cody/vscode/src/models/index.ts:47:13)
    at EditManager.executeEdit (/Users/olafurpg/dev/sourcegraph/cody/vscode/src/edit/manager.ts:102:47)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5): {
  "error": {},
  "stack": "\nTypeError: Cannot read properties of undefined (reading 'model')\n    at getModel (/Users/olafurpg/dev/sourcegraph/cody/vscode/src/models/index.ts:24:26)\n    at Object.get (/Users/olafurpg/dev/sourcegraph/cody/vscode/src/models/index.ts:47:13)\n    at EditManager.executeEdit (/Users/olafurpg/dev/sourcegraph/cody/vscode/src/edit/manager.ts:102:47)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
```

## Test plan
See added test case.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
