### PR TITLE
Edit: Always expand `doc` command

### DIFF
--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -17,12 +17,12 @@ import { getTestInputItems } from './get-items/test'
 import { executeEdit } from '../execute'
 import type { EditModelItem, EditRangeItem } from './get-items/types'
 import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './get-items/constants'
-import { isGenerateIntent } from '../utils/edit-selection'
 import { editModel } from '../../models'
 import type { AuthProvider } from '../../services/AuthProvider'
 import { getEditModelsForUser } from '../utils/edit-models'
 import { ACCOUNT_UPGRADE_URL } from '../../chat/protocol'
 import { telemetryRecorder } from '../../services/telemetry-v2'
+import { isGenerateIntent } from '../utils/edit-intent'
 
 interface QuickPickInput {
     /** The user provided instruction */

--- a/vscode/src/edit/input/get-items/range.ts
+++ b/vscode/src/edit/input/get-items/range.ts
@@ -2,10 +2,11 @@ import * as vscode from 'vscode'
 import type { GetItemsResult } from '../quick-pick'
 import { symbolIsFunctionLike } from './utils'
 import type { EditRangeItem } from './types'
-import { getEditSmartSelection, isGenerateIntent } from '../../utils/edit-selection'
+import { getEditSmartSelection } from '../../utils/edit-selection'
 import { QUICK_PICK_ITEM_CHECKED_PREFIX, QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX } from '../constants'
 import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './constants'
 import type { EditInputInitialValues } from '../get-input'
+import { isGenerateIntent } from '../../utils/edit-intent'
 
 export const getDefaultRangeItems = (
     document: vscode.TextDocument,

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -14,11 +14,12 @@ import { telemetryRecorder } from '../services/telemetry-v2'
 import type { ExecuteEditArguments } from './execute'
 import { EditProvider } from './provider'
 import { getEditLineSelection, getEditSmartSelection } from './utils/edit-selection'
-import { DEFAULT_EDIT_INTENT, DEFAULT_EDIT_MODE } from './constants'
+import { DEFAULT_EDIT_MODE } from './constants'
 import type { AuthProvider } from '../services/AuthProvider'
 import { editModel } from '../models'
 import type { AuthStatus } from '../chat/protocol'
 import { getEditModelsForUser } from './utils/edit-models'
+import { getEditIntent } from './utils/edit-intent'
 
 export interface EditManagerOptions {
     editor: VSCodeEditor
@@ -107,12 +108,12 @@ export class EditManager implements vscode.Disposable {
         const range = getEditLineSelection(document, proposedRange)
         const mode = configuration.mode || DEFAULT_EDIT_MODE
         const model = configuration.model || editModel.get(this.options.authProvider, this.models)
-        const intent = configuration.intent || DEFAULT_EDIT_INTENT
+        const intent = getEditIntent(document, range, configuration.intent)
 
         let expandedRange: vscode.Range | undefined
         // Support expanding the selection range for intents where it is useful
         if (intent !== 'add') {
-            const smartRange = await getEditSmartSelection(document, range)
+            const smartRange = await getEditSmartSelection(document, range, {}, intent)
 
             if (!smartRange.isEqual(range)) {
                 expandedRange = smartRange

--- a/vscode/src/edit/utils/edit-intent.ts
+++ b/vscode/src/edit/utils/edit-intent.ts
@@ -1,0 +1,31 @@
+import type * as vscode from 'vscode'
+import type { EditIntent } from '../types'
+import { DEFAULT_EDIT_INTENT } from '../constants'
+
+/**
+ * Checks if the current selection and editor represent a generate intent.
+ * A generate intent means the user has an empty selection on an empty line.
+ */
+export function isGenerateIntent(
+    document: vscode.TextDocument,
+    selection: vscode.Selection | vscode.Range
+): boolean {
+    return selection.isEmpty && document.lineAt(selection.start.line).isEmptyOrWhitespace
+}
+
+export function getEditIntent(
+    document: vscode.TextDocument,
+    selection: vscode.Selection | vscode.Range,
+    proposedIntent?: EditIntent
+): EditIntent {
+    if (proposedIntent !== undefined && proposedIntent !== 'add') {
+        // Return provided intent that should not be overriden
+        return proposedIntent
+    }
+
+    if (isGenerateIntent(document, selection)) {
+        return 'add'
+    }
+
+    return proposedIntent || DEFAULT_EDIT_INTENT
+}

--- a/vscode/src/edit/utils/edit-selection.ts
+++ b/vscode/src/edit/utils/edit-selection.ts
@@ -2,17 +2,8 @@ import * as vscode from 'vscode'
 
 import { getSmartSelection } from '../../editor/utils'
 import { MAX_CURRENT_FILE_TOKENS, tokensToChars } from '@sourcegraph/cody-shared'
-
-/**
- * Checks if the current selection and editor represent a generate intent.
- * A generate intent means the user has an empty selection on an empty line.
- */
-export function isGenerateIntent(
-    document: vscode.TextDocument,
-    selection: vscode.Selection | vscode.Range
-): boolean {
-    return selection.isEmpty && document.lineAt(selection.start.line).isEmptyOrWhitespace
-}
+import type { EditIntent } from '../types'
+import { getEditIntent } from './edit-intent'
 
 interface SmartSelectionOptions {
     forceExpand?: boolean
@@ -33,7 +24,8 @@ interface SmartSelectionOptions {
 export async function getEditSmartSelection(
     document: vscode.TextDocument,
     selectionRange: vscode.Range,
-    { forceExpand }: SmartSelectionOptions = {}
+    { forceExpand }: SmartSelectionOptions = {},
+    intent?: EditIntent
 ): Promise<vscode.Range> {
     // Use selectionRange when it's available
     if (!forceExpand && selectionRange && !selectionRange?.start.isEqual(selectionRange.end)) {
@@ -41,7 +33,7 @@ export async function getEditSmartSelection(
     }
 
     // Return original (empty) range if we will resolve to generate new code
-    if (!forceExpand && isGenerateIntent(document, selectionRange)) {
+    if (!forceExpand && getEditIntent(document, selectionRange, intent) === 'add') {
         return selectionRange
     }
 


### PR DESCRIPTION
## Description

We would not expand the `doc` intent if we first through we could override it to be `add`.

This just improves our `smartSelection` to always expand in this case

Before:

https://github.com/sourcegraph/cody/assets/9516420/26685fae-6afc-4fe8-8f51-29af0e478a19



After:

https://github.com/sourcegraph/cody/assets/9516420/a0917adb-f540-4cd1-93d9-67d122fe7432


## Test plan

1. Start a doc command by right clicking on an empty line inside a function
2. Check the range expands as much as it can


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
