### PR TITLE
feat: support at-mentions context on edits

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -303,7 +303,16 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                 : messageAtIndex?.text
             if (inputText) {
                 setFormInput(inputText)
+                // Add the old context files from the transcript to the map
+                if (messageAtIndex.contextFiles) {
+                    const contextFilesMap = new Map<string, ContextFile>()
+                    for (const file of messageAtIndex.contextFiles) {
+                        contextFilesMap.set(getContextFileDisplayText(file), file)
+                    }
+                    setChatContextFiles(contextFilesMap)
+                }
             }
+            // move focus back to chatbox
             setInputFocus(true)
         },
         [messageBeingEdited, setFormInput, setMessageBeingEdited, transcript]


### PR DESCRIPTION

![edit-at](https://github.com/sourcegraph/cody/assets/68532117/3e593672-cf8f-4fe3-872c-c739da6e1459)

This commit adds the functionality to include the old context files from the transcript to the chat context files map in the Chat component. It creates a new map called contextFilesMap and populates it with the old context files. This allows for easy access and reference to the context files used in edit mode. 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->


https://github.com/sourcegraph/cody/assets/68532117/a9683af7-dca7-43f6-bc0c-80d7d31bfef1

