### PR TITLE
Autocomplete: Remove same line suffix information from ollama prompts

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,7 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed an issue where the links in the welcome message for chat are unclickable. [pull/3155](https://github.com/sourcegraph/cody/pull/3155)
 - Chat: File range is now displayed correctly in the chat view. [pull/3172](https://github.com/sourcegraph/cody/pull/3172)
 - Autocomplete: Fixed an issue where the loading indicator might get stuck in the loading state. [pull/3178](https://github.com/sourcegraph/cody/pull/3178)
-- Autocomplete: Fixes an issue where Ollama results were sometimes not visible when the current line has text after the cursor. []
+- Autocomplete: Fixes an issue where Ollama results were sometimes not visible when the current line has text after the cursor. [pull/3213](https://github.com/sourcegraph/cody/pull/3213)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed an issue where the links in the welcome message for chat are unclickable. [pull/3155](https://github.com/sourcegraph/cody/pull/3155)
 - Chat: File range is now displayed correctly in the chat view. [pull/3172](https://github.com/sourcegraph/cody/pull/3172)
 - Autocomplete: Fixed an issue where the loading indicator might get stuck in the loading state. [pull/3178](https://github.com/sourcegraph/cody/pull/3178)
+- Autocomplete: Fixes an issue where Ollama results were sometimes not visible when the current line has text after the cursor. []
 
 ### Changed
 

--- a/vscode/src/completions/providers/experimental-ollama.ts
+++ b/vscode/src/completions/providers/experimental-ollama.ts
@@ -24,6 +24,7 @@ import {
     type ProviderConfig,
     type ProviderOptions,
 } from './provider'
+import { getSuffixAfterFirstNewline } from '../text-processing'
 
 interface OllamaPromptContext {
     snippets: { uri: vscode.Uri; content: string }[]
@@ -87,7 +88,7 @@ class ExperimentalOllamaProvider extends Provider {
             currentFileNameComment,
             isInfill,
             prefix: this.options.docContext.prefix,
-            suffix: this.options.docContext.suffix,
+            suffix: getSuffixAfterFirstNewline(this.options.docContext.suffix),
         }
 
         if (process.env.OLLAMA_CONTEXT_SNIPPETS) {

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -21,7 +21,12 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import { getLanguageConfig } from '../../tree-sitter/language'
-import { CLOSING_CODE_TAG, getHeadAndTail, OPENING_CODE_TAG } from '../text-processing'
+import {
+    CLOSING_CODE_TAG,
+    getHeadAndTail,
+    getSuffixAfterFirstNewline,
+    OPENING_CODE_TAG,
+} from '../text-processing'
 import type { ContextSnippet } from '../types'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 import { fetch } from '../../fetch'
@@ -173,6 +178,8 @@ class FireworksProvider extends Provider {
                 .map(line => (languageConfig ? languageConfig.commentStart + line : '// '))
                 .join('\n')}\n`
 
+            // We want to remove the same line suffix from a completion request since both StarCoder and Llama
+            // code can't handle this correctly.
             const suffixAfterFirstNewline = getSuffixAfterFirstNewline(suffix)
 
             const nextPrompt = this.createInfillingPrompt(
@@ -532,19 +539,6 @@ export function createProviderConfig({
         identifier: PROVIDER_IDENTIFIER,
         model: resolvedModel,
     }
-}
-
-// We want to remove the same line suffix from a completion request since both StarCoder and Llama
-// code can't handle this correctly.
-function getSuffixAfterFirstNewline(suffix: string): string {
-    const firstNlInSuffix = suffix.indexOf('\n')
-
-    // When there is no next line, the suffix should be empty
-    if (firstNlInSuffix === -1) {
-        return ''
-    }
-
-    return suffix.slice(suffix.indexOf('\n'))
 }
 
 function isStarCoderFamily(model: string): boolean {

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -421,3 +421,14 @@ export function getPositionAfterTextInsertion(position: Position, text?: string)
 
     return updatedPosition
 }
+
+export function getSuffixAfterFirstNewline(suffix: string): string {
+    const firstNlInSuffix = suffix.indexOf('\n')
+
+    // When there is no next line, the suffix should be empty
+    if (firstNlInSuffix === -1) {
+        return ''
+    }
+
+    return suffix.slice(suffix.indexOf('\n'))
+}

--- a/vscode/src/completions/text-processing/utils.ts
+++ b/vscode/src/completions/text-processing/utils.ts
@@ -430,5 +430,5 @@ export function getSuffixAfterFirstNewline(suffix: string): string {
         return ''
     }
 
-    return suffix.slice(suffix.indexOf('\n'))
+    return suffix.slice(firstNlInSuffix)
 }


### PR DESCRIPTION
This PR removes the same line suffix information in the ollama prompts. This is going to make it possible to have insertion in the middle of text in the current line.

The issue without that is that we currently do not have a way for yielded completion results to know wether they contain the same line suffix or not. We treat all completions as though they _do_ (so a completion of `console.log(|)` will always include the closing `)`) and if there's no overlap with the current suffix we filter them out. This logic is because in the past, models weren't good enough to deal the same line suffix.

The quick fix is to make sure we also omit the same line suffix info for Ollama prompts and have the model generate the suffix again so we can properly diff it.

## Before

<img width="783" alt="Screenshot 2024-02-19 at 16 43 01" src="https://github.com/sourcegraph/cody/assets/458591/3366a9e5-3d20-45aa-b5bf-dfc2f46c30d7">

## Test plan

## After

<img width="688" alt="Screenshot 2024-02-19 at 16 42 03" src="https://github.com/sourcegraph/cody/assets/458591/45a1b06a-630a-48b2-8dfe-de907ac0fe33">


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
