### PR TITLE
Chat: add file size warning to @-tabs

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -579,7 +579,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             telemetryService.log('CodyVSCodeExtension:at-mention:executed', { source })
             telemetryRecorder.recordEvent('cody.at-mention', 'executed', { privateMetadata: { source } })
 
-            const tabs = getOpenTabsContextFile()
+            const tabs = await getOpenTabsContextFile()
             void this.postMessage({
                 type: 'userContextFiles',
                 userContextFiles: tabs,

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -248,14 +248,14 @@ function createContextFileRange(selectionRange: vscode.Range): ContextFile['rang
  * Filters the given context files to remove files larger than 1MB and non-text files.
  * Sets the title to 'large-file' for files contains more characters than the token limit.
  */
-async function filterLargeFiles(contextFiles: ContextFileFile[]): Promise<ContextFileFile[]> {
+export async function filterLargeFiles(contextFiles: ContextFileFile[]): Promise<ContextFileFile[]> {
     const filtered = []
     for (const cf of contextFiles) {
         // Remove file larger than 1MB and non-text files
         // NOTE: Sourcegraph search only includes files up to 1MB
-        const fileStat = await vscode.workspace.fs.stat(cf.uri).then(
+        const fileStat = await vscode.workspace.fs.stat(cf.uri)?.then(
             stat => stat,
-            () => undefined
+            error => undefined
         )
         if (fileStat?.type !== vscode.FileType.File || fileStat?.size > 1000000) {
             continue

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -46,6 +46,7 @@ const throttledFindFiles = throttle(findWorkspaceFiles, 10000)
  * Searches all workspaces for files matching the given string. VS Code doesn't
  * provide an API for fuzzy file searching, only precise globs, so we recreate
  * it by getting a list of all files across all workspaces and using fuzzysort.
+ * Large files over 1MB are filtered.
  */
 export async function getFileContextFiles(
     query: string,
@@ -114,28 +115,7 @@ export async function getFileContextFiles(
 
     // TODO(toolmantim): Add fuzzysort.highlight data to the result so we can show it in the UI
 
-    const filtered = []
-    try {
-        for (const sorted of sortedResults) {
-            // Remove file larger than 1MB and non-text files
-            // NOTE: Sourcegraph search only includes files up to 1MB
-            const fileStat = await vscode.workspace.fs.stat(sorted.uri)
-            if (fileStat.type !== vscode.FileType.File || fileStat.size > 1000000) {
-                continue
-            }
-            // Check if file contains more characters than the token limit based on fileStat.size
-            // and set the title of the result as 'large-file' for webview to display file size
-            // warning.
-            if (fileStat.size > CHARS_PER_TOKEN * MAX_CURRENT_FILE_TOKENS) {
-                sorted.title = 'large-file'
-            }
-            filtered.push(sorted)
-        }
-    } catch (error) {
-        console.log('atMention:getFileContextFiles:failed', error)
-    }
-
-    return filtered
+    return await filterLargeFiles(sortedResults)
 }
 
 export async function getSymbolContextFiles(
@@ -193,21 +173,16 @@ export async function getSymbolContextFiles(
     return matches.flatMap(match => match)
 }
 
-export function getOpenTabsContextFile(): ContextFile[] {
-    // de-dupe by fspath in case if they have a file open in two tabs
-    const fsPaths = new Set()
-    return getOpenTabsUris()
-        .filter(uri => {
-            if (isCodyIgnoredFile(uri)) {
-                return false
-            }
-            if (!fsPaths.has(uri.path)) {
-                fsPaths.add(uri.path)
-                return true
-            }
-            return false
-        })
-        .flatMap(uri => createContextFileFromUri(uri, 'user', 'file'))
+/**
+ * Gets context files for each open editor tab in VS Code.
+ * Filters out large files over 1MB to avoid expensive parsing.
+ */
+export async function getOpenTabsContextFile(): Promise<ContextFileFile[]> {
+    return await filterLargeFiles(
+        getOpenTabsUris()
+            .filter(uri => !isCodyIgnoredFile(uri))
+            .flatMap(uri => createContextFileFromUri(uri, 'user', 'file'))
+    )
 }
 
 function createContextFileFromUri(
@@ -267,4 +242,31 @@ function createContextFileRange(selectionRange: vscode.Range): ContextFile['rang
             character: selectionRange.end.character,
         },
     }
+}
+
+/**
+ * Filters the given context files to remove files larger than 1MB and non-text files.
+ * Sets the title to 'large-file' for files contains more characters than the token limit.
+ */
+async function filterLargeFiles(contextFiles: ContextFileFile[]): Promise<ContextFileFile[]> {
+    const filtered = []
+    for (const cf of contextFiles) {
+        // Remove file larger than 1MB and non-text files
+        // NOTE: Sourcegraph search only includes files up to 1MB
+        const fileStat = await vscode.workspace.fs.stat(cf.uri).then(
+            stat => stat,
+            () => undefined
+        )
+        if (fileStat?.type !== vscode.FileType.File || fileStat?.size > 1000000) {
+            continue
+        }
+        // Check if file contains more characters than the token limit based on fileStat.size
+        // and set the title of the result as 'large-file' for webview to display file size
+        // warning.
+        if (fileStat.size > CHARS_PER_TOKEN * MAX_CURRENT_FILE_TOKENS) {
+            cf.title = 'large-file'
+        }
+        filtered.push(cf)
+    }
+    return filtered
 }

--- a/vscode/src/editor/utils/index.ts
+++ b/vscode/src/editor/utils/index.ts
@@ -42,14 +42,14 @@ export async function getWorkspaceSymbols(query = ''): Promise<vscode.SymbolInfo
 }
 
 /**
- * Returns an array of URI's for all open editor tabs.
+ * Returns an array of URI's for all unique open editor tabs.
  *
  * Loops through all open tab groups and tabs, collecting the URI
  * of each tab with a 'file' scheme.
  */
 export function getOpenTabsUris(): vscode.Uri[] {
-    const uris = []
-    // Get open tabs
+    // de-dupe in case if they have a file open in two tabs
+    const uris = new Map<string, vscode.Uri>()
     const tabGroups = vscode.window.tabGroups.all
     const openTabs = tabGroups.flatMap(group =>
         group.tabs.map(tab => tab.input)
@@ -58,8 +58,8 @@ export function getOpenTabsUris(): vscode.Uri[] {
     for (const tab of openTabs) {
         // Skip non-file URIs
         if (tab?.uri?.scheme === 'file') {
-            uris.push(tab.uri)
+            uris.set(tab.uri.path, tab.uri)
         }
     }
-    return uris
+    return Array.from(uris.values())
 }


### PR DESCRIPTION
Issue: Currently, we are only showing large file warning for @-mentioned file selections, but not for the files from open tabs we list at @-mentioned start-up selection. 

This PR aims to fix the above issue:
- Updated `getOpenTabsContextFile` to add the `filterLargeFiles` process for locating large files.
- Refactored `getFileContextFiles` function to use a separate `filterLargeFiles` function for better reusability and readability.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Open a large file (e.g. [SimpleChatPanelProvider.ts](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts)) in your editor
2. open Cody Chat. 
3. In the chatbox, type `@`
4. You should see the large file warning showing up for the opened tabs

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/c2dd5902-959b-4a9f-896f-b32c83b86c88)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/652fd82a-1e55-4bb8-91ed-85b11f660377)

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/23675bfe-6270-4eca-8206-c77900a27885)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/e125ba15-6e51-4264-9665-d5b54d380256)
