### PR TITLE
Agent: sort custom command context only

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -4458,493 +4458,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 94accb8dce18933da394cb5a165f6f1e
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 880
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is Squirrel?
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 18869
-        content:
-          mimeType: text/event-stream
-          size: 18869
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Source","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.ts file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.ts file.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states that it mocks something unrelated to squirrels and is related to the implementation of precise code navigation in Sourcegraph. Specifically, Squirrel is an empty interface exported from the src/squirrel.ts file.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 19 Jan 2024 15:16:06 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-01-19T15:16:04.372Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 7ddd992011e5e73bc5749687d94a8219
       _order: 0
       cache: {}
@@ -7419,430 +6932,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 89938c4d1eff65ead0b3eba4f075b1bc
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3151
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      constructor(private shouldGreet: boolean) {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Write a class Dog that implements the Animal interface in my workspace.
-                  Only show the code, no explanation needed.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 6073
-        content:
-          mimeType: text/event-stream
-          size: 6073
-          text: >+
-            event: completion
-
-            data: {"completion":" ```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"B","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isMammal =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isMammal = true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isMammal = true;","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isMammal = true;\n}","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isMammal = true;\n}\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  makeAnimalSound() {\n    return \"Bark!\";\n  }\n\n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 24 Jan 2024 16:21:59 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-01-24T16:21:54.754Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 5fab83beae207667553dfb51e89119f1
       _order: 0
       cache: {}
@@ -8187,1708 +7276,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-01-24T16:22:03.810Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 9df8244ae7344f1c53fb205aeb7fee12
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1680
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: export
-                  interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: "Explain what the selected code does in simple terms. Assume the audience
-                  is a beginner programmer who has just learned the language
-                  features and basic syntax. Focus on explaining: 1) The purpose
-                  of the code 2) What input(s) it takes 3) What output(s) it
-                  produces 4) How it achieves its purpose through the logic and
-                  algorithm. 5) Any important logic flows or data
-                  transformations happening. Use simple language a beginner
-                  could understand. Include enough detail to give a full picture
-                  of what the code aims to accomplish without getting too
-                  technical. Format the explanation in coherent paragraphs,
-                  using proper punctuation and grammar. Write the explanation
-                  assuming no prior context about the code is known. Do not make
-                  assumptions about variables or functions not shown in the
-                  shared code. Start the answer with the name of the code that
-                  is being explained."
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 280847
-        content:
-          mimeType: text/event-stream
-          size: 280847
-          text: >+
-            event: completion
-
-            data: {"completion":" Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected Type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a generic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a generic way","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a generic way based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a generic way based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a generic way based on this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a generic way based on this contract","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a generic way based on this contract.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here is an explanation of the selected TypeScript code in simple terms:\n\nThe Animal interface\n\nThe Animal interface defines the shape of an Animal object. It does not contain any actual implementation, just declarations for what properties and methods an Animal object should have.\n\nThe interface has three members:\n\n1. name - This is a string property to store the animal's name.\n\n2. makeAnimalSound() - This is a method that should return a string representing the sound the animal makes.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.\n\nThe purpose of this interface is to define a consistent structure for Animal objects. Any class that implements the Animal interface will be required to have these three members with these types. \n\nThis allows code dealing with Animal objects to know it can call animal.makeAnimalSound() and access animal.name and animal.isMammal, regardless of the specific class. The interface defines the contract between the implementation and usage of Animals, without caring about specific details.\n\nInterfaces like this are useful for writing reusable code that can handle different types of objects in a consistent way. The code using the interface doesn't need to know about the specifics of each class, just that it implements the Animal interface. This allows easily extending the code to handle new types of animals by simply creating a new class implementing Animal.\n\nSo in summary, the Animal interface defines the input expectations and output guarantees for objects representing animals in the system, allowing code to work with any animal in a generic way based on this contract.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 24 Jan 2024 18:02:05 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-01-24T18:02:03.093Z
       time: 0
       timings:
         blocked: -1
@@ -13955,2557 +11342,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 9f55cbc58f1c6bc93d5d0a02e38b6ed5
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3303
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestLogger.ts: const foo =
-                  42
-
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Review the shared code context and configurations to identify the test
-                  framework and libraries in use. Then, generate a suite of
-                  multiple unit tests for the functions in <selected> using the
-                  detected test framework and libraries. Be sure to import the
-                  function being tested. Follow the same patterns as any shared
-                  context. Only add packages, imports, dependencies, and
-                  assertions if they are used in the shared code. Pay attention
-                  to the file path of each shared context to see if test for
-                  <selected> already exists. If one exists, focus on generating
-                  new unit tests for uncovered cases. If none are detected,
-                  import common unit test libraries for {languageName}. Focus on
-                  validating key functionality with simple and complete
-                  assertions. Only include mocks if one is detected in the
-                  shared code. Before writing the tests, identify which test
-                  libraries and frameworks to import, e.g. 'No new imports
-                  needed - using existing libs' or 'Importing test framework
-                  that matches shared context usage' or 'Importing the defined
-                  framework', etc. Then briefly summarize test coverage and any
-                  limitations. At the end, enclose the full completed code for
-                  the new unit tests, including all necessary imports, in a
-                  single markdown codeblock. No fragments or TODO. The new tests
-                  should validate expected functionality and cover edge cases
-                  for <selected> with all required imports, including importing
-                  the function being tested. Do not repeat existing tests.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 238785
-        content:
-          mimeType: text/event-stream
-          size: 238785
-          text: >+
-            event: completion
-
-            data: {"completion":" Okay","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate J","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n//","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal';","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', ()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', ()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: ()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', ()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: ()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Wo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', ()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Sn","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: ()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'H","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n     ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using J","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate more","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate more complex","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate more complex object","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate more complex object shapes","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate more complex object shapes and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate more complex object shapes and logic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate more complex object shapes and logic.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Okay, reviewing the shared context, it looks like there are no existing test files provided. \n\nSince `src/animal.ts` defines an `Animal` interface, I will generate Jest unit tests for this interface in `src/animal.test.ts`:\n\n```typescript\n// src/animal.test.ts\n\nimport { Animal } from './animal'; \n\ndescribe('Animal interface', () =\u003e {\n\n  it('should have a name property', () =\u003e {\n    const animal: Animal = {\n      name: 'Cat',\n      makeAnimalSound: () =\u003e '',\n      isMammal: true\n    };\n    \n    expect(animal.name).toBeDefined();\n  });\n\n  it('should have a makeAnimalSound method', () =\u003e {\n    const animal: Animal = {\n      name: 'Dog', \n      makeAnimalSound: () =\u003e 'Woof',\n      isMammal: true\n    };\n    \n    expect(animal.makeAnimalSound).toBeDefined();\n    expect(typeof animal.makeAnimalSound).toBe('function');\n  });\n\n  it('should have an isMammal property', () =\u003e {\n    const animal: Animal = {\n      name: 'Snake',\n      makeAnimalSound: () =\u003e 'Hiss',\n      isMammal: false\n    };\n    \n    expect(animal.isMammal).toBeDefined();\n    expect(typeof animal.isMammal).toBe('boolean');\n  });\n\n});\n```\n\nThis covers basic validation of the Animal interface properties and methods using Jest assertions. Additional tests could validate more complex object shapes and logic.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 02 Feb 2024 15:29:26 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-02T15:29:22.402Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: e7ac39b86b6a9b91b3ff010d82947113
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 4528
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/trickyLogic.ts`:
-                  ```typescript
-                  export function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-                  /* CURSOR */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestLogger.ts`:
-                  ```typescript
-                  const foo = 42
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestLogger.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/sum.ts`:
-                  ```typescript
-                  export function sum(a: number, b: number): number {
-                      
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/sum.ts`:
-                  ```typescript
-                  export function sum(a: number, b: number): number {
-                      
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/example.test.ts`:
-
-                  ```typescript
-
-                  import { expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Which file is the isIgnoredByCody functions defined?
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 22563
-        content:
-          mimeType: text/event-stream
-          size: 22563
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgn","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredBy","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByC","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgn","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredBy","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByC","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order for me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order for me to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order for me to identify","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order for me to identify the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order for me to identify the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order for me to identify the file.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the context provided so far, I do not have enough information to determine which file the isIgnoredByCody function is defined in. The code snippets you've asked me to reference do not contain a definition or usage of a function called isIgnoredByCody. Please provide a code snippet that contains this function or give more context about where it is located in order for me to identify the file.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 05 Feb 2024 15:58:27 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-05T15:58:22.639Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 893d12d654d058eb6b9327499c302a4a
       _order: 0
       cache: {}
@@ -17342,827 +12178,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: dc54fbeb225741901cb862ddc75a6b32
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 435
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: If you see any file content from our current conversation, reply a single
-                  word 'yes'. If none, reply 'no'.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 3519
-        content:
-          mimeType: text/event-stream
-          size: 3519
-          text: >+
-            event: completion
-
-            data: {"completion":" I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct access","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct access to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct access to computer","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct access to computer files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct access to computer files or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct access to computer files or systems","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct access to computer files or systems.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" I do not have access to view any files or file contents. I am an AI assistant without direct access to computer files or systems.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 09:40:32 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T09:40:30.567Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 0a0c0546a689e709d84013db8945dc5e
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3299
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/trickyLogic.ts: export
-                  function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-
-                  /* CURSOR */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/sum.ts: export function
-                  sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/squirrel.ts: /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/multiple-selections.ts:
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestLogger.ts: const foo =
-                  42
-
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: How many file context have I shared with you?
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 12166
-        content:
-          mimeType: text/event-stream
-          size: 12166
-          text: >+
-            event: completion
-
-            data: {"completion":" You","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/tr","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/tricky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7. src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7. src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7. src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7. src/TestLogger","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7. src/TestLogger.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7. src/TestLogger.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" You have shared 7 file contexts with me so far:\n\n1. src/trickyLogic.ts\n2. src/sum.ts \n3. src/squirrel.ts\n4. src/multiple-selections.ts\n5. src/example.test.ts\n6. src/animal.ts\n7. src/TestLogger.ts","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 09:40:35 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T09:40:32.961Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 4d28fe9147b851eaac5a45db378d43b5
       _order: 0
       cache: {}
@@ -18317,2558 +12332,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-02-09T10:10:15.234Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 02b0b30c10fc2b81b17a2e7935274887
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2435
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: Context from
-                  file path @src/animal.ts:
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  - You are an AI programming assistant who is an expert in
-                  updating code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-
-
-                  This is part of the file: src/animal.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>/* SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */</SELECTEDCODE7662>
-
-
-                  The user wants you to replace parts of the selected code or correct a problem by following their instructions.
-
-                  Provide your generated code using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Add a new field to the class that console log the name of the animal.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: |
-                  <CODE5711>
-            model: anthropic/claude-2.0
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 9380
-        content:
-          mimeType: text/event-stream
-          size: 9380
-          text: >+
-            event: completion
-
-            data: {"completion":"/*","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SE","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound():","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    log","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName():","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n       ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}\n/*","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}\n/* SE","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}\n/* SELECTION","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}\n/* SELECTION_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}\n/* SELECTION_END","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}\n/* SELECTION_END */","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}\n/* SELECTION_END */\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/* SELECTION_START */\nexport interface Animal {\n    name: string\n    makeAnimalSound(): string \n    isMammal: boolean\n    logName(): void {\n        console.log(this.name)\n    }\n}\n/* SELECTION_END */\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 10:10:46 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T10:10:43.723Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 96f775876c6586f508bc5513d4d1f37d
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 923
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/sum.ts: export function
-                  sum(a: number, b: number): number {
-                      
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file `src/squirrel.ts`:
-
-                  <selected>
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Give me the names of the files I have shared with you so far.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 4156
-        content:
-          mimeType: text/event-stream
-          size: 4156
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n- src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n- src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n- src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n- src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n- src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you have provided, I am aware of these file paths:\n\n- src/sum.ts\n- src/squirrel.ts","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 17:56:10 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T17:56:08.460Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: fc26d19295524678917be2842dfe5258
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2946
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestLogger.ts: const foo =
-                  42
-
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/multiple-selections.ts:
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path .cody/ignore: # NOTE: For
-                  agent integration test only
-
-                  **/*Ignored.ts
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/sum.ts: export function
-                  sum(a: number, b: number): number {
-                      
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file `src/squirrel.ts`:
-
-                  <selected>
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Give me the names of the files I have shared with you so far.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 14738
-        content:
-          mimeType: text/event-stream
-          size: 14738
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n- src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n- src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n- src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n- src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n- src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided so far, the file paths are:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/animal.ts\n- src/sum.ts\n- src/squirrel.ts","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 17:56:58 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T17:56:55.661Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: aefb52bd9fcdf8a2c45200f7c80ce616
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2922
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestLogger.ts: const foo =
-                  42
-
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/multiple-selections.ts:
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path .cody/ignore: # NOTE: For
-                  agent integration test only
-
-                  **/*Ignored.ts
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/squirrel.ts: /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/sum.ts: export function
-                  sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Give me the names of the files I have shared with you so far.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 15078
-        content:
-          mimeType: text/event-stream
-          size: 15078
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/sum","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/sum.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/sum.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared so far, these are the file paths:\n\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/sum.ts","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 18:01:10 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T18:01:07.550Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 33c804026a3f55d6bfe4dfe04b0512e2
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3552
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >+
-                  Codebase context from file path src/trickyLogic.ts: export
-                  function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestLogger.ts: const foo =
-                  42
-
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/multiple-selections.ts:
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path .cody/ignore: # NOTE: For
-                  agent integration test only
-
-                  **/*Ignored.ts
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/squirrel.ts: /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/sum.ts: export function
-                  sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/trickyLogic.ts`:
-                  <selected>
-                  export function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Give me the names of the files I have shared with you so far.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 18408
-        content:
-          mimeType: text/event-stream
-          size: 18408
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/tr","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/tricky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/sum","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/sum.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/sum.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have shared with me so far, these are the file paths:\n\n- src/trickyLogic.ts\n- src/example.test.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/multiple-selections.ts\n- .cody/ignore\n- src/squirrel.ts\n- src/animal.ts\n- src/sum.ts","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 18:01:42 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T18:01:39.491Z
       time: 0
       timings:
         blocked: -1
@@ -21560,416 +13023,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-02-09T18:14:50.485Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: c5c9b359150b4154dd8b91aab98b2aac
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1020
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >+
-                  Codebase context from file path src/trickyLogic.ts: export
-                  function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/trickyLogic.ts`:
-                  <selected>
-                  export function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Give me the names of the files I have shared with you so far.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 2131
-        content:
-          mimeType: text/event-stream
-          size: 2131
-          text: >+
-            event: completion
-
-            data: {"completion":" So","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n- src/tr","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n- src/tricky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n- src/trickyLogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n- src/trickyLogic.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n- src/trickyLogic.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" So far you have shared the following file with me:\n\n- src/trickyLogic.ts","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 18:15:22 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T18:15:20.410Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 5082b060fee25daad49f4cbc0a8ed78a
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1795
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file
-                  `src/multiple-selections.ts`:
-
-                  <selected>
-
-
-                  function anotherFunction() {}
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 319
-        content:
-          mimeType: text/event-stream
-          size: 319
-          text: |+
-            event: completion
-            data: {"completion":" make","stopReason":""}
-
-            event: completion
-            data: {"completion":" makeAnimal","stopReason":""}
-
-            event: completion
-            data: {"completion":" makeAnimalSound","stopReason":""}
-
-            event: completion
-            data: {"completion":" makeAnimalSound","stopReason":"stop_sequence"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 18:15:37 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T18:15:36.165Z
       time: 0
       timings:
         blocked: -1
@@ -23780,837 +14833,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-02-09T18:15:38.975Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 70ea3a7415abcb2b2885a9b434f67ddf
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3552
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >+
-                  Codebase context from file path src/trickyLogic.ts: export
-                  function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/trickyLogic.ts`:
-                  <selected>
-                  export function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestLogger.ts: const foo =
-                  42
-
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/sum.ts: export function
-                  sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/squirrel.ts: /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/multiple-selections.ts:
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path .cody/ignore: # NOTE: For
-                  agent integration test only
-
-                  **/*Ignored.ts
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Give me the names of the files I have shared with you so far.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 16584
-        content:
-          mimeType: text/event-stream
-          size: 16584
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/tr","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/tricky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n- .","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n- .c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n- .cody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n- .cody/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n- .cody/ignore","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the codebase context you have provided me, the file paths are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n- .cody/ignore","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 18:15:57 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T18:15:55.575Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: f8a37231e2e709dccf011fec18d7332e
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1795
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file
-                  `src/multiple-selections.ts`:
-
-                  <selected>
-
-
-                  function anotherFunction() {}
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 165
-        content:
-          mimeType: text/event-stream
-          size: 165
-          text: |+
-            event: completion
-            data: {"completion":" inner","stopReason":""}
-
-            event: completion
-            data: {"completion":" inner","stopReason":"stop_sequence"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 09 Feb 2024 18:24:10 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-09T18:24:09.363Z
       time: 0
       timings:
         blocked: -1
@@ -27202,6 +17424,2660 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-02-14T20:00:55.643Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 90261ebfcb4ee90a391c9ecb0c786af0
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3151
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      constructor(private shouldGreet: boolean) {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Only show the code, no explanation needed.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 8162
+        content:
+          mimeType: text/event-stream
+          size: 8162
+          text: >+
+            event: completion
+
+            data: {"completion":" ```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'B","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true;\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 15 Feb 2024 15:18:39 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-15T15:18:34.861Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 336b652f6423693d544300d450524dac
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 880
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is Squirrel?
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 42115
+        content:
+          mimeType: text/event-stream
+          size: 42115
+          text: >+
+            event: completion
+
+            data: {"completion":" Based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant to represent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant to represent.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant to represent.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 15 Feb 2024 15:18:43 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-15T15:18:41.450Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 283fad1c8b0700c48a9f49e671ac120e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 4528
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/trickyLogic.ts`:
+                  ```typescript
+                  export function trickyLogic(a: number, b: number): number {
+                      if (a === 0) {
+                          return 1
+                      }
+                      if (b === 2) {
+                          return 1
+                      }
+
+                      return a - b
+                  }
+
+                  /* CURSOR */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestLogger.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestLogger.ts`:
+                  ```typescript
+                  const foo = 42
+                  export const TestLogger = {
+                      startLogging: () => {
+                          // Do some stuff
+
+                          function recordLog() {
+                              console.log(/* CURSOR */ 'Recording the log')
+                          }
+
+                          recordLog()
+                      },
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/sum.ts`:
+                  ```typescript
+                  export function sum(a: number, b: number): number {
+                      
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/sum.ts`:
+                  ```typescript
+                  export function sum(a: number, b: number): number {
+                      
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/example.test.ts`:
+
+                  ```typescript
+
+                  import { expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+                      it('does 1', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does 2', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does something else', () => {
+                          // This line will error due to incorrect usage of `performance.now`
+                          const startTime = performance.now(/* CURSOR */)
+                      })
+                  })
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Which file is the isIgnoredByCody functions defined?
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 28914
+        content:
+          mimeType: text/event-stream
+          size: 28914
+          text: >+
+            event: completion
+
+            data: {"completion":" Based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnored","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredBy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByC","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/tr","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/tricky","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/Test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/Test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnored","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredBy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredByC","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredByCody","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredByCody.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredByCody.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 15 Feb 2024 15:18:57 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-15T15:18:53.266Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: d614a7dc1506009bc8959ccfdb604417
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1795
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+
+                  function anotherFunction() {}
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 252
+        content:
+          mimeType: text/event-stream
+          size: 252
+          text: |+
+            event: completion
+            data: {"completion":" another","stopReason":""}
+
+            event: completion
+            data: {"completion":" anotherFunction","stopReason":""}
+
+            event: completion
+            data: {"completion":" anotherFunction","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 15 Feb 2024 15:20:08 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-15T15:20:06.911Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 1b21245751fe1edf70d5cc2a6a19f663
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3151
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      constructor(private shouldGreet: boolean) {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Only show the code, no explanation needed.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 6782
+        content:
+          mimeType: text/event-stream
+          size: 6782
+          text: >+
+            event: completion
+
+            data: {"completion":" ```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound():","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'B","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!'","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true;\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true;\n}\n```","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 15 Feb 2024 15:20:20 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-15T15:20:16.212Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -3445,1019 +3445,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 0116b6298b3b449cc3f4279bd6350a32
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 804
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            fast: true
-            maxTokensToSample: 400
-            messages:
-              - speaker: human
-                text: "You are helping the user search over a codebase. List some filename
-                  fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
-                  keyword</value><variants>a space separated list of synonyms
-                  and variants of the keyword, including acronyms,
-                  abbreviations, and expansions</variants><weight>a numerical
-                  weight between 0.0 and 1.0 that indicates the importance of
-                  the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>Write a class Dog that implements the Animal
-                  interface in my workspace. Only show the code, no explanation
-                  needed.</userQuery>"
-              - speaker: assistant
-            temperature: 0
-            topK: 1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 105534
-        content:
-          mimeType: text/event-stream
-          size: 105534
-          text: >+
-            event: completion
-
-            data: {"completion":" ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCan","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eI","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eInt","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003eIntf\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Fri, 19 Jan 2024 07:17:38 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-01-19T07:17:37.973Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 7ddd992011e5e73bc5749687d94a8219
       _order: 0
       cache: {}
@@ -7101,181 +6088,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-01-24T16:22:01.140Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 0a7cfb9343aec06dffc22f934e05438d
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1800
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file
-                  `src/multiple-selections.ts`:
-
-                  <selected>
-
-                      return function inner() {}
-
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 165
-        content:
-          mimeType: text/event-stream
-          size: 165
-          text: |+
-            event: completion
-            data: {"completion":" inner","stopReason":""}
-
-            event: completion
-            data: {"completion":" inner","stopReason":"stop_sequence"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 24 Jan 2024 16:22:06 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-01-24T16:22:03.810Z
       time: 0
       timings:
         blocked: -1
@@ -17433,470 +16245,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 90261ebfcb4ee90a391c9ecb0c786af0
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3151
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      constructor(private shouldGreet: boolean) {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Write a class Dog that implements the Animal interface in my workspace.
-                  Only show the code, no explanation needed.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 8162
-        content:
-          mimeType: text/event-stream
-          size: 8162
-          text: >+
-            event: completion
-
-            data: {"completion":" ```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'B","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true;","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true;\n}","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true;\n}\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark';\n  }\n  \n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 15 Feb 2024 15:18:39 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1293
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-15T15:18:34.861Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 336b652f6423693d544300d450524dac
       _order: 0
       cache: {}
@@ -19470,11 +17818,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d614a7dc1506009bc8959ccfdb604417
+    - _id: 6721336c88c8c3735b98c2242b8178ca
       _order: 0
       cache: {}
       request:
-        bodySize: 1795
+        bodySize: 804
         cookies: []
         headers:
           - name: content-type
@@ -19495,121 +17843,951 @@ log:
           mimeType: application/json
           params: []
           textJSON:
-            maxTokensToSample: 1000
+            fast: true
+            maxTokensToSample: 400
             messages:
               - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
+                text: "You are helping the user search over a codebase. List some filename
+                  fragments that would match files relevant to read to answer
+                  the user's query. Present your results in an XML list in the
+                  following format: <keywords><keyword><value>a single
+                  keyword</value><variants>a space separated list of synonyms
+                  and variants of the keyword, including acronyms,
+                  abbreviations, and expansions</variants><weight>a numerical
+                  weight between 0.0 and 1.0 that indicates the importance of
+                  the keyword</weight></keyword></keywords>. Here is the user
+                  query: <userQuery>Write a class Dog that implements the Animal
+                  interface in my workspace. Show the code only, no explanation
+                  needed.</userQuery>"
               - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file
-                  `src/multiple-selections.ts`:
-
-                  <selected>
-
-
-                  function anotherFunction() {}
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
-              - speaker: assistant
-            model: anthropic/claude-2.0
             temperature: 0
-            topK: -1
-            topP: -1
+            topK: 1
         queryString: []
         url: https://sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 252
+        bodySize: 104534
         content:
           mimeType: text/event-stream
-          size: 252
-          text: |+
+          size: 104534
+          text: >+
             event: completion
-            data: {"completion":" another","stopReason":""}
+
+            data: {"completion":" ","stopReason":""}
+
 
             event: completion
-            data: {"completion":" anotherFunction","stopReason":""}
+
+            data: {"completion":" \u003ckeywords","stopReason":""}
+
 
             event: completion
-            data: {"completion":" anotherFunction","stopReason":"stop_sequence"}
+
+            data: {"completion":" \u003ckeywords\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCan","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface I","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eI","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inher","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" \u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eDog\u003c/value\u003e\n    \u003cvariants\u003eCanine\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eAnimal\u003c/value\u003e\n    \u003cvariants\u003eInterface Impl\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e \n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eclass\u003c/value\u003e\n    \u003cvariants\u003eClass Def\u003c/variants\u003e\n    \u003cweight\u003e0.7\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eimplement\u003c/value\u003e\n    \u003cvariants\u003eImplements Inherit\u003c/variants\u003e\n    \u003cweight\u003e0.6\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003einterface\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e0.5\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"stop_sequence"}
+
 
             event: done
+
             data: {}
 
         cookies: []
         headers:
           - name: date
-            value: Thu, 15 Feb 2024 15:20:08 GMT
+            value: Thu, 15 Feb 2024 15:40:23 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -19638,7 +18816,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-02-15T15:20:06.911Z
+      startedDateTime: 2024-02-15T15:40:21.736Z
       time: 0
       timings:
         blocked: -1
@@ -19648,7 +18826,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1b21245751fe1edf70d5cc2a6a19f663
+    - _id: 20cf42d0fd6c4612a2bc2911a74c1694
       _order: 0
       cache: {}
       request:
@@ -19745,6 +18923,15 @@ log:
               - speaker: assistant
                 text: Ok.
               - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
                 text: >-
                   Use the following code snippet from file `src/squirrel.ts`:
 
@@ -19756,15 +18943,6 @@ log:
                    */
                   export interface Squirrel {}
 
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
 
                   ```
               - speaker: assistant
@@ -19812,7 +18990,7 @@ log:
                 text: Ok.
               - speaker: human
                 text: Write a class Dog that implements the Animal interface in my workspace.
-                  Only show the code, no explanation needed.
+                  Show the code only, no explanation needed.
               - speaker: assistant
             model: anthropic/claude-2.0
             temperature: 0
@@ -19821,10 +18999,10 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 6782
+        bodySize: 8389
         content:
           mimeType: text/event-stream
-          size: 6782
+          size: 8389
           text: >+
             event: completion
 
@@ -19843,202 +19021,232 @@ log:
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport","stopReason":""}
+            data: {"completion":" ```typescript\nimport","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class","stopReason":""}
+            data: {"completion":" ```typescript\nimport {","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal }","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n ","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name:","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n ","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  make","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimal","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound():","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name =","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = '","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n   ","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return '","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'B","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  make","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimal","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!'","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound()","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n ","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n   ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n ","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  is","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return '","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isM","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'B","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMam","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!'","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal:","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean =","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true;","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  is","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true;\n}","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isM","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true;\n}\n```","stopReason":""}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMam","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return 'Bark!';\n  }\n\n  isMammal: boolean = true;\n}\n```","stopReason":"stop_sequence"}
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true;\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
 
 
             event: done
@@ -20048,7 +19256,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 15 Feb 2024 15:20:20 GMT
+            value: Thu, 15 Feb 2024 15:41:10 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -20077,7 +19285,181 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-02-15T15:20:16.212Z
+      startedDateTime: 2024-02-15T15:41:08.200Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 0a7cfb9343aec06dffc22f934e05438d
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1800
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+                      return function inner() {}
+
+                      
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 165
+        content:
+          mimeType: text/event-stream
+          size: 165
+          text: |+
+            event: completion
+            data: {"completion":" inner","stopReason":""}
+
+            event: completion
+            data: {"completion":" inner","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 15 Feb 2024 15:42:33 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-15T15:42:31.569Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -321,11 +321,13 @@ describe('Agent', () => {
             expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(
                 `
               " \`\`\`typescript
+              import { Animal } from './animal';
+
               export class Dog implements Animal {
-                name: string;
+                name = 'Dog';
 
                 makeAnimalSound() {
-                  return "Bark!";
+                  return 'Bark';
                 }
 
                 isMammal = true;

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -310,7 +310,7 @@ describe('Agent', () => {
                 command: 'cody.search.index-update',
             })
             const lastMessage = await client.sendSingleMessageToNewChat(
-                'Write a class Dog that implements the Animal interface in my workspace. Only show the code, no explanation needed.',
+                'Write a class Dog that implements the Animal interface in my workspace. Show the code only, no explanation needed.',
                 {
                     addEnhancedContext: true,
                 }
@@ -318,8 +318,7 @@ describe('Agent', () => {
             // TODO: make this test return a TypeScript implementation of
             // `animal.ts`. It currently doesn't do this because the workspace root
             // is not a git directory and symf reports some git-related error.
-            expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(
-                `
+            expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(`
               " \`\`\`typescript
               import { Animal } from './animal';
 
@@ -327,15 +326,13 @@ describe('Agent', () => {
                 name = 'Dog';
 
                 makeAnimalSound() {
-                  return 'Bark';
+                  return 'Bark!';
                 }
 
                 isMammal = true;
               }
               \`\`\`"
-            `,
-                explainPollyError
-            )
+            `)
         }, 30_000)
 
         it('chat/submitMessage (addEnhancedContext: true, squirrel test)', async () => {

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -20,8 +20,6 @@ import { viewRangeToRange } from './chat-helpers'
 import type { RemoteSearch } from '../../context/remote-search'
 import type { ContextItem } from '../../prompt-builder/types'
 
-const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
-
 export interface GetEnhancedContextOptions {
     strategy: ConfigurationUseContext
     editor: VSCodeEditor
@@ -241,22 +239,7 @@ async function searchSymf(
             return (await Promise.all(items)).flat()
         })
 
-        const allResults = (await Promise.all(r0)).flat()
-
-        if (isAgentTesting) {
-            // Sort results for deterministic ordering for stable tests. Ideally, we
-            // could sort by some numerical score from symf based on how relevant
-            // the matches are for the query.
-            allResults.sort((a, b) => {
-                const byUri = a.uri.fsPath.localeCompare(b.uri.fsPath)
-                if (byUri !== 0) {
-                    return byUri
-                }
-                return a.text.localeCompare(b.text)
-            })
-        }
-
-        return allResults
+        return (await Promise.all(r0)).flat()
     })
 }
 

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -20,6 +20,8 @@ import { executeChat } from '../execute/ask'
 import type { ChatCommandResult, CommandResult, EditCommandResult } from '../../main'
 import { getEditor } from '../../editor/active-editor'
 
+const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
+
 /**
  * NOTE: Used by Command Controller only.
  *
@@ -175,6 +177,13 @@ export class CommandRunner implements vscode.Disposable {
         if (contextConfig) {
             const commandContext = await getCommandContextFiles(contextConfig)
             userContextFiles.push(...commandContext)
+        }
+
+        if (isAgentTesting) {
+            // Sort results for deterministic ordering for stable tests. Ideally, we
+            // could sort by some numerical score from symf based on how relevant
+            // the matches are for the query.
+            return userContextFiles.sort((a, b) => a.uri.path.localeCompare(b.uri.path))
         }
 
         return userContextFiles


### PR DESCRIPTION
Just a small follow-up from https://github.com/sourcegraph/cody/pull/3089

As discovered by Olaf in the aforementioned PR, the context we used for the custom command tests were not always in the same order when running on CI (especially on Windows), causing the tests to fail with a `recordings not found` error. As a workaround, we added a condition to sort all chat context for agent tests, which might affect the purpose of other tests that utilize enhanced context as those are ranked priorly. 

This PR is to remove the workaround that would affect all the tests that use chat context and add the workaround to context from custom commands context runtime instead. 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

All the current tests should be green.