### PR TITLE
Autocomplete: ship single-multiline requests

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -31,8 +31,6 @@ export enum FeatureFlag {
     CodyAutocompleteHotStreak = 'cody-autocomplete-hot-streak',
     // Connects to Cody Gateway directly and skips the Sourcegraph instance hop for completions
     CodyAutocompleteFastPath = 'cody-autocomplete-fast-path',
-    // Trigger only one request for every multiline completion instead of three.
-    CodyAutocompleteSingleMultilineRequest = 'cody-autocomplete-single-multiline-request',
 
     // Enable Cody PLG features on JetBrains
     CodyProJetBrains = 'cody-pro-jetbrains',

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -21,6 +21,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Enable the recent jaccard similarity improvements by default. [pull/3135](https://github.com/sourcegraph/cody/pull/3135)
 - Autocomplete: Start retrieval phase earlier to improve latency. [pull/3149](https://github.com/sourcegraph/cody/pull/3149)
 - Command: Leading slashes are removed from command names in the command menu. [pull/3061](https://github.com/sourcegraph/cody/pull/3061)
+- Autocomplete: Trigger one LLM request instead of three for multiline completions to reduce the response latency. [pull/3176](https://github.com/sourcegraph/cody/pull/3176)
 
 ## [1.4.4]
 

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -13,7 +13,6 @@ class CompletionProviderConfig {
         FeatureFlag.CodyAutocompleteContextBfgMixed,
         FeatureFlag.CodyAutocompleteDynamicMultilineCompletions,
         FeatureFlag.CodyAutocompleteHotStreak,
-        FeatureFlag.CodyAutocompleteSingleMultilineRequest,
         FeatureFlag.CodyAutocompleteFastPath,
         FeatureFlag.CodyAutocompleteUserLatency,
         FeatureFlag.CodyAutocompleteEagerCancellation,

--- a/vscode/src/completions/get-inline-completions-tests/common.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/common.test.ts
@@ -83,7 +83,6 @@ describe('[getInlineCompletions] common', () => {
                 }
             )
         )
-        expect(requests).toHaveLength(3)
         const messages = requests[0].messages
         expect(messages.at(-1)!.text).toBe('<CODE5711>class Range {')
     })

--- a/vscode/src/completions/get-inline-completions-tests/helpers.ts
+++ b/vscode/src/completions/get-inline-completions-tests/helpers.ts
@@ -362,13 +362,14 @@ expect.extend({
         const { isNot } = this
 
         return {
-            pass:
-                requests.length === 3 && isEqual(requests[0]?.stopSequences, MULTI_LINE_STOP_SEQUENCES),
+            pass: isEqual(requests[0]?.stopSequences, MULTI_LINE_STOP_SEQUENCES),
             message: () => `Completion requests are${isNot ? ' not' : ''} multi-line`,
             actual: requests.map(r => ({ stopSequences: r.stopSequences })),
-            expected: Array.from({ length: 3 }).map(() => ({
-                stopSequences: MULTI_LINE_STOP_SEQUENCES,
-            })),
+            expected: [
+                {
+                    stopSequences: MULTI_LINE_STOP_SEQUENCES,
+                },
+            ],
         }
     },
 })

--- a/vscode/src/completions/get-inline-completions-tests/languages.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/languages.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from 'vitest'
 import type { CompletionParameters } from '@sourcegraph/cody-shared'
 
 import { completion } from '../test-helpers'
-import { MULTILINE_STOP_SEQUENCE } from '../text-processing'
 
 import { getInlineCompletionsInsertText, params } from './helpers'
 

--- a/vscode/src/completions/get-inline-completions-tests/languages.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/languages.test.ts
@@ -37,8 +37,7 @@ describe('[getInlineCompletions] languages', () => {
                 }
             )
         )
-        expect(requests).toHaveLength(3)
-        expect(requests[0].stopSequences).not.toContain(MULTILINE_STOP_SEQUENCE)
+        expect(requests).toBeMultiLine()
         expect(items[0]).toMatchInlineSnapshot(`
           "print(i)
               elif i % 3 == 0:
@@ -79,8 +78,7 @@ describe('[getInlineCompletions] languages', () => {
                 }
             )
         )
-        expect(requests).toHaveLength(3)
-        expect(requests[0].stopSequences).not.toContain(MULTILINE_STOP_SEQUENCE)
+        expect(requests).toBeMultiLine()
         expect(items[0]).toMatchInlineSnapshot(`
           "System.out.println(i);
               } else if (i % 3 == 0) {
@@ -130,8 +128,7 @@ describe('[getInlineCompletions] languages', () => {
                 }
             )
         )
-        expect(requests).toHaveLength(3)
-        expect(requests[0].stopSequences).not.toContain(MULTILINE_STOP_SEQUENCE)
+        expect(requests).toBeMultiLine()
         expect(items[0]).toMatchInlineSnapshot(`
                 "Console.WriteLine(i);
                     }"
@@ -169,8 +166,7 @@ describe('[getInlineCompletions] languages', () => {
                 }
             )
         )
-        expect(requests).toHaveLength(3)
-        expect(requests[0].stopSequences).not.toContain(MULTILINE_STOP_SEQUENCE)
+        expect(requests).toBeMultiLine()
         expect(items[0]).toMatchInlineSnapshot(`
           "std::cout << i;
               } else if (i % 3 == 0) {
@@ -212,8 +208,8 @@ describe('[getInlineCompletions] languages', () => {
                 }
             )
         )
-        expect(requests).toHaveLength(3)
-        expect(requests[0].stopSequences).not.toContain(MULTILINE_STOP_SEQUENCE)
+
+        expect(requests).toBeMultiLine()
         expect(items[0]).toMatchInlineSnapshot(`
           "printf("%d", i);
               } else if (i % 3 == 0) {
@@ -256,8 +252,7 @@ describe('[getInlineCompletions] languages', () => {
             )
         )
 
-        expect(requests).toHaveLength(3)
-        expect(requests[0].stopSequences).not.toContain(MULTILINE_STOP_SEQUENCE)
+        expect(requests).toBeMultiLine()
         expect(items[0]).toMatchInlineSnapshot(`
           "echo $i;
               } else if ($i % 3 == 0) {
@@ -300,8 +295,7 @@ describe('[getInlineCompletions] languages', () => {
             )
         )
 
-        expect(requests).toHaveLength(3)
-        expect(requests[0].stopSequences).not.toContain(MULTILINE_STOP_SEQUENCE)
+        expect(requests).toBeMultiLine()
         expect(items[0]).toMatchInlineSnapshot(`
               "print(i);
                   } else if (i % 3 == 0) {

--- a/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
@@ -301,7 +301,10 @@ for (const isTreeSitterEnabled of cases) {
                             console.log('bar')
                         }┤
                     ┴┴┴┴`,
-                        ]
+                        ],
+                        {
+                            providerOptions: { n: 2 },
+                        }
                     )
                 )
 

