### PR TITLE
VSCode: Support login redirects in VSCodium

### DIFF
--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -40,7 +40,9 @@
 }
 
 /* Style @-file tokens to match TranscriptAction context files */
-.content a[href^="vscode://file"] em
+.content a[href^="vscode://file"] em,
+.content a[href^="vscode-insiders://file"] em
+.content a[href^="vscodium://file"] em
 {
     padding: 1px 2px;
     box-sizing: border-box;

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -52,6 +52,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: Support `@-mentioned` in mid sentences. [pull/3043](https://github.com/sourcegraph/cody/pull/3043)
 - Chat: Support `@-mentioned` in editing mode. [pull/3091](https://github.com/sourcegraph/cody/pull/3091)
+- Chat: Added support for `@-mentioned files` in mid sentences. [pull/3043](https://github.com/sourcegraph/cody/pull/3043)
+- Login works in VSCodium. [pull/3167](https://github.com/sourcegraph/cody/pull/3167)
 
 ### Fixed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Edit: Added keyboard shortcuts for codelens actions such as "Undo" and "Retry" [pull/2757][https://github.com/sourcegraph/cody/pull/2757]
 - Chat: Displays warnings for large @-mentioned files during selection. [pull/3118](https://github.com/sourcegraph/cody/pull/3118)
+- Login works in VSCodium. [pull/3167](https://github.com/sourcegraph/cody/pull/3167)
 
 ### Fixed
 
@@ -52,8 +53,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: Support `@-mentioned` in mid sentences. [pull/3043](https://github.com/sourcegraph/cody/pull/3043)
 - Chat: Support `@-mentioned` in editing mode. [pull/3091](https://github.com/sourcegraph/cody/pull/3091)
-- Chat: Added support for `@-mentioned files` in mid sentences. [pull/3043](https://github.com/sourcegraph/cody/pull/3043)
-- Login works in VSCodium. [pull/3167](https://github.com/sourcegraph/cody/pull/3167)
 
 ### Fixed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Edit: Added keyboard shortcuts for codelens actions such as "Undo" and "Retry" [pull/2757][https://github.com/sourcegraph/cody/pull/2757]
 - Chat: Displays warnings for large @-mentioned files during selection. [pull/3118](https://github.com/sourcegraph/cody/pull/3118)
-- Login works in VSCodium. [pull/3167](https://github.com/sourcegraph/cody/pull/3167)
+- Once [sourcegraph/sourcegraph#60515](https://github.com/sourcegraph/sourcegraph/pull/60515) is deployed, login works in VSCodium. [pull/3167](https://github.com/sourcegraph/cody/pull/3167)
 
 ### Fixed
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -435,7 +435,7 @@ const register = async (
             }
         ),
 
-        // Register URI Handler (vscode://sourcegraph.cody-ai)
+        // Register URI Handler (e.g. vscode://sourcegraph.cody-ai)
         vscode.window.registerUriHandler({
             handleUri: async (uri: vscode.Uri) => {
                 if (uri.path === '/app-done') {

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -29,8 +29,11 @@ async function openExternalAuthUrl(provider: AuthMethod): Promise<boolean> {
     // 2. Post-sign up survery redirects to the new token page
     // 3. New token page redirects back to the extension with the new token
     const uriScheme = vscode.env.uriScheme
-    const isInsiders = uriScheme === 'vscode-insiders'
-    const referralCode = isInsiders ? 'CODY_INSIDERS' : 'CODY'
+    const referralCode =
+        {
+            'vscode-insiders': 'CODY_INSIDERS',
+            vscodium: 'CODY_VSCODIUM',
+        }[uriScheme] || 'CODY'
     const newTokenUrl = `/user/settings/tokens/new/callback?requestFrom=${referralCode}`
     const postSignUpSurveyUrl = `/post-sign-up?returnTo=${newTokenUrl}`
     const site = DOTCOM_URL.toString() // Note, ends with the path /


### PR DESCRIPTION
VSCodium is a fork of VSCode. It uses a different URI scheme for app links; as a result, our login flow does not work in VSCodium. This changes the login querystring parameter so the browser-based auth flow can redirect to VSCodium when the flow is complete.

sourcegraph/sourcegraph#60515 is the related server-side change.

Fixes #3119, #2704

## Test plan

Manually test that login URLs have the CODY_VSCODIUM parameter in VSCodium:

1. `CODY_RELEASE_TYPE=stable pnpm -C vscode release:dry-run`
2. Install [VSCodium](https://vscodium.com/), run it.
3. Extensions, ..., Install from VSIX...
4. Pick `vscode/dist/cody.vsix`
5. Click the GitHub login button. You should get directed to a URL like: `https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=CODY_VSCODIUM` (note the *VSCODIUM* part.)