### PR TITLE
Chat: improve handling of at mentions

### DIFF
--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -424,7 +424,7 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             }
 
             // At mention should start with @ and contains no whitespaces
-            const isAtMention = (word: string) => /^@/.test(word) && !word.includes(' ')
+            const isAtMention = (word: string) => /^@[^ ]*$/.test(word)
 
             // Extract mention query by splitting input value into before/after caret sections.
             const extractMentionQuery = (input: string, caretPos: number) => {
@@ -442,6 +442,14 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             const mentionQuery = extractMentionQuery(inputValue, caretPosition)
             const query = mentionQuery.replace(/^@/, '')
 
+            // Cover cases where user prefer to type the file without tabbing the selection
+            if (contextSelection?.length) {
+                if (currentChatContextQuery === query.trimEnd()) {
+                    onChatContextSelected(contextSelection[0])
+                    return
+                }
+            }
+
             // Filters invalid queries and sets context query state accordingly:
             // Sets the current chat context query state if a valid mention is detected.
             // Otherwise resets the context selection and query state.
@@ -454,7 +462,13 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             setCurrentChatContextQuery(query)
             postMessage({ command: 'getUserContext', query })
         },
-        [postMessage, resetContextSelection]
+        [
+            postMessage,
+            resetContextSelection,
+            contextSelection,
+            currentChatContextQuery,
+            onChatContextSelected,
+        ]
     )
 
     const inputHandler = useCallback(

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -360,3 +360,8 @@ export async function newChat(page: Page): Promise<FrameLocator> {
 export function withPlatformSlashes(input: string) {
     return input.replaceAll(path.posix.sep, path.sep)
 }
+
+const isPlatform = (platform: string) => process.platform === platform
+export function getMetaKeyByOS(): string {
+    return isPlatform('darwin') ? 'Meta' : 'Control'
+}


### PR DESCRIPTION
The extractMentionQuery function has been updated to handle cases where the user types the file without tabbing the selection. If a context selection is available and the current chat context query matches the input query, the first context selection should be automatically selected.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green bots = 🆗 

1. at-mention a file without using tab or enter, just type out the whole file path, and end it with space
2. it should stlil include the file on submit

### After

![After](https://github.com/sourcegraph/cody/assets/68532117/b8a778b2-dd4c-460b-90f8-697ae9405288)


### Before

![before](https://github.com/sourcegraph/cody/assets/68532117/1f1170c0-fc8d-499d-a1ff-4d6781f39343)


