### PR TITLE
Agent: make tests more stable

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -16245,1579 +16245,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 336b652f6423693d544300d450524dac
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 880
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is Squirrel?
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 42115
-        content:
-          mimeType: text/event-stream
-          size: 42115
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Source","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant to represent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant to represent.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet provided, Squirrel is an interface that is exported from the src/squirrel.ts file. The interface itself is empty, meaning it has no properties or methods defined.\n\nThe original comment block stated that Squirrel mocks something unrelated to squirrels and is related to precise code navigation in Sourcegraph. However, since that comment was removed in the second snippet, I can only infer that Squirrel is a simple empty interface exported from src/squirrel.ts. Without more context it's hard to determine what it is actually meant to represent.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 15 Feb 2024 15:18:43 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1293
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-15T15:18:41.450Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 283fad1c8b0700c48a9f49e671ac120e
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 4528
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/trickyLogic.ts`:
-                  ```typescript
-                  export function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-                  /* CURSOR */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestLogger.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestLogger.ts`:
-                  ```typescript
-                  const foo = 42
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/sum.ts`:
-                  ```typescript
-                  export function sum(a: number, b: number): number {
-                      
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/sum.ts`:
-                  ```typescript
-                  export function sum(a: number, b: number): number {
-                      
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/example.test.ts`:
-
-                  ```typescript
-
-                  import { expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Which file is the isIgnoredByCody functions defined?
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 28914
-        content:
-          mimeType: text/event-stream
-          size: 28914
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgn","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredBy","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByC","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/tr","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/tricky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgn","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredBy","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredByC","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredByCody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredByCody.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets you provided, the isIgnoredByCody function does not appear to be defined in any of the files. The files you referenced are:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these files contain a definition for isIgnoredByCody.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 15 Feb 2024 15:18:57 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1293
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-15T15:18:53.266Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 6721336c88c8c3735b98c2242b8178ca
       _order: 0
       cache: {}
@@ -18826,475 +17253,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 20cf42d0fd6c4612a2bc2911a74c1694
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3151
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      constructor(private shouldGreet: boolean) {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Write a class Dog that implements the Animal interface in my workspace.
-                  Show the code only, no explanation needed.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 8389
-        content:
-          mimeType: text/event-stream
-          size: 8389
-          text: >+
-            event: completion
-
-            data: {"completion":" ```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'B","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!'","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true;","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true;\n}","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true;\n}\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nimport { Animal } from './animal';\n\nexport class Dog implements Animal {\n  name = 'Dog';\n  \n  makeAnimalSound() {\n    return 'Bark!';\n  }\n  \n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 15 Feb 2024 15:41:10 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1293
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-15T15:41:08.200Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 0a7cfb9343aec06dffc22f934e05438d
       _order: 0
       cache: {}
@@ -19398,6 +17356,7 @@ log:
 
                       return function inner() {}
 
+
                       
                   </selected>
               - speaker: assistant
@@ -19460,6 +17419,2028 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-02-15T15:42:31.569Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: bd2ceb6a466e80e86de2dd09acd24d0e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3151
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      constructor(private shouldGreet: boolean) {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Show the code only, no explanation needed.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 5448
+        content:
+          mimeType: text/event-stream
+          size: 5448
+          text: >+
+            event: completion
+
+            data: {"completion":" ```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Wo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\";","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isMammal =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isMammal = true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isMammal = true;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isMammal = true;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isMammal = true;\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n  makeAnimalSound() {\n    return \"Woof\"; \n  }\n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 16 Feb 2024 11:06:08 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-16T11:06:06.875Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 94accb8dce18933da394cb5a165f6f1e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 880
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is Squirrel?
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 49030
+        content:
+          mimeType: text/event-stream
+          size: 49030
+          text: >+
+            event: completion
+
+            data: {"completion":" Based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mock","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely just","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely just a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely just a placeholder","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely just a placeholder or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely just a placeholder or for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely just a placeholder or for fun","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely just a placeholder or for fun.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippet and comments provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an exported interface called Squirrel.\n\n- The comment states it \"mocks something completely unrelated to squirrels\" and is \"related to the implementation of precise code navigation in Sourcegraph\".\n\nSo Squirrel seems to be some sort of interface used internally by Sourcegraph to help with implementing precise code navigation, but isn't directly related to squirrels themselves. The name is likely just a placeholder or for fun.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 16 Feb 2024 11:06:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-16T11:06:09.985Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: e7ac39b86b6a9b91b3ff010d82947113
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 4528
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/trickyLogic.ts`:
+                  ```typescript
+                  export function trickyLogic(a: number, b: number): number {
+                      if (a === 0) {
+                          return 1
+                      }
+                      if (b === 2) {
+                          return 1
+                      }
+
+                      return a - b
+                  }
+
+                  /* CURSOR */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestLogger.ts`:
+                  ```typescript
+                  const foo = 42
+                  export const TestLogger = {
+                      startLogging: () => {
+                          // Do some stuff
+
+                          function recordLog() {
+                              console.log(/* CURSOR */ 'Recording the log')
+                          }
+
+                          recordLog()
+                      },
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestLogger.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                  const foo = 42
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/TestClass.ts`:
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/sum.ts`:
+                  ```typescript
+                  export function sum(a: number, b: number): number {
+                      
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/sum.ts`:
+                  ```typescript
+                  export function sum(a: number, b: number): number {
+                      
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/squirrel.ts`:
+                  ```typescript
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file `src/squirrel.ts`:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/multiple-selections.ts`:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Use the following code snippet from file
+                  `src/example.test.ts`:
+
+                  ```typescript
+
+                  import { expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+                      it('does 1', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does 2', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does something else', () => {
+                          // This line will error due to incorrect usage of `performance.now`
+                          const startTime = performance.now(/* CURSOR */)
+                      })
+                  })
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Use the following code snippet from file `src/animal.ts`:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Which file is the isIgnoredByCody functions defined?
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 30054
+        content:
+          mimeType: text/event-stream
+          size: 30054
+          text: >+
+            event: completion
+
+            data: {"completion":" Based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnored","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredBy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByC","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/tr","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/tricky","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/Test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/Test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `isIgn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `isIgnored","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `isIgnoredBy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `isIgnoredByC","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `isIgnoredByCody","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `isIgnoredByCody`.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code snippets provided so far, there is no definition for a function called `isIgnoredByCody`. The code snippets have been from the following files:\n\n- src/trickyLogic.ts\n- src/TestLogger.ts \n- src/TestClass.ts\n- src/sum.ts\n- src/squirrel.ts\n- src/multiple-selections.ts\n- src/example.test.ts\n- src/animal.ts\n\nNone of these contain a definition for `isIgnoredByCody`.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 16 Feb 2024 11:06:18 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-16T11:06:16.175Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -320,15 +320,11 @@ describe('Agent', () => {
             // is not a git directory and symf reports some git-related error.
             expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(`
               " \`\`\`typescript
-              import { Animal } from './animal';
-
-              export class Dog implements Animal {
-                name = 'Dog';
-
+              class Dog implements Animal {
+                name: string;
                 makeAnimalSound() {
-                  return 'Bark!';
+                  return "Woof";
                 }
-
                 isMammal = true;
               }
               \`\`\`"

--- a/vscode/src/chat/chat-view/agentContextSorting.ts
+++ b/vscode/src/chat/chat-view/agentContextSorting.ts
@@ -1,0 +1,45 @@
+import type { ContextFile } from '@sourcegraph/cody-shared'
+import type { ContextItem } from '../../prompt-builder/types'
+
+const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
+
+// These helper functions should be called before we pass context items/files to a prompt builder. This is necessary to get the tests
+// passing in CI because we need the prompts to be stable for the HTTP replay mode to succeed.
+
+export function sortContextItems(files: ContextItem[]): void {
+    if (!isAgentTesting) {
+        return
+    }
+    // Sort results for deterministic ordering for stable tests. Ideally, we
+    // could sort by some numerical score from symf based on how relevant
+    // the matches are for the query.
+    files.sort((a, b) => {
+        const byPath = a.uri.path.localeCompare(b.uri.path)
+        if (byPath !== 0) {
+            return byPath
+        }
+        const bySource = (a.source ?? '').localeCompare(b.source ?? '')
+        if (bySource !== 0) {
+            return bySource
+        }
+        return a.text.localeCompare(b.text)
+    })
+}
+
+export function sortContextFiles(files: ContextFile[]): void {
+    if (!isAgentTesting) {
+        return
+    }
+
+    files.sort((a, b) => {
+        const byPath = a.uri.path.localeCompare(b.uri.path)
+        if (byPath !== 0) {
+            return byPath
+        }
+        const bySource = (a.source ?? '').localeCompare(b.source ?? '')
+        if (bySource !== 0) {
+            return bySource
+        }
+        return (a.content ?? '').localeCompare(b.content ?? '')
+    })
+}

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -7,6 +7,7 @@ import { logDebug } from '../../log'
 import type { MessageWithContext, SimpleChatModel } from './SimpleChatModel'
 import { PromptBuilder } from '../../prompt-builder'
 import type { ContextItem } from '../../prompt-builder/types'
+import { sortContextItems } from './agentContextSorting'
 
 interface PromptInfo {
     prompt: Message[]
@@ -169,6 +170,7 @@ export class DefaultPrompter implements IPrompter {
                     lastMessage.message.text,
                     enhancedContextCharLimit
                 )
+                sortContextItems(additionalContextItems)
                 const { limitReached, used, ignored } = promptBuilder.tryAddContext(
                     additionalContextItems,
                     enhancedContextCharLimit

--- a/vscode/src/commands/services/runner.ts
+++ b/vscode/src/commands/services/runner.ts
@@ -19,8 +19,7 @@ import { getCommandContextFiles } from '../context'
 import { executeChat } from '../execute/ask'
 import type { ChatCommandResult, CommandResult, EditCommandResult } from '../../main'
 import { getEditor } from '../../editor/active-editor'
-
-const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
+import { sortContextFiles } from '../../chat/chat-view/agentContextSorting'
 
 /**
  * NOTE: Used by Command Controller only.
@@ -173,12 +172,7 @@ export class CommandRunner implements vscode.Disposable {
             userContextFiles.push(...commandContext)
         }
 
-        if (isAgentTesting) {
-            // Sort results for deterministic ordering for stable tests. Ideally, we
-            // could sort by some numerical score from symf based on how relevant
-            // the matches are for the query.
-            return userContextFiles.sort((a, b) => a.uri.path.localeCompare(b.uri.path))
-        }
+        sortContextFiles(userContextFiles)
 
         return userContextFiles
     }


### PR DESCRIPTION
Previously, I was failing to run the agent tests locally in replay mode from the latest `main` even if the tests were passing in CI. The root cause was that we are not sorting context items that we feed to the prompt. The CI tests seem to be flaky, because some open PRs are reproducing the failure even if those PRs have unrelated changes.

This PR fixes the problem by adding an additional sorting step for context items so that the tests pass reliably in replay mode.


## Test plan
Green CI


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
