### PR TITLE
Guardrails is enabled just via instance configuration

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -31,9 +31,7 @@ import { createWebviewTelemetryService } from './utils/telemetry'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
-    const [config, setConfig] = useState<
-        (Pick<Configuration, 'debugEnable'> & LocalEnv) | null
-    >(null)
+    const [config, setConfig] = useState<(Pick<Configuration, 'debugEnable'> & LocalEnv) | null>(null)
     const [view, setView] = useState<View | undefined>()
     // If the current webview is active (vs user is working in another editor tab)
     const [isWebviewActive, setIsWebviewActive] = useState<boolean>(true)
@@ -255,11 +253,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                                         chatModels={chatModels}
                                         setChatModels={setChatModels}
                                         welcomeMessage={getWelcomeMessageByOS(config?.os)}
-                                        guardrails={
-                                            attributionEnabled
-                                                ? guardrails
-                                                : undefined
-                                        }
+                                        guardrails={attributionEnabled ? guardrails : undefined}
                                         chatIDHistory={chatIDHistory}
                                         isWebviewActive={isWebviewActive}
                                     />

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -32,7 +32,7 @@ import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
     const [config, setConfig] = useState<
-        (Pick<Configuration, 'debugEnable' | 'experimentalGuardrails'> & LocalEnv) | null
+        (Pick<Configuration, 'debugEnable'> & LocalEnv) | null
     >(null)
     const [view, setView] = useState<View | undefined>()
     // If the current webview is active (vs user is working in another editor tab)
@@ -256,7 +256,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                                         setChatModels={setChatModels}
                                         welcomeMessage={getWelcomeMessageByOS(config?.os)}
                                         guardrails={
-                                            config.experimentalGuardrails && attributionEnabled
+                                            attributionEnabled
                                                 ? guardrails
                                                 : undefined
                                         }


### PR DESCRIPTION
Closes sourcegraph/sourcegraph#59720

This pull requests removes the requirement for experimental config to enable guardrails.

The feature is just hidden behind [a sourcegraph instance config](https://sourcegraph.com/github.com/sourcegraph/cody@30620eb96a4e112611abe1d864b72a3a4c6ad1c3/-/blob/lib/shared/src/sourcegraph-api/graphql/client.ts?L86:5-86:16).

## Test plan

- Manual check - works with site config changes