### PR TITLE
context-ranking support

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -76,6 +76,8 @@ export interface Configuration {
     testingLocalEmbeddingsModel: string | undefined
     testingLocalEmbeddingsEndpoint: string | undefined
     testingLocalEmbeddingsIndexLibraryPath: string | undefined
+
+    experimentalChatContextRanker: boolean | undefined
 }
 
 export interface AutocompleteTimeouts {

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -50,6 +50,7 @@ export interface Configuration {
     experimentalSymfContext: boolean
     experimentalTracing: boolean
     experimentalSimpleChatContext: boolean
+    experimentalChatContextRanker: boolean | undefined
 
     /**
      * Unstable Features for internal testing only
@@ -76,8 +77,6 @@ export interface Configuration {
     testingLocalEmbeddingsModel: string | undefined
     testingLocalEmbeddingsEndpoint: string | undefined
     testingLocalEmbeddingsIndexLibraryPath: string | undefined
-
-    experimentalChatContextRanker: boolean | undefined
 }
 
 export interface AutocompleteTimeouts {

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -43,6 +43,7 @@ export type Config = Pick<
     | 'experimentalSymfContext'
     | 'editorTitleCommandIcon'
     | 'internalUnstable'
+    | 'experimentalChatContextRanker'
 >
 
 enum ContextEvent {

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -21,6 +21,7 @@ import type { ChatSession, SimpleChatPanelProvider } from './SimpleChatPanelProv
 import type { ExecuteChatArguments } from '../../commands/execute/ask'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
+import { ContextRankingController } from '../../local-context/context-ranking'
 
 export const CodyChatPanelViewType = 'cody.chatPanel'
 /**
@@ -43,6 +44,7 @@ export class ChatManager implements vscode.Disposable {
         private chatClient: ChatClient,
         private enterpriseContext: EnterpriseContextFactory | null,
         private localEmbeddings: LocalEmbeddingsController | null,
+        private contextRanking: ContextRankingController | null,
         private symf: SymfRunner | null,
         private guardrails: Guardrails
     ) {
@@ -59,6 +61,7 @@ export class ChatManager implements vscode.Disposable {
             this.options,
             this.chatClient,
             this.localEmbeddings,
+            this.contextRanking,
             this.symf,
             this.enterpriseContext,
             this.guardrails

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -21,7 +21,7 @@ import type { ChatSession, SimpleChatPanelProvider } from './SimpleChatPanelProv
 import type { ExecuteChatArguments } from '../../commands/execute/ask'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
-import { ContextRankingController } from '../../local-context/context-ranking'
+import type { ContextRankingController } from '../../local-context/context-ranking'
 
 export const CodyChatPanelViewType = 'cody.chatPanel'
 /**

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -25,13 +25,17 @@ import type { SidebarViewOptions } from './SidebarViewController'
 import { SimpleChatPanelProvider } from './SimpleChatPanelProvider'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
-import { ContextRankingController } from '../../local-context/context-ranking'
+import type { ContextRankingController } from '../../local-context/context-ranking'
 
 type ChatID = string
 
 export type ChatPanelConfig = Pick<
     ConfigurationWithAccessToken,
-    'experimentalGuardrails' | 'experimentalSymfContext' | 'internalUnstable' | 'useContext'
+    | 'experimentalGuardrails'
+    | 'experimentalSymfContext'
+    | 'internalUnstable'
+    | 'useContext'
+    | 'experimentalChatContextRanker'
 >
 
 export interface ChatViewProviderWebview extends Omit<vscode.Webview, 'postMessage'> {

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -25,6 +25,7 @@ import type { SidebarViewOptions } from './SidebarViewController'
 import { SimpleChatPanelProvider } from './SimpleChatPanelProvider'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
+import { ContextRankingController } from '../../local-context/context-ranking'
 
 type ChatID = string
 
@@ -67,6 +68,7 @@ export class ChatPanelsManager implements vscode.Disposable {
         { extensionUri, ...options }: SidebarViewOptions,
         private chatClient: ChatClient,
         private readonly localEmbeddings: LocalEmbeddingsController | null,
+        private readonly contextRanking: ContextRankingController | null,
         private readonly symf: SymfRunner | null,
         private readonly enterpriseContext: EnterpriseContextFactory | null,
         private readonly guardrails: Guardrails
@@ -234,6 +236,7 @@ export class ChatPanelsManager implements vscode.Disposable {
             config: this.options.contextProvider.config,
             chatClient: this.chatClient,
             localEmbeddings: isConsumer ? this.localEmbeddings : null,
+            contextRanking: isConsumer ? this.contextRanking : null,
             symf: isConsumer ? this.symf : null,
             enterpriseContext: isConsumer ? null : this.enterpriseContext,
             models,

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -80,9 +80,13 @@ import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
 import { chatModel } from '../../models'
 import { getContextWindowForModel } from '../../models/utilts'
 import type { ContextItem } from '../../prompt-builder/types'
+<<<<<<< HEAD
 import type { Span } from '@opentelemetry/api'
 import { recordErrorToSpan, tracer } from '@sourcegraph/cody-shared/src/tracing'
 import { recordExposedExperimentsToSpan } from '../../services/open-telemetry/utils'
+=======
+import { ContextRankingController } from '../../local-context/context-ranking'
+>>>>>>> af602235 (context-ranking support)
 
 interface SimpleChatPanelProviderOptions {
     config: ChatPanelConfig
@@ -90,6 +94,7 @@ interface SimpleChatPanelProviderOptions {
     authProvider: AuthProvider
     chatClient: ChatClient
     localEmbeddings: LocalEmbeddingsController | null
+    contextRanking: ContextRankingController | null
     symf: SymfRunner | null
     enterpriseContext: EnterpriseContextFactory | null
     editor: VSCodeEditor
@@ -138,6 +143,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private readonly chatClient: ChatClient
     private readonly codebaseStatusProvider: CodebaseStatusProvider
     private readonly localEmbeddings: LocalEmbeddingsController | null
+    private readonly contextRanking: ContextRankingController | null
     private readonly symf: SymfRunner | null
     private readonly contextStatusAggregator = new ContextStatusAggregator()
     private readonly editor: VSCodeEditor
@@ -161,6 +167,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         authProvider,
         chatClient,
         localEmbeddings,
+        contextRanking,
         symf,
         editor,
         treeView,
@@ -173,6 +180,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         this.authProvider = authProvider
         this.chatClient = chatClient
         this.localEmbeddings = localEmbeddings
+        this.contextRanking = contextRanking
         this.symf = symf
         this.repoPicker = enterpriseContext?.repoPicker || null
         this.remoteSearch = enterpriseContext?.createRemoteSearch() || null
@@ -187,6 +195,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
         // Advise local embeddings to start up if necessary.
         void this.localEmbeddings?.start()
+
+        // Start the context Ranking module
+        void this.contextRanking?.start()
 
         // Push context status to the webview when it changes.
         this.disposables.push(
@@ -395,6 +406,34 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 FeatureFlag.CodyChatFusedContext
             )
 
+<<<<<<< HEAD
+=======
+        const userContextItems = await contextFilesToContextItems(
+            this.editor,
+            userContextFiles || [],
+            true
+        )
+        const prompter = new DefaultPrompter(
+            userContextItems,
+            addEnhancedContext
+                ? (text, maxChars) =>
+                      getEnhancedContext({
+                          strategy: this.config.useContext,
+                          editor: this.editor,
+                          text,
+                          providers: {
+                              localEmbeddings: this.localEmbeddings,
+                              symf: this.config.experimentalSymfContext ? this.symf : null,
+                              remoteSearch: this.remoteSearch,
+                          },
+                          featureFlags: this.config,
+                          hints: { maxChars },
+                          contextRanking: this.contextRanking,
+                      })
+                : undefined
+        )
+        const sendTelemetry = (contextSummary: any): void => {
+>>>>>>> af602235 (context-ranking support)
             const authStatus = this.authProvider.getAuthStatus()
             const sharedProperties = {
                 requestID,

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -473,9 +473,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                                   featureFlags: {
                                       fusedContext:
                                           this.config.internalUnstable || (await useFusedContextPromise),
-                                      testingContextRanking:
-                                          this.config.internalUnstable &&
-                                          this.config.experimentalChatContextRanker,
                                   },
                                   hints: { maxChars },
                                   contextRanking: this.contextRanking,

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -80,13 +80,10 @@ import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
 import { chatModel } from '../../models'
 import { getContextWindowForModel } from '../../models/utilts'
 import type { ContextItem } from '../../prompt-builder/types'
-<<<<<<< HEAD
 import type { Span } from '@opentelemetry/api'
 import { recordErrorToSpan, tracer } from '@sourcegraph/cody-shared/src/tracing'
 import { recordExposedExperimentsToSpan } from '../../services/open-telemetry/utils'
-=======
-import { ContextRankingController } from '../../local-context/context-ranking'
->>>>>>> af602235 (context-ranking support)
+import type { ContextRankingController } from '../../local-context/context-ranking'
 
 interface SimpleChatPanelProviderOptions {
     config: ChatPanelConfig
@@ -406,34 +403,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 FeatureFlag.CodyChatFusedContext
             )
 
-<<<<<<< HEAD
-=======
-        const userContextItems = await contextFilesToContextItems(
-            this.editor,
-            userContextFiles || [],
-            true
-        )
-        const prompter = new DefaultPrompter(
-            userContextItems,
-            addEnhancedContext
-                ? (text, maxChars) =>
-                      getEnhancedContext({
-                          strategy: this.config.useContext,
-                          editor: this.editor,
-                          text,
-                          providers: {
-                              localEmbeddings: this.localEmbeddings,
-                              symf: this.config.experimentalSymfContext ? this.symf : null,
-                              remoteSearch: this.remoteSearch,
-                          },
-                          featureFlags: this.config,
-                          hints: { maxChars },
-                          contextRanking: this.contextRanking,
-                      })
-                : undefined
-        )
-        const sendTelemetry = (contextSummary: any): void => {
->>>>>>> af602235 (context-ranking support)
             const authStatus = this.authProvider.getAuthStatus()
             const sharedProperties = {
                 requestID,
@@ -504,8 +473,12 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                                   featureFlags: {
                                       fusedContext:
                                           this.config.internalUnstable || (await useFusedContextPromise),
+                                      testingContextRanking:
+                                          this.config.internalUnstable &&
+                                          this.config.experimentalChatContextRanker,
                                   },
                                   hints: { maxChars },
+                                  contextRanking: this.contextRanking,
                               })
                         : undefined
                 )

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -19,6 +19,7 @@ import { logDebug, logError } from '../../log'
 import { viewRangeToRange } from './chat-helpers'
 import type { RemoteSearch } from '../../context/remote-search'
 import type { ContextItem } from '../../prompt-builder/types'
+import { ContextRankingController } from '../../local-context/context-ranking'
 
 export interface GetEnhancedContextOptions {
     strategy: ConfigurationUseContext
@@ -35,6 +36,7 @@ export interface GetEnhancedContextOptions {
     hints: {
         maxChars: number
     }
+    contextRanking: ContextRankingController | null
     // TODO(@philipp-spiess): Add abort controller to be able to cancel expensive retrievers
 }
 export async function getEnhancedContext({
@@ -44,6 +46,7 @@ export async function getEnhancedContext({
     providers,
     featureFlags,
     hints,
+    contextRanking,
 }: GetEnhancedContextOptions): Promise<ContextItem[]> {
     if (featureFlags.fusedContext) {
         return getEnhancedContextFused({
@@ -53,6 +56,7 @@ export async function getEnhancedContext({
             providers,
             featureFlags,
             hints,
+            contextRanking
         })
     }
 
@@ -113,6 +117,7 @@ async function getEnhancedContextFused({
     text,
     providers,
     hints,
+    contextRanking,
 }: GetEnhancedContextOptions): Promise<ContextItem[]> {
     return wrapInActiveSpan('chat.enhancedContextFused', async () => {
         // use user attention context only if config is set to none

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -32,7 +32,6 @@ export interface GetEnhancedContextOptions {
     }
     featureFlags: {
         fusedContext: boolean
-        testingContextRanking: boolean | undefined
     }
     hints: {
         maxChars: number
@@ -49,7 +48,7 @@ export async function getEnhancedContext({
     hints,
     contextRanking,
 }: GetEnhancedContextOptions): Promise<ContextItem[]> {
-    if (featureFlags.testingContextRanking && contextRanking) {
+    if (contextRanking) {
         return getEnhancedContextFromRanker({
             strategy,
             editor,
@@ -217,7 +216,9 @@ async function getEnhancedContextFromRanker({
         if (!contextRanking) {
             return allContext
         }
-        const rankedContext = contextRanking.rankContextItems(text, allContext)
+        const rankedContext = wrapInActiveSpan('chat.enhancedContextRanker.reranking', () =>
+            contextRanking.rankContextItems(text, allContext)
+        )
         return rankedContext
     })
 }

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -153,6 +153,7 @@ describe('getConfiguration', () => {
             testingLocalEmbeddingsEndpoint: undefined,
             testingLocalEmbeddingsIndexLibraryPath: undefined,
             testingLocalEmbeddingsModel: undefined,
+            experimentalChatContextRanker: false,
         } satisfies Configuration)
     })
 })

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -100,6 +100,8 @@ describe('getConfiguration', () => {
                         return undefined
                     case 'cody.internal.unstable':
                         return false
+                    case 'cody.experimental.chatContextRanker':
+                        return false
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -170,6 +170,10 @@ export function getConfiguration(
         testingLocalEmbeddingsIndexLibraryPath: isTesting
             ? getHiddenSetting<string | undefined>('testing.localEmbeddings.indexLibraryPath', undefined)
             : undefined,
+
+        experimentalChatContextRanker:
+            getHiddenSetting('internal.unstable', false) &&
+            getHiddenSetting('experimental.chatContextRanker', false),
     }
 }
 

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -124,6 +124,8 @@ export function getConfiguration(
         experimentalGuardrails: getHiddenSetting('experimental.guardrails', isTesting),
         experimentalTracing: getHiddenSetting('experimental.tracing', false),
 
+        experimentalChatContextRanker: getHiddenSetting('experimental.chatContextRanker', false),
+
         autocompleteExperimentalDynamicMultilineCompletions: getHiddenSetting(
             'autocomplete.experimental.dynamicMultilineCompletions',
             false
@@ -170,10 +172,6 @@ export function getConfiguration(
         testingLocalEmbeddingsIndexLibraryPath: isTesting
             ? getHiddenSetting<string | undefined>('testing.localEmbeddings.indexLibraryPath', undefined)
             : undefined,
-
-        experimentalChatContextRanker:
-            getHiddenSetting('internal.unstable', false) &&
-            getHiddenSetting('experimental.chatContextRanker', false),
     }
 }
 

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -22,7 +22,7 @@ import type {
 } from './services/open-telemetry/OpenTelemetryService.node'
 import { captureException, type SentryService } from './services/sentry/sentry'
 import type { CommandsProvider } from './commands/services/provider'
-import { ContextRankingController } from './local-context/context-ranking'
+import { ContextRankerConfig, ContextRankingController } from './local-context/context-ranking'
 
 type Constructor<T extends new (...args: any) => any> = T extends new (
     ...args: infer A
@@ -33,7 +33,7 @@ type Constructor<T extends new (...args: any) => any> = T extends new (
 export interface PlatformContext {
     createCommandsProvider?: Constructor<typeof CommandsProvider>
     createLocalEmbeddingsController?: (config: LocalEmbeddingsConfig) => LocalEmbeddingsController
-    createContextRankingController?: () => ContextRankingController
+    createContextRankingController?: (config: ContextRankerConfig) => ContextRankingController
     createSymfRunner?: Constructor<typeof SymfRunner>
     createBfgRetriever?: () => BfgRetriever
     createCompletionsClient:

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -22,6 +22,7 @@ import type {
 } from './services/open-telemetry/OpenTelemetryService.node'
 import { captureException, type SentryService } from './services/sentry/sentry'
 import type { CommandsProvider } from './commands/services/provider'
+import { ContextRankingController } from './local-context/context-ranking'
 
 type Constructor<T extends new (...args: any) => any> = T extends new (
     ...args: infer A
@@ -32,6 +33,7 @@ type Constructor<T extends new (...args: any) => any> = T extends new (
 export interface PlatformContext {
     createCommandsProvider?: Constructor<typeof CommandsProvider>
     createLocalEmbeddingsController?: (config: LocalEmbeddingsConfig) => LocalEmbeddingsController
+    createContextRankingController?: () => ContextRankingController
     createSymfRunner?: Constructor<typeof SymfRunner>
     createBfgRetriever?: () => BfgRetriever
     createCompletionsClient:

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -22,7 +22,7 @@ import type {
 } from './services/open-telemetry/OpenTelemetryService.node'
 import { captureException, type SentryService } from './services/sentry/sentry'
 import type { CommandsProvider } from './commands/services/provider'
-import { ContextRankerConfig, ContextRankingController } from './local-context/context-ranking'
+import type { ContextRankerConfig, ContextRankingController } from './local-context/context-ranking'
 
 type Constructor<T extends new (...args: any) => any> = T extends new (
     ...args: infer A

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -10,6 +10,9 @@ import {
     type LocalEmbeddingsConfig,
     type LocalEmbeddingsController,
 } from './local-context/local-embeddings'
+import {
+    createContextRankingController
+} from './local-context/context-ranking'
 import { SymfRunner } from './local-context/symf'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
 import { NodeSentryService } from './services/sentry/sentry.node'
@@ -33,6 +36,7 @@ export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi
             ? undefined
             : (config: LocalEmbeddingsConfig): LocalEmbeddingsController =>
                   createLocalEmbeddingsController(context, config),
+        createContextRankingController: (...args) => createContextRankingController(context),
         createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),
         createCommandsProvider: () => new CommandsProvider(),
         createSymfRunner: (...args) => new SymfRunner(...args),

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -12,7 +12,7 @@ import {
 } from './local-context/local-embeddings'
 import {
     createContextRankingController,
-    type ContextRankerConfig
+    type ContextRankerConfig,
 } from './local-context/context-ranking'
 import { SymfRunner } from './local-context/symf'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
@@ -37,7 +37,8 @@ export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi
             ? undefined
             : (config: LocalEmbeddingsConfig): LocalEmbeddingsController =>
                   createLocalEmbeddingsController(context, config),
-        createContextRankingController: (config: ContextRankerConfig) => createContextRankingController(context, config),
+        createContextRankingController: (config: ContextRankerConfig) =>
+            createContextRankingController(context, config),
         createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),
         createCommandsProvider: () => new CommandsProvider(),
         createSymfRunner: (...args) => new SymfRunner(...args),

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -11,7 +11,8 @@ import {
     type LocalEmbeddingsController,
 } from './local-context/local-embeddings'
 import {
-    createContextRankingController
+    createContextRankingController,
+    type ContextRankerConfig
 } from './local-context/context-ranking'
 import { SymfRunner } from './local-context/symf'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
@@ -36,7 +37,7 @@ export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi
             ? undefined
             : (config: LocalEmbeddingsConfig): LocalEmbeddingsController =>
                   createLocalEmbeddingsController(context, config),
-        createContextRankingController: (...args) => createContextRankingController(context),
+        createContextRankingController: (config: ContextRankerConfig) => createContextRankingController(context, config),
         createCompletionsClient: (...args) => new SourcegraphNodeCompletionsClient(...args),
         createCommandsProvider: () => new CommandsProvider(),
         createSymfRunner: (...args) => new SymfRunner(...args),

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -15,9 +15,10 @@ import {
 import { createClient as createCodeCompletionsClient } from './completions/client'
 import type { PlatformContext } from './extension.common'
 import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
+import type { ContextRankerConfig } from './local-context/context-ranking'
 import type { SymfRunner } from './local-context/symf'
 import { logDebug, logger } from './log'
-import { ContextRankingController } from './local-context/context-ranking'
+import type { ContextRankingController } from './local-context/context-ranking'
 
 interface ExternalServices {
     intentDetector: IntentDetector
@@ -43,7 +44,8 @@ type ExternalServicesConfiguration = Pick<
     | 'debugVerbose'
     | 'experimentalTracing'
 > &
-    LocalEmbeddingsConfig
+    LocalEmbeddingsConfig &
+    ContextRankerConfig
 
 export async function configureExternalServices(
     context: vscode.ExtensionContext,
@@ -77,7 +79,10 @@ export async function configureExternalServices(
         )
     }
 
-    const contextRanking = platform.createContextRankingController?.(initialConfig)
+    const contextRanking = initialConfig.experimentalChatContextRanker
+        ? platform.createContextRankingController?.(initialConfig)
+        : undefined
+
     const localEmbeddings = platform.createLocalEmbeddingsController?.(initialConfig)
 
     const chatClient = new ChatClient(completionsClient)

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -17,12 +17,14 @@ import type { PlatformContext } from './extension.common'
 import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
 import type { SymfRunner } from './local-context/symf'
 import { logDebug, logger } from './log'
+import { ContextRankingController } from './local-context/context-ranking'
 
 interface ExternalServices {
     intentDetector: IntentDetector
     chatClient: ChatClient
     codeCompletionsClient: CodeCompletionsClient
     guardrails: Guardrails
+    contextRanking: ContextRankingController | undefined
     localEmbeddings: LocalEmbeddingsController | undefined
     symfRunner: SymfRunner | undefined
 
@@ -53,6 +55,7 @@ export async function configureExternalServices(
         | 'createSentryService'
         | 'createOpenTelemetryService'
         | 'createSymfRunner'
+        | 'createContextRankingController'
     >
 ): Promise<ExternalServices> {
     const sentryService = platform.createSentryService?.(initialConfig)
@@ -74,6 +77,7 @@ export async function configureExternalServices(
         )
     }
 
+    const contextRanking = platform.createContextRankingController?.()
     const localEmbeddings = platform.createLocalEmbeddingsController?.(initialConfig)
 
     const chatClient = new ChatClient(completionsClient)
@@ -86,6 +90,7 @@ export async function configureExternalServices(
         codeCompletionsClient,
         guardrails,
         localEmbeddings,
+        contextRanking,
         symfRunner,
         onConfigurationChange: newConfig => {
             sentryService?.onConfigurationChange(newConfig)

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -77,7 +77,7 @@ export async function configureExternalServices(
         )
     }
 
-    const contextRanking = platform.createContextRankingController?.()
+    const contextRanking = platform.createContextRankingController?.(initialConfig)
     const localEmbeddings = platform.createLocalEmbeddingsController?.(initialConfig)
 
     const chatClient = new ChatClient(completionsClient)

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -103,6 +103,7 @@ export async function configureExternalServices(
             completionsClient.onConfigurationChange(newConfig)
             codeCompletionsClient.onConfigurationChange(newConfig)
             void localEmbeddings?.setAccessToken(newConfig.serverEndpoint, newConfig.accessToken)
+            void contextRanking?.setAccessToken(newConfig.serverEndpoint, newConfig.accessToken)
         },
     }
 }

--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -13,7 +13,7 @@ import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
 // Do not include 'v' in this string.
-const defaultBfgVersion = '5.2.23617'
+const defaultBfgVersion = '5.3.1781'
 
 // We use this Promise to only have one downloadBfg running at once.
 let serializeBfgDownload: Promise<string | null> = Promise.resolve(null)

--- a/vscode/src/jsonrpc/context-ranking-protocol.ts
+++ b/vscode/src/jsonrpc/context-ranking-protocol.ts
@@ -1,0 +1,30 @@
+interface InitializeParams {
+    indexPath: string
+}
+
+interface ComputeFeaturesParams {
+    repoPath: string
+    BM25ChunkingStrategy: 'file-level-chunking'
+}
+
+export interface RankContextItem {
+    index: number,
+    filePath?: string,
+    content: string,
+    source?: string
+}
+
+interface RankItemsParams {
+    rankContextItem: RankContextItem[],
+    query: string
+}
+
+export type Requests = {
+    'context-ranking/echo': [string, string],
+    'context-ranking/initialize': [InitializeParams, string],
+    // try to load the features and if features does not exist, return false. 
+    'context-ranking/load-features': [string, boolean],
+    'context-ranking/compute-features': [ComputeFeaturesParams, string],
+    'context-ranking/rank-items': [RankItemsParams, RankItemsParams]
+}
+

--- a/vscode/src/jsonrpc/context-ranking-protocol.ts
+++ b/vscode/src/jsonrpc/context-ranking-protocol.ts
@@ -25,6 +25,7 @@ export interface RankerPredictions {
 }
 
 export interface RankerPrediction {
+    //todo: Change to camel case, when changing the protocol on bfg.
     document_id: number
     score: number
 }

--- a/vscode/src/jsonrpc/context-ranking-protocol.ts
+++ b/vscode/src/jsonrpc/context-ranking-protocol.ts
@@ -4,7 +4,7 @@ interface InitializeParams {
 
 interface ComputeFeaturesParams {
     repoPath: string
-    BM25ChunkingStrategy: 'file-level-chunking'
+    bm25ChunkingStrategy: 'full-file-chunks'
 }
 
 export interface RankContextItem {
@@ -15,16 +15,18 @@ export interface RankContextItem {
 }
 
 interface RankItemsParams {
-    rankContextItem: RankContextItem[],
-    query: string
+    repoPath: string,
+    bm25ChunkingStrategy: 'full-file-chunks',
+    query: string,
+    contextItems: RankContextItem[],
+    
 }
 
 export type Requests = {
     'context-ranking/echo': [string, string],
     'context-ranking/initialize': [InitializeParams, string],
-    // try to load the features and if features does not exist, return false. 
-    'context-ranking/load-features': [string, boolean],
-    'context-ranking/compute-features': [ComputeFeaturesParams, string],
-    'context-ranking/rank-items': [RankItemsParams, RankItemsParams]
+    // try to load the features and if features does not exist, return false.
+    'context-ranking/compute-features': [ComputeFeaturesParams, boolean],
+    'context-ranking/rank-items': [RankItemsParams, RankContextItem[] ]
 }
 

--- a/vscode/src/jsonrpc/context-ranking-protocol.ts
+++ b/vscode/src/jsonrpc/context-ranking-protocol.ts
@@ -1,32 +1,37 @@
 interface InitializeParams {
     indexPath: string
+    accessToken: string
 }
 
 interface ComputeFeaturesParams {
     repoPath: string
-    bm25ChunkingStrategy: 'full-file-chunks'
 }
 
 export interface RankContextItem {
-    index: number,
-    filePath?: string,
-    content: string,
+    document_id: number
+    filePath?: string
+    content: string
     source?: string
 }
 
 interface RankItemsParams {
-    repoPath: string,
-    bm25ChunkingStrategy: 'full-file-chunks',
-    query: string,
-    contextItems: RankContextItem[],
-    
+    repoPath: string
+    query: string
+    contextItems: RankContextItem[]
+}
+
+export interface RankerPredictions {
+    prediction: RankerPrediction[]
+}
+
+export interface RankerPrediction {
+    document_id: number
+    score: number
 }
 
 export type Requests = {
-    'context-ranking/echo': [string, string],
-    'context-ranking/initialize': [InitializeParams, string],
-    // try to load the features and if features does not exist, return false.
-    'context-ranking/compute-features': [ComputeFeaturesParams, boolean],
-    'context-ranking/rank-items': [RankItemsParams, RankContextItem[] ]
+    'context-ranking/echo': [string, string]
+    'context-ranking/initialize': [InitializeParams, string]
+    'context-ranking/compute-features': [ComputeFeaturesParams, string]
+    'context-ranking/rank-items': [RankItemsParams, RankerPredictions]
 }
-

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -11,8 +11,9 @@ import { isRateLimitError, logError } from '@sourcegraph/cody-shared'
 import type * as agent from './agent-protocol'
 import type * as bfg from './bfg-protocol'
 import type * as embeddings from './embeddings-protocol'
+import type * as contextRanking from './context-ranking-protocol'
 
-type Requests = bfg.Requests & agent.Requests & embeddings.Requests
+type Requests = bfg.Requests & agent.Requests & embeddings.Requests & contextRanking.Requests
 type Notifications = bfg.Notifications & agent.Notifications & embeddings.Notifications
 
 // This file is a standalone implementation of JSON-RPC for Node.js

--- a/vscode/src/local-context/cody-engine.ts
+++ b/vscode/src/local-context/cody-engine.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode'
+import { spawnBfg } from '../graph/bfg/spawn-bfg'
+import { MessageHandler } from '../jsonrpc/jsonrpc'
+import { logDebug } from '../log'
+import { captureException } from '../services/sentry/sentry'
+
+export class CodyEngineService {
+    // Starting this service leads to spawning seperate codyEngine process. 
+    // Making this singleton helps ensure only single instance of engine running.  
+    private static instance: CodyEngineService | null = null
+    private service : Promise<MessageHandler> | undefined
+
+    // Ensure only one instance starts the process at a time.
+
+    private constructor(private readonly context: vscode.ExtensionContext) {
+        logDebug('CodyEngineService', 'constructor')
+    }
+
+    public static getInstance(context: vscode.ExtensionContext): CodyEngineService {
+        if (!CodyEngineService.instance) {
+            CodyEngineService.instance = new CodyEngineService(context)
+        }
+        return CodyEngineService.instance
+    }
+
+    public getService(): Promise<MessageHandler> {
+        if (!this.service) {
+            this.service = this.spawnAndBindService()   
+        }
+        return this.service
+    }
+
+    public async setupServiceHandler(serviceSetupCB: (service: MessageHandler) => Promise<void>): Promise<void> {
+        const service = await this.getService()
+        serviceSetupCB(service)
+    }
+    
+    private async spawnAndBindService(): Promise<MessageHandler> {
+        const service = await new Promise<MessageHandler>((resolve, reject) => {
+            spawnBfg(this.context, reject).then(
+                bfg => resolve(bfg),
+                error => {
+                    captureException(error)
+                    reject(error)
+                }
+            )
+        })
+        logDebug('CodyEngineService', 'spawnAndBindService', 'service started, initializing')
+        return service
+    }
+}

--- a/vscode/src/local-context/context-ranking.ts
+++ b/vscode/src/local-context/context-ranking.ts
@@ -1,0 +1,199 @@
+import * as vscode from 'vscode'
+// import { URI } from 'vscode-uri'
+import { logDebug } from '../log'
+
+// import {
+//     isDotCom,
+//     type FileURI,
+// } from '@sourcegraph/cody-shared'
+import type { ContextItem } from '../prompt-builder/types'
+import { MessageHandler } from '../jsonrpc/jsonrpc'
+import { spawnBfg } from '../graph/bfg/spawn-bfg'
+import { captureException } from '../services/sentry/sentry'
+import { FileURI, isFileURI } from '@sourcegraph/cody-shared'
+import { URI } from 'vscode-uri'
+import { RankContextItem } from '../jsonrpc/context-ranking-protocol'
+
+export interface ContextRanker {
+    rankContextItems(query: string, contextItems: ContextItem[]): Promise<ContextItem[]>   
+}
+
+export function createContextRankingController(
+    context: vscode.ExtensionContext,
+): ContextRankingController {
+    return new ContextRankingController(context)
+}
+
+function getIndexLibraryPath(): FileURI {
+    switch (process.platform) {
+        case 'darwin':
+            return URI.file(`${process.env.HOME}/Library/Caches/com.sourcegraph.cody/context-ranking`)
+        case 'linux':
+            return URI.file(`${process.env.HOME}/.cache/com.sourcegraph.cody/context-ranking`)
+        case 'win32':
+            return URI.file(`${process.env.LOCALAPPDATA}\\com.sourcegraph.cody\\context-ranking`)
+        default:
+            throw new Error(`Unsupported platform: ${process.platform}`)
+    }
+}
+
+export class ContextRankingController implements ContextRanker{
+
+    // The cody-engine child process, if starting or started.
+    private service: Promise<MessageHandler> | undefined
+    // True if the service has finished starting and been initialized.
+    private serviceStarted = false
+    // Whether the account is a consumer account.
+    private endpointIsDotcom = false
+    private readonly indexLibraryPath: FileURI | undefined
+
+    private doesFeaturesExist: boolean = false
+
+    constructor(private readonly context: vscode.ExtensionContext) {
+        logDebug('ContextRankingController', 'constructor')
+    }
+
+    public async start(): Promise<void> {
+        logDebug('ContextRankingController', 'start')
+        await this.getService()
+        const repoUri = vscode.workspace.workspaceFolders?.[0]?.uri
+        if (repoUri && isFileURI(repoUri)) {
+            await this.eagerlyLoad(repoUri)
+        }
+    }
+    
+    // Tries loading the features at the start of the service and if not exist, try compute the features
+    private async eagerlyLoad(repoDir: FileURI): Promise<boolean> {
+        try {
+            const service = await this.getService()
+            const doesFeaturesExist = await service.request(
+                'context-ranking/load-features',
+                repoDir.fsPath
+            )
+            if(!doesFeaturesExist) {
+                // Initialize the feature computation without blocking
+                void (async () => {
+                    try {
+                        const featureComputationRes = await (await this.getService()).request('context-ranking/compute-features', {
+                            repoPath: repoDir.fsPath,
+                            BM25ChunkingStrategy: 'file-level-chunking',
+                        })
+                        logDebug('ContextRankingController', 'compute-features', JSON.stringify(featureComputationRes))
+                        const doesFeaturesExist = await (await this.getService()).request(
+                            'context-ranking/load-features',
+                            repoDir.fsPath
+                        )
+                        this.doesFeaturesExist = doesFeaturesExist;    
+                    } catch (error) {
+                        logDebug('ContextRankingController', 'eagerlyLoad', captureException(error), JSON.stringify(error))
+                    }
+                })()
+                this.doesFeaturesExist = false;
+            }
+            this.doesFeaturesExist = true;
+        } catch (error: any) {
+            logDebug('ContextRankingController', 'eagerlyLoad', captureException(error), JSON.stringify(error))
+            this.doesFeaturesExist = false
+        }
+        return this.doesFeaturesExist
+    }
+
+    private getService(): Promise<MessageHandler> {
+        if (!this.service) {
+            this.service = this.spawnAndBindService(this.context)
+        }
+        return this.service
+    }
+
+    private async spawnAndBindService(context: vscode.ExtensionContext): Promise<MessageHandler> {
+        const service = await new Promise<MessageHandler>((resolve, reject) => {
+            spawnBfg(context, reject).then(
+                bfg => resolve(bfg),
+                error => {
+                    captureException(error)
+                    reject(error)
+                }
+            )
+        })
+        logDebug('ContextRankingController', 'spawnAndBindService', 'service started, initializing')
+        let indexPath = getIndexLibraryPath()
+        // Tests may override the index library path
+        if (this.indexLibraryPath) {
+            logDebug(
+                'ContextRankingController',
+                'spawnAndBindService',
+                'overriding index library path',
+                this.indexLibraryPath
+            )
+            indexPath = this.indexLibraryPath
+        }
+        const initResult = await service.request('context-ranking/initialize', {
+            indexPath: indexPath.fsPath,
+        })
+        logDebug(
+            'LocalEmbeddingsController',
+            'spawnAndBindService',
+            'initialized',
+            initResult,
+        )
+        this.serviceStarted = true
+        return service
+    }
+
+    public async rankContextItems(query: string, contextItems: ContextItem[]): Promise<ContextItem[]> {
+        // if (!this.endpointIsDotcom) {
+        //     return contextItems
+        // }
+        // if (!this.serviceStarted || !this.doesFeaturesExist) {
+        //     return contextItems
+        // }
+        console.log(`values: ${this.endpointIsDotcom}, ${this.serviceStarted}`)
+        try {
+            const service = await this.getService()
+            const rankItems = this.convertContextItemsToRankItems(contextItems)
+            const rankedItemsOrder = await service.request('context-ranking/rank-items', {
+                rankContextItem: rankItems,
+                query: query,
+            })
+            // ToDo: Add more checks to ensure validity of reRanked Items
+            if (rankedItemsOrder.rankContextItem.length!== contextItems.length) {
+                logDebug('ContextRankingController', 'rank-items', 'unexpected-response, length of reranked items does not match', 'original items', JSON.stringify(contextItems), ' reranked items', JSON.stringify(rankedItemsOrder.rankContextItem))
+                return contextItems
+            }
+            const reRankedContextItems = this.orderContextItemsAsRankItems(contextItems, rankedItemsOrder.rankContextItem)
+            return reRankedContextItems
+        } catch (error) {
+            logDebug('ContextRankingController', 'rank-items', captureException(error), error)
+            return contextItems
+        }
+    }
+
+    private convertContextItemsToRankItems(contextItems: ContextItem[]): RankContextItem[] {
+        const rankContextItems = contextItems.map((item, index) => ({
+            index: index,
+            filePath: item.uri?.path,
+            content: item.text,
+            source: item.source
+        }))
+        return rankContextItems
+    }
+
+    private orderContextItemsAsRankItems(contextItems: ContextItem[], rankedItemsOrder: RankContextItem[]): ContextItem[] {
+        let orderedContextItems: ContextItem[] = []; // Initialize the array
+        for (const rankItem of rankedItemsOrder) {
+            const newIndex = rankItem.index;
+            if(newIndex<0 || newIndex>=contextItems.length) {
+                logDebug('ContextRankingController', 'length of rankItems', JSON.stringify(rankedItemsOrder), 'does not match context items', JSON.stringify(contextItems))
+                return contextItems
+            }
+            orderedContextItems.push(contextItems[newIndex]);
+        }
+        return orderedContextItems;
+    }
+    
+}
+
+
+
+
+

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -168,8 +168,7 @@ export class LocalEmbeddingsController
     private getService(): Promise<MessageHandler> {
         if (!this.service) {
             const instance = CodyEngineService.getInstance(this.context)
-            this.service = instance.getService()
-            instance.setupServiceHandler(this.setupLocalEmbeddingsService)
+            this.service = instance.getService(this.setupLocalEmbeddingsService)
         }
         return this.service
     }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -171,6 +171,7 @@ const register = async (
         codeCompletionsClient,
         guardrails,
         localEmbeddings,
+        contextRanking,
         onConfigurationChange: externalServicesOnDidConfigurationChange,
         symfRunner,
     } = await configureExternalServices(context, initialConfig, platform)
@@ -215,6 +216,7 @@ const register = async (
         chatClient,
         enterpriseContextFactory,
         localEmbeddings || null,
+        contextRanking || null,
         symfRunner || null,
         guardrails
     )

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -841,4 +841,5 @@ export const DEFAULT_VSCODE_SETTINGS = {
     testingLocalEmbeddingsEndpoint: undefined,
     testingLocalEmbeddingsIndexLibraryPath: undefined,
     testingLocalEmbeddingsModel: undefined,
+    experimentalChatContextRanker: false,
 } satisfies Configuration


### PR DESCRIPTION
## Context

Adding a context ranking module for chat command, which ranks the context from different sources such as embeddings, symf and editor. This feature currently is behind the flag `cody.experimental.chatContextRanker`. We plan to launch the changes first for the internal users.

**Note**: This updates bfg version and the related BFG release associated with this change is: https://github.com/sourcegraph/bfg/releases/tag/v5.3.1781.

Project Plan and offline analysis: https://docs.google.com/document/d/1rg9P-xqAwn_HfgKlzpHqX6v8Mf9cN-9r-S4kjr88jP8/edit?pli=1

### Feature Precomputation
Similar to local embeddings, additional indexes are created with [base path here](https://github.com/sourcegraph/cody/blob/hitesh/context-ranking-support/vscode/src/local-context/context-ranking.ts#L36). More specifically, When a user click the chat panel for the first time, we send an event to start feature pre-computations (BM25 index, embddings):

1. BM25 Index (On repos ~1.5 GB, it takes ~34 seconds to compute the index, with index size ~45 MBs)
2. Sentence transformer embeddings index (We use local embedding backend to generate the same)

### Ranking call
In case the user has selected the enhanced context option and `cody.experimental.chatContextRanker` flag is set.
1. We compute context item from all context providers (embeddings, symf and editor)
2. Make a call to the cody engine via json-rpc to get the scores for each context item.  
3. Finally sort the context items, based on the ranker score.

## Dependent PR's
1. https://github.com/sourcegraph/bfg-private/pull/167 (changes in the cody engine to support context-ranking)

## Test plan

### Manul Integration test
I have tested the approach on macos and linux based system.

1.  Setup the following flag in the vscode user settings
```
  "cody.experimental.chatContextRanker": true
```

3. Checkout to this branch and start the vscode debugger.
4. Open a repo and click on the chat command from the vscode commands. This will start the feature computation job and the artifacts should start populating in the relevant directories. (For embedding the file names start with `.tmp`, so to list the embedding list do `ls -a`)
- For macos: `~/Library/Caches/com.sourcegraph.cody/context-ranking`
- For Linux: `~/.cache/com.sourcegraph.cody/context-ranking`
6. Testing ranker call: type a question in the chat and add a breakpoint [here](https://github.com/sourcegraph/cody/blob/hitesh/context-ranking-support/vscode/src/local-context/context-ranking.ts#L138), the output will be the predicted ranker scores for the context items and we get the ranked context items which should reflect in the UI.

Note:: The flags in the video below are outdated, we only need to set the flag: `"cody.experimental.chatContextRanker": true`.

https://github.com/sourcegraph/cody/assets/20701220/f4040008-7c57-44b0-8ecd-110b55050cb5

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
