### PR TITLE
Ensure multi-root integration tests run if single-root tests have failures

### DIFF
--- a/vscode/test/integration/main.ts
+++ b/vscode/test/integration/main.ts
@@ -31,31 +31,39 @@ async function main(): Promise<void> {
         { testsFolder: 'multi-root', workspace: 'multi-root.code-workspace' },
     ]
 
+    let exitCode = 0
     try {
         // Download VS Code, unzip it, and run the integration test.
         await MockServer.run(async () => {
             for (const testConfig of testConfigs) {
-                await runTests({
-                    // The VS Code version to use for integration tests (there is also a version in ../e2e/install-deps.ts for e2e tests).
-                    //
-                    // We set this to stable so that tests are always running on the version of VS Code users are likely to be using. This may
-                    // result in tests breaking after a VS Code release but it's better for them to be investigated than potential bugs being
-                    // missed because we're running on an older version than users.
-                    version: 'stable',
-                    extensionDevelopmentPath,
-                    extensionTestsPath: path.normalize(
-                        path.resolve(integrationTestsPath, testConfig.testsFolder, 'index')
-                    ),
-                    launchArgs: [
-                        path.normalize(path.resolve(testFixturesPath, testConfig.workspace)),
-                        '--disable-extensions', // disable other extensions
-                    ],
-                })
+                try {
+                    const testRunExitCode = await runTests({
+                        // The VS Code version to use for integration tests (there is also a version in ../e2e/install-deps.ts for e2e tests).
+                        //
+                        // We set this to stable so that tests are always running on the version of VS Code users are likely to be using. This may
+                        // result in tests breaking after a VS Code release but it's better for them to be investigated than potential bugs being
+                        // missed because we're running on an older version than users.
+                        version: 'stable',
+                        extensionDevelopmentPath,
+                        extensionTestsPath: path.normalize(
+                            path.resolve(integrationTestsPath, testConfig.testsFolder, 'index')
+                        ),
+                        launchArgs: [
+                            path.normalize(path.resolve(testFixturesPath, testConfig.workspace)),
+                            '--disable-extensions', // disable other extensions
+                        ],
+                    })
+                    exitCode += testRunExitCode
+                } catch (error) {
+                    console.error(`Failed to run tests (${testConfig.testsFolder}):`, error)
+                    exitCode++
+                }
             }
         })
     } catch (error) {
         console.error('Failed to run tests:', error)
-        process.exit(1)
+        exitCode++
     }
+    process.exit(exitCode)
 }
 main()


### PR DESCRIPTION
This ensures the exit codes from multiple test runs are combined correctly.

Although in my testing, failed tests always result un `runTests()` throwing, so the behaviour I saw locally was that if the single-root tests failed, the multi-root tests would never run. This fixes that - both suites will always run now, and whether they fail by `runTests()` throwing, or returning non-zero, we will always get a correct non-zero exit code.


## Test plan

- green CI, both multi-root and single-root tests shown in logs; and
- verify locally that `pnpm test:integration` runs both suites of tests even if there's a forced failure in the single-root tests
