### PR TITLE
Autocomplete: Log if a completion was suggested again

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -540,6 +540,9 @@ export function suggested(id: CompletionLogID, span?: Span): void {
                 event.suggestionAnalyticsLoggedAt = performance.now()
             }
         }, READ_TIMEOUT_MS)
+    } else {
+        span?.setAttributes(getSharedParams(event) as any)
+        span?.addEvent('suggested-again')
     }
 }
 


### PR DESCRIPTION
Add a span event when a completion was already logged as suggested. Mainly to ensure we have attributes attached.

Noticed a few spans with source `null` in Honeycomb. 

## Test plan

- Ensured that this is the codepath taken via adding debugger breakpoints.