### PR TITLE
fix flanky e2e test

### DIFF
--- a/vscode/test/e2e/core-commands.test.ts
+++ b/vscode/test/e2e/core-commands.test.ts
@@ -65,7 +65,7 @@ test('Explain Command & Smell Command & Chat from Command Menu', async ({ page, 
 
     // Submit a chat question via command menu using /ask option
     await page.getByRole('tab', { name: 'index.html' }).click()
-    await page.getByRole('button', { name: /Commands \(.*/ }).click()
+    await page.getByRole('button', { name: /Commands \(.*/ }).dblclick()
     const commandInputBox = page.getByPlaceholder(/Search for a command or enter/)
     await expect(commandInputBox).toBeVisible()
     await commandInputBox.fill('hello cody')

--- a/vscode/test/e2e/core-commands.test.ts
+++ b/vscode/test/e2e/core-commands.test.ts
@@ -66,7 +66,9 @@ test('Explain Command & Smell Command & Chat from Command Menu', async ({ page, 
     // Submit a chat question via command menu using /ask option
     await page.getByRole('tab', { name: 'index.html' }).click()
     await page.getByRole('button', { name: /Commands \(.*/ }).click()
-    await page.getByPlaceholder('Search for a command or enter your question here...').fill('hello cody')
+    const commandInputBox = page.getByPlaceholder(/Search for a command or enter/)
+    await expect(commandInputBox).toBeVisible()
+    await commandInputBox.fill('hello cody')
     await page.getByLabel('/ask, Ask a question').locator('a').click()
     // the question should show up in the chat panel on submit
     await chatPanel.getByText('hello cody').click()


### PR DESCRIPTION
wait for the input box to show up before `.fill`

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

bot should be green