### PR TITLE
Require a timeout when getting a loading lease

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed an issue where Cody Chat steals focus from file editor after a request is completed. [pull/3147](https://github.com/sourcegraph/cody/pull/3147)
 - Chat: Fixed an issue where the links in the welcome message for chat are unclickable. [pull/3155](https://github.com/sourcegraph/cody/pull/3155)
 - Chat: File range is now displayed correctly in the chat view. [pull/3172](https://github.com/sourcegraph/cody/pull/3172)
+- Autocomplete: Fixed an issue where the loading indicator might get stuck in the loading state. [pull/3178](https://github.com/sourcegraph/cody/pull/3178)
 
 ### Changed
 

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -235,7 +235,8 @@ export class InlineCompletionItemProvider
                     const hasRateLimitError = this.config.statusBar.hasError(RateLimitError.errorName)
                     if (!hasRateLimitError) {
                         stopLoading = this.config.statusBar.startLoading(
-                            'Completions are being generated'
+                            'Completions are being generated',
+                            30000 // 30 second timeout before loading is cancelled
                         )
                     }
                 } else {

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -236,7 +236,9 @@ export class InlineCompletionItemProvider
                     if (!hasRateLimitError) {
                         stopLoading = this.config.statusBar.startLoading(
                             'Completions are being generated',
-                            30000 // 30 second timeout before loading is cancelled
+                            {
+                                timeoutMs: 30_000,
+                            }
                         )
                     }
                 } else {

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -249,13 +249,13 @@ export function createStatusBar(): CodyStatusBar {
     verifyActiveEditor(vscode.window.activeTextEditor?.document?.uri)
 
     return {
-        startLoading(label: string, timeoutMs: number) {
+        startLoading(label: string, params: { timeoutMs?: number } = {}) {
             openLoadingLeases++
             statusBarItem.tooltip = label
             rerender()
 
             let didClose = false
-            const timeoutId = setTimeout(stopLoading, timeoutMs)
+            const timeoutId = params.timeoutMs ? setTimeout(stopLoading, params.timeoutMs) : null
             function stopLoading() {
                 if (didClose) {
                     return
@@ -264,7 +264,9 @@ export function createStatusBar(): CodyStatusBar {
 
                 openLoadingLeases--
                 rerender()
-                clearTimeout(timeoutId)
+                if (timeoutId) {
+                    clearTimeout(timeoutId)
+                }
             }
 
             return stopLoading

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -17,7 +17,7 @@ interface StatusBarError {
 
 export interface CodyStatusBar {
     dispose(): void
-    startLoading(label: string): () => void
+    startLoading(label: string, timeoutMs: number): () => void
     addError(error: StatusBarError): () => void
     hasError(error: StatusBarErrorName): boolean
 }
@@ -249,13 +249,14 @@ export function createStatusBar(): CodyStatusBar {
     verifyActiveEditor(vscode.window.activeTextEditor?.document?.uri)
 
     return {
-        startLoading(label: string) {
+        startLoading(label: string, timeoutMs: number) {
             openLoadingLeases++
             statusBarItem.tooltip = label
             rerender()
 
             let didClose = false
-            return () => {
+            const timeoutId = setTimeout(stopLoading, timeoutMs)
+            function stopLoading() {
                 if (didClose) {
                     return
                 }
@@ -263,7 +264,10 @@ export function createStatusBar(): CodyStatusBar {
 
                 openLoadingLeases--
                 rerender()
+                clearTimeout(timeoutId)
             }
+
+            return stopLoading
         },
         addError(error: StatusBarError) {
             const errorObject = { error, createdAt: Date.now() }

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -17,7 +17,13 @@ interface StatusBarError {
 
 export interface CodyStatusBar {
     dispose(): void
-    startLoading(label: string, params?: { timeoutMs: number }): () => void
+    startLoading(
+        label: string,
+        params?: {
+            // When set, the loading lease will expire after the timeout to avoid getting stuck
+            timeoutMs: number
+        }
+    ): () => void
     addError(error: StatusBarError): () => void
     hasError(error: StatusBarErrorName): boolean
 }

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -17,7 +17,7 @@ interface StatusBarError {
 
 export interface CodyStatusBar {
     dispose(): void
-    startLoading(label: string, timeoutMs: number): () => void
+    startLoading(label: string, params?: { timeoutMs: number }): () => void
     addError(error: StatusBarError): () => void
     hasError(error: StatusBarErrorName): boolean
 }


### PR DESCRIPTION
This fixes cases like https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1707987812090509 where a loading lease that is never returned would be stuck forever.

## Test plan

- Remove the call of `stopLoading()` in the completions code
- Trigger a completion and wait 30sec.
- The loading indicator now stops