--- a/vscode/src/completions/get-inline-completions-tests/post-processing.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/post-processing.test.ts
@@ -82,7 +82,10 @@ for (const isTreeSitterEnabled of cases) {
                         completion`
                         ├console.log('foo')┤
                     `,
-                    ]
+                    ],
+                    {
+                        providerOptions: { n: 3 },
+                    }
                 )
             )
 
@@ -175,7 +178,10 @@ for (const isTreeSitterEnabled of cases) {
                         completions.map(completion => ({
                             completion,
                             stopReason: 'unknown',
-                        }))
+                        })),
+                        {
+                            providerOptions: { n: 3 },
+                        }
                     )
                 )
 
@@ -215,37 +221,29 @@ for (const isTreeSitterEnabled of cases) {
                     `,
                     ['array) {\nreturn array.sort()\n} function two() {}', 'array) new\n']
                 )
+                const [completion] = completions.map(c =>
+                    pick(c, ['insertText', 'nodeTypes', 'nodeTypesWithCompletion', 'parseErrorCount'])
+                )
 
-                expect(
-                    completions.map(c =>
-                        pick(c, [
-                            'insertText',
-                            'nodeTypes',
-                            'nodeTypesWithCompletion',
-                            'parseErrorCount',
-                        ])
-                    )
-                ).toMatchInlineSnapshot(`
-                  [
-                    {
-                      "insertText": "array) {",
-                      "nodeTypes": {
-                        "atCursor": "(",
-                        "grandparent": "function_signature",
-                        "greatGrandparent": "program",
-                        "lastAncestorOnTheSameLine": "function_signature",
-                        "parent": "formal_parameters",
-                      },
-                      "nodeTypesWithCompletion": {
-                        "atCursor": "(",
-                        "grandparent": "function_declaration",
-                        "greatGrandparent": "program",
-                        "lastAncestorOnTheSameLine": "function_declaration",
-                        "parent": "formal_parameters",
-                      },
-                      "parseErrorCount": 0,
+                expect(completion).toMatchInlineSnapshot(`
+                  {
+                    "insertText": "array) {",
+                    "nodeTypes": {
+                      "atCursor": "(",
+                      "grandparent": "function_signature",
+                      "greatGrandparent": "program",
+                      "lastAncestorOnTheSameLine": "function_signature",
+                      "parent": "formal_parameters",
                     },
-                  ]
+                    "nodeTypesWithCompletion": {
+                      "atCursor": "(",
+                      "grandparent": "function_declaration",
+                      "greatGrandparent": "program",
+                      "lastAncestorOnTheSameLine": "function_declaration",
+                      "parent": "formal_parameters",
+                    },
+                    "parseErrorCount": 0,
+                  }
                 `)
             })
 

--- a/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/triggers.test.ts
@@ -25,7 +25,7 @@ describe('[getInlineCompletions] triggers', () => {
 
         it('middle of line', async () => {
             const result = await getInlineCompletions(
-                params('function bubbleSort(█)', [completion`array) {`, completion`items) {`])
+                params('function bubbleSort(█)', [completion`array) {`])
             )
 
             expect(
@@ -33,10 +33,7 @@ describe('[getInlineCompletions] triggers', () => {
                     insertText: item.insertText,
                     range: item.range,
                 }))
-            ).toEqual([
-                { insertText: 'array) {', range: range(0, 20, 0, 21) },
-                { insertText: 'items) {', range: range(0, 20, 0, 21) },
-            ])
+            ).toEqual([{ insertText: 'array) {', range: range(0, 20, 0, 21) }])
         })
 
         describe('same line suffix behavior', () => {

--- a/vscode/src/completions/get-inline-completions-tests/windows.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/windows.test.ts
@@ -7,15 +7,7 @@ import { getInlineCompletionsInsertText, params } from './helpers'
 
 describe('[getInlineCompletions] windows ', () => {
     it('works works with \\r\\n line terminators', async () => {
-        const completion1 = completion`
-                ├console.log('foo')
-            }
-
-            add() {
-                console.log('bar')
-            }┤
-        ┴┴┴┴`
-        const completion2 = completion`
+        const completionResponse = completion`
                 ├if (foo) {
                     console.log('foo1');
                 }
@@ -26,8 +18,7 @@ describe('[getInlineCompletions] windows ', () => {
             }┤
         ┴┴┴┴`
 
-        completion1.completion = windowsify(completion1.completion)
-        completion2.completion = windowsify(completion2.completion)
+        completionResponse.completion = windowsify(completionResponse.completion)
 
         const items = await getInlineCompletionsInsertText(
             params(
@@ -38,12 +29,11 @@ describe('[getInlineCompletions] windows ', () => {
                         }
                     }
                 `),
-                [completion1, completion2]
+                [completionResponse]
             )
         )
 
         expect(items[0]).toBe("if (foo) {\n            console.log('foo1');\n        }")
-        expect(items[1]).toBe("console.log('foo')")
     })
 })
 

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -418,23 +418,21 @@ function getCompletionProvider(params: GetCompletionProvidersParams): Provider {
         firstCompletionTimeout: 1900,
     }
 
+    // Show more if manually triggered (but only showing 1 is faster, so we use it
+    // in the automatic trigger case).
+    const n = triggerKind === TriggerKind.Automatic ? 1 : 3
+
     if (docContext.multilineTrigger) {
         return providerConfig.create({
             ...sharedProviderOptions,
-            n: completionProviderConfig.getPrefetchedFlag(
-                FeatureFlag.CodyAutocompleteSingleMultilineRequest
-            )
-                ? 1
-                : 3, // 3 vs. 1 does not meaningfully affect perf
+            n,
             multiline: true,
         })
     }
 
     return providerConfig.create({
         ...sharedProviderOptions,
-        // Show more if manually triggered (but only showing 1 is faster, so we use it
-        // in the automatic trigger case).
-        n: triggerKind === TriggerKind.Automatic ? 1 : 3,
+        n,
         multiline: false,
     })
 }

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -1,12 +1,7 @@
 import type * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 
-import {
-    FeatureFlag,
-    getActiveTraceAndSpanId,
-    isAbortError,
-    wrapInActiveSpan,
-} from '@sourcegraph/cody-shared'
+import { getActiveTraceAndSpanId, isAbortError, wrapInActiveSpan } from '@sourcegraph/cody-shared'
 
 import { logError } from '../log'
 import type { CompletionIntent } from '../tree-sitter/query-sdk'


### PR DESCRIPTION
## Context

- By default, we now trigger one multiline completion request instead of three. As expected, the latency is better (with multiline wins of up to 150ms).

## Test plan

CI
