### PR TITLE
Command Hints: Update setting enablement

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -821,8 +821,8 @@
                     "order": 12,
                     "title": "Cody Command Hints",
                     "type": "boolean",
-                    "markdownDescription": "Enable hints for Edit and Chat shortcuts, displayed alongside editor selections.",
-                    "default": false
+                    "markdownDescription": "Enable hints for Edit and Chat shortcuts (\"Opt+K to Edit, Opt+L to Chat\"), displayed alongside editor selections.",
+                    "default": true
                 },
                 "cody.experimental.simpleChatContext": {
                     "order": 99,

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -39,12 +39,16 @@ export async function getGhostHintEnablement(): Promise<boolean> {
     const config = vscode.workspace.getConfiguration('cody')
     const configSettings = config.inspect<boolean>('commandHints.enabled')
 
-    // Return the actual configuration setting, if set. Otherwise return the default value from the feature flag.
-    return (
-        configSettings?.workspaceValue ??
-        configSettings?.globalValue ??
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyCommandHints)
-    )
+    const userSetConfigValue = configSettings?.workspaceValue ?? configSettings?.globalValue
+
+    if (userSetConfigValue !== undefined) {
+        // Always prefer any value that has been explicitly set by the user.
+        // This ensures users can still override the default behaviour regardless of any A/B test.
+        return userSetConfigValue
+    }
+
+    // Return the default value as determined by the A/B test.
+    return featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyCommandHints)
 }
 
 /**

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -39,16 +39,12 @@ export async function getGhostHintEnablement(): Promise<boolean> {
     const config = vscode.workspace.getConfiguration('cody')
     const configSettings = config.inspect<boolean>('commandHints.enabled')
 
-    const userSetConfigValue = configSettings?.workspaceValue ?? configSettings?.globalValue
-
-    if (userSetConfigValue !== undefined) {
-        // Always prefer any value that has been explicitly set by the user.
-        // This ensures users can still override the default behaviour regardless of any A/B test.
-        return userSetConfigValue
-    }
-
-    // Return the default value as determined by the A/B test.
-    return featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyCommandHints)
+    // Return the actual configuration setting, if set. Otherwise return the default value from the feature flag.
+    return (
+        configSettings?.workspaceValue ??
+        configSettings?.globalValue ??
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyCommandHints)
+    )
 }
 
 /**


### PR DESCRIPTION
## Description

1. Defaults the setting to on, as visible to the user. See comment below as to why that is important
2. Adds default text to the setting description, so users can easily search VS Code settings to disable this if they want to.

## Test plan

**When `cody.commandHints.enabled` setting is not set:**

1. Set `cody-command-hints` flag to 100%. Check command hints are enabled. Check value is correctly shown in "Cody Settings" menu. 
2. Set `cody-command-hints` flag to 0%. Reload and check command hints are NOT enabled. Check value is correctly shown in "Cody Settings" menu. 

**When `cody.commandHints.enabled` setting is already set to `true`:**

1. Set `cody-command-hints` flag to 0%. Reload and check command hints are STILL enabled. Check value is correctly shown in "Cody Settings" menu. 

**When `cody.commandHints.enabled` setting is already set to `false`:**

1. Set `cody-command-hints` flag to 100%. Check command hints are NOT enabled. Check value is correctly shown in "Cody Settings" menu. 


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
