### PR TITLE
Edit: Add feature flag / AB test logic for command hints

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -49,6 +49,9 @@ export enum FeatureFlag {
 
     // A feature flag to test potential chat experiments. No functionality is gated by it.
     CodyChatMockTest = 'cody-chat-mock-test',
+
+    // Show command hints alongside editor selections. "Opt+K to Edit, Opt+L to Chat"
+    CodyCommandHints = 'cody-command-hints',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -38,10 +38,13 @@ function isEmptyOrIncompleteSelection(
 export async function getGhostHintEnablement(): Promise<boolean> {
     const config = vscode.workspace.getConfiguration('cody')
     const configSettings = config.inspect<boolean>('commandHints.enabled')
-    const enabledAsFlag = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyCommandHints)
 
     // Return the actual configuration setting, if set. Otherwise return the default value from the feature flag.
-    return configSettings?.workspaceValue ?? configSettings?.globalValue ?? enabledAsFlag
+    return (
+        configSettings?.workspaceValue ??
+        configSettings?.globalValue ??
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyCommandHints)
+    )
 }
 
 /**

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -5,6 +5,7 @@ import { isCodyIgnoredFile, type Configuration } from '@sourcegraph/cody-shared'
 import { getConfiguration } from '../configuration'
 
 import { FeedbackOptionItems } from './FeedbackOptions'
+import { getGhostHintEnablement } from '../commands/GhostHintDecorator'
 
 interface StatusBarError {
     title: string
@@ -46,16 +47,16 @@ export function createStatusBar(): CodyStatusBar {
         const workspaceConfig = vscode.workspace.getConfiguration()
         const config = getConfiguration(workspaceConfig)
 
-        function createFeatureToggle(
+        async function createFeatureToggle(
             name: string,
             description: string | undefined,
             detail: string,
             setting: string,
-            getValue: (config: Configuration) => boolean,
+            getValue: (config: Configuration) => boolean | Promise<boolean>,
             requiresReload = false,
             buttons: readonly vscode.QuickInputButton[] | undefined = undefined
-        ): StatusBarItem {
-            const isEnabled = getValue(config)
+        ): Promise<StatusBarItem> {
+            const isEnabled = await getValue(config)
             return {
                 label:
                     (isEnabled ? QUICK_PICK_ITEM_CHECKED_PREFIX : QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX) +
@@ -103,7 +104,7 @@ export function createStatusBar(): CodyStatusBar {
                   ]
                 : []),
             { label: 'enable/disable features', kind: vscode.QuickPickItemKind.Separator },
-            createFeatureToggle(
+            await createFeatureToggle(
                 'Code Autocomplete',
                 undefined,
                 'Enable Cody-powered code autocompletions',
@@ -121,35 +122,35 @@ export function createStatusBar(): CodyStatusBar {
                     } as vscode.QuickInputButton,
                 ]
             ),
-            createFeatureToggle(
+            await createFeatureToggle(
                 'Code Actions',
                 undefined,
                 'Enable Cody fix and explain options in the Quick Fix menu',
                 'cody.codeActions.enabled',
                 c => c.codeActions
             ),
-            createFeatureToggle(
+            await createFeatureToggle(
                 'Editor Title Icon',
                 undefined,
                 'Enable Cody to appear in editor title menu for quick access to Cody commands',
                 'cody.editorTitleCommandIcon',
                 c => c.editorTitleCommandIcon
             ),
-            createFeatureToggle(
+            await createFeatureToggle(
                 'Code Lenses',
                 undefined,
                 'Enable Code Lenses in documents for quick access to Cody commands',
                 'cody.commandCodeLenses',
                 c => c.commandCodeLenses
             ),
-            createFeatureToggle(
+            await createFeatureToggle(
                 'Command Hints',
                 undefined,
                 'Enable hints for Edit and Chat shortcuts, displayed alongside editor selections',
                 'cody.commandHints.enabled',
-                c => c.commandHints
+                getGhostHintEnablement
             ),
-            createFeatureToggle(
+            await createFeatureToggle(
                 'Search Context',
                 'Beta',
                 'Enable using the natural language search index as an Enhanced Context chat source',


### PR DESCRIPTION
## Description

This PR:
- Adds default enablement for the `cody.commandHints.enabled` setting via a feature flag
  - We still respect the default setting value, so users can easily override this if they want

## Test plan

**When `cody.commandHints.enabled` setting is not set:**

1. Set `cody-command-hints` flag to 100%. Check command hints are enabled. Check value is correctly shown in "Cody Settings" menu. 
2. Set `cody-command-hints` flag to 0%. Reload and check command hints are NOT enabled. Check value is correctly shown in "Cody Settings" menu. 

**When `cody.commandHints.enabled` setting is already set to `true`:**

1. Set `cody-command-hints` flag to 0%. Reload and check command hints are STILL enabled. Check value is correctly shown in "Cody Settings" menu. 

**When `cody.commandHints.enabled` setting is already set to `false`:**

1. Set `cody-command-hints` flag to 100%. Check command hints are NOT enabled. Check value is correctly shown in "Cody Settings" menu. 

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
