### PR TITLE
Add logging of slow/blocking operations in the agent

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -29,6 +29,7 @@
     "@sourcegraph/cody-shared": "workspace:*",
     "@sourcegraph/telemetry": "^0.16.0",
     "@types/js-levenshtein": "^1.1.1",
+    "blocked-at": "^1.2.0",
     "commander": "^11.1.0",
     "csv-writer": "^1.6.0",
     "dedent": "^0.7.0",

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -20,6 +20,12 @@ process.on('uncaughtException', e => {
     console.error('Uncaught exception:', e)
 })
 
+const blocked = require('blocked-at');
+
+blocked((time: number, stack: string[]) => {
+  console.log(`Blocked for ${time}ms, operation started here:`, stack)
+});
+
 const args = process.argv.slice(2)
 const { operands } = rootCommand.parseOptions(args)
 if (operands.length === 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@types/js-levenshtein':
         specifier: ^1.1.1
         version: 1.1.1
+      blocked-at:
+        specifier: ^1.2.0
+        version: 1.2.0
       commander:
         specifier: ^11.1.0
         version: 11.1.0
@@ -6898,6 +6901,10 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.2
     dev: true
+
+  /blocked-at@1.2.0:
+    resolution: {integrity: sha512-Ba9yhK4KcFrgqEPgsU0qVGiMimf+VrD9QJo9pgwjg4yl0GXwgOJS8IRx2rPepQjalrmUdGTqX47bSuJLUMLX7w==}
+    dev: false
 
   /bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}


### PR DESCRIPTION
## Changes

In case of slow node operations now in the idea.log we will see stack traces like this:

```
2024-02-20 16:16:51,826 [   6560]   WARN - #c.s.c.a.CodyAgent - Blocked for 34.6219169998169ms, operation started here: [
2024-02-20 16:16:51,826 [   6560]   WARN - #c.s.c.a.CodyAgent -   '    at AsyncHook.init3 (/snapshot/dist/agent.js)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at emitInitNative (node:internal/async_hooks:202:43)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at emitInitScript (node:internal/async_hooks:505:3)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at promiseInitHook (node:internal/async_hooks:324:3)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at promiseInitHookWithDestroyTracking (node:internal/async_hooks:328:3)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at register (/snapshot/dist/agent.js)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at async start3 (/snapshot/dist/agent.js)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at async activate (/snapshot/dist/agent.js)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at async initializeVscodeExtension (/snapshot/dist/agent.js)',
2024-02-20 16:16:51,827 [   6561]   WARN - #c.s.c.a.CodyAgent -   '    at async /snapshot/dist/agent.js'
2024-02-20 16:16:51,828 [   6562]   WARN - #c.s.c.a.CodyAgent - ]
``` 