### PR TITLE
properly enforce prompt context limit

### DIFF
--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SimpleChatModel } from './SimpleChatModel'
 import { DefaultPrompter } from './prompt'
+import { PromptBuilder } from '../../prompt-builder'
 
 describe('DefaultPrompter', () => {
     afterEach(() => {
@@ -68,5 +69,28 @@ describe('DefaultPrompter', () => {
           ]
         `)
         expect(newContextUsed).toMatchInlineSnapshot('[]')
+    })
+
+    it('tryAddContext limit should not allow prompt to exceed overall limit', async () => {
+        const overallLimit = 1
+        const promptBuilder = new PromptBuilder(overallLimit)
+        const contextItems = [
+            {
+                uri: vscode.Uri.file('/foo/bar'),
+                text: 'foobar',
+            },
+        ]
+
+        const { limitReached, ignored, duplicate, used } = promptBuilder.tryAddContext(
+            contextItems,
+            10_000_000
+        )
+        expect(limitReached).toBeTruthy()
+        expect(ignored).toEqual(contextItems)
+        expect(duplicate).toEqual([])
+        expect(used).toEqual([])
+
+        const prompt = promptBuilder.build()
+        expect(prompt).toMatchInlineSnapshot('[]')
     })
 })

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -50,6 +50,10 @@ export class PromptBuilder {
     /**
      * Tries to add context items to the prompt, tracking characters used.
      * Returns info about which items were used vs. ignored.
+     *
+     * If charLimit is specified, then imposes an additional limit on the
+     * amount of context added from contextItems. This does not affect the
+     * overall character limit, which is still enforced.
      */
     public tryAddContext(
         contextItems: ContextItem[],
@@ -60,7 +64,11 @@ export class PromptBuilder {
         ignored: ContextItem[]
         duplicate: ContextItem[]
     } {
-        const effectiveCharLimit = charLimit ? this.charsUsed + charLimit : this.charLimit
+        let effectiveCharLimit = this.charLimit - this.charsUsed
+        if (charLimit && charLimit < effectiveCharLimit) {
+            effectiveCharLimit = charLimit
+        }
+
         let limitReached = false
         const used: ContextItem[] = []
         const ignored: ContextItem[] = []


### PR DESCRIPTION
There was a bug in the logic of `tryAddContext` that could effectively expand the overall char limit we imposed on the prompt by the number of bytes we allocated to enhanced context (60%). This contributed to https://github.com/sourcegraph/cody/issues/3104.

This change properly enforces the overall prompt limit.

## Test plan

See added unit test