### PR TITLE
Agent: add protocol documentation

### DIFF
--- a/.github/workflows/agent-bindings.yml
+++ b/.github/workflows/agent-bindings.yml
@@ -1,4 +1,9 @@
-name: agent-bindings
+# It's OK to disable this CI check if it's causing problems because the
+# JetBrains client team can manually update and maintain the bindings
+# until we fix the automation. This automation should NOT be blocking
+# you from making progress on critical work.
+# Please post in #wg-cody-agent to share feedback about this CI check.
+name: agent-bindings (disable if causing problems)
 on:
   pull_request:
     paths:

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Date.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Date.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName")
 package com.sourcegraph.cody.protocol_generated
 
-typealias Date = Double
+typealias Date = String
 

--- a/agent/protocol.md
+++ b/agent/protocol.md
@@ -1,0 +1,502 @@
+# Cody Agent
+
+The Cody Agent is a JSON-RPC based protocol that allows clients written in any
+programming language to interact with Cody. The Cody Agent currently powers the
+JetBrains and Neovim plugins so it supports the full breadth of features that
+are available in those plugins, including autocomplete, chat, chat-based
+commands, and edit-based commands.
+
+## Base protocol
+
+[JSON-RPC](https://www.jsonrpc.org) is a specification that enables two
+processes runningu on the same computer to communicate with each other using
+JSON and stdout/stdin, TCP, or IPC sockets. The Cody Agent currently only
+supports communication via stdin/stdout.
+
+In simplified terms, JSON-RPC works like the following:
+
+* A JSON-RPC protocol is a list of *methods*
+* A *method* has a string name like `'textDocument/initialize'` or `'initialize'`
+* A *method* can either be a *request* or a *notification*
+* A *request* must be paired with a *response*
+* A *notification* method must not be matched with a response
+* Both the server and the client can send a request or a method
+
+At a low-level, the Cody Agent uses the exact same flavor of JSON-RPC as the Language Server
+Protocol (LSP) does.  The full specification for this flavor of JSON-RPC is
+documented on the [LSP
+website](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#baseProtocol).
+
+While we conventionally refer to the Cody agent as being the "server", it's
+worth noting that JSON-RPC allows the server to initiate requests and
+notifications. This attribute makes JSON-RPC a peer-to-peer architecture, more
+than a traditional client/server architecture for other RPC systems (including
+HTTP).
+
+
+## Protocol methods
+
+<!-- PROTOCOL START -->
+<h2 id="initialize"><a href="#initialize" name="initialize"><code>initialize</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+initialize: [ClientInfo, ServerInfo]
+```
+<h2 id="shutdown"><a href="#shutdown" name="shutdown"><code>shutdown</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+shutdown: [null, null]
+```
+<h2 id="chat_new"><a href="#chat_new" name="chat_new"><code>chat/new</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'chat/new': [null, string]
+```
+<h2 id="chat_restore"><a href="#chat_restore" name="chat_restore"><code>chat/restore</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'chat/restore': [{ modelID: string; messages: ChatMessage[]; chatID: string; }, string]
+```
+<h2 id="chat_models"><a href="#chat_models" name="chat_models"><code>chat/models</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'chat/models': [{ id: string; }, { models: ModelProvider[]; }]
+```
+<h2 id="chat_remoteRepos"><a href="#chat_remoteRepos" name="chat_remoteRepos"><code>chat/remoteRepos</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'chat/remoteRepos': [{ id: string; }, { remoteRepos?: Repo[] | undefined; }]
+```
+<h2 id="chat_submitMessage"><a href="#chat_submitMessage" name="chat_submitMessage"><code>chat/submitMessage</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'chat/submitMessage': [{ id: string; message: WebviewMessage; }, ExtensionMessage]
+```
+<h2 id="chat_editMessage"><a href="#chat_editMessage" name="chat_editMessage"><code>chat/editMessage</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'chat/editMessage': [{ id: string; message: WebviewMessage; }, ExtensionMessage]
+```
+<h2 id="commands_explain"><a href="#commands_explain" name="commands_explain"><code>commands/explain</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'commands/explain': [null, string]
+```
+<h2 id="commands_test"><a href="#commands_test" name="commands_test"><code>commands/test</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'commands/test': [null, string]
+```
+<h2 id="commands_smell"><a href="#commands_smell" name="commands_smell"><code>commands/smell</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'commands/smell': [null, string]
+```
+<h2 id="commands_custom"><a href="#commands_custom" name="commands_custom"><code>commands/custom</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'commands/custom': [{ key: string; }, CustomCommandResult]
+```
+<h2 id="editCommands_test"><a href="#editCommands_test" name="editCommands_test"><code>editCommands/test</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'editCommands/test': [null, EditTask]
+```
+<h2 id="commands_document"><a href="#commands_document" name="commands_document"><code>commands/document</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'commands/document': [null, EditTask]
+```
+<h2 id="command_execute"><a href="#command_execute" name="command_execute"><code>command/execute</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'command/execute': [ExecuteCommandParams, any]
+```
+<h2 id="autocomplete_execute"><a href="#autocomplete_execute" name="autocomplete_execute"><code>autocomplete/execute</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'autocomplete/execute': [AutocompleteParams, AutocompleteResult]
+```
+<h2 id="graphql_getRepoIds"><a href="#graphql_getRepoIds" name="graphql_getRepoIds"><code>graphql/getRepoIds</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'graphql/getRepoIds': [{ names: string[]; first: number; }, { repos: { name: string; id: string; }[]; }]
+```
+<h2 id="graphql_currentUserId"><a href="#graphql_currentUserId" name="graphql_currentUserId"><code>graphql/currentUserId</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'graphql/currentUserId': [null, string]
+```
+<h2 id="graphql_currentUserIsPro"><a href="#graphql_currentUserIsPro" name="graphql_currentUserIsPro"><code>graphql/currentUserIsPro</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'graphql/currentUserIsPro': [null, boolean]
+```
+<h2 id="featureFlags_getFeatureFlag"><a href="#featureFlags_getFeatureFlag" name="featureFlags_getFeatureFlag"><code>featureFlags/getFeatureFlag</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'featureFlags/getFeatureFlag': [{ flagName: string; }, boolean | null]
+```
+<h2 id="graphql_getCurrentUserCodySubscription"><a href="#graphql_getCurrentUserCodySubscription" name="graphql_getCurrentUserCodySubscription"><code>graphql/getCurrentUserCodySubscription</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'graphql/getCurrentUserCodySubscription': [null, CurrentUserCodySubscription | null]
+```
+<h2 id="graphql_logEvent"><a href="#graphql_logEvent" name="graphql_logEvent"><code>graphql/logEvent</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'graphql/logEvent': [event, null]
+```
+<h2 id="telemetry_recordEvent"><a href="#telemetry_recordEvent" name="telemetry_recordEvent"><code>telemetry/recordEvent</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+<p>Description: Record telemetry events.</p>
+
+```ts
+'telemetry/recordEvent': [TelemetryEvent, null]
+```
+<h2 id="graphql_getRepoIdIfEmbeddingExists"><a href="#graphql_getRepoIdIfEmbeddingExists" name="graphql_getRepoIdIfEmbeddingExists"><code>graphql/getRepoIdIfEmbeddingExists</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'graphql/getRepoIdIfEmbeddingExists': [{ repoName: string; }, string | null]
+```
+<h2 id="graphql_getRepoId"><a href="#graphql_getRepoId" name="graphql_getRepoId"><code>graphql/getRepoId</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'graphql/getRepoId': [{ repoName: string; }, string | null]
+```
+<h2 id="check_isCodyIgnoredFile"><a href="#check_isCodyIgnoredFile" name="check_isCodyIgnoredFile"><code>check/isCodyIgnoredFile</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+<p>Description: Checks if a given set of URLs includes a Cody ignored file.</p>
+
+```ts
+'check/isCodyIgnoredFile': [{ urls: string[]; }, boolean]
+```
+<h2 id="git_codebaseName"><a href="#git_codebaseName" name="git_codebaseName"><code>git/codebaseName</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'git/codebaseName': [{ url: string; }, string | null]
+```
+<h2 id="webview_didDispose"><a href="#webview_didDispose" name="webview_didDispose"><code>webview/didDispose</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'webview/didDispose': [{ id: string; }, null]
+```
+<h2 id="webview_receiveMessage"><a href="#webview_receiveMessage" name="webview_receiveMessage"><code>webview/receiveMessage</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'webview/receiveMessage': [{ id: string; message: WebviewMessage; }, null]
+```
+<h2 id="testing_progress"><a href="#testing_progress" name="testing_progress"><code>testing/progress</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'testing/progress': [{ title: string; }, { result: string; }]
+```
+<h2 id="testing_networkRequests"><a href="#testing_networkRequests" name="testing_networkRequests"><code>testing/networkRequests</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'testing/networkRequests': [null, { requests: NetworkRequest[]; }]
+```
+<h2 id="testing_requestErrors"><a href="#testing_requestErrors" name="testing_requestErrors"><code>testing/requestErrors</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'testing/requestErrors': [null, { errors: NetworkRequest[]; }]
+```
+<h2 id="testing_progressCancelation"><a href="#testing_progressCancelation" name="testing_progressCancelation"><code>testing/progressCancelation</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'testing/progressCancelation': [{ title: string; }, { result: string; }]
+```
+<h2 id="testing_reset"><a href="#testing_reset" name="testing_reset"><code>testing/reset</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'testing/reset': [null, null]
+```
+<h2 id="extensionConfiguration_change"><a href="#extensionConfiguration_change" name="extensionConfiguration_change"><code>extensionConfiguration/change</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'extensionConfiguration/change': [ExtensionConfiguration, AuthStatus | null]
+```
+<h2 id="extensionConfiguration_status"><a href="#extensionConfiguration_status" name="extensionConfiguration_status"><code>extensionConfiguration/status</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'extensionConfiguration/status': [null, AuthStatus | null]
+```
+<h2 id="attribution_search"><a href="#attribution_search" name="attribution_search"><code>attribution/search</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the client to client server.</p>
+
+
+```ts
+'attribution/search': [{ id: string; snippet: string; }, { error: string | null; repoNames: string[]; limitHit: boolean; }]
+```
+<h2 id="initialized"><a href="#initialized" name="initialized"><code>initialized</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+initialized: [null]
+```
+<h2 id="exit"><a href="#exit" name="exit"><code>exit</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+exit: [null]
+```
+<h2 id="extensionConfiguration_didChange"><a href="#extensionConfiguration_didChange" name="extensionConfiguration_didChange"><code>extensionConfiguration/didChange</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'extensionConfiguration/didChange': [ExtensionConfiguration]
+```
+<h2 id="textDocument_didOpen"><a href="#textDocument_didOpen" name="textDocument_didOpen"><code>textDocument/didOpen</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'textDocument/didOpen': [ProtocolTextDocument]
+```
+<h2 id="textDocument_didChange"><a href="#textDocument_didChange" name="textDocument_didChange"><code>textDocument/didChange</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'textDocument/didChange': [ProtocolTextDocument]
+```
+<h2 id="textDocument_didFocus"><a href="#textDocument_didFocus" name="textDocument_didFocus"><code>textDocument/didFocus</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'textDocument/didFocus': [{ uri: string; }]
+```
+<h2 id="textDocument_didSave"><a href="#textDocument_didSave" name="textDocument_didSave"><code>textDocument/didSave</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'textDocument/didSave': [{ uri: string; }]
+```
+<h2 id="textDocument_didClose"><a href="#textDocument_didClose" name="textDocument_didClose"><code>textDocument/didClose</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'textDocument/didClose': [ProtocolTextDocument]
+```
+<h2 id="workspace_didDeleteFiles"><a href="#workspace_didDeleteFiles" name="workspace_didDeleteFiles"><code>workspace/didDeleteFiles</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'workspace/didDeleteFiles': [DeleteFilesParams]
+```
+<h2 id="workspace_didCreateFiles"><a href="#workspace_didCreateFiles" name="workspace_didCreateFiles"><code>workspace/didCreateFiles</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'workspace/didCreateFiles': [CreateFilesParams]
+```
+<h2 id="workspace_didRenameFiles"><a href="#workspace_didRenameFiles" name="workspace_didRenameFiles"><code>workspace/didRenameFiles</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'workspace/didRenameFiles': [RenameFilesParams]
+```
+<h2 id="cancelRequest"><a href="#cancelRequest" name="cancelRequest"><code>$/cancelRequest</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'$/cancelRequest': [CancelParams]
+```
+<h2 id="autocomplete_clearLastCandidate"><a href="#autocomplete_clearLastCandidate" name="autocomplete_clearLastCandidate"><code>autocomplete/clearLastCandidate</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'autocomplete/clearLastCandidate': [null]
+```
+<h2 id="autocomplete_completionSuggested"><a href="#autocomplete_completionSuggested" name="autocomplete_completionSuggested"><code>autocomplete/completionSuggested</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'autocomplete/completionSuggested': [CompletionItemParams]
+```
+<h2 id="autocomplete_completionAccepted"><a href="#autocomplete_completionAccepted" name="autocomplete_completionAccepted"><code>autocomplete/completionAccepted</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'autocomplete/completionAccepted': [CompletionItemParams]
+```
+<h2 id="progress_cancel"><a href="#progress_cancel" name="progress_cancel"><code>progress/cancel</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the client to client server.</p>
+
+
+```ts
+'progress/cancel': [{ id: string; }]
+```
+<h2 id="window_showMessage"><a href="#window_showMessage" name="window_showMessage"><code>window/showMessage</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the server to the client.</p>
+
+
+```ts
+'window/showMessage': [ShowWindowMessageParams, string | null]
+```
+<h2 id="textDocument_edit"><a href="#textDocument_edit" name="textDocument_edit"><code>textDocument/edit</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the server to the client.</p>
+
+
+```ts
+'textDocument/edit': [TextDocumentEditParams, boolean]
+```
+<h2 id="textDocument_openUntitledDocument"><a href="#textDocument_openUntitledDocument" name="textDocument_openUntitledDocument"><code>textDocument/openUntitledDocument</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the server to the client.</p>
+
+
+```ts
+'textDocument/openUntitledDocument': [UntitledTextDocument, boolean]
+```
+<h2 id="textDocument_show"><a href="#textDocument_show" name="textDocument_show"><code>textDocument/show</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the server to the client.</p>
+
+
+```ts
+'textDocument/show': [{ uri: string; options?: TextDocumentShowOptions | undefined; }, boolean]
+```
+<h2 id="workspace_edit"><a href="#workspace_edit" name="workspace_edit"><code>workspace/edit</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the server to the client.</p>
+
+
+```ts
+'workspace/edit': [WorkspaceEditParams, boolean]
+```
+<h2 id="webview_create"><a href="#webview_create" name="webview_create"><code>webview/create</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Request sent from the server to the client.</p>
+
+
+```ts
+'webview/create': [{ id: string; data: any; }, null]
+```
+<h2 id="debug_message"><a href="#debug_message" name="debug_message"><code>debug/message</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the server to the client.</p>
+
+
+```ts
+'debug/message': [DebugMessage]
+```
+<h2 id="editTaskState_didChange"><a href="#editTaskState_didChange" name="editTaskState_didChange"><code>editTaskState/didChange</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the server to the client.</p>
+
+
+```ts
+'editTaskState/didChange': [EditTask]
+```
+<h2 id="codeLenses_display"><a href="#codeLenses_display" name="codeLenses_display"><code>codeLenses/display</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the server to the client.</p>
+
+
+```ts
+'codeLenses/display': [DisplayCodeLensParams]
+```
+<h2 id="webview_postMessage"><a href="#webview_postMessage" name="webview_postMessage"><code>webview/postMessage</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the server to the client.</p>
+
+
+```ts
+'webview/postMessage': [WebviewPostMessageParams]
+```
+<h2 id="progress_start"><a href="#progress_start" name="progress_start"><code>progress/start</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the server to the client.</p>
+
+
+```ts
+'progress/start': [ProgressStartParams]
+```
+<h2 id="progress_report"><a href="#progress_report" name="progress_report"><code>progress/report</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the server to the client.</p>
+
+
+```ts
+'progress/report': [ProgressReportParams]
+```
+<h2 id="progress_end"><a href="#progress_end" name="progress_end"><code>progress/end</code> (<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">)</a></h2>
+<p>Notification sent from the server to the client.</p>
+
+
+```ts
+'progress/end': [{ id: string; }]
+```
+<!-- PROTOCOL END -->

--- a/agent/src/cli/scip-codegen/BaseCodegen.ts
+++ b/agent/src/cli/scip-codegen/BaseCodegen.ts
@@ -1,0 +1,264 @@
+import { scip } from './scip'
+import type { SymbolTable } from './SymbolTable'
+import { typescriptKeyword } from './utils'
+import type * as pb_1 from 'google-protobuf'
+import type { ConsoleReporter } from './ConsoleReporter'
+import type { CodegenOptions } from './command'
+
+export enum ProtocolMethodDirection {
+    ClientToServer = 1,
+    ServerToClient = 2,
+}
+
+export enum ProtocolMethodKind {
+    Notification = 1,
+    Request = 2,
+}
+
+export interface ProtocolSymbol {
+    symbol: string
+    direction: ProtocolMethodDirection
+    kind: ProtocolMethodKind
+}
+
+export abstract class BaseCodegen {
+    public siblingDiscriminatedUnionProperties = new Map<string, string[]>()
+    public static protocolSymbols = {
+        client: {
+            requests: 'cody-ai src/jsonrpc/`agent-protocol.ts`/ClientRequests#',
+            notifications: 'cody-ai src/jsonrpc/`agent-protocol.ts`/ClientNotifications#',
+        },
+        server: {
+            requests: 'cody-ai src/jsonrpc/`agent-protocol.ts`/ServerRequests#',
+            notifications: 'cody-ai src/jsonrpc/`agent-protocol.ts`/ServerNotifications#',
+        },
+    }
+    public allProtocolSymbols(): ProtocolSymbol[] {
+        return [
+            {
+                symbol: BaseCodegen.protocolSymbols.client.requests,
+                direction: ProtocolMethodDirection.ClientToServer,
+                kind: ProtocolMethodKind.Request,
+            },
+            {
+                symbol: BaseCodegen.protocolSymbols.client.notifications,
+                direction: ProtocolMethodDirection.ClientToServer,
+                kind: ProtocolMethodKind.Notification,
+            },
+            {
+                symbol: BaseCodegen.protocolSymbols.server.requests,
+                direction: ProtocolMethodDirection.ServerToClient,
+                kind: ProtocolMethodKind.Request,
+            },
+            {
+                symbol: BaseCodegen.protocolSymbols.server.notifications,
+                direction: ProtocolMethodDirection.ServerToClient,
+                kind: ProtocolMethodKind.Notification,
+            },
+        ].map(symbol => ({ ...symbol, symbol: this.symtab.canonicalSymbol(symbol.symbol) }))
+    }
+
+    constructor(
+        public readonly options: CodegenOptions,
+        public readonly symtab: SymbolTable,
+        public readonly reporter: ConsoleReporter
+    ) {}
+
+    public abstract run(): Promise<void>
+
+    // Intentionally not private to prevent "unused method" warnings.
+    public debug(msg: pb_1.Message, params?: { verbose: boolean }): string {
+        if (params?.verbose) {
+            return JSON.stringify(
+                {
+                    message: msg.toObject(),
+                    debug: this.symtab.debuggingInfo.map(({ line, info }) => ({
+                        line,
+                        info: info.toObject(),
+                    })),
+                },
+                null,
+                2
+            )
+        }
+        return JSON.stringify(msg.toObject(), null, 2)
+    }
+
+    protected isStringType(type: scip.Type): boolean {
+        if (type.has_constant_type) {
+            return type.constant_type.constant.has_string_constant
+        }
+
+        if (type.has_union_type) {
+            return type.union_type.types.every(type => this.isStringType(type))
+        }
+
+        if (type.has_intersection_type) {
+            return Boolean(
+                type.intersection_type.types.find(
+                    type => type.has_type_ref && type.type_ref.symbol === typescriptKeyword('string')
+                )
+            )
+        }
+
+        if (type.has_type_ref) {
+            return (
+                type.type_ref.symbol === typescriptKeyword('string') ||
+                this.isStringTypeInfo(this.symtab.info(type.type_ref.symbol))
+            )
+        }
+
+        return false
+    }
+
+    protected isStringTypeInfo(info: scip.SymbolInformation): boolean {
+        if (info.signature.has_value_signature) {
+            return this.isStringType(info.signature.value_signature.tpe)
+        }
+
+        if (
+            info.signature.has_type_signature &&
+            info.signature.type_signature.type_parameters &&
+            info.signature.type_signature.type_parameters.symlinks.length === 0
+        ) {
+            return this.isStringType(info.signature.type_signature.lower_bound)
+        }
+
+        if (info.signature.has_class_signature && info.kind === scip.SymbolInformation.Kind.Enum) {
+            return info.signature.class_signature.declarations.symlinks.every(member =>
+                this.isStringTypeInfo(this.symtab.info(member))
+            )
+        }
+
+        return false
+    }
+
+    public compatibleSignatures(a: scip.SymbolInformation, b: scip.SymbolInformation): boolean {
+        if (this.isStringTypeInfo(a) && this.isStringTypeInfo(b)) {
+            return true
+        }
+        // TODO: more optimized comparison?
+        return JSON.stringify(a.signature.toObject()) === JSON.stringify(b.signature.toObject())
+    }
+
+    protected infoProperties(info: scip.SymbolInformation): string[] {
+        if (info.signature.has_class_signature) {
+            const result: string[] = []
+            result.push(...info.signature.class_signature.declarations.symlinks)
+            for (const parent of info.signature.class_signature.parents) {
+                result.push(...this.properties(parent))
+            }
+            return result
+        }
+
+        if (info.signature.has_type_signature) {
+            return this.properties(info.signature.type_signature.lower_bound)
+        }
+
+        this.reporter.error(info.symbol, `info has no properties: ${this.debug(info)}`)
+        return []
+    }
+
+    protected stringConstantsFromType(type: scip.Type): string[] {
+        return this.stringConstantsFromInfo(
+            new scip.SymbolInformation({
+                signature: new scip.Signature({
+                    value_signature: new scip.ValueSignature({ tpe: type }),
+                }),
+            })
+        )
+    }
+    protected stringConstantsFromInfo(info: scip.SymbolInformation): string[] {
+        const result: string[] = []
+        const isVisited = new Set<string>()
+        const visitInfo = (info: scip.SymbolInformation) => {
+            if (isVisited.has(info.symbol)) {
+                return
+            }
+            isVisited.add(info.symbol)
+            for (const sibling of this.siblingDiscriminatedUnionProperties.get(info.symbol) ?? []) {
+                visitInfo(this.symtab.info(sibling))
+            }
+            if (info.signature.has_value_signature) {
+                visitType(info.signature.value_signature.tpe)
+                return
+            }
+            if (info.signature.has_type_signature) {
+                visitType(info.signature.type_signature.lower_bound)
+                return
+            }
+            if (info.signature.has_class_signature && info.kind === scip.SymbolInformation.Kind.Enum) {
+                for (const member of info.signature.class_signature.declarations.symlinks) {
+                    visitInfo(this.symtab.info(member))
+                }
+                return
+            }
+            return info.symbol === typescriptKeyword('string')
+        }
+        const visitType = (type: scip.Type) => {
+            if (type.has_constant_type && type.constant_type.constant.has_string_constant) {
+                result.push(type.constant_type.constant.string_constant.value)
+            }
+            if (type.has_union_type) {
+                for (const constant of type.union_type.types) {
+                    visitType(constant)
+                }
+            }
+            if (type.has_type_ref) {
+                visitInfo(this.symtab.info(type.type_ref.symbol))
+            }
+        }
+        visitInfo(info)
+        return result
+    }
+
+    protected pickProperties(type: scip.Type): string[] {
+        const [t, k] = type.type_ref.type_arguments
+        const constants = new Set<string>(this.stringConstantsFromType(k))
+        return this.properties(t).filter(property =>
+            constants.has(this.symtab.info(property).display_name)
+        )
+    }
+
+    protected omitProperties(type: scip.Type): string[] {
+        const [t, k] = type.type_ref.type_arguments
+        const constants = new Set<string>(this.stringConstantsFromType(k))
+        return this.properties(t).filter(
+            property => !constants.has(this.symtab.info(property).display_name)
+        )
+    }
+
+    protected properties(type: scip.Type): string[] {
+        if (type.has_structural_type) {
+            return type.structural_type.declarations.symlinks
+        }
+
+        if (type.has_intersection_type) {
+            return type.intersection_type.types.flatMap(intersectionType =>
+                this.properties(intersectionType)
+            )
+        }
+
+        if (type.has_union_type) {
+            return type.union_type.types.flatMap(unionType => this.properties(unionType))
+        }
+
+        if (type.has_type_ref) {
+            if (type.type_ref.symbol.endsWith(' lib/`lib.es5.d.ts`/Pick#')) {
+                return this.pickProperties(type)
+            }
+            if (type.type_ref.symbol.endsWith(' lib/`lib.es5.d.ts`/Omit#')) {
+                return this.omitProperties(type)
+            }
+            return this.infoProperties(this.symtab.info(type.type_ref.symbol))
+        }
+
+        // NOTE: we must not return [] for non-class-like types such as string
+        // literals. If you're hitting on this error with types like string
+        // literals it means you are not guarding against it higher up in the
+        // call stack.
+        // throw new TypeError(`type has no properties: ${this.debug(type)}`)
+        this.reporter.error('', `type has no properties: ${this.debug(type)}`)
+        return []
+    }
+}

--- a/agent/src/cli/scip-codegen/MarkdownCodegen.ts
+++ b/agent/src/cli/scip-codegen/MarkdownCodegen.ts
@@ -1,0 +1,85 @@
+import fspromises from 'fs/promises'
+import {
+    BaseCodegen,
+    ProtocolMethodDirection,
+    ProtocolMethodKind,
+    type ProtocolSymbol,
+} from './BaseCodegen'
+import type { scip } from './scip'
+import dedent from 'dedent'
+
+export class MarkdownCodegen extends BaseCodegen {
+    public async run(): Promise<void> {
+        const text = (await fspromises.readFile(this.options.output, 'utf-8')).toString()
+        const startMarker = '<!-- PROTOCOL START -->'
+        const startOffset = findMarkerOffset(text, startMarker)
+        const endOffset = findMarkerOffset(text, '<!-- PROTOCOL END -->')
+        const docs: string[] = []
+        for (const protocolSymbol of this.allProtocolSymbols()) {
+            for (const method of this.symtab.structuralType(protocolSymbol.symbol)) {
+                const doc = this.formatJsonrpcMethod(protocolSymbol, method)
+                if (doc) {
+                    docs.push(doc)
+                }
+            }
+        }
+        await fspromises.writeFile(
+            this.options.output,
+            [
+                text.substring(0, startOffset + startMarker.length),
+                ...docs,
+                text.substring(endOffset),
+            ].join('\n')
+        )
+    }
+
+    private formatJsonrpcMethod(protocolSymbol: ProtocolSymbol, method: scip.SymbolInformation): string {
+        let signature = method.documentation.find(doc => doc.startsWith('```ts')) ?? ''
+        if (!signature) {
+            return ''
+        }
+        signature = signature.replace('(property) ', '')
+
+        let docstring = method.documentation.find(doc => !doc.startsWith('```ts')) ?? ''
+        if (docstring) {
+            docstring = `<p>Description: ${docstring}</p>`
+        }
+        const kind = ProtocolMethodKind[protocolSymbol.kind]
+        const direction =
+            protocolSymbol.direction === ProtocolMethodDirection.ClientToServer
+                ? `${kind} sent from the client to client server.`
+                : `${kind} sent from the server to the client.`
+        const id = method.display_name.replace('$/', '').replace('/', '_')
+        const icon = protocolSymbol.kind === ProtocolMethodKind.Request ? requestIcon : notificationIcon
+        return dedent`<h2 id="${id}"><a href="#${id}" name="${id}"><code>${method.display_name}</code> (${icon})</a></h2>
+               <p>${direction}</p>
+               ${docstring}
+
+               ${signature}
+               `
+    }
+}
+const requestIcon = `<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">`
+const notificationIcon = `<img class="emoji" title=":arrow_right:" alt=":arrow_right:" src="https://github.githubassets.com/images/icons/emoji/unicode/27a1.png" height="20" width="20">`
+
+export function stripPrefix(text: string, prefix: string): string {
+    if (text.startsWith(prefix)) {
+        return text.slice(prefix.length)
+    }
+    return text
+}
+
+export function stripSuffix(text: string, suffix: string): string {
+    if (text.endsWith(suffix)) {
+        return text.slice(0, text.length - suffix.length)
+    }
+    return text
+}
+
+export function findMarkerOffset(text: string, marker: string): number {
+    const index = text.indexOf(marker)
+    if (index < 0) {
+        throw new Error('missing marker: ' + marker)
+    }
+    return index
+}

