### PR TITLE
VSCode: Do not show update toast on new installs

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -159,8 +159,7 @@ export class InlineCompletionItemProvider
         )
 
         const chatHistory = localStorage.getChatHistory(this.config.authStatus)?.chat
-        this.isProbablyNewInstall =
-            !chatHistory || [...Object.values(chatHistory)].some(chat => chat.interactions.length > 0)
+        this.isProbablyNewInstall = !chatHistory || Object.entries(chatHistory).length === 0
 
         logDebug(
             'CodyCompletionProvider:initialized',

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -159,7 +159,8 @@ export class InlineCompletionItemProvider
         )
 
         const chatHistory = localStorage.getChatHistory(this.config.authStatus)?.chat
-        this.isProbablyNewInstall = !chatHistory || Object.entries(chatHistory).length === 0
+        this.isProbablyNewInstall =
+            !chatHistory || [...Object.values(chatHistory)].some(chat => chat.interactions.length > 0)
 
         logDebug(
             'CodyCompletionProvider:initialized',

--- a/vscode/test/e2e/update-notice.test.ts
+++ b/vscode/test/e2e/update-notice.test.ts
@@ -1,0 +1,73 @@
+import { expect } from '@playwright/test'
+
+import { sidebarSignin } from './common'
+import { test } from './helpers'
+
+const versionUpdateStorageKey = 'notices.last-dismissed-version'
+const greetingChatText = 'Welcome to Cody!'
+const updateToastText = /Cody updated to v\d+\.\d+/
+
+test('new installs should not show the update toast', async ({ page, sidebar }) => {
+    // Sign in and start a chat
+    await sidebarSignin(page, sidebar)
+    await page.getByRole('button', { name: 'New Chat', exact: true }).click()
+    const chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
+
+    // The "updated" toast should not appear
+    const introChat = chatFrame.getByText(greetingChatText)
+    await expect(introChat).toBeVisible()
+    const chatNotice = chatFrame.getByText(updateToastText)
+    await expect(chatNotice).not.toBeVisible()
+
+    // Local storage should reflect the extension version, for future update
+    // notices
+    expect(
+        await chatFrame.locator(':root').evaluate((_, versionUpdateStorageKey) => {
+            return localStorage.getItem(versionUpdateStorageKey)
+        }, versionUpdateStorageKey)
+    ).toMatch(/\d+\.\d+/)
+})
+
+test('existing installs should show the update toast when the last dismissed version is different', async ({
+    page,
+    sidebar,
+}) => {
+    // Sign in
+    await sidebarSignin(page, sidebar)
+
+    // Use chat.
+    await page.getByRole('button', { name: 'New Chat', exact: true }).click()
+    let chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
+    const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
+    await chatInput.fill('hey buddy')
+    await chatInput.press('Enter')
+
+    // Forge an older dismissed version into local storage.
+    expect(
+        await chatFrame.locator(':root').evaluate((_, versionUpdateStorageKey) => {
+            localStorage.setItem(versionUpdateStorageKey, '0.7')
+            return localStorage.getItem(versionUpdateStorageKey)
+        }, versionUpdateStorageKey)
+    ).toBe('0.7')
+
+    // Wait for this chat to be available in the sidebar
+    const chatHistoryEntry = page.getByRole('treeitem', { name: 'hey buddy' })
+    await expect(chatHistoryEntry).toBeVisible()
+    await page.locator('*[aria-label="Tab actions"] *[aria-label~="Close"]').click()
+
+    // Reopen the chat; the update notice should be visible.
+    await chatHistoryEntry.click()
+    chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
+    const introChat = chatFrame.getByText(greetingChatText)
+    await expect(introChat).toBeVisible()
+    const chatNotice = chatFrame.getByText(updateToastText)
+    await expect(chatNotice).toBeVisible()
+
+    // Dismiss the notice, expect local storage to have been updated
+    await chatFrame.locator('.codicon.codicon-close').click()
+    expect(
+        await chatFrame.locator(':root').evaluate((_, versionUpdateStorageKey) => {
+            return localStorage.getItem(versionUpdateStorageKey)
+        }, versionUpdateStorageKey)
+    ).not.toBe('0.7')
+})

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -217,7 +217,10 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
             ) : (
                 <>
                     <Notices
-                        probablyNewInstall={!!userHistory && Object.entries(userHistory).length === 0}
+                        probablyNewInstall={
+                            !!userHistory &&
+                            [...Object.values(userHistory)].every(chat => chat.interactions.length === 0)
+                        }
                     />
                     {errorMessages && (
                         <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />


### PR DESCRIPTION
Fixes #3171 

I have seen the first automated test flake on occasion, probably due to timing of loading the chat history at all, so the updated notice could flicker in that case. Future work.

## Test plan

Automated test:

```
pnpm test:e2e -- install-notice
```

Manual test:

1. Build the Cody VSIX: `CODY_RELEASE_TYPE=stable pnpm release:dry-run`
2. Set up the condition of a fresh install (in place of `Code`, use `Code\ -\ Insiders` for VSCode Insiders; `VSCodium` for VSCodium.)

```
$ sqlite3 ~/Library/Application\ Support/Code/User/globalStorage/state.vscdb "DELETE FROM ItemTable WHERE key = 'sourcegraph.cody-ai';"
```

3. Open VSCode, Extensions, ..., Install VSIX and install `dist/cody.vsix` generated in step 1.
4. Log in, start a chat.
5. Verify that the "Cody updated" toast does not appear.