### PR TITLE
Edit: Stop clearing ghost text when input opens

### DIFF
--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -85,11 +85,6 @@ export class EditManager implements vscode.Disposable {
             return
         }
 
-        if (editor.active) {
-            // Clear out any active ghost text
-            this.options.ghostHintDecorator.clearGhostText(editor.active)
-        }
-
         // Set default edit configuration, if not provided
         // It is possible that these values may be overriden later, e.g. if the user changes them in the edit input.
         const range = getEditLineSelection(document, proposedRange)


### PR DESCRIPTION
## Description

Small change to stop hiding the ghost text when the input opens. This makes the UI less flicker-y.



## Test plan

1. With command hints enabled, open edit input from selection.
2. Check command hints still show

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
