### PR TITLE
Chat: fix welcome messages in chat view

### DIFF
--- a/lib/shared/src/chat/markdown.ts
+++ b/lib/shared/src/chat/markdown.ts
@@ -11,7 +11,8 @@ import {
  *  - e.g. command:cody.welcome: VS Code command scheme exception we add to support directly linking to the welcome guide from within the chat.
  * {@link CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID}
  */
-const ALLOWED_URI_REGEXP = /^((https?|vscode):\/\/[^\s#$./?].\S*|command:(_cody.vscode.open\?.*))$/i
+const ALLOWED_URI_REGEXP =
+    /^((https?|vscode):\/\/[^\s#$./?].\S*|command:cody.*|command:(_cody.vscode.open\?.*))$/i
 
 const DOMPURIFY_CONFIG = {
     ALLOWED_TAGS: [

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,8 +7,11 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Cody can now generate commit messages from your changes. Triggered through the input field in the VS Code "Source Control" sidebar. [pull/2306](https://github.com/sourcegraph/cody/pull/2306)
+- Chat: Displays warnings for large @-mentioned files during selection. [pull/3118](https://github.com/sourcegraph/cody/pull/3118)
 
 ### Fixed
+
+- Chat: Fixed an issue where the links in the welcome message for chat are unclickable. [pull/3155](https://github.com/sourcegraph/cody/pull/3155)
 
 ### Changed
 

--- a/vscode/test/e2e/commit-message.test.ts
+++ b/vscode/test/e2e/commit-message.test.ts
@@ -71,7 +71,7 @@ test('commit message generation - happy path with staged changes', async ({ page
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByLabel(/index.js • Modified$/)
+    const gitChange = page.getByRole('treeitem', { name: /index.js/ })
     await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
@@ -108,7 +108,7 @@ test('commit message generation - happy path with no staged changes', async ({ p
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByLabel(/index.js • Modified$/)
+    const gitChange = page.getByRole('treeitem', { name: /index.js/ })
     await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
@@ -141,8 +141,7 @@ test('commit message generation - cody ignore', async ({ page, sidebar }) => {
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByLabel(/ignored.js • Modified$/)
-    await gitChange.hover()
+    const gitChange = page.getByRole('treeitem', { name: /ignored.js/ })
     await expect(gitChange).toBeVisible()
 
     // Stage Git change

--- a/vscode/test/e2e/commit-message.test.ts
+++ b/vscode/test/e2e/commit-message.test.ts
@@ -71,7 +71,7 @@ test('commit message generation - happy path with staged changes', async ({ page
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByLabel('index.js • Modified')
+    const gitChange = page.locator('a').filter({ hasText: 'index.js' })
     await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
@@ -108,7 +108,7 @@ test('commit message generation - happy path with no staged changes', async ({ p
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByLabel('index.js • Modified')
+    const gitChange = page.locator('a').filter({ hasText: 'index.js' })
     await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
@@ -141,7 +141,7 @@ test('commit message generation - cody ignore', async ({ page, sidebar }) => {
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByLabel('ignored.js • Modified')
+    const gitChange = page.locator('a').filter({ hasText: 'ignored.js' })
     await gitChange.hover()
     await expect(gitChange).toBeVisible()
 

--- a/vscode/test/e2e/commit-message.test.ts
+++ b/vscode/test/e2e/commit-message.test.ts
@@ -79,8 +79,8 @@ test('commit message generation - happy path with staged changes', async ({ page
     await gitChange.getByLabel('Stage Changes').click()
 
     // Activate the Cody commit message feature
-    const generateCommitMessageCta = await page.getByLabel('Generate Commit Message (Cody)')
-    expect(generateCommitMessageCta).toBeVisible()
+    const generateCommitMessageCta = page.getByLabel('Generate Commit Message (Cody)')
+    await expect(generateCommitMessageCta).toBeVisible()
     await generateCommitMessageCta.hover()
     await generateCommitMessageCta.click()
 
@@ -111,8 +111,8 @@ test('commit message generation - happy path with no staged changes', async ({ p
     await expect(gitChange).toBeVisible()
 
     // Activate the Cody commit message feature
-    const generateCommitMessageCta = await page.getByLabel('Generate Commit Message (Cody)')
-    expect(generateCommitMessageCta).toBeVisible()
+    const generateCommitMessageCta = page.getByLabel('Generate Commit Message (Cody)')
+    await expect(generateCommitMessageCta).toBeVisible()
     await generateCommitMessageCta.hover()
     await generateCommitMessageCta.click()
 
@@ -147,8 +147,8 @@ test('commit message generation - cody ignore', async ({ page, sidebar }) => {
     await gitChange.getByLabel('Stage Changes').click()
 
     // Activate the Cody commit message feature
-    const generateCommitMessageCta = await page.getByLabel('Generate Commit Message (Cody)')
-    expect(generateCommitMessageCta).toBeVisible()
+    const generateCommitMessageCta = page.getByLabel('Generate Commit Message (Cody)')
+    await expect(generateCommitMessageCta).toBeVisible()
     await generateCommitMessageCta.click()
 
     const expectedEvents = [

--- a/vscode/test/e2e/commit-message.test.ts
+++ b/vscode/test/e2e/commit-message.test.ts
@@ -72,6 +72,7 @@ test('commit message generation - happy path with staged changes', async ({ page
 
     // Check the change is showing as a Git change
     const gitChange = page.getByLabel('index.js • Modified')
+    await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
     // Stage Git change
@@ -108,6 +109,7 @@ test('commit message generation - happy path with no staged changes', async ({ p
 
     // Check the change is showing as a Git change
     const gitChange = page.getByLabel('index.js • Modified')
+    await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
     // Activate the Cody commit message feature
@@ -140,6 +142,7 @@ test('commit message generation - cody ignore', async ({ page, sidebar }) => {
 
     // Check the change is showing as a Git change
     const gitChange = page.getByLabel('ignored.js • Modified')
+    await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
     // Stage Git change

--- a/vscode/test/e2e/commit-message.test.ts
+++ b/vscode/test/e2e/commit-message.test.ts
@@ -71,8 +71,7 @@ test('commit message generation - happy path with staged changes', async ({ page
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByRole('treeitem', { name: /index.js/ })
-    await gitChange.hover()
+    const gitChange = page.getByLabel('index.js • Modified')
     await expect(gitChange).toBeVisible()
 
     // Stage Git change
@@ -80,8 +79,8 @@ test('commit message generation - happy path with staged changes', async ({ page
     await gitChange.getByLabel('Stage Changes').click()
 
     // Activate the Cody commit message feature
-    const generateCommitMessageCta = page.getByLabel('Generate Commit Message (Cody)')
-    await expect(generateCommitMessageCta).toBeVisible()
+    const generateCommitMessageCta = await page.getByLabel('Generate Commit Message (Cody)')
+    expect(generateCommitMessageCta).toBeVisible()
     await generateCommitMessageCta.hover()
     await generateCommitMessageCta.click()
 
@@ -108,13 +107,12 @@ test('commit message generation - happy path with no staged changes', async ({ p
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByRole('treeitem', { name: /index.js/ })
-    await gitChange.hover()
+    const gitChange = page.getByLabel('index.js • Modified')
     await expect(gitChange).toBeVisible()
 
     // Activate the Cody commit message feature
-    const generateCommitMessageCta = page.getByLabel('Generate Commit Message (Cody)')
-    await expect(generateCommitMessageCta).toBeVisible()
+    const generateCommitMessageCta = await page.getByLabel('Generate Commit Message (Cody)')
+    expect(generateCommitMessageCta).toBeVisible()
     await generateCommitMessageCta.hover()
     await generateCommitMessageCta.click()
 
@@ -141,7 +139,7 @@ test('commit message generation - cody ignore', async ({ page, sidebar }) => {
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.getByRole('treeitem', { name: /ignored.js/ })
+    const gitChange = page.getByLabel('ignored.js • Modified')
     await expect(gitChange).toBeVisible()
 
     // Stage Git change
@@ -149,8 +147,8 @@ test('commit message generation - cody ignore', async ({ page, sidebar }) => {
     await gitChange.getByLabel('Stage Changes').click()
 
     // Activate the Cody commit message feature
-    const generateCommitMessageCta = page.getByLabel('Generate Commit Message (Cody)')
-    await expect(generateCommitMessageCta).toBeVisible()
+    const generateCommitMessageCta = await page.getByLabel('Generate Commit Message (Cody)')
+    expect(generateCommitMessageCta).toBeVisible()
     await generateCommitMessageCta.click()
 
     const expectedEvents = [

--- a/vscode/test/e2e/commit-message.test.ts
+++ b/vscode/test/e2e/commit-message.test.ts
@@ -71,7 +71,7 @@ test('commit message generation - happy path with staged changes', async ({ page
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.locator('a').filter({ hasText: 'index.js' })
+    const gitChange = page.getByLabel(/index.js • Modified$/)
     await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
@@ -108,7 +108,7 @@ test('commit message generation - happy path with no staged changes', async ({ p
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.locator('a').filter({ hasText: 'index.js' })
+    const gitChange = page.getByLabel(/index.js • Modified$/)
     await gitChange.hover()
     await expect(gitChange).toBeVisible()
 
@@ -141,7 +141,7 @@ test('commit message generation - cody ignore', async ({ page, sidebar }) => {
         .click()
 
     // Check the change is showing as a Git change
-    const gitChange = page.locator('a').filter({ hasText: 'ignored.js' })
+    const gitChange = page.getByLabel(/ignored.js • Modified$/)
     await gitChange.hover()
     await expect(gitChange).toBeVisible()
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/3085

The regex for allowed URIs in chat messages was updated to allow additional custom URI schemes like 'command:cody.*'. This allows linking directly to Cody guides and other custom VS Code commands from within the chat.

Previously only the `_cody.vscode.open` command is allowed in the chat view, which blocked the `Cody Commands` and `Getting Started Guide` commands from working in the chat view.

This PR adds the `command:cody.` prefix to fix the aforementioned issue.

![image](https://github.com/sourcegraph/cody/assets/68532117/08b5118d-a1d9-4238-aa20-ff963fbde935)


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Click on the `Cody Commands` and `Getting Started Guide` links in a new chat to make sure they work:

https://github.com/sourcegraph/cody/assets/68532117/bf12648f-1f05-48da-bdeb-8a52dfb57eca


