### PR TITLE
Autocomplete: Tracing improvements

### DIFF
--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -310,8 +310,10 @@ export function logResponseHeadersToSpan(span: Span, response: BrowserOrNodeResp
     response.headers.forEach((value, key) => {
         responseHeaders[key] = value
     })
-    span.addEvent('response', {
+    const properties = {
         ...responseHeaders,
         status: response.status,
-    })
+    }
+    span.addEvent('response')
+    span.setAttributes(properties)
 }

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -310,10 +310,9 @@ export function logResponseHeadersToSpan(span: Span, response: BrowserOrNodeResp
     response.headers.forEach((value, key) => {
         responseHeaders[key] = value
     })
-    const properties = {
+    span.addEvent('response')
+    span.setAttributes({
         ...responseHeaders,
         status: response.status,
-    }
-    span.addEvent('response')
-    span.setAttributes(properties)
+    })
 }

--- a/vscode/src/extension-api.ts
+++ b/vscode/src/extension-api.ts
@@ -1,3 +1,4 @@
+import type { ExtensionMode } from 'vscode'
 import { TestSupport } from './test-support'
 
 // The API surface exported to other extensions.
@@ -6,8 +7,7 @@ export class ExtensionApi {
     // environment contains CODY_TESTING=true . This is only for
     // testing and the API will change.
     public testing: TestSupport | undefined = undefined
-
-    constructor() {
+    constructor(public extensionMode: ExtensionMode) {
         if (process.env.CODY_TESTING === 'true') {
             console.warn('Setting up testing hooks')
             this.testing = new TestSupport()

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -45,7 +45,7 @@ export async function activate(
     context: vscode.ExtensionContext,
     platformContext: PlatformContext
 ): Promise<ExtensionApi> {
-    const api = new ExtensionApi()
+    const api = new ExtensionApi(context.extensionMode)
 
     try {
         const disposable = await start(context, platformContext)

--- a/vscode/src/services/open-telemetry/utils.ts
+++ b/vscode/src/services/open-telemetry/utils.ts
@@ -3,10 +3,32 @@ import { featureFlagProvider } from '@sourcegraph/cody-shared'
 import { getConfiguration } from '../../configuration'
 import * as vscode from 'vscode'
 import { getExtensionDetails } from '../telemetry'
+import type { ExtensionApi } from '../../extension-api'
 
 // Ensure to ad exposed experiments at the very end to make sure we include experiments that the
 // user is being exposed to while the span was generated
 export function recordExposedExperimentsToSpan(span: Span): void {
     span.setAttributes(featureFlagProvider.getExposedExperiments())
-    span.setAttributes(getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration())) as any)
+    const extensionDetails = getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration()))
+    span.setAttributes(extensionDetails as any)
+
+    const extensionApi: ExtensionApi | undefined =
+        vscode.extensions.getExtension('sourcegraph.cody-ai')?.exports
+    if (extensionApi && extensionDetails.ide === 'VSCode') {
+        const vscodeChannel: 'release' | 'pre-release' | 'development' | 'test' | null =
+            extensionApi.extensionMode === vscode.ExtensionMode.Development
+                ? 'development'
+                : extensionApi.extensionMode === vscode.ExtensionMode.Test
+                  ? 'test'
+                  : inferVSCodeChannelFromVersion(extensionDetails.version)
+        span.setAttribute('vscodeChannel', vscodeChannel)
+    }
+}
+
+function inferVSCodeChannelFromVersion(version: string): 'pre-release' | 'release' {
+    const [, , patch] = version.split('.').map(Number)
+    if (patch > 1000) {
+        return 'pre-release'
+    }
+    return 'release'
 }


### PR DESCRIPTION
Two small improvements:

1. Added a `vscodeChannel` to the root trace so we can group by pre-release vs. release
2. Expose the resolved model header to the span (and not the event) so we can at least see how this affects overall network speed. Ideally I want to add this to the root trace but this seems impossible so 🤷 

## Test plan

- Debugger
- Only trivial changes
