### PR TITLE
VS Code: changelog cleanup

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,10 +12,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ## [1.4.3]
 
-### Fixed
-
-- Chat: Fixed an issue where Cody would sometimes exceed the context window limit for shorter context OpenAI models. [pull/3121](https://github.com/sourcegraph/cody/pull/3121)
-
 ### Changed
 
 - Autocomplete: Updated the BFG binary version. [pull/3130](https://github.com/sourcegraph/cody/pull/3130)


### PR DESCRIPTION
Removing the duplicate changelog entry.

## Test plan

n/a, docs update.
