### PR TITLE
Commands: Include Custom Commands in main menu

### DIFF
--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -32,6 +32,9 @@ export async function showCommandMenu(
         // Add Default Commands
         if (type !== 'custom') {
             for (const _command of CodyCommandMenuItems) {
+                if (_command.key === 'custom') {
+                    continue
+                }
                 const key = _command.key
                 const label = `$(${_command.icon}) ${_command.description}`
                 const command = _command.command.command

--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -24,14 +24,18 @@ export async function showCommandMenu(
     telemetryService.log(`CodyVSCodeExtension:menu:command:${type}:clicked`)
     telemetryRecorder.recordEvent(`cody.menu:command:${type}`, 'clicked')
 
-    // Add items to menu
+    // Add items to menus accordingly:
+    // 1. default: contains default commands and custom commands
+    // 2. custom (custom commands): contain custom commands and add custom command option
+    // 3. config (settings): setting options for custom commands
     if (type === 'config') {
         items.push(...CustomCommandConfigMenuItems)
     } else {
-        items.push(CommandMenuSeperator.commands)
         // Add Default Commands
         if (type !== 'custom') {
+            items.push(CommandMenuSeperator.commands)
             for (const _command of CodyCommandMenuItems) {
+                // Skip the 'Custom Commands' option
                 if (_command.key === 'custom') {
                     continue
                 }
@@ -46,22 +50,24 @@ export async function showCommandMenu(
         }
 
         // Add Custom Commands
-        items.push(CommandMenuSeperator.custom)
-        for (const customCommand of customCommands) {
-            const label = `$(tools) ${customCommand.key}`
-            const description = customCommand.description ?? customCommand.prompt
-            const command = customCommand.key
-            const key = customCommand.key
-            const type = customCommand.type ?? CustomCommandType.User
-            items.push({ label, description, command, type, key })
+        if (customCommands?.length) {
+            items.push(CommandMenuSeperator.custom)
+            for (const customCommand of customCommands) {
+                const label = `$(tools) ${customCommand.key}`
+                const description = customCommand.description ?? customCommand.prompt
+                const command = customCommand.key
+                const key = customCommand.key
+                const type = customCommand.type ?? CustomCommandType.User
+                items.push({ label, description, command, type, key })
+            }
         }
 
         // Extra options - Settings
+        items.push(CommandMenuSeperator.settings)
         if (type === 'custom') {
-            // The Create New Command option should show up in custom command menu only
-            items.push(CommandMenuSeperator.settings, addOption)
+            items.push(addOption) // Create New Custom Command option
         }
-        items.push(configOption)
+        items.push(configOption) // Configure Custom Command option
     }
 
     const options = CommandMenuTitleItem[type]

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -241,13 +241,14 @@ test.extend<ExpectedEvents>({
     await page.getByLabel('Chats Section').click()
 
     // Check button click to open the cody.json file in the editor
-    const label = 'gear  Configure Custom Commands..., Manage your custom reusable commands, settings'
-    const configMenuItem = page.getByLabel(label).locator('a')
+    // const label = 'gear  Configure Custom Commands..., Manage your custom reusable commands, settings'
+    // const configMenuItem = page.getByLabel(label).locator('a')
     const customCommandSidebar = page.getByRole('treeitem', { name: 'Custom Commands' }).locator('a')
 
     // Able to open the cody.json file in the editor from the command menu
     await customCommandSidebar.click()
-    await configMenuItem.click()
+    await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
+    await page.getByLabel('Configure Custom Commands...', { exact: true }).click()
     await page.locator('a').filter({ hasText: 'Open Workspace Settings (JSON)' }).hover()
     await expect(page.getByRole('button', { name: 'Open or Create Settings File' })).toBeVisible()
     await page.getByRole('button', { name: 'Open or Create Settings File' }).click()
@@ -256,7 +257,8 @@ test.extend<ExpectedEvents>({
 
     // Check button click to delete the cody.json file from the workspace tree view
     await customCommandSidebar.click()
-    await configMenuItem.click()
+    await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
+    await page.getByLabel('Configure Custom Commands...', { exact: true }).click()
     await page.locator('a').filter({ hasText: 'Open Workspace Settings (JSON)' }).hover()
     await page.getByRole('button', { name: 'Delete Settings File' }).hover()
     await page.getByRole('button', { name: 'Delete Settings File' }).click()


### PR DESCRIPTION
Default Commands Menu

![image](https://github.com/sourcegraph/cody/assets/68532117/04a6d12c-f060-4608-a877-d39c5b34780a)

Custom Commands Menu

![image](https://github.com/sourcegraph/cody/assets/68532117/8b97836d-28c4-466b-aea8-04873d4512dd)

PR to add custom commands back to the main menu as discussed with @toolmantim 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Open the main command menu to check if custom commands are included.

#### Before

<img width="884" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/21178812-30d4-48c7-9ad6-d16874dd0d71">
