### PR TITLE
Autocomplete: Remove unused feature flags and models

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -62,7 +62,6 @@ export interface Configuration {
     autocompleteExperimentalSyntacticPostProcessing?: boolean
     autocompleteExperimentalDynamicMultilineCompletions?: boolean
     autocompleteExperimentalHotStreak?: boolean
-    autocompleteExperimentalFastPath?: boolean
     autocompleteExperimentalGraphContext: 'bfg' | 'bfg-mixed' | null
     autocompleteExperimentalOllamaOptions: OllamaOptions
 

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -12,8 +12,6 @@ export enum FeatureFlag {
     // This flag is used to track the overall eligibility to use the StarCoder model. The `-hybrid`
     // suffix is no longer relevant
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
-    // Force all StarCoder traffic (controlled by the above flag) to point to the 16b model.
-    CodyAutocompleteStarCoder16B = 'cody-autocomplete-default-starcoder-16b',
     // Enable Llama Code 13b as the default model via Fireworks
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-llama-code-13b',
     // Enables the bfg-mixed context retriever that will combine BFG with the default local editor
@@ -29,8 +27,6 @@ export enum FeatureFlag {
     // Continue generations after a single-line completion and use the response to see the next line
     // if the first completion is accepted.
     CodyAutocompleteHotStreak = 'cody-autocomplete-hot-streak',
-    // Connects to Cody Gateway directly and skips the Sourcegraph instance hop for completions
-    CodyAutocompleteFastPath = 'cody-autocomplete-fast-path',
 
     // Enable Cody PLG features on JetBrains
     CodyProJetBrains = 'cody-pro-jetbrains',

--- a/lib/shared/src/inferenceClient/misc.ts
+++ b/lib/shared/src/inferenceClient/misc.ts
@@ -23,10 +23,6 @@ export type CompletionResponseGenerator = AsyncGenerator<CompletionResponse>
 
 export interface CodeCompletionsClient<T = CodeCompletionsParams> {
     logger: CompletionLogger | undefined
-    complete(
-        params: T,
-        abortController: AbortController,
-        featureFlags?: { fastPath?: boolean }
-    ): CompletionResponseGenerator
+    complete(params: T, abortController: AbortController): CompletionResponseGenerator
     onConfigurationChange(newConfig: CompletionsClientConfig): void
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -916,17 +916,7 @@
                 "cody.autocomplete.advanced.model": {
                     "type": "string",
                     "default": null,
-                    "enum": [
-                        null,
-                        "starcoder-16b",
-                        "starcoder-7b",
-                        "starcoder-3b",
-                        "starcoder-1b",
-                        "llama-code-7b",
-                        "llama-code-13b",
-                        "llama-code-13b-instruct",
-                        "mistral-7b-instruct-4k"
-                    ],
+                    "enum": [null, "starcoder-16b", "starcoder-7b", "llama-code-13b"],
                     "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
                 },
                 "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -968,11 +958,6 @@
                     "type": "boolean",
                     "default": false,
                     "markdownDescription": "Preload follow-up completions"
-                },
-                "cody.autocomplete.experimental.fastPath": {
-                    "type": "boolean",
-                    "default": false,
-                    "markdownDescription": "Routes code completion requests directly to our Cody Gateway instance. Only works when connected to the Cody community edition and when using the default StarCoder model."
                 },
                 "cody.autocomplete.experimental.graphContext": {
                     "type": "string",

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -13,7 +13,6 @@ class CompletionProviderConfig {
         FeatureFlag.CodyAutocompleteContextBfgMixed,
         FeatureFlag.CodyAutocompleteDynamicMultilineCompletions,
         FeatureFlag.CodyAutocompleteHotStreak,
-        FeatureFlag.CodyAutocompleteFastPath,
         FeatureFlag.CodyAutocompleteUserLatency,
         FeatureFlag.CodyAutocompleteEagerCancellation,
         FeatureFlag.CodyAutocompleteTracing,
@@ -61,13 +60,6 @@ class CompletionProviderConfig {
         return (
             this.config.autocompleteExperimentalHotStreak ||
             this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteHotStreak)
-        )
-    }
-
-    public get fastPath(): boolean {
-        return (
-            this.config.autocompleteExperimentalFastPath ||
-            this.getPrefetchedFlag(FeatureFlag.CodyAutocompleteFastPath)
         )
     }
 

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -396,7 +396,6 @@ function getCompletionProvider(params: GetCompletionProvidersParams): Provider {
         position,
         dynamicMultilineCompletions: completionProviderConfig.dynamicMultilineCompletions,
         hotStreak: completionProviderConfig.hotStreak,
-        fastPath: completionProviderConfig.fastPath,
         // For the now the value is static and based on the average multiline completion latency.
         firstCompletionTimeout: 1900,
     }

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -207,8 +207,8 @@ describe('createProviderConfig', () => {
 
                 // fireworks
                 {
-                    codyLLMConfig: { provider: 'fireworks', completionModel: 'llama-code-7b' },
-                    expected: { provider: 'fireworks', model: 'llama-code-7b' },
+                    codyLLMConfig: { provider: 'fireworks', completionModel: 'llama-code-13b' },
+                    expected: { provider: 'fireworks', model: 'llama-code-13b' },
                 },
                 {
                     codyLLMConfig: { provider: 'fireworks' },

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -132,9 +132,8 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         return { provider: configuredProvider }
     }
 
-    const [starCoderHybrid, starCoder16B, llamaCode13B] = await Promise.all([
+    const [starCoderHybrid, llamaCode13B] = await Promise.all([
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder16B),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
     ])
 
@@ -143,7 +142,7 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
     }
 
     if (starCoderHybrid) {
-        return { provider: 'fireworks', model: starCoder16B ? 'starcoder-16b' : 'starcoder-hybrid' }
+        return { provider: 'fireworks', model: 'starcoder-hybrid' }
     }
 
     return null

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -21,7 +21,6 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { getLanguageConfig } from '../../tree-sitter/language'
-import { CLOSING_CODE_TAG, getHeadAndTail, OPENING_CODE_TAG } from '../text-processing'
 import type { ContextSnippet } from '../types'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 import { fetch } from '../../fetch'
@@ -66,10 +65,7 @@ const MODEL_MAP = {
     'starcoder-7b': 'fireworks/starcoder-7b',
 
     // Fireworks model identifiers
-    'llama-code-7b': 'fireworks/accounts/fireworks/models/llama-v2-7b-code',
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
-    'llama-code-13b-instruct': 'fireworks/accounts/fireworks/models/llama-v2-13b-code-instruct',
-    'mistral-7b-instruct-4k': 'fireworks/accounts/fireworks/models/mistral-7b-instruct-4k',
 }
 
 type FireworksModel =
@@ -87,13 +83,9 @@ function getMaxContextTokens(model: FireworksModel): number {
             // other providers.
             return 2048
         }
-        case 'llama-code-7b':
         case 'llama-code-13b':
-        case 'llama-code-13b-instruct':
             // Llama 2 on Fireworks supports up to 4k tokens. We're constraining it here to better
             // compare the results
-            return 2048
-        case 'mistral-7b-instruct-4k':
             return 2048
         default:
             return 1200
@@ -128,7 +120,6 @@ class FireworksProvider extends Provider {
 
         const isNode = typeof process !== 'undefined'
         this.fastPathAccessToken =
-            this.options.fastPath &&
             config.accessToken &&
             // Require the upstream to be dotcom
             this.authStatus.isDotCom &&
@@ -270,19 +261,6 @@ class FireworksProvider extends Provider {
         if (isLlamaCode(this.model)) {
             // c.f. https://github.com/facebookresearch/codellama/blob/main/llama/generation.py#L402
             return `<PRE> ${intro}${prefix} <SUF>${suffix} <MID>`
-        }
-        if (this.model === 'mistral-7b-instruct-4k') {
-            // This part is copied from the anthropic prompt but fitted into the Mistral instruction format
-            const relativeFilePath = vscode.workspace.asRelativePath(this.options.document.fileName)
-            const { head, tail } = getHeadAndTail(this.options.docContext.prefix)
-            const infillSuffix = this.options.docContext.suffix
-            const infillBlock = tail.trimmed.endsWith('{\n') ? tail.trimmed.trimEnd() : tail.trimmed
-            const infillPrefix = head.raw
-            return `<s>[INST] Below is the code from file path ${relativeFilePath}. Review the code outside the XML tags to detect the functionality, formats, style, patterns, and logics in use. Then, use what you detect and reuse methods/libraries to complete and enclose completed code only inside XML tags precisely without duplicating existing implementations. Here is the code:
-\`\`\`
-${intro}${infillPrefix}${OPENING_CODE_TAG}${CLOSING_CODE_TAG}${infillSuffix}
-\`\`\`[/INST]
- ${OPENING_CODE_TAG}${infillBlock}`
         }
 
         console.error('Could not generate infilling prompt for', this.model)

--- a/vscode/src/completions/providers/provider.ts
+++ b/vscode/src/completions/providers/provider.ts
@@ -75,7 +75,6 @@ export interface ProviderOptions {
     // feature flags
     dynamicMultilineCompletions?: boolean
     hotStreak?: boolean
-    fastPath?: boolean
 }
 
 export abstract class Provider {

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -85,8 +85,6 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.experimental.hotStreak':
                         return false
-                    case 'cody.autocomplete.experimental.fastPath':
-                        return false
                     case 'cody.autocomplete.experimental.ollamaOptions':
                         return {
                             model: 'codellama:7b-code',
@@ -140,7 +138,6 @@ describe('getConfiguration', () => {
             autocompleteDisableInsideComments: false,
             autocompleteExperimentalDynamicMultilineCompletions: false,
             autocompleteExperimentalHotStreak: false,
-            autocompleteExperimentalFastPath: false,
             autocompleteExperimentalGraphContext: 'bfg',
             autocompleteExperimentalOllamaOptions: {
                 model: 'codellama:7b-code',

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -132,7 +132,6 @@ export function getConfiguration(
             'autocomplete.experimental.hotStreak',
             false
         ),
-        autocompleteExperimentalFastPath: getHiddenSetting('autocomplete.experimental.fastPath', false),
         autocompleteExperimentalOllamaOptions: getHiddenSetting(
             'autocomplete.experimental.ollamaOptions',
             {

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -828,7 +828,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
     autocompleteDisableInsideComments: false,
     autocompleteExperimentalDynamicMultilineCompletions: false,
     autocompleteExperimentalHotStreak: false,
-    autocompleteExperimentalFastPath: false,
     autocompleteExperimentalGraphContext: null,
     autocompleteExperimentalOllamaOptions: {
         model: 'codellama:7b-code',


### PR DESCRIPTION
Removes feature flags and Fireworks models that are no longer deployed and not used. Ships fast path though (only for dotcom and it's already rolled out to 100% anyways).

## Test plan

- it builds