### PR TITLE
Auth: Add input validation for instance URL

### DIFF
--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -319,5 +319,14 @@ export type AuthMethod = 'dotcom' | 'github' | 'gitlab' | 'google'
 // Provide backward compatibility for the old token regex
 // Details: https://docs.sourcegraph.com/dev/security/secret_formats
 const sourcegraphTokenRegex =
-    /^(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}|[a-fA-F0-9]{40}|sgd_[a-fA-F0-9]{64}|slk_[a-fA-F0-9]{64}|sgs_[a-fA-F0-9]{64})$/
-export const isSourcegraphToken = (text: string): boolean => sourcegraphTokenRegex.test(text)
+    /(sgp_(?:[a-fA-F0-9]{16}|local)|sgp_)?[a-fA-F0-9]{40}|(sgd|slk|sgs)_[a-fA-F0-9]{64}/
+
+/**
+ * Checks if the given text matches the regex for a Sourcegraph access token.
+ *
+ * @param text - The text to check against the regex.
+ * @returns Whether the text matches the Sourcegraph token regex.
+ */
+export function isSourcegraphToken(text: string): boolean {
+    return sourcegraphTokenRegex.test(text)
+}

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -316,5 +316,8 @@ export function isLoggedIn(authStatus: AuthStatus): boolean {
 
 export type AuthMethod = 'dotcom' | 'github' | 'gitlab' | 'google'
 
-const sourcegraphTokenRegex = /sgp_[a-zA-Z0-9]+_[a-zA-Z0-9]+/
+// Provide backward compatibility for the old token regex
+// Details: https://docs.sourcegraph.com/dev/security/secret_formats
+const sourcegraphTokenRegex =
+    /^(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}|[a-fA-F0-9]{40}|sgd_[a-fA-F0-9]{64}|slk_[a-fA-F0-9]{64}|sgs_[a-fA-F0-9]{64})$/
 export const isSourcegraphToken = (text: string): boolean => sourcegraphTokenRegex.test(text)

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -315,3 +315,6 @@ export function isLoggedIn(authStatus: AuthStatus): boolean {
 }
 
 export type AuthMethod = 'dotcom' | 'github' | 'gitlab' | 'google'
+
+const sourcegraphTokenRegex = /sgp_[a-zA-Z0-9]+_[a-zA-Z0-9]+/
+export const isSourcegraphToken = (text: string): boolean => sourcegraphTokenRegex.test(text)

