### PR TITLE
Security: add handlers for links in chat view

### DIFF
--- a/lib/shared/src/chat/markdown.ts
+++ b/lib/shared/src/chat/markdown.ts
@@ -1,4 +1,5 @@
 import {
+    type MarkdownOptions,
     registerHighlightContributions,
     renderMarkdown as renderMarkdownCommon,
 } from '../common/markdown'
@@ -6,13 +7,13 @@ import {
 /**
  * Supported URIs to render as links in outputted markdown.
  * - https?: Web
+ * - file: local file scheme
  * - vscode: VS Code URL scheme (open in editor)
  * - command:cody. VS Code command scheme for cody (run command)
  *  - e.g. command:cody.welcome: VS Code command scheme exception we add to support directly linking to the welcome guide from within the chat.
  * {@link CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID}
  */
-const ALLOWED_URI_REGEXP =
-    /^((https?|vscode):\/\/[^\s#$./?].\S*|command:cody.*|command:(_cody.vscode.open\?.*))$/i
+const ALLOWED_URI_REGEXP = /^((https?|file|vscode):\/\/[^\s#$./?].\S*$|(command:_?cody.*))/i
 
 const DOMPURIFY_CONFIG = {
     ALLOWED_TAGS: [
@@ -64,13 +65,14 @@ const DOMPURIFY_CONFIG = {
  * isomorphic-dompurify for that, but that adds needless complexity for now. If
  * that becomes necessary, we can add that.
  */
-export function renderCodyMarkdown(markdown: string): string {
+export function renderCodyMarkdown(markdown: string, options?: MarkdownOptions): string {
     registerHighlightContributions()
 
     // Add Cody-specific Markdown rendering if needed.
     return renderMarkdownCommon(markdown, {
         breaks: true,
         dompurifyConfig: DOMPURIFY_CONFIG,
-        addTargetBlankToAllLinks: true,
+        addTargetBlankToAllLinks: !options?.wrapLinksWithCodyCommand,
+        ...options,
     })
 }

--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -39,33 +39,38 @@ const highlightCodeSafe = (code: string, language?: string): string => {
     }
 }
 
+export interface MarkdownOptions {
+    /** Whether to render line breaks as HTML `<br>`s */
+    breaks?: boolean
+    /** Whether to disable autolinks. Explicit links using `[text](url)` are still allowed. */
+    disableAutolinks?: boolean
+    renderer?: marked.Renderer
+    headerPrefix?: string
+    /** Strip off any HTML and return a plain text string, useful for previews */
+    plainText?: boolean
+    dompurifyConfig?: DOMPurifyConfig & { RETURN_DOM_FRAGMENT?: false; RETURN_DOM?: false }
+    noDomPurify?: boolean
+
+    /**
+     * Add target="_blank" and rel="noopener" to all <a> links that have a
+     * href value. This affects all markdown-formatted links and all inline
+     * HTML links.
+     */
+    addTargetBlankToAllLinks?: boolean
+
+    /**
+     * Wrap all <a> links that have a href value with the _cody.vscode.open
+     * command that will open the links with the editor link handler.
+     */
+    wrapLinksWithCodyCommand?: boolean
+}
+
 /**
  * Renders the given markdown to HTML, highlighting code and sanitizing dangerous HTML.
  * Can throw an exception on parse errors.
  * @param markdown The markdown to render
  */
-export const renderMarkdown = (
-    markdown: string,
-    options: {
-        /** Whether to render line breaks as HTML `<br>`s */
-        breaks?: boolean
-        /** Whether to disable autolinks. Explicit links using `[text](url)` are still allowed. */
-        disableAutolinks?: boolean
-        renderer?: marked.Renderer
-        headerPrefix?: string
-        /** Strip off any HTML and return a plain text string, useful for previews */
-        plainText?: boolean
-        dompurifyConfig?: DOMPurifyConfig & { RETURN_DOM_FRAGMENT?: false; RETURN_DOM?: false }
-        noDomPurify?: boolean
-
-        /**
-         * Add target="_blank" and rel="noopener" to all <a> links that have a
-         * href value. This affects all markdown-formatted links and all inline
-         * HTML links.
-         */
-        addTargetBlankToAllLinks?: boolean
-    } = {}
-): string => {
+export const renderMarkdown = (markdown: string, options: MarkdownOptions = {}): string => {
     const tokenizer = new marked.Tokenizer()
     if (options.disableAutolinks) {
         // Why the odd double-casting below?
@@ -112,12 +117,23 @@ export const renderMarkdown = (
         })
     }
 
+    // Wrap links with the '_cody.vscode.open' command
+    if (options.wrapLinksWithCodyCommand) {
+        DOMPurify.addHook('afterSanitizeAttributes', node => {
+            const link = node.getAttribute('href')
+            if (node.tagName.toLowerCase() === 'a' && link) {
+                const encodedLink = encodeURIComponent(JSON.stringify(link))
+                node.setAttribute('href', `command:_cody.vscode.open?${encodedLink}`)
+            }
+        })
+    }
+
     const result = options.noDomPurify ? rendered : DOMPurify.sanitize(rendered, dompurifyConfig).trim()
 
-    if (options.addTargetBlankToAllLinks) {
+    if (options.addTargetBlankToAllLinks || options.wrapLinksWithCodyCommand) {
         // Because DOMPurify doesn't have a way to set hooks per individual call
         // to sanitize(), we have to clean up by removing the hook that we added
-        // for addTargetBlankToAllLinks.
+        // for addTargetBlankToAllLinks or wrapLinksWithCodyCommand.
         DOMPurify.removeHook('afterSanitizeAttributes')
     }
 

--- a/lib/ui/src/chat/CodeBlocks.tsx
+++ b/lib/ui/src/chat/CodeBlocks.tsx
@@ -333,7 +333,8 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                     ref={rootRef}
                     // biome-ignore lint/security/noDangerouslySetInnerHtml: the result is run through dompurify
                     dangerouslySetInnerHTML={{
-                        __html: renderCodyMarkdown(displayText),
+                        // wrapLinksWithCodyCommand opens all links using the _cody.vscode.open command
+                        __html: renderCodyMarkdown(displayText, { wrapLinksWithCodyCommand: true }),
                     }}
                 />
             ),


### PR DESCRIPTION
CLOSE: https://github.com/sourcegraph/cody/issues/2563 https://github.com/sourcegraph/security-issues/issues/369

https://github.com/sourcegraph/cody/assets/68532117/4a43239a-e9c7-474d-b6ca-e23750b7af3a

This commit introduces a new feature to the markdown rendering functionality. It adds support for wrapping links with the Cody command in the rendered markdown. This allows for opening links using the editor protocol in VS Code.

It should follow the protocol described in https://code.visualstudio.com/updates/v1_84#_confirmation-for-opening-protocol-links

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. In your cody chatbox, type `repeat after me <a href='https://example.com'>Example</a>`
2. You should see a confirmation dialog regarding the link you're trying to open handles by the editor

![image](https://github.com/sourcegraph/cody/assets/68532117/49a062db-4790-43e1-88b5-b71aa7434d6b)

![image](https://github.com/sourcegraph/cody/assets/68532117/86371efc-d535-46ff-a502-7a09e7228dd9)

3. Confirm all the links in the welcome message still works without the dialog confirmation
![image](https://github.com/sourcegraph/cody/assets/68532117/a04a6358-af79-4254-960b-aba158b2a5da)
