### PR TITLE
Edit: Always set `models` on initialization

### DIFF
--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -40,6 +40,7 @@ export class EditManager implements vscode.Disposable {
     private models: ModelProvider[] = []
 
     constructor(public options: EditManagerOptions) {
+        this.models = getEditModelsForUser(options.authProvider.getAuthStatus())
         this.controller = new FixupController(options.authProvider)
         this.disposables.push(
             this.controller,


### PR DESCRIPTION
## Description

Removed in: https://github.com/sourcegraph/cody/pull/3058

We still need to do this on init, as `syncAuthStatus` is only called if the auth status is actually changed. This change handles the case where the user is already authenticated and e.g. just reloads the editor.

## Test plan

1. Ensure authenticated
2. Reload the VS Code window
3. Try to trigger an edit

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
