### PR TITLE
Agent CodeLenses: Allow consumers to control how they render `title` icons and omit shortcut labels

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/IconsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/IconsParams.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class IconsParams(
+  val value: String? = null,
+  val position: Int? = null,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolCommand.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolCommand.kt
@@ -2,7 +2,7 @@
 package com.sourcegraph.cody.protocol_generated
 
 data class ProtocolCommand(
-  val title: String? = null,
+  val title: TitleParams? = null,
   val command: String? = null,
   val tooltip: String? = null,
   val arguments: List<Any>? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TitleParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/TitleParams.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class TitleParams(
+  val text: String? = null,
+  val icons: List<IconsParams>? = null,
+)
+

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -40,6 +40,7 @@ import type {
     CustomCommandResult,
     EditTask,
     ExtensionConfiguration,
+    ProtocolCommand,
     TextEdit,
 } from './protocol-alias'
 import { AgentHandlerTelemetryRecorderProvider } from './telemetry'
@@ -850,6 +851,25 @@ export class Agent extends MessageHandler {
     }
 
     private codeLensToken = new vscode.CancellationTokenSource()
+    /** Matches VS Code codicon syntax, e.g. $(cody-logo) */
+    private labelWithIconsRegex = /(\\)?\$\(([A-Za-z0-9-]+(?:~[A-Za-z]+)?)\)/g
+    /**
+     * Given a title, such as "$(cody-logo) Cody", returns the raw
+     * title without icons and the icons matched with their respective positions.
+     */
+    private extractIconsFromTitle(title: string): Pick<ProtocolCommand, 'title' | 'icons'> {
+        const icons: { value: string; position: number }[] = []
+        const matches = [...title.matchAll(this.labelWithIconsRegex)]
+
+        for (const match of matches) {
+            if (match.index !== undefined) {
+                icons.push({ value: match[0], position: match.index })
+            }
+        }
+
+        return { title: title.replace(this.labelWithIconsRegex, ''), icons }
+    }
+
     private async updateCodeLenses(): Promise<void> {
         const uri = this.workspace.activeDocumentFilePath
         if (!uri) {
@@ -867,9 +887,28 @@ export class Agent extends MessageHandler {
         }
         const lenses = (await Promise.all(promises)).flat()
 
+        // VS Code supports icons in code lenses, but we cannot render these through agent.
+        // We need to strip any icons from the title and provide those seperately, so the client can decide how to render them.
+        const agentLenses = lenses.map(lens => {
+            if (!lens.command) {
+                return {
+                    ...lens,
+                    command: undefined,
+                }
+            }
+
+            return {
+                ...lens,
+                command: {
+                    ...lens.command,
+                    ...this.extractIconsFromTitle(lens.command.title),
+                },
+            }
+        })
+
         this.notify('codeLenses/display', {
             uri: uri.toString(),
-            codeLenses: lenses,
+            codeLenses: agentLenses,
         })
     }
     private async provideCodeLenses(

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -851,7 +851,10 @@ export class Agent extends MessageHandler {
     }
 
     private codeLensToken = new vscode.CancellationTokenSource()
-    /** Matches VS Code codicon syntax, e.g. $(cody-logo) */
+    /**
+     * Matches VS Code codicon syntax, e.g. $(cody-logo)
+     * Source: https://sourcegraph.com/github.com/microsoft/vscode@f34d4/-/blob/src/vs/base/browser/ui/iconLabel/iconLabels.ts?L9
+     */
     private labelWithIconsRegex = /(\\)?\$\(([A-Za-z0-9-]+(?:~[A-Za-z]+)?)\)/g
     /**
      * Given a title, such as "$(cody-logo) Cody", returns the raw

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -273,17 +273,17 @@ export class Agent extends MessageHandler {
             this.workspace.workspaceRootUri = clientInfo.workspaceRootUri
                 ? vscode.Uri.parse(clientInfo.workspaceRootUri)
                 : vscode.Uri.from({
-                    scheme: 'file',
-                    path: clientInfo.workspaceRootPath,
-                })
+                      scheme: 'file',
+                      path: clientInfo.workspaceRootPath,
+                  })
             try {
                 await initializeVscodeExtension(this.workspace.workspaceRootUri)
                 this.registerWebviewHandlers()
 
                 this.authenticationPromise = clientInfo.extensionConfiguration
                     ? this.handleConfigChanges(clientInfo.extensionConfiguration, {
-                        forceAuthentication: true,
-                    })
+                          forceAuthentication: true,
+                      })
                     : this.authStatus()
                 const authStatus = await this.authenticationPromise
 
@@ -462,8 +462,8 @@ export class Agent extends MessageHandler {
                                 reject(
                                     new Error(
                                         'testing/progressCancelation did not resolve within 5 seconds. ' +
-                                        'To fix this problem, send a progress/cancel notification with the same ID ' +
-                                        'as the progress/start notification with title "testing/progressCancelation"'
+                                            'To fix this problem, send a progress/cancel notification with the same ID ' +
+                                            'as the progress/start notification with title "testing/progressCancelation"'
                                     )
                                 ),
                             5_000
@@ -494,8 +494,8 @@ export class Agent extends MessageHandler {
                 typeof params.uri === 'string'
                     ? vscode.Uri.parse(params.uri)
                     : params?.filePath
-                        ? vscode.Uri.file(params.filePath)
-                        : undefined
+                      ? vscode.Uri.file(params.filePath)
+                      : undefined
             if (!uri) {
                 logError(
                     'Agent',
@@ -531,17 +531,17 @@ export class Agent extends MessageHandler {
                             vscode.InlineCompletionTriggerKind[params.triggerKind || 'Automatic'],
                         selectedCompletionInfo:
                             params.selectedCompletionInfo?.text === undefined ||
-                                params.selectedCompletionInfo?.text === null
+                            params.selectedCompletionInfo?.text === null
                                 ? undefined
                                 : {
-                                    text: params.selectedCompletionInfo.text,
-                                    range: new vscode.Range(
-                                        params.selectedCompletionInfo.range.start.line,
-                                        params.selectedCompletionInfo.range.start.character,
-                                        params.selectedCompletionInfo.range.end.line,
-                                        params.selectedCompletionInfo.range.end.character
-                                    ),
-                                },
+                                      text: params.selectedCompletionInfo.text,
+                                      range: new vscode.Range(
+                                          params.selectedCompletionInfo.range.start.line,
+                                          params.selectedCompletionInfo.range.start.character,
+                                          params.selectedCompletionInfo.range.end.line,
+                                          params.selectedCompletionInfo.range.end.character
+                                      ),
+                                  },
                     },
                     token
                 )
@@ -1052,10 +1052,10 @@ export class Agent extends MessageHandler {
     private codyError(error?: Error): CodyError | undefined {
         return error
             ? {
-                message: error.message,
-                stack: error.stack,
-                cause: error.cause instanceof Error ? this.codyError(error.cause) : undefined,
-            }
+                  message: error.message,
+                  stack: error.stack,
+                  cause: error.cause instanceof Error ? this.codyError(error.cause) : undefined,
+              }
             : undefined
     }
 
@@ -1124,8 +1124,8 @@ export class Agent extends MessageHandler {
             logError(
                 'Agent',
                 'client does not support vscode.workspace.applyEdit() yet. ' +
-                'If you are a client author, enable this operation by setting ' +
-                'the client capability `editWorkspace: "enabled"`',
+                    'If you are a client author, enable this operation by setting ' +
+                    'the client capability `editWorkspace: "enabled"`',
                 new Error().stack // adding the stack trace to help debugging by this method is being called
             )
             return Promise.resolve(false)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -273,17 +273,17 @@ export class Agent extends MessageHandler {
             this.workspace.workspaceRootUri = clientInfo.workspaceRootUri
                 ? vscode.Uri.parse(clientInfo.workspaceRootUri)
                 : vscode.Uri.from({
-                      scheme: 'file',
-                      path: clientInfo.workspaceRootPath,
-                  })
+                    scheme: 'file',
+                    path: clientInfo.workspaceRootPath,
+                })
             try {
                 await initializeVscodeExtension(this.workspace.workspaceRootUri)
                 this.registerWebviewHandlers()
 
                 this.authenticationPromise = clientInfo.extensionConfiguration
                     ? this.handleConfigChanges(clientInfo.extensionConfiguration, {
-                          forceAuthentication: true,
-                      })
+                        forceAuthentication: true,
+                    })
                     : this.authStatus()
                 const authStatus = await this.authenticationPromise
 
@@ -462,8 +462,8 @@ export class Agent extends MessageHandler {
                                 reject(
                                     new Error(
                                         'testing/progressCancelation did not resolve within 5 seconds. ' +
-                                            'To fix this problem, send a progress/cancel notification with the same ID ' +
-                                            'as the progress/start notification with title "testing/progressCancelation"'
+                                        'To fix this problem, send a progress/cancel notification with the same ID ' +
+                                        'as the progress/start notification with title "testing/progressCancelation"'
                                     )
                                 ),
                             5_000
@@ -494,8 +494,8 @@ export class Agent extends MessageHandler {
                 typeof params.uri === 'string'
                     ? vscode.Uri.parse(params.uri)
                     : params?.filePath
-                      ? vscode.Uri.file(params.filePath)
-                      : undefined
+                        ? vscode.Uri.file(params.filePath)
+                        : undefined
             if (!uri) {
                 logError(
                     'Agent',
@@ -531,17 +531,17 @@ export class Agent extends MessageHandler {
                             vscode.InlineCompletionTriggerKind[params.triggerKind || 'Automatic'],
                         selectedCompletionInfo:
                             params.selectedCompletionInfo?.text === undefined ||
-                            params.selectedCompletionInfo?.text === null
+                                params.selectedCompletionInfo?.text === null
                                 ? undefined
                                 : {
-                                      text: params.selectedCompletionInfo.text,
-                                      range: new vscode.Range(
-                                          params.selectedCompletionInfo.range.start.line,
-                                          params.selectedCompletionInfo.range.start.character,
-                                          params.selectedCompletionInfo.range.end.line,
-                                          params.selectedCompletionInfo.range.end.character
-                                      ),
-                                  },
+                                    text: params.selectedCompletionInfo.text,
+                                    range: new vscode.Range(
+                                        params.selectedCompletionInfo.range.start.line,
+                                        params.selectedCompletionInfo.range.start.character,
+                                        params.selectedCompletionInfo.range.end.line,
+                                        params.selectedCompletionInfo.range.end.character
+                                    ),
+                                },
                     },
                     token
                 )
@@ -857,7 +857,7 @@ export class Agent extends MessageHandler {
      * Given a title, such as "$(cody-logo) Cody", returns the raw
      * title without icons and the icons matched with their respective positions.
      */
-    private extractIconsFromTitle(title: string): Pick<ProtocolCommand, 'title' | 'icons'> {
+    private splitIconsFromTitle(title: string): ProtocolCommand['title'] {
         const icons: { value: string; position: number }[] = []
         const matches = [...title.matchAll(this.labelWithIconsRegex)]
 
@@ -867,7 +867,7 @@ export class Agent extends MessageHandler {
             }
         }
 
-        return { title: title.replace(this.labelWithIconsRegex, ''), icons }
+        return { text: title.replace(this.labelWithIconsRegex, ''), icons }
     }
 
     private async updateCodeLenses(): Promise<void> {
@@ -901,7 +901,7 @@ export class Agent extends MessageHandler {
                 ...lens,
                 command: {
                     ...lens.command,
-                    ...this.extractIconsFromTitle(lens.command.title),
+                    title: this.splitIconsFromTitle(lens.command.title),
                 },
             }
         })
@@ -1052,10 +1052,10 @@ export class Agent extends MessageHandler {
     private codyError(error?: Error): CodyError | undefined {
         return error
             ? {
-                  message: error.message,
-                  stack: error.stack,
-                  cause: error.cause instanceof Error ? this.codyError(error.cause) : undefined,
-              }
+                message: error.message,
+                stack: error.stack,
+                cause: error.cause instanceof Error ? this.codyError(error.cause) : undefined,
+            }
             : undefined
     }
 
@@ -1124,8 +1124,8 @@ export class Agent extends MessageHandler {
             logError(
                 'Agent',
                 'client does not support vscode.workspace.applyEdit() yet. ' +
-                    'If you are a client author, enable this operation by setting ' +
-                    'the client capability `editWorkspace: "enabled"`',
+                'If you are a client author, enable this operation by setting ' +
+                'the client capability `editWorkspace: "enabled"`',
                 new Error().stack // adding the stack trace to help debugging by this method is being called
             )
             return Promise.resolve(false)

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -641,8 +641,8 @@ describe('Agent', () => {
                 }
 
                 // Check the command is corrected parsed by the agent
-                expect(acceptCommand.command.title).toBe(' Accept')
-                expect(acceptCommand.command.icons).toStrictEqual([
+                expect(acceptCommand.command.title.text).toBe(' Accept')
+                expect(acceptCommand.command.title.icons).toStrictEqual([
                     { position: 0, value: '$(cody-logo)' },
                 ])
 

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -639,6 +639,13 @@ describe('Agent', () => {
                         `Expected accept command, found none. Lenses ${JSON.stringify(lenses, null, 2)}`
                     )
                 }
+
+                // Check the command is corrected parsed by the agent
+                expect(acceptCommand.command.title).toBe(' Accept')
+                expect(acceptCommand.command.icons).toStrictEqual([
+                    { position: 0, value: '$(cody-logo)' },
+                ])
+
                 await documentClient.request('command/execute', acceptCommand.command)
                 expect(documentClient.codeLenses.get(uri.toString()) ?? []).toHaveLength(0)
                 const newContent = documentClient.workspace.getDocument(uri)?.content

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -607,11 +607,13 @@ export interface ProtocolCodeLens {
 }
 
 export interface ProtocolCommand {
-    title: string
-    icons: {
-        value: string
-        position: number
-    }[]
+    title: {
+        text: string
+        icons: {
+            value: string
+            position: number
+        }[]
+    },
     command: string
     tooltip?: string
     arguments?: any[]

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -613,7 +613,7 @@ export interface ProtocolCommand {
             value: string
             position: number
         }[]
-    },
+    }
     command: string
     tooltip?: string
     arguments?: any[]

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -608,6 +608,10 @@ export interface ProtocolCodeLens {
 
 export interface ProtocolCommand {
     title: string
+    icons: {
+        value: string
+        position: number
+    }[]
     command: string
     tooltip?: string
     arguments?: any[]

--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -4,6 +4,7 @@ import { isRateLimitError } from '@sourcegraph/cody-shared'
 
 import type { FixupTask } from '../FixupTask'
 import { CodyTaskState } from '../utils'
+import { isRunningInsideAgent } from '../../jsonrpc/isRunningInsideAgent'
 
 // Create Lenses based on state
 export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
@@ -135,9 +136,9 @@ function getFormattingSkipLens(codeLensRange: vscode.Range, id: string): vscode.
 
 function getCancelLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
-    const shortcut = process.platform === 'darwin' ? '⌥Z' : 'Alt+Z'
+    const shortcut = isRunningInsideAgent() ? '' : ` (${process.platform === 'darwin' ? '⌥Z' : 'Alt+Z'})`
     lens.command = {
-        title: `Cancel (${shortcut})`,
+        title: `Cancel${shortcut}`,
         command: 'cody.fixup.codelens.cancel',
         arguments: [id],
     }
@@ -166,9 +167,9 @@ function getDiffLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
 
 function getRetryLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
-    const shortcut = process.platform === 'darwin' ? '⌥R' : 'Alt+R'
+    const shortcut = isRunningInsideAgent() ? '' : ` (${process.platform === 'darwin' ? '⌥R' : 'Alt+R'})`
     lens.command = {
-        title: `Edit & Retry (${shortcut})`,
+        title: `Edit & Retry${shortcut}`,
         command: 'cody.fixup.codelens.retry',
         arguments: [id],
     }
@@ -177,9 +178,9 @@ function getRetryLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens 
 
 function getUndoLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
-    const shortcut = process.platform === 'darwin' ? '⌥X' : 'Alt+X'
+    const shortcut = isRunningInsideAgent() ? '' : ` (${process.platform === 'darwin' ? '⌥X' : 'Alt+X'})`
     lens.command = {
-        title: `Undo (${shortcut})`,
+        title: `Undo${shortcut}`,
         command: 'cody.fixup.codelens.undo',
         arguments: [id],
     }
@@ -188,9 +189,9 @@ function getUndoLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
 
 function getAcceptLens(codeLensRange: vscode.Range, id: string): vscode.CodeLens {
     const lens = new vscode.CodeLens(codeLensRange)
-    const shortcut = process.platform === 'darwin' ? '⌥A' : 'Alt+A'
+    const shortcut = isRunningInsideAgent() ? '' : ` (${process.platform === 'darwin' ? '⌥A' : 'Alt+A'})`
     lens.command = {
-        title: `$(cody-logo) Accept (${shortcut})`,
+        title: `$(cody-logo) Accept${shortcut}`,
         command: 'cody.fixup.codelens.accept',
         arguments: [id],
     }


### PR DESCRIPTION
## Description

**Problem:**
- VS Code allows rendering icons (via an icon font) in code lens, e.g. `$(cody-logo) Accept`
- We cannot assume consumers of Agent will be able to render these icons in the same way
- (Other problem): We include VS Code specific shortcuts in the text of the agent lens

**Solution:**
- Extract icon syntax from title string
- Return `icons[]` with the icon value and the original position in the string
- Consumers of the agent can decide if and how they will render these icons.

**Example:**

VS Code codelens title:
`$(cody-logo) Accept`
Agent output:
```
{
  "isResolved": true,
  "range": {
    "start": {
      "line": 4,
      "character": 0
    },
    "end": {
      "line": 4,
      "character": 0
    }
  },
  "command": {
    "title": {
      "text": " Accept",
      "icons": [
        {
          "value": "$(cody-logo)",
          "position": 0
        }
      ]
    },
    "command": "cody.fixup.codelens.accept",
    "arguments": [
      "lsutws"
    ]
  }
}
```

[This is derived from the way VS Code parses these icons
](https://sourcegraph.com/github.com/microsoft/vscode/-/blob/src/vs/base/browser/ui/iconLabel/iconLabels.ts?L10) We just skip rendering these, and let the consumer decide that.

## Test plan

1. Run agent
2. Check that code lenses that include titles correctly split the title text and the icon posiitons
3. Check that the original code lens title can be reconstructed by inserting the icon positions at their respective position in the string

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
