### PR TITLE
Autocomplete: Remove double-debounce

### DIFF
--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -315,21 +315,9 @@ async function doGetInlineCompletions(
     const remainingInterval = debounceTime - waitInterval
     if (waitInterval > 0) {
         await wrapInActiveSpan('autocomplete.debounce.wait', () => sleep(waitInterval))
-    }
-
-    // Debounce to avoid firing off too many network requests as the user is still typing.
-    await wrapInActiveSpan('autocomplete.debounce', async () => {
-        const interval =
-            ((multiline ? debounceInterval?.multiLine : debounceInterval?.singleLine) ?? 0) +
-            (artificialDelay ?? 0)
-        if (triggerKind === TriggerKind.Automatic && interval !== undefined && interval > 0) {
-            await new Promise<void>(resolve => setTimeout(resolve, interval))
+        if (abortSignal?.aborted) {
+            return null
         }
-    })
-
-    // We don't need to make a request at all if the signal is already aborted after the debounce.
-    if (abortSignal?.aborted) {
-        return null
     }
 
     setIsLoading?.(true)


### PR DESCRIPTION
Ouch this looks like a merge conflict. 😬 

## Before

<img width="1290" alt="Screenshot 2024-02-15 at 18 21 41" src="https://github.com/sourcegraph/cody/assets/458591/ed02871c-96ce-413a-b56a-ba1888bdfdc9">


## Test plan 

### After

<img width="1267" alt="Screenshot 2024-02-15 at 18 20 03" src="https://github.com/sourcegraph/cody/assets/458591/5b1a9ea3-6210-457a-aa17-ad99db2c566e">
