### PR TITLE
Chat: add transcript messages in pairs

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: Fixed error `found consecutive messages with the same speaker 'assistant'` that occurred when prompt length exceeded limit. [pull/3228](https://github.com/sourcegraph/cody/pull/3228)
+
 ### Changed
 
 ## [1.6.0]
@@ -28,7 +30,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: File range is now displayed correctly in the chat view. [pull/3172](https://github.com/sourcegraph/cody/pull/3172)
 - Autocomplete: Fixed an issue where the loading indicator might get stuck in the loading state. [pull/3178](https://github.com/sourcegraph/cody/pull/3178)
 - Autocomplete: Fixes an issue where Ollama results were sometimes not visible when the current line has text after the cursor. [pull/3213](https://github.com/sourcegraph/cody/pull/3213)
-- Chat: Fixed error `found consecutive messages with the same speaker 'assistant'` that occurred when prompt length exceeded limit. [pull/3228](https://github.com/sourcegraph/cody/pull/3228)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -28,8 +28,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed an issue where Cody Chat steals focus from file editor after a request is completed. [pull/3147](https://github.com/sourcegraph/cody/pull/3147)
 - Chat: Fixed an issue where the links in the welcome message for chat are unclickable. [pull/3155](https://github.com/sourcegraph/cody/pull/3155)
 - Chat: File range is now displayed correctly in the chat view. [pull/3172](https://github.com/sourcegraph/cody/pull/3172)
-- Autocomplete: Fixed an issue where the loading indicator might get stuck in the loading state. [pull/3178](https://github.com/sourcegraph/cody/pull/3178)
-- Autocomplete: Fixes an issue where Ollama results were sometimes not visible when the current line has text after the cursor. [pull/3213](https://github.com/sourcegraph/cody/pull/3213)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: File range is now displayed correctly in the chat view. [pull/3172](https://github.com/sourcegraph/cody/pull/3172)
 - Autocomplete: Fixed an issue where the loading indicator might get stuck in the loading state. [pull/3178](https://github.com/sourcegraph/cody/pull/3178)
 - Autocomplete: Fixes an issue where Ollama results were sometimes not visible when the current line has text after the cursor. [pull/3213](https://github.com/sourcegraph/cody/pull/3213)
+- Chat: Fixed error `found consecutive messages with the same speaker 'assistant'` that occurred when prompt length exceeded limit. [pull/3228](https://github.com/sourcegraph/cody/pull/3228)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -109,10 +109,10 @@ export class DefaultPrompter implements IPrompter {
 
             // Add existing transcript messages
             const reverseTranscript: MessageWithContext[] = [...chat.getMessagesWithContext()].reverse()
-            const contextLimitReached = promptBuilder.tryAddTranscript(reverseTranscript)
+            const contextLimitReached = promptBuilder.tryAddMessages(reverseTranscript)
             if (contextLimitReached) {
                 logDebug(
-                    'DefaultPrompter.tryAddTranscript',
+                    'DefaultPrompter.makePrompt',
                     `Ignored ${contextLimitReached} transcript messages due to context limit`
                 )
                 return {

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -20,62 +20,6 @@ export interface IPrompter {
 
 const ENHANCED_CONTEXT_ALLOCATION = 0.6 // Enhanced context should take up 60% of the context window
 
-export class CommandPrompter implements IPrompter {
-    constructor(private getContextItems: (maxChars: number) => Promise<ContextItem[]>) {}
-    public async makePrompt(chat: SimpleChatModel, charLimit: number): Promise<PromptInfo> {
-        const enhancedContextCharLimit = Math.floor(charLimit * ENHANCED_CONTEXT_ALLOCATION)
-        const promptBuilder = new PromptBuilder(charLimit)
-        const newContextUsed: ContextItem[] = []
-        const preInstruction: string | undefined = vscode.workspace
-            .getConfiguration('cody.chat')
-            .get('preInstruction')
-
-        const preambleMessages = getSimplePreamble(preInstruction)
-        const preambleSucceeded = promptBuilder.tryAddToPrefix(preambleMessages)
-        if (!preambleSucceeded) {
-            throw new Error(`Preamble length exceeded context window size ${charLimit}`)
-        }
-
-        // Add existing transcript messages
-        const reverseTranscript: MessageWithContext[] = [...chat.getMessagesWithContext()].reverse()
-        for (let i = 0; i < reverseTranscript.length; i++) {
-            const messageWithContext = reverseTranscript[i]
-            const contextLimitReached = promptBuilder.tryAdd(messageWithContext.message)
-            if (!contextLimitReached) {
-                logDebug(
-                    'CommandPrompter.makePrompt',
-                    `Ignored ${reverseTranscript.length - i} transcript messages due to context limit`
-                )
-                return {
-                    prompt: promptBuilder.build(),
-                    newContextUsed,
-                }
-            }
-        }
-
-        const contextItems = await this.getContextItems(enhancedContextCharLimit)
-        const { limitReached, used, ignored } = promptBuilder.tryAddContext(
-            contextItems,
-            enhancedContextCharLimit
-        )
-        newContextUsed.push(...used)
-        if (limitReached) {
-            // TODO(beyang): we're masking this error (repro: try /explain),
-            // we should improve the commands context selection process
-            logDebug(
-                'CommandPrompter',
-                'makePrompt',
-                `context limit reached, ignored ${ignored.length} items`
-            )
-        }
-
-        return {
-            prompt: promptBuilder.build(),
-            newContextUsed,
-        }
-    }
-}
-
 export class DefaultPrompter implements IPrompter {
     constructor(
         private explicitContext: ContextItem[],

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -108,21 +108,12 @@ export class DefaultPrompter implements IPrompter {
             }
 
             // Add existing transcript messages
-            const reverseTranscript: MessageWithContext[] = [...chat.getMessagesWithContext()].reverse()
-            for (let i = 0; i < reverseTranscript.length; i++) {
-                const messageWithContext = reverseTranscript[i]
-                const contextLimitReached = promptBuilder.tryAdd(messageWithContext.message)
-                if (!contextLimitReached) {
-                    logDebug(
-                        'DefaultPrompter.makePrompt',
-                        `Ignored ${
-                            reverseTranscript.length - i
-                        } transcript messages due to context limit`
-                    )
-                    return {
-                        prompt: promptBuilder.build(),
-                        newContextUsed,
-                    }
+            const transcript = [...chat.getMessagesWithContext()]
+            const contextLimitReached = promptBuilder.tryAddTranscript(transcript)
+            if (contextLimitReached) {
+                return {
+                    prompt: promptBuilder.build(),
+                    newContextUsed,
                 }
             }
 
@@ -139,6 +130,7 @@ export class DefaultPrompter implements IPrompter {
                 }
             }
 
+            const reverseTranscript: MessageWithContext[] = transcript.reverse()
             // TODO(beyang): Decide whether context from previous messages is less
             // important than user added context, and if so, reorder this.
             {

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -111,6 +111,10 @@ export class DefaultPrompter implements IPrompter {
             const transcript = [...chat.getMessagesWithContext()]
             const contextLimitReached = promptBuilder.tryAddTranscript(transcript)
             if (contextLimitReached) {
+                logDebug(
+                    'DefaultPrompter.tryAddTranscript',
+                    `Ignored ${contextLimitReached} transcript messages due to context limit`
+                )
                 return {
                     prompt: promptBuilder.build(),
                     newContextUsed,

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -108,8 +108,8 @@ export class DefaultPrompter implements IPrompter {
             }
 
             // Add existing transcript messages
-            const transcript = [...chat.getMessagesWithContext()]
-            const contextLimitReached = promptBuilder.tryAddTranscript(transcript)
+            const reverseTranscript: MessageWithContext[] = [...chat.getMessagesWithContext()].reverse()
+            const contextLimitReached = promptBuilder.tryAddTranscript(reverseTranscript)
             if (contextLimitReached) {
                 logDebug(
                     'DefaultPrompter.tryAddTranscript',
@@ -134,7 +134,6 @@ export class DefaultPrompter implements IPrompter {
                 }
             }
 
-            const reverseTranscript: MessageWithContext[] = transcript.reverse()
             // TODO(beyang): Decide whether context from previous messages is less
             // important than user added context, and if so, reorder this.
             {

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -98,12 +98,11 @@ export const buildInteraction = async ({
     const preamble = getSimplePreamble()
     promptBuilder.tryAddToPrefix(preamble)
 
-    const reversedTranscript: MessageWithContext[] = []
+    const transcript: MessageWithContext[] = [{ message: { speaker: 'human', text: prompt } }]
     if (assistantText) {
-        reversedTranscript.push({ message: { speaker: 'assistant', text: assistantText } })
+        transcript.push({ message: { speaker: 'assistant', text: assistantText } })
     }
-    reversedTranscript.push({ message: { speaker: 'human', text: prompt } })
-    promptBuilder.tryAddTranscript(reversedTranscript)
+    promptBuilder.tryAddMessages(transcript.reverse())
 
     const contextItems = await getContext({
         intent: task.intent,

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -98,11 +98,12 @@ export const buildInteraction = async ({
     const preamble = getSimplePreamble()
     promptBuilder.tryAddToPrefix(preamble)
 
-    const transcript: MessageWithContext[] = [{ message: { speaker: 'human', text: prompt } }]
+    const reversedTranscript: MessageWithContext[] = []
     if (assistantText) {
-        transcript.push({ message: { speaker: 'assistant', text: assistantText } })
+        reversedTranscript.push({ message: { speaker: 'assistant', text: assistantText } })
     }
-    promptBuilder.tryAddTranscript(transcript)
+    reversedTranscript.push({ message: { speaker: 'human', text: prompt } })
+    promptBuilder.tryAddTranscript(reversedTranscript)
 
     const contextItems = await getContext({
         intent: task.intent,

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -17,6 +17,7 @@ import type { EditLLMInteraction, GetLLMInteractionOptions, LLMInteraction } fro
 import { openai } from './models/openai'
 import { claude } from './models/claude'
 import { PromptBuilder } from '../../prompt-builder'
+import type { MessageWithContext } from '../../chat/chat-view/SimpleChatModel'
 
 const INTERACTION_MODELS: Record<EditModel, EditLLMInteraction> = {
     'anthropic/claude-2.0': claude,
@@ -97,10 +98,11 @@ export const buildInteraction = async ({
     const preamble = getSimplePreamble()
     promptBuilder.tryAddToPrefix(preamble)
 
+    const transcript: MessageWithContext[] = [{ message: { speaker: 'human', text: prompt } }]
     if (assistantText) {
-        promptBuilder.tryAdd({ speaker: 'assistant', text: assistantText })
+        transcript.push({ message: { speaker: 'assistant', text: assistantText } })
     }
-    promptBuilder.tryAdd({ speaker: 'human', text: prompt })
+    promptBuilder.tryAddTranscript(transcript)
 
     const contextItems = await getContext({
         intent: task.intent,

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -5,6 +5,23 @@ import type { MessageWithContext } from '../chat/chat-view/SimpleChatModel'
 
 describe('PromptBuilder', () => {
     describe('tryAddMessages', () => {
+        it('adds single valid transcript', () => {
+            const builder = new PromptBuilder(100)
+            const transcript: MessageWithContext[] = [{ message: { speaker: 'human', text: 'Hi!' } }]
+            builder.tryAddMessages(transcript.reverse())
+            const messages = builder.build()
+            expect(messages.length).toBe(1)
+            expect(messages[0].speaker).toBe('human')
+        })
+
+        it('throw on transcript starts with assistant', () => {
+            const builder = new PromptBuilder(100)
+            const transcript: MessageWithContext[] = [{ message: { speaker: 'assistant', text: 'Hi!' } }]
+            expect(() => {
+                builder.tryAddMessages(transcript)
+            }).toThrowError()
+        })
+
         it('adds valid transcript in reverse order', () => {
             const builder = new PromptBuilder(1000)
             const transcript: MessageWithContext[] = [
@@ -26,7 +43,9 @@ describe('PromptBuilder', () => {
             const builder = new PromptBuilder(1000)
             const invalidTranscript: MessageWithContext[] = [
                 { message: { speaker: 'human', text: 'Hi there!' } },
-                { message: { speaker: 'human', text: 'How are you?' } },
+                { message: { speaker: 'human', text: 'Hello there!' } },
+                { message: { speaker: 'assistant', text: 'How are you?' } },
+                { message: { speaker: 'assistant', text: 'Hello there!' } },
             ]
             expect(() => {
                 builder.tryAddMessages(invalidTranscript)

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -52,6 +52,19 @@ describe('PromptBuilder', () => {
             }).toThrowError()
         })
 
+        it('throws on transcript with human speakers only', () => {
+            const builder = new PromptBuilder(1000)
+            const invalidTranscript: MessageWithContext[] = [
+                { message: { speaker: 'human', text: '1' } },
+                { message: { speaker: 'human', text: '2' } },
+                { message: { speaker: 'human', text: '3' } },
+                { message: { speaker: 'human', text: '4' } },
+            ]
+            expect(() => {
+                builder.tryAddMessages(invalidTranscript)
+            }).toThrowError()
+        })
+
         it('stops adding message-pairs when limit has been reached', () => {
             const builder = new PromptBuilder(30)
             const longTranscript: MessageWithContext[] = [

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { PromptBuilder } from './index'
+import type { MessageWithContext } from '../chat/chat-view/SimpleChatModel'
+
+describe('PromptBuilder', () => {
+    describe('tryAddMessages', () => {
+        it('adds valid transcript in reverse order', () => {
+            const builder = new PromptBuilder(1000)
+            const transcript: MessageWithContext[] = [
+                { message: { speaker: 'human', text: 'Hi assistant!' } },
+                { message: { speaker: 'assistant', text: 'Hello there!' } },
+                { message: { speaker: 'human', text: 'Hi again!' } },
+                { message: { speaker: 'assistant', text: 'Hello there again!' } },
+            ]
+            builder.tryAddMessages(transcript.reverse())
+            const messages = builder.build()
+            expect(messages.length).toBe(4)
+            expect(messages[0].speaker).toBe('human')
+            expect(messages[0].speaker === messages[2].speaker).toBeTruthy()
+            expect(messages[1].speaker).toBe('assistant')
+            expect(messages[1].speaker === messages[3].speaker).toBeTruthy()
+        })
+
+        it('throws on consecutive speakers order', () => {
+            const builder = new PromptBuilder(1000)
+            const invalidTranscript: MessageWithContext[] = [
+                { message: { speaker: 'human', text: 'Hi there!' } },
+                { message: { speaker: 'human', text: 'How are you?' } },
+            ]
+            expect(() => {
+                builder.tryAddMessages(invalidTranscript)
+            }).toThrowError()
+        })
+
+        it('stops adding message-pairs when limit has been reached', () => {
+            const builder = new PromptBuilder(30)
+            const longTranscript: MessageWithContext[] = [
+                { message: { speaker: 'human', text: 'Hi assistant!' } },
+                { message: { speaker: 'assistant', text: 'Hello there!' } },
+                { message: { speaker: 'human', text: 'Hi again!' } },
+                {
+                    message: {
+                        speaker: 'assistant',
+                        text: 'This is a very long message that should exceed the character limit',
+                    },
+                },
+                // Only this message should be added
+                { message: { speaker: 'human', text: 'This should be added.' } },
+            ]
+            const numberOfMessagesIgnored = builder.tryAddMessages(longTranscript.reverse())
+            expect(numberOfMessagesIgnored).toBe(4)
+            const messages = builder.build()
+            expect(messages.length).toBe(1)
+        })
+    })
+})

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -70,10 +70,10 @@ export class PromptBuilder {
         // All Human message is expected to be followed by response from Assistant,
         // except for the Human message at the last index that Assistant hasn't responded yet.
         let i = reverseTranscript.findIndex(msg => msg.message?.speaker === 'human')
-        while (i < reverseTranscript.length) {
+        while (i <= reverseTranscript.length) {
             const humanMsg = reverseTranscript[i]?.message
             const assistantMsg = reverseTranscript[i - 1]?.message
-            if (humanMsg?.speaker !== 'human' || (humanMsg && !assistantMsg)) {
+            if (humanMsg?.speaker !== 'human' || (!humanMsg && assistantMsg)) {
                 throw new Error(`Invalid transcript order: expected human message at index ${i}`)
             }
             if (humanMsg?.speaker === assistantMsg?.speaker) {
@@ -82,14 +82,14 @@ export class PromptBuilder {
             const getLength = (msg: Message) => msg.speaker.length + (msg.text?.length || 0) + 3
             const msgLen = getLength(humanMsg) + (assistantMsg ? getLength(assistantMsg) : 0)
             if (this.charsUsed + msgLen > this.charLimit) {
-                return i
+                return reverseTranscript.length - i + 1
             }
+            this.charsUsed += msgLen
             // Push the assistant response first to the reverseMessages to maintain the order.
             if (assistantMsg) {
                 this.reverseMessages.push(assistantMsg)
             }
             this.reverseMessages.push(humanMsg)
-            this.charsUsed += msgLen
             i += 2
         }
         return 0

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -36,7 +36,7 @@ export class PromptBuilder {
     }
 
     /**
-     * @deprecated Use 'tryAddTranscript' instead.
+     * @deprecated Use 'tryAddMessages' instead.
      */
     public tryAdd(message: Message): boolean {
         const lastMessage = this.reverseMessages.at(-1)
@@ -66,15 +66,15 @@ export class PromptBuilder {
      * Validates that the transcript alternates between human and assistant speakers.
      * Stops adding when the character limit would be exceeded.
      */
-    public tryAddTranscript(reverseTranscript: MessageWithContext[]): number {
+    public tryAddMessages(reverseTranscript: MessageWithContext[]): number {
         // All Human message is expected to be followed by response from Assistant,
         // except for the Human message at the last index that Assistant hasn't responded yet.
         let i = reverseTranscript.findIndex(msg => msg.message?.speaker === 'human')
         while (i < reverseTranscript.length) {
             const humanMsg = reverseTranscript[i]?.message
             const assistantMsg = reverseTranscript[i - 1]?.message
-            if (humanMsg?.speaker !== 'human') {
-                throw new Error('Invalid transcript: expected human message at index ' + i)
+            if (humanMsg?.speaker !== 'human' || (humanMsg && !assistantMsg)) {
+                throw new Error(`Invalid transcript order: expected human message at index ${i}`)
             }
             if (humanMsg?.speaker === assistantMsg?.speaker) {
                 throw new Error('Cannot add message with same speaker as last message')

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -36,30 +36,6 @@ export class PromptBuilder {
     }
 
     /**
-     * @deprecated Use 'tryAddMessages' instead.
-     */
-    public tryAdd(message: Message): boolean {
-        const lastMessage = this.reverseMessages.at(-1)
-        if (lastMessage?.speaker === message.speaker) {
-            throw new Error('Cannot add message with same speaker as last message')
-        }
-
-        const msgLen = message.speaker.length + (message.text?.length || 0) + 3 // space and 2 newlines
-        if (this.charsUsed + msgLen > this.charLimit) {
-            // Remove the last assistant message which is a response to the current message
-            // from human to avoid the `found consecutive messages with the same speaker 'assistant'`
-            // error when we add the preamble that ends with 'assistant'.
-            if (message.speaker === 'human' && lastMessage?.speaker === 'assistant') {
-                this.reverseMessages.pop()
-            }
-            return false
-        }
-        this.reverseMessages.push(message)
-        this.charsUsed += msgLen
-        return true
-    }
-
-    /**
      * Tries to add messages in pairs from reversed transcript to the prompt builder.
      * Returns the index of the last message that was successfully added.
      *

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -60,19 +60,19 @@ export class PromptBuilder {
     }
 
     /**
-     * Tries to add messages from transcript in pairs to the prompt builder, in reverse order.
+     * Tries to add messages in pairs from reversed transcript to the prompt builder.
      * Returns the index of the last message that was successfully added.
      *
      * Validates that the transcript alternates between human and assistant speakers.
      * Stops adding when the character limit would be exceeded.
      */
-    public tryAddTranscript(transcript: MessageWithContext[]): number {
+    public tryAddTranscript(reverseTranscript: MessageWithContext[]): number {
         // All Human message is expected to be followed by response from Assistant,
         // except for the Human message at the last index that Assistant hasn't responded yet.
-        let i = transcript.findLastIndex(msg => msg.message?.speaker === 'human')
-        while (i >= 0) {
-            const humanMsg = transcript[i]?.message
-            const assistantMsg = transcript[i + 1]?.message
+        let i = reverseTranscript.findIndex(msg => msg.message?.speaker === 'human')
+        while (i < reverseTranscript.length) {
+            const humanMsg = reverseTranscript[i]?.message
+            const assistantMsg = reverseTranscript[i - 1]?.message
             if (humanMsg?.speaker !== 'human') {
                 throw new Error('Invalid transcript: expected human message at index ' + i)
             }
@@ -90,7 +90,7 @@ export class PromptBuilder {
             }
             this.reverseMessages.push(humanMsg)
             this.charsUsed += msgLen
-            i -= 2
+            i += 2
         }
         return 0
     }

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -42,6 +42,12 @@ export class PromptBuilder {
 
         const msgLen = message.speaker.length + (message.text?.length || 0) + 3 // space and 2 newlines
         if (this.charsUsed + msgLen > this.charLimit) {
+            // Remove the last assistant message which is a response to the current message
+            // from human to avoid the `found consecutive messages with the same speaker 'assistant'`
+            // error when we add the preamble that ends with 'assistant'.
+            if (message.speaker === 'human' && lastMessage?.speaker === 'assistant') {
+                this.reverseMessages.pop()
+            }
             return false
         }
         this.reverseMessages.push(message)

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -35,6 +35,9 @@ export class PromptBuilder {
         return true
     }
 
+    /**
+     * @deprecated Use 'tryAddTranscript' instead.
+     */
     public tryAdd(message: Message): boolean {
         const lastMessage = this.reverseMessages.at(-1)
         if (lastMessage?.speaker === message.speaker) {
@@ -57,7 +60,7 @@ export class PromptBuilder {
     }
 
     /**
-     * Tries to add the given transcript of messages to the prompt builder in reverse order.
+     * Tries to add messages from transcript in pairs to the prompt builder, in reverse order.
      * Returns the index of the last message that was successfully added.
      *
      * Validates that the transcript alternates between human and assistant speakers.


### PR DESCRIPTION
FIX: https://github.com/sourcegraph/cody/issues/3126

Update to remove consecutive assistant messages after a human message cannot be added due to context limit reach.

Currently, we would stop adding old transcript messages when the limit has been reached, which was causing `found consecutive messages with the same speaker 'assistant'` error because we are not removing the (assistant) response that is associated with the (human) message we are skipping (as we loop through them from back to front).

~~This PR updates to removing the last assistant message responding to the current human message when the limit has been reached, instead of keeping assistant response without adding human message. This prevents the error when adding the preamble ending in 'assistant'.~~

#### Updated

Changes included:
- removed `tryAdd` which was adding message individually
- added `tryAddMessages` which takes the reversed transcript before adding the messages in pairs (human and assistant messages). When the limit has been reached, both the human and assistant messages will not be added. 
  - also check to ensure an assistant message must be followed by a human message
- added unit test for `tryAddMessages`
- removed the unused `CommandPrompter`

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Keep asking Cody questions until you have reached the context limit (check output channel for something similar to `DefaultPrompter.makePrompt: Ignored 19 transcript messages due to context limit`). You should not encounter the `found consecutive messages with the same speaker 'assistant'` error.

#### Before

![Screenshot 2024-02-20 at 1 24 30 PM](https://github.com/sourcegraph/cody/assets/68532117/a3a8ccc9-6746-489e-ae64-64729bdadf45)

Output Channel - the first message after the added preamble is from `assistant`:
```
█ DefaultPrompter.makePrompt: Ignored 19 transcript messages due to context limit
█ CompletionLogger:onError: {"type":"completion","endpoint":"https://sourcegraph.com/.api/completions/stream","status":"error","duration":302,"err":"found consecutive messages with the same speaker 'assistant'"}  {
  "params": {
    "temperature": 0.2,
    "maxTokensToSample": 1000,
    "topK": -1,
    "topP": -1,
    "model": "anthropic/claude-2.0",
    "messages": [
      {
        "speaker": "human",
        "text": "You are Cody, an AI coding assistant from Sourcegraph."
      },
      {
        "speaker": "assistant",
        "text": "I am Cody, an AI coding assistant from Sourcegraph."
      },
      {
        "speaker": "assistant",
        "text": " Based on reviewing the terminal output:\n\n- It is building a VS Code extension using pnpm, Vite, esbuild and referencing @sourcegraph packages.\n\n- There are deprecation warnings about Vite's CJS API that should be addressed by upgrading Vite.\n\n- The main output files are extension.node.js (10.7mb) and extension.node.js.map (18.9mb).\n\n- Build times are fast, around 300-400ms.\n\n- The build commands complete successfully with exit code 0.\n\nTo address the deprecation warnings:\n\n1. Open package.json and identify the Vite version.\n\n2. Update Vite to the latest stable version.\n\n3. Run `pnpm install` to install updated dependencies.\n\n4. Re-run `pnpm run build:dev:desktop` \n\n5. The warnings should no longer occur.\n\nLet me know if you need any clarification or have additional questions!"
      },
      {
        "speaker": "human",
        "text": "\nReview and analyze this terminal output from the `node` process and summarize the key information. If this indicates an error, provide step-by-step instructions on how I can resolve this:\n\n```\n\n*  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 368ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 349ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 405ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 337ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 426ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 376ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it.\n\n```\n\nProcess options: {\"name\":\"Build VS Code Extension (Desktop)\",\"shellPath\":\"/bin/zsh\",\"shellArgs\":[\"-l\",\"-c\",\"pnpm --silent run build:dev:desktop\"],\"cwd\":{\"$mid\":1,\"fsPath\":\"/Users/bwork/dev/cody-3/vscode\",\"path\":\"/Users/bwork/dev/cody-3/vscode\",\"scheme\":\"file\"},\"env\":{}}"
      },
      {
        "speaker": "assistant",
        "text": " Here is a summary of the key information from the terminal output:\n\n- This is building a VS Code extension using pnpm, Vite, esbuild and @sourcegraph packages.\n\n- There are deprecation warnings for the Vite CJS API that should be addressed. \n\n- The main output files are extension.node.js (10.7mb) and extension.node.js.map (18.9mb).\n\n- Build times are fast - around 300-400ms.\n\n- Build commands complete successfully with exit code 0.\n\nTo fix the deprecation warnings:\n\n1. Open package.json and identify the current Vite version.\n\n2. Update Vite to the latest stable version.\n\n3. Run `pnpm install` to update dependencies.\n\n4. Re-run the build command: `pnpm run build:dev:desktop`\n\n5. The deprecation warnings should no longer occur after updating Vite.\n\nLet me know if you need any clarification or have additional questions!"
      },
```


#### After

![Screenshot 2024-02-20 at 1 35 30 PM](https://github.com/sourcegraph/cody/assets/68532117/3736fdd9-0ba2-4933-b9df-e48dacc5c897)

Output Channel - the first message after the added preamble is from `human`, and the `assistant` message has been removed:
```
█ DefaultPrompter.makePrompt: Ignored 19 transcript messages due to context limit
█ logEvent (telemetry disabled): CodyVSCodeExtension:chat-question:executed VSCode {"properties":{"requestID":"33bda8b1-1a9a-45b3-81c3-97d59973c294","chatModel":"anthropic/claude-2.0","traceId":"c165b0facf0167c1398dc34f2ec413b0","contextSummary":{}},"opts":{"hasV2Event":true}}
█ telemetry-v2: recordEvent: cody.chat-question/executed: {"parameters":{"version":0,"metadata":[{"key":"recordsPrivateMetadataTranscript","value":1}],"privateMetadata":{"properties":{"requestID":"33bda8b1-1a9a-45b3-81c3-97d59973c294","chatModel":"anthropic/claude-2.0","traceId":"c165b0facf0167c1398dc34f2ec413b0","contextSummary":{}},"promptText":"hey"}},"timestamp":"2024-02-20T21:51:45.960Z"}
█ CompletionLogger:onComplete: {"type":"completion","endpoint":"https://sourcegraph.com/.api/completions/stream","status":"success","duration":9126}  {
  "result": " Hello!",
  "params": {
    "temperature": 0.2,
    "maxTokensToSample": 1000,
    "topK": -1,
    "topP": -1,
    "model": "anthropic/claude-2.0",
    "messages": [
      {
        "speaker": "human",
        "text": "You are Cody, an AI coding assistant from Sourcegraph."
      },
      {
        "speaker": "assistant",
        "text": "I am Cody, an AI coding assistant from Sourcegraph."
      },
      {
        "speaker": "human",
        "text": "\nReview and analyze this terminal output from the `node` process and summarize the key information. If this indicates an error, provide step-by-step instructions on how I can resolve this:\n\n```\n\n*  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 368ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 349ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 405ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 337ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 426ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it. \n\n *  Executing task: pnpm --silent run build:dev:desktop \n\n[1] The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.\n[0] All wasm modules are in place, have a good day!\n[0] \n[0]   dist/extension.node.js      10.7mb ⚠️\n[0]   dist/extension.node.js.map  18.9mb\n[0] \n[0] ⚡ Done in 376ms\n[0] pnpm run -s _build:esbuild:desktop --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src --alias:@sourcegraph/cody-ui=@sourcegraph/cody-ui/src/index --alias:@sourcegraph/cody-ui/src=@sourcegraph/cody-ui/src exited with code 0\n[1] pnpm run -s _build:webviews --mode development exited with code 0\n *  Terminal will be reused by tasks, press any key to close it.\n\n```\n\nProcess options: {\"name\":\"Build VS Code Extension (Desktop)\",\"shellPath\":\"/bin/zsh\",\"shellArgs\":[\"-l\",\"-c\",\"pnpm --silent run build:dev:desktop\"],\"cwd\":{\"$mid\":1,\"fsPath\":\"/Users/bwork/dev/cody-3/vscode\",\"path\":\"/Users/bwork/dev/cody-3/vscode\",\"scheme\":\"file\"},\"env\":{}}"
      },
      {
        "speaker": "assistant",
        "text": " Here is a summary of the key information from the terminal output:\n\n- This is building a VS Code extension using pnpm, Vite, esbuild and @sourcegraph packages.\n\n- There are deprecation warnings for the Vite CJS API that should be addressed. \n\n- The main output files are extension.node.js (10.7mb) and extension.node.js.map (18.9mb).\n\n- Build times are fast - around 300-400ms.\n\n- Build commands complete successfully with exit code 0.\n\nTo fix the deprecation warnings:\n\n1. Open package.json and identify the current Vite version.\n\n2. Update Vite to the latest stable version.\n\n3. Run `pnpm install` to update dependencies.\n\n4. Re-run the build command: `pnpm run build:dev:desktop`\n\n5. The deprecation warnings should no longer occur after updating Vite.\n\nLet me know if you need any clarification or have additional questions!"
      },
```