### PR TITLE
Edit: Skip applicable diff logic when only inserting code

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -500,17 +500,19 @@ export class FixupController
         // Always ensure that any scheduled diffs have ran before applying edits
         this.updateDiffs()
 
-        const diff = this.applicableDiffOrRespin(task, document)
-        if (!diff) {
-            return
-        }
-
         // We will format this code once applied, so we avoid placing an undo stop after this edit to avoid cluttering the undo stack.
         const applyEditOptions = { undoStopBefore: true, undoStopAfter: false }
-        const editOk =
-            task.mode === 'edit'
-                ? await this.replaceEdit(edit, diff, task, applyEditOptions)
-                : await this.insertEdit(edit, document, task, applyEditOptions)
+
+        let editOk: boolean
+        if (task.mode === 'edit') {
+            const applicableDiff = this.applicableDiffOrRespin(task, document)
+            if (!applicableDiff) {
+                return
+            }
+            editOk = await this.replaceEdit(edit, applicableDiff, task, applyEditOptions)
+        } else {
+            editOk = await this.insertEdit(edit, document, task, applyEditOptions)
+        }
 
         this.logTaskCompletion(task, editOk)
 


### PR DESCRIPTION
## Description

We currently attempt to compute the applicable diff even in cases where we don't need it, such as `insert` mode for Edit.

This PR just skips that step.

## Test plan

1. Create an edit, check works as expected
2. Create an insert mode edit, like `Document Code`. Check works as expected

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
