### PR TITLE
support auth from cursor

### DIFF
--- a/lib/ui/src/chat/TranscriptItem.module.css
+++ b/lib/ui/src/chat/TranscriptItem.module.css
@@ -41,8 +41,9 @@
 
 /* Style @-file tokens to match TranscriptAction context files */
 .content a[href^="vscode://file"] em,
-.content a[href^="vscode-insiders://file"] em
-.content a[href^="vscodium://file"] em
+.content a[href^="vscode-insiders://file"] em,
+.content a[href^="vscodium://file"] em,
+.content a[href^="cursor://file"] em
 {
     padding: 1px 2px;
     box-sizing: border-box;

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Auth: Logging in via redirect should now work in Cursor. This requires Sourcegraph 5.3.2 or later. [pull/3241](https://github.com/sourcegraph/cody/pull/3241)
+
 ### Changed
 
 ## [1.6.0]

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -33,6 +33,7 @@ async function openExternalAuthUrl(provider: AuthMethod): Promise<boolean> {
         {
             'vscode-insiders': 'CODY_INSIDERS',
             vscodium: 'CODY_VSCODIUM',
+            cursor: 'CODY_CURSOR',
         }[uriScheme] || 'CODY'
     const newTokenUrl = `/user/settings/tokens/new/callback?requestFrom=${referralCode}`
     const postSignUpSurveyUrl = `/post-sign-up?returnTo=${newTokenUrl}`


### PR DESCRIPTION
## Test plan

Once https://github.com/sourcegraph/sourcegraph/pull/60681 is merged,
- Run dev instance from Cursor
- Auth via GitHub