### PR TITLE
fix: sync edit models on AuthStatus change

### DIFF
--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -79,7 +79,7 @@ export const getInput = async (
 
     const authStatus = authProvider.getAuthStatus()
     const isCodyPro = !authStatus.userCanUpgrade
-    const modelOptions = getEditModelsForUser(authProvider)
+    const modelOptions = getEditModelsForUser(authStatus)
     const modelItems = getModelOptionItems(modelOptions, isCodyPro)
     const showModelSelector = modelOptions.length > 1 && authStatus.isDotCom
 

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -23,6 +23,7 @@ import { DEFAULT_EDIT_INTENT, DEFAULT_EDIT_MODE } from './constants'
 import type { AuthProvider } from '../services/AuthProvider'
 import { editModel } from '../models'
 import { getEditModelsForUser } from './utils/edit-models'
+import type { AuthStatus } from '../chat/protocol'
 
 export interface EditManagerOptions {
     editor: VSCodeEditor
@@ -39,7 +40,6 @@ export class EditManager implements vscode.Disposable {
     private models: ModelProvider[] = []
 
     constructor(public options: EditManagerOptions) {
-        this.models = getEditModelsForUser(options.authProvider)
         this.controller = new FixupController(options.authProvider)
         this.disposables.push(
             this.controller,
@@ -48,6 +48,10 @@ export class EditManager implements vscode.Disposable {
                 (args: ExecuteEditArguments, source?: ChatEventSource) => this.executeEdit(args, source)
             )
         )
+    }
+
+    public syncAuthStatus(authStatus: AuthStatus): void {
+        this.models = getEditModelsForUser(authStatus)
     }
 
     public async executeEdit(

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -1,10 +1,9 @@
 import { ModelProvider } from '@sourcegraph/cody-shared'
-import type { AuthProvider } from '../../services/AuthProvider'
 import { type EditModel, ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
 import type { EditIntent } from '../types'
+import type { AuthStatus } from '../../chat/protocol'
 
-export function getEditModelsForUser(authProvider: AuthProvider): ModelProvider[] {
-    const authStatus = authProvider.getAuthStatus()
+export function getEditModelsForUser(authStatus: AuthStatus): ModelProvider[] {
     if (authStatus?.configOverwrites?.chatModel) {
         ModelProvider.add(
             new ModelProvider(authStatus.configOverwrites.chatModel, [

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -219,17 +219,14 @@ const register = async (
     )
 
     const ghostHintDecorator = new GhostHintDecorator()
-    disposables.push(
+    const editorManager = new EditManager({
+        chat: chatClient,
+        editor,
+        contextProvider,
         ghostHintDecorator,
-        new EditManager({
-            chat: chatClient,
-            editor,
-            contextProvider,
-            ghostHintDecorator,
-            authProvider,
-        }),
-        new CodeActionProvider({ contextProvider })
-    )
+        authProvider,
+    })
+    disposables.push(ghostHintDecorator, editorManager, new CodeActionProvider({ contextProvider }))
 
     let oldConfig = JSON.stringify(initialConfig)
     async function onConfigurationChange(newConfig: ConfigurationWithAccessToken): Promise<void> {
@@ -286,6 +283,7 @@ const register = async (
     authProvider.addChangeListener(async (authStatus: AuthStatus) => {
         // Chat Manager uses Simple Context Provider
         await chatManager.syncAuthStatus(authStatus)
+        editorManager.syncAuthStatus(authStatus)
         // Update context provider first it will also update the configuration
         await contextProvider.syncAuthStatus()
         const parallelPromises: Promise<void>[] = []


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/jetbrains/issues/511
CONTEXT: https://sourcegraph.slack.com/archives/C05B7C6FBPX/p1707210738623389

Sync the edit models used by the edit manager with the latest authentication status rather than just initializing them once on startup. This allows edit models to be refreshed when auth config changes.

- Syncing the edit models in the edit manager when the auth status changes rather than just on init
- Getting the edit models based on the auth status rather than directly from the auth provider

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- All current tests should continue passing.
- Edit should work.

Confirmed this change work with https://github.com/sourcegraph/cody/pull/3055:

![image](https://github.com/sourcegraph/cody/assets/68532117/a051c036-8f12-4a87-b429-09c851bf5ef4)