--- a/vscode/src/services/AuthMenus.ts
+++ b/vscode/src/services/AuthMenus.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import { isDotCom, LOCAL_APP_URL } from '@sourcegraph/cody-shared'
+import { isSourcegraphToken } from './AuthProvider'
 
 interface LoginMenuItem {
     id: string
@@ -60,6 +61,13 @@ export async function showInstanceURLInputBox(title: string): Promise<string | u
         placeHolder: 'https://sourcegraph.example.com',
         password: false,
         ignoreFocusOut: true,
+        // valide input to ensure the user is not entering a token as URL
+        validateInput: (value: string) => {
+            if (isSourcegraphToken(value)) {
+                return 'Invalid input. Please enter a valid URL'
+            }
+            return null
+        },
     })
 
     if (typeof result === 'string') {

--- a/vscode/src/services/AuthMenus.ts
+++ b/vscode/src/services/AuthMenus.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 
 import { isDotCom, LOCAL_APP_URL } from '@sourcegraph/cody-shared'
-import { isSourcegraphToken } from './AuthProvider'
+import { isSourcegraphToken } from '../chat/protocol'
 
 interface LoginMenuItem {
     id: string

--- a/vscode/src/services/AuthMenus.ts
+++ b/vscode/src/services/AuthMenus.ts
@@ -57,14 +57,25 @@ export const AuthMenu = async (
 export async function showInstanceURLInputBox(title: string): Promise<string | undefined> {
     const result = await vscode.window.showInputBox({
         title,
-        prompt: 'Enter the URL of the Sourcegraph instance',
+        prompt: 'Enter the URL of the Sourcegraph instance. For example, https://sourcegraph.example.com.',
         placeHolder: 'https://sourcegraph.example.com',
+        value: 'https://',
         password: false,
         ignoreFocusOut: true,
         // valide input to ensure the user is not entering a token as URL
         validateInput: (value: string) => {
+            // ignore empty value
+            if (!value) {
+                return null
+            }
             if (isSourcegraphToken(value)) {
-                return 'Invalid input. Please enter a valid URL'
+                return 'Please enter a valid URL'
+            }
+            if (value.length > 4 && !value.startsWith('http')) {
+                return 'URL must start with http or https'
+            }
+            if (!/([.]|^https?:\/\/)/.test(value)) {
+                return 'Please enter a valid URL'
             }
             return null
         },

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -17,6 +17,7 @@ import {
     networkErrorAuthStatus,
     unauthenticatedStatus,
     type AuthStatus,
+    isSourcegraphToken,
 } from '../chat/protocol'
 import { newAuthStatus } from '../chat/utils'
 import { getFullConfig } from '../configuration'
@@ -30,9 +31,6 @@ import { telemetryRecorder } from './telemetry-v2'
 
 type Listener = (authStatus: AuthStatus) => void
 type Unsubscribe = () => void
-
-const sourcegraphTokenRegex = /sgp_[a-zA-Z0-9]+_[a-zA-Z0-9]+/
-export const isSourcegraphToken = (text: string): boolean => sourcegraphTokenRegex.test(text)
 
 export class AuthProvider {
     private endpointHistory: string[] = []
@@ -457,9 +455,7 @@ function formatURL(uri: string): string | null {
 
         // Check if the URI is a sourcegraph token
         if (isSourcegraphToken(uri)) {
-            const errorMsg = 'Token is not a valid URL'
-            void vscode.window.showErrorMessage(errorMsg)
-            throw new Error(errorMsg)
+            throw new Error('Access Token is not a valid URL')
         }
 
         // Check if the URI is in the correct URL format

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -55,7 +55,13 @@ class LocalStorage {
     }
 
     public getEndpoint(): string | null {
-        return this.storage.get<string | null>(this.LAST_USED_ENDPOINT, null)
+        const endpoint = this.storage.get<string | null>(this.LAST_USED_ENDPOINT, null)
+        // Clear last used endpoint if it is a Sourcegraph token
+        if (endpoint && isSourcegraphToken(endpoint)) {
+            this.deleteEndpoint()
+            return null
+        }
+        return endpoint
     }
 
     public async saveEndpoint(endpoint: string): Promise<void> {
@@ -64,9 +70,7 @@ class LocalStorage {
         }
         try {
             // Do not save sourcegraph tokens as the last used endpoint
-            // Clear last used endpoint if it is a sourcegraph token
             if (isSourcegraphToken(endpoint)) {
-                this.deleteEndpoint()
                 return
             }
 
@@ -91,6 +95,11 @@ class LocalStorage {
     }
 
     private async addEndpointHistory(endpoint: string): Promise<void> {
+        // Do not save sourcegraph tokens as endpoint
+        if (isSourcegraphToken(endpoint)) {
+            return
+        }
+
         const history = this.storage.get<string[] | null>(this.CODY_ENDPOINT_HISTORY, null)
         const historySet = new Set(history)
         historySet.delete(endpoint)

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -4,6 +4,7 @@ import type { Memento } from 'vscode'
 import type { ChatHistory, ChatInputHistory, UserLocalHistory } from '@sourcegraph/cody-shared'
 
 import type { AuthStatus } from '../chat/protocol'
+import { isSourcegraphToken } from './AuthProvider'
 
 type ChatHistoryKey = `${string}-${string}`
 type AccountKeyedChatHistory = {
@@ -60,6 +61,12 @@ class LocalStorage {
 
     public async saveEndpoint(endpoint: string): Promise<void> {
         if (!endpoint) {
+            return
+        }
+        // Do not save sourcegraph tokens as the last used endpoint
+        // Clear last used endpoint if it is a sourcegraph token
+        if (isSourcegraphToken(endpoint)) {
+            this.deleteEndpoint()
             return
         }
         try {

--- a/vscode/src/services/LocalStorageProvider.ts
+++ b/vscode/src/services/LocalStorageProvider.ts
@@ -3,8 +3,7 @@ import type { Memento } from 'vscode'
 
 import type { ChatHistory, ChatInputHistory, UserLocalHistory } from '@sourcegraph/cody-shared'
 
-import type { AuthStatus } from '../chat/protocol'
-import { isSourcegraphToken } from './AuthProvider'
+import { isSourcegraphToken, type AuthStatus } from '../chat/protocol'
 
 type ChatHistoryKey = `${string}-${string}`
 type AccountKeyedChatHistory = {
@@ -63,13 +62,14 @@ class LocalStorage {
         if (!endpoint) {
             return
         }
-        // Do not save sourcegraph tokens as the last used endpoint
-        // Clear last used endpoint if it is a sourcegraph token
-        if (isSourcegraphToken(endpoint)) {
-            this.deleteEndpoint()
-            return
-        }
         try {
+            // Do not save sourcegraph tokens as the last used endpoint
+            // Clear last used endpoint if it is a sourcegraph token
+            if (isSourcegraphToken(endpoint)) {
+                this.deleteEndpoint()
+                return
+            }
+
             const uri = new URL(endpoint).href
             await this.storage.update(this.LAST_USED_ENDPOINT, uri)
             await this.addEndpointHistory(uri)


### PR DESCRIPTION
This commit adds validation for sourcegraph tokens in the AuthMenus and AuthProvider files. The showInstanceURLInputBox function in AuthMenus now checks if the user is entering a token as a URL and displays an error message if so. 
Similarly, the formatURL function in AuthProvider now throws an error if the URI is a sourcegraph token, and return `null`.

 Additionally, the LocalStorageProvider file now ignores and clears the last used endpoint if the provided endpoint is a sourcegraph token.

![image](https://github.com/sourcegraph/cody/assets/68532117/c77005be-edd9-4018-9c42-4655baff2782)

Update placeholder value for URL to always starts with `https://` to make it clear that the field is for URL input:

![image](https://github.com/sourcegraph/cody/assets/68532117/cea4f78a-d39e-4819-bc97-a59f6af4c369)



## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->



https://github.com/sourcegraph/cody/assets/68532117/9d44427a-3b8b-4c35-812d-aa5b22120d6d

