### PR TITLE
Move semgrep rules directory

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           repository: sourcegraph/security-semgrep-rules
           token: ${{ secrets.GH_SEMGREP_SAST_TOKEN }}
-          path: semgrep-rules
 
       - name: Run Semgrep SAST Scan
         run: |
-          semgrep ci -f semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif --exclude='semgrep-rules'
+          mv semgrep-rules ../
+          semgrep ci -f semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -25,11 +25,12 @@ jobs:
         with:
           repository: sourcegraph/security-semgrep-rules
           token: ${{ secrets.GH_SEMGREP_SAST_TOKEN }}
+          path: semgrep-rules
 
       - name: Run Semgrep SAST Scan
         run: |
           mv semgrep-rules ../
-          semgrep ci -f semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif
+          semgrep ci -f ../semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2
         with:


### PR DESCRIPTION
Moved semgrep rules out of source directory to prevent dangling changes during semgrep scan.

## Test plan

- CI is 🟢 

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
