### PR TITLE
Autocomplete: always log `onComplete` debug event

### DIFF
--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -433,20 +433,22 @@ ${intro}${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}
                 lastResponse.stopReason = CompletionStopReason.RequestFinished
             }
 
-            log?.onComplete(lastResponse)
-
             return lastResponse
         } catch (error) {
             if (isRateLimitError(error as Error)) {
                 throw error
             }
             if (isAbortError(error as Error) && lastResponse) {
+                lastResponse.stopReason = CompletionStopReason.RequestAborted
+            } else {
+                const message = `error parsing CodeCompletionResponse: ${error}`
+                log?.onError(message, error)
+                throw new TracedError(message, traceId)
+            }
+        } finally {
+            if (lastResponse) {
                 log?.onComplete(lastResponse)
             }
-
-            const message = `error parsing streaming CodeCompletionResponse: ${error}`
-            log?.onError(message, error)
-            throw new TracedError(message, traceId)
         }
     }
 }

--- a/vscode/src/completions/utils.ts
+++ b/vscode/src/completions/utils.ts
@@ -91,24 +91,31 @@ export async function* generatorWithTimeout<T>(
     timeoutMs: number,
     abortController: AbortController
 ): AsyncGenerator<T> {
-    if (timeoutMs === 0) {
-        return
-    }
-
-    const timeoutPromise = createTimeout(timeoutMs).finally(() => {
-        abortController.abort()
-    })
-
-    while (true) {
-        const { value, done } = await Promise.race([generator.next(), timeoutPromise])
-
-        if (value) {
-            yield value
+    try {
+        if (timeoutMs === 0) {
+            return
         }
 
-        if (done) {
-            break
+        const timeoutPromise = createTimeout(timeoutMs).finally(() => {
+            abortController.abort()
+        })
+
+        while (true) {
+            const { value, done } = await Promise.race([generator.next(), timeoutPromise])
+
+            if (value) {
+                yield value
+            }
+
+            if (done) {
+                break
+            }
         }
+    } finally {
+        // The return value is optional according to MDN
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/return
+        // @ts-ignore
+        generator.return()
     }
 }
 


### PR DESCRIPTION
## Context

- The `generatorWithTimeout` did not finish the inner generator if the consumer stopped earlier. It caused the `onComplete` completion event never to be logged to the Cody output channel. This PR fixes it by introducing the `finally` clause that finishes the inner generator instance.
- I did not experience this issue until I turned off hot-streak completions locally.

## Test plan

Added unit test
