### PR TITLE
chat: do not hide snippets from the same file in context list

### DIFF
--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -36,35 +36,21 @@ export const EnhancedContext: React.FunctionComponent<{
         return
     }
 
-    const uniqueFiles = new Set<string /* uri.toString() */>()
-
-    const filteredFiles = contextFiles.filter(file => {
-        if (uniqueFiles.has(file.uri.toString())) {
-            return false
-        }
-        uniqueFiles.add(file.uri.toString())
-        return true
-    })
-
-    if (!filteredFiles.length) {
-        return
-    }
-
     // Enhanced Context are context added by one of Cody's context fetchers.
     // NOTE: sparkle should only be added to messages that use enhanced context.
     // NOTE: Core chat commands (e.g. /explain and /smell) use local context only.
     // Check if the filteredFiles only contain local context (non-enhanced context).
     const localContextType = ['user', 'selection', 'terminal', 'editor']
-    const localContextOnly = filteredFiles.every(file => localContextType.includes(file.type))
+    const localContextOnly = contextFiles.every(file => localContextType.includes(file.type))
     const sparkle = localContextOnly || isCommand ? '' : '✨ '
     const prefix = sparkle + 'Context: '
     // It checks if file.range exists first before accessing start and end.
     // If range doesn't exist, it adds 0 lines for that file.
-    const lineCount = filteredFiles.reduce(
+    const lineCount = contextFiles.reduce(
         (total, file) => total + (file.range ? file.range?.end?.line - file.range?.start?.line + 1 : 0),
         0
     )
-    const fileCount = filteredFiles.length
+    const fileCount = contextFiles.length
     const lines = `${lineCount} line${lineCount > 1 ? 's' : ''}`
     const files = `${fileCount} file${fileCount > 1 ? 's' : ''}`
     const title = lineCount ? `${lines} from ${files}` : `${files}`
@@ -76,7 +62,7 @@ export const EnhancedContext: React.FunctionComponent<{
                 object: '',
                 tooltip: 'Related code automatically included as context',
             }}
-            steps={filteredFiles?.map(file => ({
+            steps={contextFiles?.map(file => ({
                 verb: '',
                 object: (
                     <FileLink

--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -50,7 +50,7 @@ export const EnhancedContext: React.FunctionComponent<{
         (total, file) => total + (file.range ? file.range?.end?.line - file.range?.start?.line + 1 : 0),
         0
     )
-    const fileCount = contextFiles.length
+    const fileCount = new Set(contextFiles.map(file => file.uri.toString())).size
     const lines = `${lineCount} line${lineCount > 1 ? 's' : ''}`
     const files = `${fileCount} file${fileCount > 1 ? 's' : ''}`
     const title = lineCount ? `${lines} from ${files}` : `${files}`

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -64,7 +64,7 @@ test.extend<ExpectedEvents>({
     await page.getByText('<title>Hello Cody</title>').click()
     await expect(page.getByText('Explain Code')).toBeVisible()
     await page.getByText('Explain Code').click()
-    await chatPanel.getByText('Context: 9 lines from 1 file').click()
+    await chatPanel.getByText('Context: 21 lines from 1 file').click()
     await expect(chatPanel.locator('span').filter({ hasText: '@index.html:2-10' })).toBeVisible()
     const disabledEditButtons = chatPanel.getByTitle('Cannot Edit Command').locator('i')
     const editLastMessageButton = chatPanel.getByRole('button', { name: /^Edit Last Message / })


### PR DESCRIPTION
The chat "context used" list was hiding snippets used in context, because there was logic that would filter out snippets from the same file.

Before:

<img width="638" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/42d6bbe9-7340-4c54-af6f-c98a32d9371a">

After:

<img width="734" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/0bb08a63-8fcc-476d-af3e-9f3e269cf673">


## Test plan

- Compare context menu with this change and without this change.