### PR TITLE
Fixing logs on the failed GQL queries for refreshConfigFeatures

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -874,8 +874,10 @@ export class ConfigFeaturesSingleton {
     private refreshConfigFeatures(): void {
         const previousConfigFeatures = this.configFeatures
         this.configFeatures = this.fetchConfigFeatures().catch((error: Error) => {
-            // Ignore a fetcherror as older SG instances will always face this because their GQL is outdated
-            if (!error.message.includes('FetchError')) {
+            // Ignore fetcherrors as older SG instances will always face this because their GQL is outdated
+            if (
+                !(error.message.includes('FetchError') || error.message.includes('Cannot query field'))
+            ) {
                 logError('ConfigFeaturesSingleton', 'refreshConfigFeatures', error.message)
             }
             // In case of an error, return previously fetched value


### PR DESCRIPTION
Solves the issue https://github.com/sourcegraph/sourcegraph/issues/60050
Basically we already wanted to make sure that GQL and fetch errors aren't something that hammer the logs console so this PR adds an extra case of checking that the error message doesn't have the string that gets repeatedly printed in this users console. 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

I didn't thoroughly test this PR in the sense that going back to v5.2.0 and then testing. I did go to that version but doing the setup on my local instance caused other issues for me so I left it. My understanding is that this issue is just about seeing something non necessary in the logs so its not really an actually problematic issue. 