### PR TITLE
Autocomplete: Only sample requests that are also suggested

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -441,15 +441,7 @@ export class InlineCompletionItemProvider
                     this.unstable_handleDidShowCompletionItem(autocompleteItems[0])
                 }
 
-                // If the completion callbacks makes it this far, it is going to be displayed on the
-                // client (for VS Code we have already run the did show handler). However, since we
-                // are still inside the callback, we can add some final data to the span and decide
-                // wether to sample it or not.
-                markSpanAsSampled(
-                    span,
-                    result.source,
-                    completionProviderConfig.getPrefetchedFlag(FeatureFlag.CodyAutocompleteTracing)
-                )
+                addExposedExperimentsToSpan(span, result.source)
 
                 return autocompleteResult
             } catch (error) {
@@ -793,18 +785,9 @@ function onlyCompletionWidgetSelectionChanged(
     return prevSelectedCompletionInfo.text !== nextSelectedCompletionInfo.text
 }
 
-function markSpanAsSampled(
-    span: Span,
-    source: InlineCompletionsResultSource,
-    tracingFlagEnabled: boolean
-): void {
+function addExposedExperimentsToSpan(span: Span, source: InlineCompletionsResultSource): void {
     // Add exposed experiments at the very end to make sure we include experiments that the user is
     // being exposed to while the completion was generated
     span.setAttributes(featureFlagProvider.getExposedExperiments())
     span.setAttributes(getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration())) as any)
-
-    const shouldSample = tracingFlagEnabled && source !== InlineCompletionsResultSource.HotStreak
-    if (shouldSample) {
-        span.setAttribute('sampled', true)
-    }
 }

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -10,6 +10,7 @@ import { InlineCompletionsResultSource, TriggerKind } from './get-inline-complet
 import * as CompletionLogger from './logger'
 import type { RequestParams } from './request-manager'
 import { documentAndPosition } from './test-helpers'
+import { initCompletionProviderConfig } from './get-inline-completions-tests/helpers'
 
 const defaultArgs = {
     multiline: false,
@@ -46,7 +47,8 @@ const completionItemId = 'completion-item-id' as CompletionLogger.CompletionItem
 describe('logger', () => {
     let logSpy: MockInstance
     let recordSpy: MockInstance
-    beforeEach(() => {
+    beforeEach(async () => {
+        await initCompletionProviderConfig({})
         logSpy = vi.spyOn(telemetryService, 'log')
         recordSpy = vi.spyOn(telemetryRecorder, 'recordEvent')
     })

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -2,7 +2,12 @@ import { LRUCache } from 'lru-cache'
 import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
-import { isNetworkError, type BillingCategory, type BillingProduct } from '@sourcegraph/cody-shared'
+import {
+    isNetworkError,
+    type BillingCategory,
+    type BillingProduct,
+    FeatureFlag,
+} from '@sourcegraph/cody-shared'
 import type { KnownString, TelemetryEventParameters } from '@sourcegraph/telemetry'
 
 import { getConfiguration } from '../configuration'
@@ -20,6 +25,7 @@ import type { InlineCompletionItemWithAnalytics } from './text-processing/proces
 import { lines } from './text-processing/utils'
 import type { InlineCompletionItem } from './types'
 import type { Span } from '@opentelemetry/api'
+import { completionProviderConfig } from './completion-provider-config'
 
 // A completion ID is a unique identifier for a specific completion text displayed at a specific
 // point in the document. A single completion can be suggested multiple times.
@@ -523,6 +529,15 @@ export function suggested(id: CompletionLogID, span?: Span): void {
         span?.setAttributes(getSharedParams(event) as any)
         span?.addEvent('suggested')
 
+        // Mark the completion as sampled if tracing is enable for this user
+        const shouldSample = completionProviderConfig.getPrefetchedFlag(
+            FeatureFlag.CodyAutocompleteTracing
+        )
+
+        if (shouldSample && span) {
+            span.setAttribute('sampled', true)
+        }
+
         setTimeout(() => {
             const event = activeSuggestionRequests.get(id)
             if (!event) {
@@ -540,9 +555,6 @@ export function suggested(id: CompletionLogID, span?: Span): void {
                 event.suggestionAnalyticsLoggedAt = performance.now()
             }
         }, READ_TIMEOUT_MS)
-    } else {
-        span?.setAttributes(getSharedParams(event) as any)
-        span?.addEvent('suggested-again')
     }
 }
 


### PR DESCRIPTION
Thinking about #3136 again, I don't think it's helpful to sample these traces even. It's not bad per-se, but it's easier to aggregate if we don't have to filter based on a root span attribute everywhere.

E.g. I want to see the "median" completion time so I get the median timings of specific spans but if I have to exclude some values in the root span, this is getting more complex then necessary. Let's keep it simple and don't even sample these (which also saves some bandwidth)

## Test plan

- Added a debugger breakpoint to see if the sampled attribute is set
