### PR TITLE
Commit Messages: Fix bug with unstaged files and add feature toggle to menu

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -852,7 +852,7 @@
                     "order": 99,
                     "type": "boolean",
                     "default": true,
-                    "markdownDescription": "Adds a button to the SCM input field to generate a relevant commit message for the current changes."
+                    "markdownDescription": "Enable Cody to appear in the Source Control input field, to generate a relevant commit message from your changes."
                 },
                 "cody.debug.enable": {
                     "order": 99,

--- a/vscode/src/scm/CommitMessageProvider.ts
+++ b/vscode/src/scm/CommitMessageProvider.ts
@@ -206,16 +206,12 @@ export class CommitMessageProvider implements VSCodeCommitMessageProvider, vscod
         }
 
         if (!diffs?.length) {
-            console.log('Getting from cli')
             diffs = await this.getDiffFromGitCli(workspaceUri.fsPath)
         }
 
         if (diffs.length === 0) {
-            console.log('No diffs, even from the cli')
             return { isEmpty: true, isTruncated: false, prompt: '' }
         }
-
-        console.log('Got diffs', diffs)
 
         const allowedDiffs = diffs.filter(diff => {
             const files = parseDiff(diff)

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -158,6 +158,13 @@ export function createStatusBar(): CodyStatusBar {
                 c => c.experimentalSymfContext,
                 false
             ),
+            await createFeatureToggle(
+                'Commit Messages',
+                'Experimental',
+                'Enable Cody to appear in the Source Control input field, to generate a relevant commit message from your changes.',
+                'cody.experimental.commitMessage',
+                c => c.experimentalCommitMessage
+            ),
             { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
             {
                 label: '$(gear) Cody Extension Settings',


### PR DESCRIPTION
## Description

This PR:
- Fixes an issue where VS Code would provide `changes` as an empty array for unstaged files
- Adds a e2e test to cover this
- Adds an item to the Cody feature menu to enable/disable the setting

## Test plan

1. Trigger the Cody commit message with no staged files
2. Check it works!

Other:

1. Check that disabling/enabling the feature from the menu works

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
