### PR TITLE
Update the logged out status bar item with more obvious CTA

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -3485,6 +3485,111 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 7dff941dfa6c21b42b65737c883afa5f
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 352
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseClientabcde1234
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "352"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 318
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: shown
+                  feature: cody.signInNotification
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.8.3
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 38
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 38
+          text: |
+            Private mode requires authentication.
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 15 Mar 2024 11:57:08 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "38"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1217
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-03-15T11:57:08.460Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: b38540ce2256c839f6ea9b4ee26f34fd
       _order: 0
       cache: {}

--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -778,6 +778,111 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: e68efafb65f7c8292e78490a07aa0bb0
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 352
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseMainBranchClientabcde1234
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "352"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 352
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: shown
+                  feature: cody.signInNotification
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.8.3
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 38
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 38
+          text: |
+            Private mode requires authentication.
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 15 Mar 2024 11:57:09 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "38"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1218
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-03-15T11:57:09.518Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 3b1b5f59d45319c7ea64d97ad93384aa
       _order: 0
       cache: {}

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -626,6 +626,7 @@ export class InlineCompletionItemProvider
                 title: errorTitle,
                 description: `${error.userMessage} ${error.retryMessage ?? ''}`.trim(),
                 errorType: error.name,
+                removeAfterSelected: true,
                 onSelect: () => {
                     if (canUpgrade) {
                         telemetryService.log('CodyVSCodeExtension:upsellUsageLimitCTA:clicked', {
@@ -633,7 +634,6 @@ export class InlineCompletionItemProvider
                         })
                     }
                     void vscode.commands.executeCommand('cody.show-page', pageName)
-                    return true
                 },
                 onShow: () => {
                     if (shown) {
@@ -678,6 +678,7 @@ export class InlineCompletionItemProvider
                 title: errorTitle,
                 description: 'Contact your Sourcegraph site admin to enable autocomplete',
                 errorType: 'AutoCompleteDisabledByAdmin',
+                removeAfterSelected: false,
                 onShow: () => {
                     if (shown) {
                         return

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -633,6 +633,7 @@ export class InlineCompletionItemProvider
                         })
                     }
                     void vscode.commands.executeCommand('cody.show-page', pageName)
+                    return true
                 },
                 onShow: () => {
                     if (shown) {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -536,6 +536,7 @@ const register = async (
         if (removeAuthStatusBarError) {
             removeAuthStatusBarError()
             removeAuthStatusBarError = undefined
+            statusBar.clearOnStatusBarClick()
         }
         if (!authProvider.getAuthStatus().isLoggedIn) {
             removeAuthStatusBarError = statusBar.addError({
@@ -548,6 +549,10 @@ const register = async (
                     // Bring up the sidebar view
                     void vscode.commands.executeCommand('cody.focus')
                 },
+            })
+            statusBar.setOnStatusBarClick(() => {
+                // Bring up the sidebar view
+                void vscode.commands.executeCommand('cody.focus')
             })
         }
     }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -539,9 +539,10 @@ const register = async (
         }
         if (!authProvider.getAuthStatus().isLoggedIn) {
             removeAuthStatusBarError = statusBar.addError({
-                title: 'Sign In to Use Cody',
+                title: 'Sign in to use Cody',
                 errorType: 'auth',
                 description: 'You need to sign in to use Cody.',
+                statusButtonLabel: 'Sign in to Cody',
                 onSelect: () => {
                     // Bring up the sidebar view
                     void vscode.commands.executeCommand('cody.focus')

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -528,37 +528,6 @@ const register = async (
         vscode.commands.registerCommand('cody.debug.enable.all', () => enableDebugMode())
     )
 
-    /**
-     * Signed out status bar indicator
-     */
-    let removeAuthStatusBarError: undefined | (() => void)
-    function updateAuthStatusBarIndicator(): void {
-        if (removeAuthStatusBarError) {
-            removeAuthStatusBarError()
-            removeAuthStatusBarError = undefined
-            statusBar.setOnClick(undefined)
-        }
-        if (!authProvider.getAuthStatus().isLoggedIn) {
-            removeAuthStatusBarError = statusBar.addError({
-                title: 'Sign in to use Cody',
-                errorType: 'auth',
-                description: 'You need to sign in to use Cody.',
-                statusButtonLabel: 'Sign in to Cody',
-                removeAfterSelected: false,
-                onSelect: () => {
-                    // Bring up the sidebar view
-                    void vscode.commands.executeCommand('cody.focus')
-                },
-            })
-            statusBar.setOnClick(() => {
-                // Bring up the sidebar view
-                void vscode.commands.executeCommand('cody.focus')
-            })
-        }
-    }
-    authProvider.addChangeListener(() => updateAuthStatusBarIndicator())
-    updateAuthStatusBarIndicator()
-
     let setupAutocompleteQueue = Promise.resolve() // Create a promise chain to avoid parallel execution
 
     let autocompleteDisposables: vscode.Disposable[] = []

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -546,6 +546,7 @@ const register = async (
                 onSelect: () => {
                     // Bring up the sidebar view
                     void vscode.commands.executeCommand('cody.focus')
+                    return false
                 },
             })
         }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -543,10 +543,10 @@ const register = async (
                 errorType: 'auth',
                 description: 'You need to sign in to use Cody.',
                 statusButtonLabel: 'Sign in to Cody',
+                removeAfterSelected: false,
                 onSelect: () => {
                     // Bring up the sidebar view
                     void vscode.commands.executeCommand('cody.focus')
-                    return false
                 },
             })
         }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -536,7 +536,7 @@ const register = async (
         if (removeAuthStatusBarError) {
             removeAuthStatusBarError()
             removeAuthStatusBarError = undefined
-            statusBar.clearOnStatusBarClick()
+            statusBar.setOnClick(undefined)
         }
         if (!authProvider.getAuthStatus().isLoggedIn) {
             removeAuthStatusBarError = statusBar.addError({
@@ -550,7 +550,7 @@ const register = async (
                     void vscode.commands.executeCommand('cody.focus')
                 },
             })
-            statusBar.setOnStatusBarClick(() => {
+            statusBar.setOnClick(() => {
                 // Bring up the sidebar view
                 void vscode.commands.executeCommand('cody.focus')
             })

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -26,10 +26,10 @@ export const showSetupNotification = async (config: ConfigurationWithAccessToken
     }
 
     return showActionNotification({
-        message: 'Continue setting up Cody',
+        message: 'Sign in to Cody to get started',
         actions: [
             {
-                label: 'Setup',
+                label: 'Sign In',
                 onClick: () => vscode.commands.executeCommand('cody.focus'),
             },
             {

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -50,9 +50,11 @@ export const showSetupNotification = async (config: ConfigurationWithAccessToken
                 onClick: async () => {
                     localStorage.set('notification.setupDismissed', 'true')
                     telemetryService.log(
-                        'CodyVSCodeExtension:signInNotification:doNotShow:Clicked',
+                        'CodyVSCodeExtension:signInNotification:doNotShow:clicked',
                         undefined,
-                        { hasV2Event: true }
+                        {
+                            hasV2Event: true,
+                        }
                     )
                     telemetryRecorder.recordEvent('cody.signInNotification.doNotShow', 'clicked')
                 },

--- a/vscode/src/notifications/setup-notification.ts
+++ b/vscode/src/notifications/setup-notification.ts
@@ -5,6 +5,8 @@ import type { ConfigurationWithAccessToken } from '@sourcegraph/cody-shared'
 import { localStorage } from '../services/LocalStorageProvider'
 
 import { showActionNotification } from '.'
+import { telemetryService } from '../services/telemetry'
+import { telemetryRecorder } from '../services/telemetry-v2'
 
 export const showSetupNotification = async (config: ConfigurationWithAccessToken): Promise<void> => {
     if (config.serverEndpoint && config.accessToken) {
@@ -25,16 +27,35 @@ export const showSetupNotification = async (config: ConfigurationWithAccessToken
         return
     }
 
+    telemetryService.log('CodyVSCodeExtension:signInNotification:shown', undefined, { hasV2Event: true })
+    telemetryRecorder.recordEvent('cody.signInNotification', 'shown')
+
     return showActionNotification({
         message: 'Sign in to Cody to get started',
         actions: [
             {
                 label: 'Sign In',
-                onClick: () => vscode.commands.executeCommand('cody.focus'),
+                onClick: async () => {
+                    vscode.commands.executeCommand('cody.focus')
+                    telemetryService.log(
+                        'CodyVSCodeExtension:signInNotification:signIn:clicked',
+                        undefined,
+                        { hasV2Event: true }
+                    )
+                    telemetryRecorder.recordEvent('cody.signInNotification.signInButton', 'clicked')
+                },
             },
             {
                 label: 'Do not show again',
-                onClick: () => localStorage.set('notification.setupDismissed', 'true'),
+                onClick: async () => {
+                    localStorage.set('notification.setupDismissed', 'true')
+                    telemetryService.log(
+                        'CodyVSCodeExtension:signInNotification:doNotShow:Clicked',
+                        undefined,
+                        { hasV2Event: true }
+                    )
+                    telemetryRecorder.recordEvent('cody.signInNotification.doNotShow', 'clicked')
+                },
             },
         ],
     })

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -29,6 +29,8 @@ export interface CodyStatusBar {
     ): () => void
     addError(error: StatusBarError): () => void
     hasError(error: StatusBarErrorName): boolean
+    setOnStatusBarClick(callback: (() => void) | undefined): void
+    clearOnStatusBarClick(): void
     syncAuthStatus(newStatus: AuthStatus): void
 }
 
@@ -54,7 +56,12 @@ export function createStatusBar(): CodyStatusBar {
     statusBarItem.show()
 
     let authStatus: AuthStatus | undefined
+    let onStatusBarClick: (() => void) | undefined
     const command = vscode.commands.registerCommand(statusBarItem.command, async () => {
+        if (onStatusBarClick) {
+            onStatusBarClick()
+            return
+        }
         const workspaceConfig = vscode.workspace.getConfiguration()
         const config = getConfiguration(workspaceConfig)
 
@@ -326,6 +333,16 @@ export function createStatusBar(): CodyStatusBar {
         },
         syncAuthStatus(newStatus: AuthStatus) {
             authStatus = newStatus
+        },
+        /**
+         * Set a custom statusbar click handler. If unset, the default settings
+         * quickpick will be shown on click.
+         */
+        setOnStatusBarClick(callback: () => void) {
+            onStatusBarClick = callback
+        },
+        clearOnStatusBarClick() {
+            onStatusBarClick = undefined
         },
         dispose() {
             statusBarItem.dispose()

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -14,8 +14,9 @@ interface StatusBarError {
     errorType: StatusBarErrorName
     statusButtonLabel?: string
     onShow?: () => void
-    onSelect?: () => void
+    onSelect?: () => boolean
 }
+
 
 export interface CodyStatusBar {
     dispose(): void
@@ -111,11 +112,13 @@ export function createStatusBar(): CodyStatusBar {
                           description: '',
                           detail: QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX + error.error.description,
                           onSelect(): Promise<void> {
-                              error.error.onSelect?.()
-                              const index = errors.indexOf(error)
-                              errors.splice(index)
-                              rerender()
-                              return Promise.resolve()
+                            const removeError = error.error.onSelect?.()
+                            if (removeError) {
+                                const index = errors.indexOf(error)
+                                errors.splice(index)
+                                rerender()
+                            }
+                            return Promise.resolve()
                           },
                       })),
                   ]

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -12,6 +12,7 @@ interface StatusBarError {
     title: string
     description: string
     errorType: StatusBarErrorName
+    statusButtonLabel?: string
     onShow?: () => void
     onSelect?: () => void
 }
@@ -239,6 +240,9 @@ export function createStatusBar(): CodyStatusBar {
         if (errors.length > 0) {
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
             statusBarItem.tooltip = errors[0].error.title
+            if (errors[0].error.statusButtonLabel) {
+                statusBarItem.text = `$(cody-logo-heavy) ${errors[0].error.statusButtonLabel}`
+            }
         } else {
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.activeBackground')
         }

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -256,7 +256,10 @@ export function createStatusBar(): CodyStatusBar {
             statusBarItem.tooltip = DEFAULT_TOOLTIP
         }
 
-        if (!authStatus?.isLoggedIn) {
+        // Only show this if authStatus is present, otherwise you get a flash of
+        // yellow status bar icon when extension first loads but login hasn't
+        // initialized yet
+        if (authStatus && !authStatus.isLoggedIn) {
             statusBarItem.text = 'Sign in to Cody'
             statusBarItem.tooltip = 'You need to sign in to use Cody'
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
@@ -346,6 +349,7 @@ export function createStatusBar(): CodyStatusBar {
         },
         syncAuthStatus(newStatus: AuthStatus) {
             authStatus = newStatus
+            rerender()
         },
         dispose() {
             statusBarItem.dispose()

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -17,7 +17,6 @@ interface StatusBarError {
     onSelect?: () => boolean
 }
 
-
 export interface CodyStatusBar {
     dispose(): void
     startLoading(
@@ -112,13 +111,13 @@ export function createStatusBar(): CodyStatusBar {
                           description: '',
                           detail: QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX + error.error.description,
                           onSelect(): Promise<void> {
-                            const removeError = error.error.onSelect?.()
-                            if (removeError) {
-                                const index = errors.indexOf(error)
-                                errors.splice(index)
-                                rerender()
-                            }
-                            return Promise.resolve()
+                              const removeError = error.error.onSelect?.()
+                              if (removeError) {
+                                  const index = errors.indexOf(error)
+                                  errors.splice(index)
+                                  rerender()
+                              }
+                              return Promise.resolve()
                           },
                       })),
                   ]

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -29,8 +29,7 @@ export interface CodyStatusBar {
     ): () => void
     addError(error: StatusBarError): () => void
     hasError(error: StatusBarErrorName): boolean
-    setOnStatusBarClick(callback: (() => void) | undefined): void
-    clearOnStatusBarClick(): void
+    setOnClick(callback: (() => void) | undefined): void
     syncAuthStatus(newStatus: AuthStatus): void
 }
 
@@ -56,10 +55,10 @@ export function createStatusBar(): CodyStatusBar {
     statusBarItem.show()
 
     let authStatus: AuthStatus | undefined
-    let onStatusBarClick: (() => void) | undefined
+    let onClick: (() => void) | undefined
     const command = vscode.commands.registerCommand(statusBarItem.command, async () => {
-        if (onStatusBarClick) {
-            onStatusBarClick()
+        if (onClick) {
+            onClick()
             return
         }
         const workspaceConfig = vscode.workspace.getConfiguration()
@@ -338,11 +337,8 @@ export function createStatusBar(): CodyStatusBar {
          * Set a custom statusbar click handler. If unset, the default settings
          * quickpick will be shown on click.
          */
-        setOnStatusBarClick(callback: () => void) {
-            onStatusBarClick = callback
-        },
-        clearOnStatusBarClick() {
-            onStatusBarClick = undefined
+        setOnClick(callback: () => void) {
+            onClick = callback
         },
         dispose() {
             statusBarItem.dispose()

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -261,7 +261,7 @@ export function createStatusBar(): CodyStatusBar {
         // initialized yet
         if (authStatus && !authStatus.isLoggedIn) {
             statusBarItem.text = 'Sign in to Cody'
-            statusBarItem.tooltip = 'You need to sign in to use Cody'
+            statusBarItem.tooltip = 'Sign in to get started with Cody'
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
             return
         }

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -13,8 +13,9 @@ interface StatusBarError {
     description: string
     errorType: StatusBarErrorName
     statusButtonLabel?: string
+    removeAfterSelected: boolean
     onShow?: () => void
-    onSelect?: () => boolean
+    onSelect?: () => void
 }
 
 export interface CodyStatusBar {
@@ -111,8 +112,8 @@ export function createStatusBar(): CodyStatusBar {
                           description: '',
                           detail: QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX + error.error.description,
                           onSelect(): Promise<void> {
-                              const removeError = error.error.onSelect?.()
-                              if (removeError) {
+                              error.error.onSelect?.()
+                              if (error.error.removeAfterSelected) {
                                   const index = errors.indexOf(error)
                                   errors.splice(index)
                                   rerender()

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -260,7 +260,7 @@ export function createStatusBar(): CodyStatusBar {
         // yellow status bar icon when extension first loads but login hasn't
         // initialized yet
         if (authStatus && !authStatus.isLoggedIn) {
-            statusBarItem.text = 'Sign in to Cody'
+            statusBarItem.text = 'Sign In'
             statusBarItem.tooltip = 'Sign in to get started with Cody'
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
             return

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -14,7 +14,6 @@ interface StatusBarError {
     title: string
     description: string
     errorType: StatusBarErrorName
-    statusButtonLabel?: string
     removeAfterSelected: boolean
     onShow?: () => void
     onSelect?: () => void
@@ -267,9 +266,6 @@ export function createStatusBar(): CodyStatusBar {
         if (errors.length > 0) {
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground')
             statusBarItem.tooltip = errors[0].error.title
-            if (errors[0].error.statusButtonLabel) {
-                statusBarItem.text = `$(cody-logo-heavy) ${errors[0].error.statusButtonLabel}`
-            }
         } else {
             statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.activeBackground')
         }

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -51,7 +51,7 @@ test.extend<ExpectedEvents>({
     ).toBeVisible()
 
     // Click on Cody at the bottom menu to open sign in
-    await page.getByRole('button', { name: 'Sign in to Cody, Sign in to get started with Cody' }).click()
+    await page.getByRole('button', { name: 'Sign In, Sign in to get started with Cody' }).click()
 
     // Makes sure the sign in page is loaded in the sidebar view with Cody: Chat as the heading
     // instead of the chat panel.

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -22,6 +22,7 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:logout:clicked',
         'CodyVSCodeExtension:Auth:failed',
         'CodyVSCodeExtension:Auth:disconnected',
+        'CodyVSCodeExtension:statusBarIcon:clicked',
     ],
 })('requires a valid auth token and allows logouts', async ({ page, sidebar }) => {
     await expect(page.getByText('Authentication failed.')).not.toBeVisible()
@@ -49,13 +50,9 @@ test.extend<ExpectedEvents>({
         sidebarFrame.getByRole('button', { name: 'Sign In to Your Enterprise Instance' })
     ).toBeVisible()
 
-    // Click on Cody at the bottom menu to open the Cody Settings Menu and click on Sign In.
-    await page.getByRole('button', { name: 'cody-logo-heavy, Sign in to use Cody' }).click()
-    await page
-        .getByLabel('alert  Sign In to Use Cody, You need to sign in to use Cody., notice')
-        .locator('a')
-        .first()
-        .click()
+    // Click on Cody at the bottom menu to open sign in
+    await page.getByRole('button', { name: 'Sign in to Cody, You need to sign in to use Cody' }).click()
+
     // Makes sure the sign in page is loaded in the sidebar view with Cody: Chat as the heading
     // instead of the chat panel.
     await expect(page.getByRole('heading', { name: 'Cody: Chat' })).toBeVisible()

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -50,7 +50,7 @@ test.extend<ExpectedEvents>({
     ).toBeVisible()
 
     // Click on Cody at the bottom menu to open the Cody Settings Menu and click on Sign In.
-    await page.getByRole('button', { name: 'cody-logo-heavy, Sign In to Use Cody' }).click()
+    await page.getByRole('button', { name: 'cody-logo-heavy, Sign in to use Cody' }).click()
     await page
         .getByLabel('alert  Sign In to Use Cody, You need to sign in to use Cody., notice')
         .locator('a')

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -51,7 +51,7 @@ test.extend<ExpectedEvents>({
     ).toBeVisible()
 
     // Click on Cody at the bottom menu to open sign in
-    await page.getByRole('button', { name: 'Sign in to Cody, You need to sign in to use Cody' }).click()
+    await page.getByRole('button', { name: 'Sign in to Cody, Sign in to get started with Cody' }).click()
 
     // Makes sure the sign in page is loaded in the sidebar view with Cody: Chat as the heading
     // instead of the chat panel.


### PR DESCRIPTION
Updates the Cody status bar button to have the text "Sign in to Cody" when not logged in.

[PRD](https://docs.google.com/document/d/1vYkk-LY65k2x0J1AOldbUyxfK_JQCFc3eCUbULZXx70/edit)

[Asana task](https://app.asana.com/0/1206519077296236/1206519077296305)

Before:

https://github.com/sourcegraph/cody/assets/153/a413dfd0-4ad2-4eec-9549-99a17551511e

After:

https://github.com/sourcegraph/cody/assets/153/8d2214f8-1582-4801-b73a-25b4c4cc6451

Events added:

- `CodyVSCodeExtension:signInNotification:shown`
- `CodyVSCodeExtension:signInNotification:signIn:clicked`
- `CodyVSCodeExtension:signInNotification:doNotShow:clicked`
- `CodyVSCodeExtension:statusBarIcon:clicked, { loggedIn: boolean }`

## Test plan

- CI
- Test logged out & logging in
- Test logged in