### PR TITLE
Autocomplete: use `executeFormatDocumentProvider` for completion formatting

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Autocomplete: Fixed the completion partial removal upon acceptance caused by `cody.autocomplete.formatOnAccept`. [pull/3083](https://github.com/sourcegraph/cody/pull/3083)
+
 ### Changed
 
 - Custom Command: The `description` field is now optional and will default to use the command prompt. [pull/3025](https://github.com/sourcegraph/cody/pull/3025)

--- a/vscode/src/completions/format-completion.ts
+++ b/vscode/src/completions/format-completion.ts
@@ -19,17 +19,14 @@ export async function formatCompletion(autocompleteItem: AutocompleteItem): Prom
         const endPosition =
             insertedLines.length <= 1
                 ? new vscode.Position(position.line, currentLinePrefix.length + insertedLines[0].length)
-                : new vscode.Position(
-                      position.line + insertedLines.length - 1,
-                      insertedLines.at(-1)!.length
-                  )
+                : new vscode.Position(position.line + insertedLines.length, 0)
+
         // Start at the beginning of the line to format the whole line if needed.
         const rangeToFormat = new vscode.Range(new vscode.Position(position.line, 0), endPosition)
 
         const formattingChanges = await vscode.commands.executeCommand<vscode.TextEdit[] | undefined>(
-            'vscode.executeFormatRangeProvider',
+            'vscode.executeFormatDocumentProvider',
             document.uri,
-            rangeToFormat,
             {
                 tabSize: getEditorTabSize(document.uri),
                 insertSpaces: getEditorInsertSpaces(document.uri),


### PR DESCRIPTION
## Context

- Closes https://github.com/sourcegraph/cody/issues/3050
- Seems like a bug in the `executeFormatRangeProvider` command. It does not produce consistent results and does not honor `rangeToFormat`. This PR falls back to the `executeFormatDocumentProvider` command we use for the edit command.

## Test plan

1. Start a new if statement: `if (` without closing bracket
2. Wait for a suggestion to pop up
3. Accept a suggestion
4. The first line often should not be removed
