### PR TITLE
Reenable Sentry and enable default integrations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,8 @@
         // "TSS_DEBUG": "5859"
         // Let extension behave like you're on dotcom when connected locally:
         // "TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
+        // Enable Sentry in local development mode:
+        // "ENABLE_SENTRY": "true"
       }
     },
     {

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -38,7 +38,7 @@ export abstract class SentryService {
 
             // Used to enable Sentry reporting in the development environment.
             const isSentryEnabled = process.env.ENABLE_SENTRY === 'true'
-            if (!isSentryEnabled) {
+            if (!isProd && !isSentryEnabled) {
                 return
             }
 
@@ -66,14 +66,6 @@ export abstract class SentryService {
 
                     return null
                 },
-
-                // The extension host is shared across other extensions, so listening on the default
-                // unhandled error listeners would not be helpful in case other extensions or VS Code
-                // throw. Instead, use the manual `captureException` API.
-                //
-                // When running inside Agent, we control the whole Node environment so we can safely
-                // listen to unhandled errors/rejections.
-                ...(this.config.isRunningInsideAgent ? {} : { defaultIntegrations: false }),
             }
 
             this.reconfigure(options)


### PR DESCRIPTION
It seems like some change has (unexpectedly?) removed Sentry from being enabled (at least I could not find `ENABLE_SENTRY` ever being set for production). This PR brings Sentry back plus enables all default integrations when run inside VS Code (so this will add the default `onUncaughtException` handlers etc.

If this is too noisy we can turn it off easily.

## Test plan

- Enable `ENABLE_SENTRY` in local development
- Put a `throw new Error()` somewhere
- Notice that it is being reported by Sentry