### PR TITLE
Custom Command:  set userConfigFile on runtime

### DIFF
--- a/vscode/src/commands/services/custom-commands.ts
+++ b/vscode/src/commands/services/custom-commands.ts
@@ -30,8 +30,9 @@ export class CustomCommandsManager implements vscode.Disposable {
     public customCommandsMap = new Map<string, CodyCommand>()
     public userJSON: Record<string, unknown> | null = null
 
-    protected configFileName = ConfigFiles.COMMAND
-    private userConfigFile = Utils.joinPath(URI.file(userHomePath), this.configFileName)
+    // Configuration files
+    protected configFileName
+    private userConfigFile
     private get workspaceConfigFile(): vscode.Uri | undefined {
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri
         if (!workspaceRoot) {
@@ -41,6 +42,14 @@ export class CustomCommandsManager implements vscode.Disposable {
     }
 
     constructor() {
+        // TODO (bee) Migrate to use .cody/commands.json for VS Code
+        // Right now agent is using .cody/commands.json for Custom Commands,
+        // .vscode/cody.json in VS Code.
+        const workspaceConfig = vscode.workspace.getConfiguration()
+        const config = getConfiguration(workspaceConfig)
+        this.configFileName = config.isRunningInsideAgent ? ConfigFiles.COMMAND : ConfigFiles.VSCODE
+        this.userConfigFile = Utils.joinPath(URI.file(userHomePath), this.configFileName)
+
         this.disposables.push(
             vscode.commands.registerCommand('cody.menu.custom.build', () =>
                 this.newCustomCommandQuickPick()
@@ -64,12 +73,6 @@ export class CustomCommandsManager implements vscode.Disposable {
      * Automatically update the command map when the cody.json files are changed
      */
     public init(): void {
-        const workspaceConfig = vscode.workspace.getConfiguration()
-        const config = getConfiguration(workspaceConfig)
-        if (!config.isRunningInsideAgent) {
-            this.configFileName = ConfigFiles.VSCODE
-        }
-
         const userConfigWatcher = createFileWatchers(this.userConfigFile)
         if (userConfigWatcher) {
             this.fileWatcherDisposables.push(

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -221,7 +221,7 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:menu:command:custom:clicked',
         'CodyVSCodeExtension:menu:command:config:clicked',
     ],
-})('open and delete cody.json from the custom command menu', async ({ page, sidebar }) => {
+}).only('open and delete cody.json from the custom command menu', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 
@@ -268,4 +268,12 @@ test.extend<ExpectedEvents>({
 
     // The opened cody.json file should be shown as "Deleted"
     await expect(page.getByRole('list').getByLabel(/cody.json(.*)Deleted$/)).toBeVisible()
+
+    // Open the cody.json from User Settings
+    await customCommandSidebar.click()
+    await page.locator('a').filter({ hasText: 'Open User Settings (JSON)' }).hover()
+    await page.getByRole('button', { name: 'Open or Create Settings File' }).hover()
+    await page.getByRole('button', { name: 'Open or Create Settings File' }).click()
+    await page.getByLabel('cody.json, preview', { exact: true }).hover()
+    await expect(page.getByLabel('cody.json, preview', { exact: true })).toBeVisible()
 })

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -221,7 +221,7 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:menu:command:custom:clicked',
         'CodyVSCodeExtension:menu:command:config:clicked',
     ],
-}).only('open and delete cody.json from the custom command menu', async ({ page, sidebar }) => {
+})('open and delete cody.json from the custom command menu', async ({ page, sidebar }) => {
     // Sign into Cody
     await sidebarSignin(page, sidebar)
 


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1707992847314209

**NOTE:** No Changelog entry needed as this is a recent change that's not included in stable yet.

Previously, userConfigFile was initialized using this.configFileName but did not get updated when this.configFileName changed at runtime (init()). Now it is set dynamically based on the runtime config.

workspaceConfigFile was already using this.configFileName dynamically. Make userConfigFile consistent by also setting it dynamically based on runtime config.

This allows custom commands to be configured separately for the agent and editor.

### Note

We use separate config files (.cody/commands.json and .vscode/cody.json) for the Cody agent and VS Code for configuration Custom Commands right now, with a plan to migrate the one VS Code used into `.cody/commands.json` in the near future.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Added new e2e test coverage to make sure the correct file name is used for both workspace and User settings.
- All the current tests on agent are still passing.

###.Step to reproduce:

Open the Custom Commands Menu from the sidebar to select `Configure Custom Commands`:

![image](https://github.com/sourcegraph/cody/assets/68532117/1e65f8cc-8224-44a2-a982-8e4aeaab6165)

Then `Open User Settings`:

![image](https://github.com/sourcegraph/cody/assets/68532117/9f09d546-9353-476a-b190-f0aa71e460e9)


After, It should open `cody.json` for you:

![image](https://github.com/sourcegraph/cody/assets/68532117/d1449e39-c5fa-4606-b0b9-2f813d3d7e67)

Before, it would open `commands.json`:

![image](https://github.com/sourcegraph/cody/assets/68532117/a12ac734-cc24-4922-a37f-5d3275c77195)
