### PR TITLE
`findFiles`: add test case for `.cody/ignore`

### DIFF
--- a/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.test.ts
+++ b/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.test.ts
@@ -49,4 +49,35 @@ describe('matchesGlobPatterns', () => {
             expect(result).toBe(expected)
         }
     })
+
+    function testMatches(include: string[], value: string): void {
+        it(`should match ${include.join(',')} '${value}'`, () => {
+            const result = matchesGlobPatterns(include, [], value)
+            expect(result).toBe(true)
+        })
+    }
+    function testNotMatches(include: string[], value: string): void {
+        it(`should not match ${include.join(',')} '${value}'`, () => {
+            const result = matchesGlobPatterns(include, [], value)
+            expect(result).toBe(false)
+        })
+    }
+    const includeGlobs: string[] = ['ignore', '.codyignore']
+    const cases: {
+        value: string
+        expected: boolean
+    }[] = [
+        { value: '.codyignore', expected: true },
+        { value: '.cody/ignore', expected: false /* TODO: make this true */ },
+        { value: '.git/index', expected: false },
+        { value: 'node_modules/foo', expected: false },
+    ]
+
+    for (const { value, expected } of cases) {
+        if (expected) {
+            testMatches(includeGlobs, value)
+        } else {
+            testNotMatches(includeGlobs, value)
+        }
+    }
 })


### PR DESCRIPTION
The test is currently failing because `{ dot: true }` makes it not find `.cody/ignore` files.


## Test plan
Green CI. Note that we are still asserting undesirable behavior, `findFiles` should be able to find `.cody/ignore` but it can't at the moment.

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