--- a/agent/src/cli/scip-codegen/command.ts
+++ b/agent/src/cli/scip-codegen/command.ts
@@ -1,9 +1,11 @@
 import fspromises from 'fs/promises'
-import { Command } from 'commander'
+import { Command, InvalidOptionArgumentError, Option } from 'commander'
 import { KotlinCodegen } from './KotlinCodegen'
 import { scip } from './scip'
 import { SymbolTable } from './SymbolTable'
 import { ConsoleReporter } from './ConsoleReporter'
+import type { BaseCodegen } from './BaseCodegen'
+import { MarkdownCodegen } from './MarkdownCodegen'
 
 export interface CodegenOptions {
     input: string
@@ -14,10 +16,32 @@ export interface CodegenOptions {
     severity: string
 }
 
+enum CodegenLanguage {
+    Kotlin = 'kotlin',
+    Markdown = 'markdown',
+}
+
+function languageOption(value: string): CodegenLanguage {
+    switch (value) {
+        case 'kotlin':
+            return CodegenLanguage.Kotlin
+        case 'markdown':
+            return CodegenLanguage.Markdown
+        default:
+            throw new InvalidOptionArgumentError(
+                `Invalid language. Valid options are ${CodegenLanguage.Kotlin}.`
+            )
+    }
+}
+
 const command = new Command('scip-codegen')
     .option('--input <path>', 'path to SCIP file', 'index.scip')
     .option('--output <directory>', 'path where to generate bindings')
-    .option('--language <value>', 'what programming language to generate the bindings', 'kotlin')
+    .addOption(
+        new Option('--language <value>', 'what programming language to generate the bindings')
+            .argParser(languageOption)
+            .default(CodegenLanguage.Kotlin)
+    )
     .option('--protocol <value>', 'what protocol to generate bindings for', 'agent')
     .option('--severity <warning|error>', 'what protocol to generate bindings for', 'error')
     .option(
@@ -26,23 +50,30 @@ const command = new Command('scip-codegen')
         'com.sourcegraph.cody.protocol_generated'
     )
     .action(async (options: CodegenOptions) => {
-        const bytes = await fspromises.readFile(options.input)
-        if (options.language === 'kotlin') {
-            const index = scip.Index.deserialize(bytes)
-            const symtab = new SymbolTable(index)
-            const reporter = new ConsoleReporter(index, { severity: options.severity as any })
-            const codegen = new KotlinCodegen(options, symtab, reporter)
-            await codegen.run()
+        const codegen = await initializeCodegen(options)
 
-            if (reporter.hasErrors()) {
-                reporter.reportErrorCount()
-                process.exit(1)
-            }
-        } else {
-            console.error(`unknown language: ${options.language}`)
+        await codegen.run()
+
+        if (codegen.reporter.hasErrors()) {
+            codegen.reporter.reportErrorCount()
             process.exit(1)
         }
     })
+
+async function initializeCodegen(options: CodegenOptions): Promise<BaseCodegen> {
+    const bytes = await fspromises.readFile(options.input)
+    const index = scip.Index.deserialize(bytes)
+    const symtab = new SymbolTable(index)
+    const reporter = new ConsoleReporter(index, { severity: options.severity as any })
+    switch (options.language) {
+        case CodegenLanguage.Kotlin:
+            return new KotlinCodegen(options, symtab, reporter)
+        case CodegenLanguage.Markdown:
+            return new MarkdownCodegen(options, symtab, reporter)
+        default:
+            throw new Error(`unknown language: ${options.language}`)
+    }
+}
 
 const args = process.argv.slice(2)
 

--- a/agent/src/cli/scip-codegen/resetOutputPath.ts
+++ b/agent/src/cli/scip-codegen/resetOutputPath.ts
@@ -1,0 +1,11 @@
+import fspromises from 'fs/promises'
+
+export async function resetOutputPath(outputPath: string): Promise<void> {
+    try {
+        await fspromises.stat(outputPath)
+        await fspromises.rm(outputPath, { recursive: true })
+    } catch {
+        // ignore
+    }
+    await fspromises.mkdir(outputPath, { recursive: true })
+}


### PR DESCRIPTION
Previously, we didn't have any clearly written high-level overview of the Cody Agent protocol. As we are increasingly relying on this protocol for different use-cases (JetBrains plugin, ML evaluations, testing), it's worth investing time into documenting the protocol.


## Test plan

Green CI
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
