### PR TITLE
Agent: don't kill entire process on uncaught exceptions

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -10,6 +10,16 @@ console.log = console.error
 // stdout/stdin to communicate with the agent client.
 const rootCommand: Command = require('./cli/root').rootCommand
 
+process.on('uncaughtException', e => {
+    // By default, an uncaught exception will take down the entire process.
+    // Instead of taking down the process, we just report it to stderr and move
+    // on.  In almost all cases, an uncaught exception is an innocent error that
+    // does not have to take down the process. For example, if a telemetry
+    // request fails, then it's totally fine to just report it here with a stack
+    // trace so we can look into it and fix it.
+    console.error('Uncaught exception:', e)
+})
+
 const args = process.argv.slice(2)
 const { operands } = rootCommand.parseOptions(args)
 if (operands.length === 0) {


### PR DESCRIPTION
Previously, the agent process would kill itself if the Node.js process encountered an uncaught exception because this is the default behavior for Node.js. This was problematic because most uncaught exceptions are innocent, they're typically non-critical code that runs in some un-awaited promise where we forget to wrap the code in try/catch.

This PR adds an uncaught error handler that logs the error (and stack trace) to stderr instead. For clients like JetBrains, we automatically redirect stderr to `idea.log` making it easy to troubleshoot the problem.

This change should be a big stability boost since tiny programming mistakes no longer take down the entire agent process. I am embarrassed we didn't do this sooner, but better late than never.


## Test plan

* Manually add `setTimeout(() => {throw new Error('boom')}, 100)` somewhere in the code
* Comment out the uncaught exception handler
* Run `pnpm run test agent/src/index.test.ts`
* Confirm that tests fail
* Uncomment exception handler
* Confirm all tests pass

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
