### PR TITLE
Autocomplete: Add Llama Code 13b feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -13,7 +13,7 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
     // Force all StarCoder traffic (controlled by the above flag) to point to the 16b model.
     CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
-    // Force all StarCoder traffic (controlled by the above flag) to point to the 16b model.
+    // Enable Llama Code 13b as the default model via Fireworks
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-llama-code-13b',
     // Enables the bfg-mixed context retriever that will combine BFG with the default local editor
     // context.

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -13,6 +13,8 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
     // Force all StarCoder traffic (controlled by the above flag) to point to the 16b model.
     CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
+    // Force all StarCoder traffic (controlled by the above flag) to point to the 16b model.
+    CodyAutocompleteLlamaCode13B = 'cody-autocomplete-llama-code-13b',
     // Enables the bfg-mixed context retriever that will combine BFG with the default local editor
     // context.
     CodyAutocompleteContextBfgMixed = 'cody-autocomplete-context-bfg-mixed',

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -132,10 +132,15 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         return { provider: configuredProvider }
     }
 
-    const [starCoderHybrid, starCoder16B] = await Promise.all([
+    const [starCoderHybrid, starCoder16B, llamaCode13B] = await Promise.all([
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
     ])
+
+    if (llamaCode13B) {
+        return { provider: 'fireworks', model: 'llama-code-13b' }
+    }
 
     if (starCoderHybrid) {
         return { provider: 'fireworks', model: starCoder16B ? 'starcoder-16b' : 'starcoder-hybrid' }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -88,7 +88,7 @@ function getMaxContextTokens(model: FireworksModel): number {
         case 'llama-code-7b':
         case 'llama-code-13b':
         case 'llama-code-13b-instruct':
-            // Llama Code was trained on 16k context windows, we're constraining it here to better
+            // Llama 2 on Fireworks supports up to 4k tokens. We're constraining it here to better
             // compare the results
             return 2048
         case 'mistral-7b-instruct-4k':


### PR DESCRIPTION
c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1707411649398769?thread_ts=1706882079.259169&cid=C05AGQYD528

## Test plan

- Enable the feature flag
- Observe the right model is used (`█ CodyCompletionProvider:initialized: fireworks/llama-code-13b`)

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
