### PR TITLE
Test: update chat history e2e test

### DIFF
--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -75,6 +75,8 @@ test.extend<ExpectedEvents>({
     await expect(page.getByRole('tab', { name: 'Hola' })).not.toBeVisible()
 
     // Once the chat history is empty, the 'New Chat' button should show up
+    await page.waitForSelector('div[class*="welcome-view-content"]')
+    await page.locator('.welcome-view-content').hover()
     await page.getByRole('button', { name: 'New Chat', exact: true }).hover()
     await expect(page.getByRole('button', { name: 'New Chat', exact: true })).toBeVisible()
 })

--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -58,18 +58,23 @@ test.extend<ExpectedEvents>({
         .filter({ hasText: 'Hey' })
         .nth(3)
         .click()
-    await expect(page.getByRole('tab', { name: 'Hola' })).toBeVisible()
     await expect(page.getByRole('tab', { name: 'Hey' })).toBeVisible()
 
-    // Chat buttons may only appear when we're hovering a chat.
+    // NOTE: Action buttons may only appear when we're hovering a chat.
+    // Deleting a chat should also close its associated chat panel
     await heyTreeItem.hover()
+    await heyTreeItem.getByLabel('Delete Chat').hover()
     await heyTreeItem.getByLabel('Delete Chat').click()
-    await holaTreeItem.hover()
-    await holaTreeItem.getByLabel('Delete Chat').click()
-
     expect(heyTreeItem).not.toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Hey' })).not.toBeVisible()
+
+    await holaTreeItem.hover()
+    await holaTreeItem.getByLabel('Delete Chat').hover()
+    await holaTreeItem.getByLabel('Delete Chat').click()
     expect(holaTreeItem).not.toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Hola' })).not.toBeVisible()
 
     // Once the chat history is empty, the 'New Chat' button should show up
+    await page.getByRole('button', { name: 'New Chat', exact: true }).hover()
     await expect(page.getByRole('button', { name: 'New Chat', exact: true })).toBeVisible()
 })


### PR DESCRIPTION
Attempt to fix the flanky chat history e2e test that was failing in our Windows CI.

![image](https://github.com/sourcegraph/cody/assets/68532117/f4e4e032-4fa8-40c9-828c-634b36f0e5a5)


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green bots