### PR TITLE
Add a hint about how to include specific files or functions

### DIFF
--- a/vscode/webviews/Components/EnhancedContextSettings.module.css
+++ b/vscode/webviews/Components/EnhancedContextSettings.module.css
@@ -236,3 +236,11 @@
         opacity: 0;
     }
 }
+
+.popup .hint {
+    font-size: 11px;
+    line-height: 1.3;
+    opacity: 0.8;
+    margin-bottom: 0;
+    font-style: italic;
+}

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -437,6 +437,10 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                                 handleRemove={handleRemoveRemoteSearchRepo}
                             />
                         )}
+                        <p className={styles.hint}>
+                            Tip: To include a specific file or symbol as context, type @ in the message
+                            input.
+                        </p>
                     </div>
                 </div>
             </PopupFrame>


### PR DESCRIPTION
We've had feedback from users who miss the text input placeholder text and go looking in Enhanced Context for how to add a particular file or function (probably also a learned behaviour from other apps and systems that have an explicit button to add files/symbols).

Long term we should move to a UI that has an explicit button. Short term, we can add a hint to let people know how to do that: this PR adds that hint.

| Before | After |
| - | - |
| ![CleanShot 2024-02-12 at 11 48 02@2x](https://github.com/sourcegraph/cody/assets/153/c8d7eb8f-f1f5-4780-a43d-df02973b7b06) | ![CleanShot 2024-02-12 at 11 45 16@2x](https://github.com/sourcegraph/cody/assets/153/935a61fe-0abf-45df-ab29-0c3856b6b15c) |

## Cody Free vs Pro vs Enterprise

I've made no distinction between Cody Free+Pro and Cody Enterprise.

For Enterprise, given they can add other repositories to Enhanced Context I can imagine people wanting to @-mention files from other repos too. and this tip may exacerbate that problem. But I think it's important to still show the tip for Enterprise, because if your repository isn't indexed on your instance it is helpful to know you can still @-mention local files to include them as context.

I'd suggest we look at adding support for @-mention'ing files in other repositories in a following release.

## Test plan

- Opened the Enhanced Context selector
- Verified label is shown