### PR TITLE
Chat: Add flag to enable fused context

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -45,6 +45,8 @@ export enum FeatureFlag {
 
     // A feature flag to test potential chat experiments. No functionality is gated by it.
     CodyChatMockTest = 'cody-chat-mock-test',
+    // When enabled, fuses embeddings and symf context for chat.
+    CodyChatFusedContext = 'cody-chat-fused-context',
 
     // Show command hints alongside editor selections. "Opt+K to Edit, Opt+L to Chat"
     CodyCommandHints = 'cody-command-hints',

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -30,7 +30,7 @@ export interface GetEnhancedContextOptions {
         remoteSearch: RemoteSearch | null
     }
     featureFlags: {
-        internalUnstable: boolean
+        fusedContext: boolean
     }
     hints: {
         maxChars: number
@@ -45,7 +45,7 @@ export async function getEnhancedContext({
     featureFlags,
     hints,
 }: GetEnhancedContextOptions): Promise<ContextItem[]> {
-    if (featureFlags.internalUnstable) {
+    if (featureFlags.fusedContext) {
         return getEnhancedContextFused({
             strategy,
             editor,


### PR DESCRIPTION
The fused context feature was running for a while inside the `internalUnstable` config and I think it's time to ship this. To avoid breaking things, I'd like to do this with a feature flag (so we can easily killswitch this feature). 

## Test plan

- I added a breakpoint in the debugger to ensure this evaluates to the right value
- You can try it locally by enabling the `cody-chat-fused-context` feature flag on your SG instance and disable `cody.internal.unstable`
