### PR TITLE
Agent: correctly dispose code lens providers

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -915,7 +915,6 @@ const _env: Partial<typeof vscode.env> = {
 }
 export const env = _env as typeof vscode.env
 
-const codeLensProviders = new Set<vscode.CodeLensProvider>()
 const newCodeLensProvider = new EventEmitter<vscode.CodeLensProvider>()
 const removeCodeLensProvider = new EventEmitter<vscode.CodeLensProvider>()
 export const onDidRegisterNewCodeLensProvider = newCodeLensProvider.event
@@ -942,7 +941,7 @@ const _languages: Partial<typeof vscode.languages> = {
     registerCodeActionsProvider: () => emptyDisposable,
     registerCodeLensProvider: (_selector, provider) => {
         newCodeLensProvider.fire(provider)
-        return { dispose: () => codeLensProviders.delete(provider) }
+        return { dispose: () => removeCodeLensProvider.fire(provider) }
     },
     registerInlineCompletionItemProvider: (_selector, provider) => {
         latestCompletionProvider = provider as any


### PR DESCRIPTION
Previously, we never respected the `dispose()` callback for code lens providers due to a bug in the implementation. I haven't confirmed 100%, but this bug could have caused code lenses to accumulate for agent clients. This PR fixes the bug where we handle the `dispose()` callback, but I don't have time right now to add test cases or validate it fixes the accumulation issue.


## Test plan

Manually verify that code lenses no longer accumulate. Ideally, we should have a test case to reproduce this as well.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
