### PR TITLE
Chat: enable editing chat command prompts

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -4508,1417 +4508,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7025d36a8bdc785588b1c7f73b192f71
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1239
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Please review and analyze the selected code and identify potential areas
-                  for improvement related to code smells, readability,
-                  maintainability, performance, security, etc. Do not list
-                  issues already addressed in the given code. Focus on providing
-                  up to 5 constructive suggestions that could make the code more
-                  robust, efficient, or align with best practices. For each
-                  suggestion, provide a brief explanation of the potential
-                  benefits. After listing any recommendations, summarize if you
-                  found notable opportunities to enhance the code quality
-                  overall or if the code generally follows sound design
-                  principles. If no issues found, reply 'There are no errors.'
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 182189
-        content:
-          mimeType: text/event-stream
-          size: 182189
-          text: >+
-            event: completion
-
-            data: {"completion":" Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected Type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number):","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-document","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Cre","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  //","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal'","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Cre","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature'","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmake","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound'","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound'","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conve","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nis","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves read","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JS","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Cre","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  //","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJS","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understand","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encaps","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would increment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but no","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but no major","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but no major issues","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but no major issues were","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but no major issues were found","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but no major issues were found.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return values:\n\n```\nexport interface Animal {\n  name: string\n  makeAnimalSound(volume?: number): string \n  isMammal: boolean\n}\n```\n\nAdding type annotations makes the code more self-documenting and enables stronger type checking.\n\n2. Make interface name more semantic:\n\n```\nexport interface Creature {\n  // ...\n}\n```\n\nThe name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.\n\n3. Make sound method name more semantic: \n\n``` \nmakeSound()\n```\n\nThe name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.\n\n4. Use boolean type for isMammal property:\n\n```\nisMammal: boolean\n```\n\nUsing the boolean type instead of just true/false improves readability.\n\n5. Add JSDoc comments for documentation:\n\n```\n/**\n * Represents a creature in the game\n */\nexport interface Creature {\n  // ...\n}\n```\n\nJSDoc comments enable generating API documentation and improve understandability.\n\nOverall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but no major issues were found.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 23 Jan 2024 17:40:52 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1289
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-01-23T17:40:49.795Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 5fab83beae207667553dfb51e89119f1
       _order: 0
       cache: {}
@@ -13578,1606 +12167,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 60aceb2b5c9513da47cc094790737485
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1443
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: "Explain what the selected code does in simple terms. Assume the audience
-                  is a beginner programmer who has just learned the language
-                  features and basic syntax. Focus on explaining: 1) The purpose
-                  of the code 2) What input(s) it takes 3) What output(s) it
-                  produces 4) How it achieves its purpose through the logic and
-                  algorithm. 5) Any important logic flows or data
-                  transformations happening. Use simple language a beginner
-                  could understand. Include enough detail to give a full picture
-                  of what the code aims to accomplish without getting too
-                  technical. Format the explanation in coherent paragraphs,
-                  using proper punctuation and grammar. Write the explanation
-                  assuming no prior context about the code is known. Do not make
-                  assumptions about variables or functions not shown in the
-                  shared code. Start the answer with the name of the code that
-                  is being explained."
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 262476
-        content:
-          mimeType: text/event-stream
-          size: 262476
-          text: >+
-            event: completion
-
-            data: {"completion":" Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in Type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achie","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows Type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows Type","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to stat","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfill","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal interface having","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal interface having the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal interface having the defined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal interface having the defined structure","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal interface having the defined structure.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Animal Interface\n\nThe selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:\n\n1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have. \n\n2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).\n\n3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.\n\n4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean. \n\n5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.\n\nSo in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal interface having the defined structure.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 14 Feb 2024 20:00:58 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1293
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-02-14T20:00:55.643Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 6721336c88c8c3735b98c2242b8178ca
       _order: 0
       cache: {}
@@ -16288,6 +13277,7 @@ log:
                   <selected>
 
                       return function inner() {}
+
 
 
 
@@ -18494,11 +15484,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 5fab83beae207667553dfb51e89119f1
+    - _id: 64980f0bce8f57b532ac8adeacad512a
       _order: 0
       cache: {}
       request:
-        bodySize: 1795
+        bodySize: 1445
         cookies: []
         headers:
           - name: content-type
@@ -18527,84 +15517,34 @@ log:
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file
-                  `src/multiple-selections.ts`:
-
+                  "My selected TypeScript code from file `src/animal.ts`:
                   <selected>
 
-
-                  function anotherFunction() {}
-
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
 
                   </selected>
               - speaker: assistant
                 text: Ok.
               - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
+                text: "Explain what @src/animal.ts:1-7  does in simple terms. Assume the
+                  audience is a beginner programmer who has just learned the
+                  language features and basic syntax. Focus on explaining: 1)
+                  The purpose of the code 2) What input(s) it takes 3) What
+                  output(s) it produces 4) How it achieves its purpose through
+                  the logic and algorithm. 5) Any important logic flows or data
+                  transformations happening. Use simple language a beginner
+                  could understand. Include enough detail to give a full picture
+                  of what the code aims to accomplish without getting too
+                  technical. Format the explanation in coherent paragraphs,
+                  using proper punctuation and grammar. Write the explanation
+                  assuming no prior context about the code is known. Do not make
+                  assumptions about variables or functions not shown in the
+                  shared code. Start the answer with the name of the code that
+                  is being explained."
               - speaker: assistant
             model: anthropic/claude-2.0
             temperature: 0
@@ -18613,27 +15553,1184 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 252
+        bodySize: 148693
         content:
           mimeType: text/event-stream
-          size: 252
-          text: |+
+          size: 148693
+          text: >+
             event: completion
-            data: {"completion":" another","stopReason":""}
+
+            data: {"completion":" The","stopReason":""}
+
 
             event: completion
-            data: {"completion":" anotherFunction","stopReason":""}
+
+            data: {"completion":" The code","stopReason":""}
+
 
             event: completion
-            data: {"completion":" anotherFunction","stopReason":"stop_sequence"}
+
+            data: {"completion":" The code defines","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound()","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface would","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface would provide","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface would provide the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface would provide the actual","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface would provide the actual implementation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface would provide the actual implementation.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" The code defines an Animal interface:\n\nThe Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have. \n\nIt has three members:\n\n1. name - This is a string property that represents the animal's name. All animals should have a name.\n\n2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.\n\n3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.\n\nBy defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.\n\nSo in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface would provide the actual implementation.","stopReason":"stop_sequence"}
+
 
             event: done
+
             data: {}
 
         cookies: []
         headers:
           - name: date
-            value: Fri, 16 Feb 2024 15:01:51 GMT
+            value: Thu, 22 Feb 2024 01:11:32 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -18662,7 +16759,1483 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-02-16T15:01:48.261Z
+      startedDateTime: 2024-02-22T01:11:29.207Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: f1991d8035e6d03c3f31291f3da16b43
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1241
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_3709f5bf232c2abca4c612f0768368b57919ca6eaa470e3fd7160cbf3e8d0ec3
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Please review and analyze @src/animal.ts:1-7  and identify potential areas
+                  for improvement related to code smells, readability,
+                  maintainability, performance, security, etc. Do not list
+                  issues already addressed in the given code. Focus on providing
+                  up to 5 constructive suggestions that could make the code more
+                  robust, efficient, or align with best practices. For each
+                  suggestion, provide a brief explanation of the potential
+                  benefits. After listing any recommendations, summarize if you
+                  found notable opportunities to enhance the code quality
+                  overall or if the code generally follows sound design
+                  principles. If no issues found, reply 'There are no errors.'
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 209164
+        content:
+          mimeType: text/event-stream
+          size: 209164
+          text: >+
+            event: completion
+
+            data: {"completion":" Here","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected Type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number):","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understand","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be re","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number):","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nRead","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmake","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(l","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loud","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number):","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve read","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends Base","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(l","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loud","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number):","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInher","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JS","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  //","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments. No","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments. No major","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments. No major issues","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments. No major issues were","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments. No major issues were identified","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments. No major issues were identified.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Here are 5 potential improvements for the selected TypeScript code:\n\n1. Add type annotations for method parameters and return types:\n\nexport interface Animal {\n  name: string;\n  makeAnimalSound(volume?: number): string;\n  isMammal: boolean;\n}\n\nAdding annotations improves understandability and enables stronger type checking.\n\n2. Make interface properties readonly if they are not meant to be reassigned: \n\nexport interface Animal {\n  readonly name: string;\n  makeAnimalSound(volume?: number): string;\n  readonly isMammal: boolean;\n}\n\nReadonly properties clarify intent and prevent accidental mutation.\n\n3. Use more specific parameter names than volume for makeAnimalSound():\n\nmakeAnimalSound(loudness?: number): string;\n\nMore descriptive names improve readability.\n\n4. Consider extending the interface from a base class for code reuse:\n\nexport interface Animal extends BaseAnimal {\n  makeAnimalSound(loudness?: number): string;\n}\n\nInheritance promotes abstraction and reduces duplication.\n\n5. Add JSDoc comments for overall interface description:\n\n/**\n * Represents an animal with common attributes.\n */\nexport interface Animal {\n  // ...\n} \n\nComments improve understanding of intent and usage.\n\nOverall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments. No major issues were identified.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 22 Feb 2024 01:11:42 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1293
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-02-22T01:11:40.791Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -672,21 +672,21 @@ describe('Agent', () => {
             const lastMessage = await client.firstNonEmptyTranscript(id)
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              " Animal Interface
+              " The code defines an Animal interface:
 
-              The selected code defines an interface called Animal. An interface in TypeScript is like a blueprint or contract that defines the structure of an object. Specifically:
+              The Animal interface defines the structure of an animal object. It takes no inputs. The purpose is to define the properties and methods that any animal object should have.
 
-              1. The purpose of this Animal interface is to define the shape of Animal objects - that is, to specify what properties and methods any object implementing the Animal interface must have.
+              It has three members:
 
-              2. The Animal interface itself does not take any inputs. However, any concrete classes that implement the Animal interface would take inputs to instantiate an object (for example, constructor arguments).
+              1. name - This is a string property that represents the animal's name. All animals should have a name.
 
-              3. Similarly, the Animal interface does not directly produce any outputs. Its role is to define the shape of objects. Any class implementing Animal would be responsible for producing outputs through its concrete methods and properties.
+              2. makeAnimalSound() - This is a method that returns a string. It represents the sound the animal makes. All animals should be able to make a sound.
 
-              4. The interface achieves its purpose by declaring a name property of type string, a makeAnimalSound method that returns a string, and an isMammal property of type boolean.
+              3. isMammal - This is a boolean property that indicates if the animal is a mammal or not. All animals can be classified as mammals or not mammals.
 
-              5. By defining this structure, the interface ensures that any class implementing Animal will have these required members with the specified types. This allows TypeScript to enforce that objects adhere to the Animal contract.
+              By defining this interface, we can then create animal objects of different types like Dog, Cat, Cow etc that follow this structure. They will be guaranteed to have these members that we can rely on when writing code that interacts with animal objects.
 
-              So in summary, the Animal interface defines a blueprint for Animal objects by specifying required properties and methods. This allows TypeScript to statically analyze objects based on their fulfillment of the interface contract. The interface itself does not contain logic - it simply defines the shape of objects. Any consuming code can then rely on objects implementing the Animal interface having the defined structure."
+              So in summary, it defines a consistent structure for animal data without needing to know the specific animal type. The interface itself doesn't contain implementation details, it just defines the contract. Classes that implement the Animal interface would provide the actual implementation."
             `,
                 explainPollyError
             )
@@ -772,58 +772,52 @@ describe('Agent', () => {
                 `
               " Here are 5 potential improvements for the selected TypeScript code:
 
-              1. Add type annotations for method parameters and return values:
+              1. Add type annotations for method parameters and return types:
 
-              \`\`\`
               export interface Animal {
-                name: string
-                makeAnimalSound(volume?: number): string
-                isMammal: boolean
+                name: string;
+                makeAnimalSound(volume?: number): string;
+                isMammal: boolean;
               }
-              \`\`\`
 
-              Adding type annotations makes the code more self-documenting and enables stronger type checking.
+              Adding annotations improves understandability and enables stronger type checking.
 
-              2. Make interface name more semantic:
+              2. Make interface properties readonly if they are not meant to be reassigned:
 
-              \`\`\`
-              export interface Creature {
-                // ...
+              export interface Animal {
+                readonly name: string;
+                makeAnimalSound(volume?: number): string;
+                readonly isMammal: boolean;
               }
-              \`\`\`
 
-              The name 'Animal' is not very descriptive. A name like 'Creature' captures the intent better.
+              Readonly properties clarify intent and prevent accidental mutation.
 
-              3. Make sound method name more semantic:
+              3. Use more specific parameter names than volume for makeAnimalSound():
 
-              \`\`\`
-              makeSound()
-              \`\`\`
+              makeAnimalSound(loudness?: number): string;
 
-              The name 'makeAnimalSound' is verbose. A shorter name like 'makeSound' conveys the purpose clearly.
+              More descriptive names improve readability.
 
-              4. Use boolean type for isMammal property:
+              4. Consider extending the interface from a base class for code reuse:
 
-              \`\`\`
-              isMammal: boolean
-              \`\`\`
+              export interface Animal extends BaseAnimal {
+                makeAnimalSound(loudness?: number): string;
+              }
 
-              Using the boolean type instead of just true/false improves readability.
+              Inheritance promotes abstraction and reduces duplication.
 
-              5. Add JSDoc comments for documentation:
+              5. Add JSDoc comments for overall interface description:
 
-              \`\`\`
               /**
-               * Represents a creature in the game
+               * Represents an animal with common attributes.
                */
-              export interface Creature {
+              export interface Animal {
                 // ...
               }
-              \`\`\`
 
-              JSDoc comments enable generating API documentation and improve understandability.
+              Comments improve understanding of intent and usage.
 
-              Overall, the selected code follows reasonable design principles. The interface encapsulates animal data nicely. The suggestions above would incrementally improve quality but no major issues were found."
+              Overall, the code is well-structured but could benefit from some minor improvements like annotations, readonly properties, descriptive names, inheritance, and comments. No major issues were identified."
             `,
                 explainPollyError
             )

--- a/lib/shared/src/chat/input/at-mentioned.ts
+++ b/lib/shared/src/chat/input/at-mentioned.ts
@@ -20,6 +20,7 @@ export function getAtMentionedInputText(
     queryEndsWithColon = false
 ): { newInput: string; newInputCaretPosition: number } | undefined {
     const inputBeforeCaret = formInput.slice(0, inputCaretPosition) || ''
+    const inputAfterCaret = formInput.slice(inputCaretPosition)
     const lastAtIndex = inputBeforeCaret.lastIndexOf('@')
     if (lastAtIndex < 0 || !formInput.trim()) {
         return undefined
@@ -27,15 +28,14 @@ export function getAtMentionedInputText(
 
     if (/:\d+(-)?(\d+)?( )?$/.test(inputBeforeCaret)) {
         // Add a space after inputBeforeCaret to formInput
-        const newInput = formInput.replace(inputBeforeCaret, `${inputBeforeCaret} `)
-        return { newInput, newInputCaretPosition: inputCaretPosition }
+        const newInput = `${inputBeforeCaret} ${inputAfterCaret.trimStart()}`
+        return { newInput, newInputCaretPosition: inputCaretPosition + 1 }
     }
 
     // Trims any existing @file text from the input.
     const inputPrefix = inputBeforeCaret.slice(0, lastAtIndex)
-    const afterCaret = formInput.slice(inputCaretPosition)
-    const spaceAfterCaret = afterCaret.indexOf(' ')
-    const inputSuffix = !spaceAfterCaret ? afterCaret : afterCaret.slice(spaceAfterCaret)
+    const spaceAfterCaret = inputAfterCaret.indexOf(' ')
+    const inputSuffix = !spaceAfterCaret ? inputAfterCaret : inputAfterCaret.slice(spaceAfterCaret)
     // Add empty space at the end to end the file matching process,
     // if the query ends with colon, add a colon instead as it's used for initial range selection.
     const colon = queryEndsWithColon ? ':' : ''

--- a/lib/shared/src/chat/input/user-context.test.ts
+++ b/lib/shared/src/chat/input/user-context.test.ts
@@ -85,7 +85,7 @@ describe('verifyContextFilesFromInput', () => {
         ])
     })
 
-    it('handles invalid line numbers gracefully', () => {
+    it('returns empty array for invalid line numbers', () => {
         const input = '@foo.ts:5-1'
         const contextFilesMap = new Map<string, ContextFileFile>([
             ['foo.ts', { uri: URI.file('foo.ts'), type: 'file' }],
@@ -93,7 +93,7 @@ describe('verifyContextFilesFromInput', () => {
 
         const contextFiles = verifyContextFilesFromInput(input, contextFilesMap)
 
-        expect(contextFiles).toEqual([{ uri: URI.file('foo.ts'), type: 'file' }])
+        expect(contextFiles).toEqual([])
     })
 
     it('sets range property even if only start line number is included', () => {

--- a/lib/shared/src/chat/input/user-context.ts
+++ b/lib/shared/src/chat/input/user-context.ts
@@ -42,10 +42,9 @@ export function verifyContextFilesFromInput(
 
         // Get the line number behind the file name if there is one:
         // SingleLines Example: foo/bar.ts:1 > 1
-        const singleLines = input.matchAll(new RegExp(atFileName + ':([0-9]+)(?!-)', 'g'))
+        const singleLines = input.matchAll(new RegExp(atFileName + ':(\\d+)(?!-)', 'g'))
         // MultiLines example: foo/bar.ts:1-2 > 1, 2
-        const multiLines = input.matchAll(new RegExp(atFileName + ':([0-9]+)-([0-9]+)', 'g'))
-
+        const multiLines = input.matchAll(new RegExp(atFileName + ':(\\d+)-(\\d+)', 'g'))
         // loop all matches and set the range property on the contextFile object
         for (const match of [...Array.from(singleLines), ...Array.from(multiLines)]) {
             const contextFileMatch = { ...contextFile }
@@ -62,9 +61,8 @@ export function verifyContextFilesFromInput(
                     start: { line: startLineNum, character: 0 },
                     end: { line: endLineNum, character: 0 },
                 }
+                userContextFiles.push(contextFileMatch)
             }
-
-            userContextFiles.push(contextFileMatch)
         }
     }
 

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -24,7 +24,7 @@ import type { CodeBlockMeta } from './chat/CodeBlocks'
 import type { FileLinkProps } from './chat/components/EnhancedContext'
 import type { SymbolLinkProps } from './chat/PreciseContext'
 import { Transcript } from './chat/Transcript'
-import { isDefaultCommandPrompts, type TranscriptItemClassNames } from './chat/TranscriptItem'
+import type { TranscriptItemClassNames } from './chat/TranscriptItem'
 
 import styles from './Chat.module.css'
 import { ChatActions } from './chat/components/ChatActions'
@@ -262,20 +262,11 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
     // Users can toggle this feature via "shift" + "Meta(Mac)/Control" keys
     const [enableNewChatMode, setEnableNewChatMode] = useState(false)
 
-    const [isLastItemCommand, setIsLastItemCommand] = useState(false)
-
     const lastHumanMessageIndex = useMemo<number | undefined>(() => {
         if (!transcript?.length) {
             return undefined
         }
         const index = transcript.findLastIndex(msg => msg.speaker === 'human')
-
-        // TODO (bee) can be removed once we support editing command prompts.
-        // Used for displaying "Edit Last Message" chat action button
-        const lastDisplayText = transcript[index]?.displayText ?? ''
-        const isCustomCommand = !!lastDisplayText.startsWith('/')
-        const isCoreCommand = isDefaultCommandPrompts(lastDisplayText)
-        setIsLastItemCommand(isCustomCommand || isCoreCommand)
 
         return index
     }, [transcript])
@@ -861,7 +852,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                     isEmptyChat={transcript.length < 1}
                     isMessageInProgress={!!messageInProgress?.speaker}
                     isEditing={transcript.length > 1 && messageBeingEdited !== undefined}
-                    disableEditLastMessage={isLastItemCommand}
                     onChatResetClick={onChatResetClick}
                     onCancelEditClick={() => setEditMessageState()}
                     onEditLastMessageClick={() => setEditMessageState(lastHumanMessageIndex)}

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -359,10 +359,13 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
             const inputBeforeCaret = formInput.slice(0, inputCaretPosition)
             const isSettingRange = atRangeEndingRegex.test(inputBeforeCaret)
             if (chatContextFiles.has(`@${displayPath(selected.uri)}`)) {
-                if (isSettingRange) {
-                    // Add a space after inputBeforeCaret to formInput
-                    setFormInput(formInput.replace(inputBeforeCaret, inputBeforeCaret + ' '))
-                    setInputCaretPosition(formInput.length + 1)
+                if (isSettingRange && inputCaretPosition) {
+                    const inputAfterCaret = formInput.slice(inputCaretPosition)
+                    if (!inputAfterCaret.trimStart().startsWith('-')) {
+                        // Add a space after inputBeforeCaret to formInput
+                        setFormInput(`${inputBeforeCaret} ${inputAfterCaret}`)
+                        setInputCaretPosition(inputCaretPosition + 1)
+                    }
                     resetContextSelection()
                     return
                 }

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -13,7 +13,6 @@ import {
     type ContextFile,
     type Guardrails,
     getContextFileDisplayText,
-    displayPath,
     getAtMentionQuery,
     getAtMentionedInputText,
     isAtMention,
@@ -357,19 +356,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
         (selected: ContextFile, queryEndsWithColon = false): void => {
             const atRangeEndingRegex = /:\d+(-\d+)?$/
             const inputBeforeCaret = formInput.slice(0, inputCaretPosition)
-            const isSettingRange = atRangeEndingRegex.test(inputBeforeCaret)
-            if (chatContextFiles.has(`@${displayPath(selected.uri)}`)) {
-                if (isSettingRange && inputCaretPosition) {
-                    const inputAfterCaret = formInput.slice(inputCaretPosition)
-                    if (!inputAfterCaret.trimStart().startsWith('-')) {
-                        // Add a space after inputBeforeCaret to formInput
-                        setFormInput(`${inputBeforeCaret} ${inputAfterCaret}`)
-                        setInputCaretPosition(inputCaretPosition + 1)
-                    }
-                    resetContextSelection()
-                    return
-                }
-            }
 
             const fileDisplayText = getContextFileDisplayText(selected, inputBeforeCaret)
             if (inputCaretPosition && fileDisplayText) {

--- a/lib/ui/src/chat/TranscriptItem.tsx
+++ b/lib/ui/src/chat/TranscriptItem.tsx
@@ -94,11 +94,6 @@ export const TranscriptItem: React.FunctionComponent<
     // A boolean indicating whether the current transcript item is the one being edited.
     const isItemBeingEdited = beingEdited === index
 
-    // TODO (bee) can be removed once we support editing command prompts.
-    // A boolean indicating whether the current message is a known command input.
-    const isCommandInput =
-        message?.displayText?.startsWith('/') || isDefaultCommandPrompts(message?.text)
-
     return (
         <div
             className={classNames(
@@ -131,7 +126,7 @@ export const TranscriptItem: React.FunctionComponent<
                             className={styles.feedbackEditButtonsContainer}
                             messageBeingEdited={index}
                             setMessageBeingEdited={setBeingEdited}
-                            disabled={isCommandInput || isInEditingMode}
+                            disabled={isInEditingMode}
                         />
                     </header>
                 </div>
@@ -183,7 +178,6 @@ export const TranscriptItem: React.FunctionComponent<
                             contextFiles={message.contextFiles}
                             fileLinkComponent={fileLinkComponent}
                             className={transcriptActionClassName}
-                            isCommand={isCommandInput}
                         />
                     ) : (
                         inProgress && <LoadingContext />
@@ -212,18 +206,3 @@ export const TranscriptItem: React.FunctionComponent<
         </div>
     )
 })
-
-// TODO: TO BE REMOVED
-// This is a temporary workaround for disabling editing on the default chat commands.
-const commandPrompts = {
-    explain:
-        'Explain what the selected code does in simple terms. Assume the audience is a beginner programmer who has just learned the language features and basic syntax. Focus on explaining: 1) The purpose of the code 2) What input(s) it takes 3) What output(s) it produces 4) How it achieves its purpose through the logic and algorithm. 5) Any important logic flows or data transformations happening. Use simple language a beginner could understand. Include enough detail to give a full picture of what the code aims to accomplish without getting too technical. Format the explanation in coherent paragraphs, using proper punctuation and grammar. Write the explanation assuming no prior context about the code is known. Do not make assumptions about variables or functions not shown in the shared code. Start the answer with the name of the code that is being explained.',
-    smell: `Please review and analyze the selected code and identify potential areas for improvement related to code smells, readability, maintainability, performance, security, etc. Do not list issues already addressed in the given code. Focus on providing up to 5 constructive suggestions that could make the code more robust, efficient, or align with best practices. For each suggestion, provide a brief explanation of the potential benefits. After listing any recommendations, summarize if you found notable opportunities to enhance the code quality overall or if the code generally follows sound design principles. If no issues found, reply 'There are no errors.'`,
-}
-
-export function isDefaultCommandPrompts(text?: string): boolean {
-    if (!text) {
-        return false
-    }
-    return Object.values(commandPrompts).includes(text)
-}

--- a/lib/ui/src/chat/components/ChatActions.tsx
+++ b/lib/ui/src/chat/components/ChatActions.tsx
@@ -14,7 +14,6 @@ export const ChatActions: React.FunctionComponent<{
     onEditLastMessageClick: () => void
     setInputFocus: (focus: boolean) => void
     onRestoreLastChatClick?: () => void
-    disableEditLastMessage: boolean
 }> = React.memo(function ContextFilesContent({
     isEditing,
     isEmptyChat,
@@ -23,7 +22,6 @@ export const ChatActions: React.FunctionComponent<{
     onCancelEditClick,
     onEditLastMessageClick,
     setInputFocus,
-    disableEditLastMessage,
     onRestoreLastChatClick,
     isWebviewActive,
 }) {
@@ -52,7 +50,7 @@ export const ChatActions: React.FunctionComponent<{
             keybind: `${osIcon}K`,
             onClick: onEditLastMessageClick,
             focus: true,
-            when: !isEmptyChat && !isEditing && !disableEditLastMessage,
+            when: !isEmptyChat && !isEditing,
         },
         {
             name: '← Return to Previous Chat',

--- a/lib/ui/src/chat/components/EnhancedContext.tsx
+++ b/lib/ui/src/chat/components/EnhancedContext.tsx
@@ -25,13 +25,7 @@ export const EnhancedContext: React.FunctionComponent<{
     contextFiles: ContextFile[]
     fileLinkComponent: React.FunctionComponent<FileLinkProps>
     className?: string
-    isCommand: boolean
-}> = React.memo(function ContextFilesContent({
-    contextFiles,
-    fileLinkComponent: FileLink,
-    className,
-    isCommand,
-}) {
+}> = React.memo(function ContextFilesContent({ contextFiles, fileLinkComponent: FileLink, className }) {
     if (!contextFiles.length) {
         return
     }
@@ -42,7 +36,7 @@ export const EnhancedContext: React.FunctionComponent<{
     // Check if the filteredFiles only contain local context (non-enhanced context).
     const localContextType = ['user', 'selection', 'terminal', 'editor']
     const localContextOnly = contextFiles.every(file => localContextType.includes(file.type))
-    const sparkle = localContextOnly || isCommand ? '' : '✨ '
+    const sparkle = localContextOnly ? '' : '✨ '
     const prefix = sparkle + 'Context: '
     // It checks if file.range exists first before accessing start and end.
     // If range doesn't exist, it adds 0 lines for that file.

--- a/vscode/src/commands/execute/explain.ts
+++ b/vscode/src/commands/execute/explain.ts
@@ -1,4 +1,4 @@
-import { logDebug, type ContextFile } from '@sourcegraph/cody-shared'
+import { logDebug, type ContextFile, displayPath } from '@sourcegraph/cody-shared'
 import { getContextFileFromCursor } from '../context/selection'
 import { getContextFileFromCurrentFile } from '../context/current-file'
 import { type ExecuteChatArguments, executeChat } from './ask'
@@ -37,6 +37,12 @@ export async function explainCommand(
 
     const currentFile = await getContextFileFromCurrentFile()
     contextFiles.push(...currentFile)
+
+    const cs = currentSelection[0] ?? currentFile[0]
+    if (cs) {
+        const range = cs.range && `:${cs.range.start.line + 1}-${cs.range.end.line + 1}`
+        prompt = prompt.replace('the selected code', `@${displayPath(cs.uri)}${range ?? ''} `)
+    }
 
     return {
         text: prompt,

--- a/vscode/src/commands/execute/smell.ts
+++ b/vscode/src/commands/execute/smell.ts
@@ -1,4 +1,4 @@
-import { logDebug, type ContextFile } from '@sourcegraph/cody-shared'
+import { logDebug, type ContextFile, displayPath } from '@sourcegraph/cody-shared'
 import { getContextFileFromCursor } from '../context/selection'
 import { type ExecuteChatArguments, executeChat } from './ask'
 import { DefaultChatCommands } from '@sourcegraph/cody-shared/src/commands/types'
@@ -32,6 +32,12 @@ export async function smellCommand(
 
     const currentSelection = await getContextFileFromCursor()
     contextFiles.push(...currentSelection)
+
+    const cs = currentSelection[0]
+    if (cs) {
+        const range = cs.range && `:${cs.range.start.line + 1}-${cs.range.end.line + 1}`
+        prompt = prompt.replace('the selected code', `@${displayPath(cs.uri)}${range ?? ''} `)
+    }
 
     return {
         text: prompt,

--- a/vscode/src/commands/utils/display-text.ts
+++ b/vscode/src/commands/utils/display-text.ts
@@ -41,10 +41,10 @@ export function replaceFileNameWithMarkdownLink(
     symbolName?: string
 ): string {
     const inputRepr = inputRepresentation(humanInput, file, range, symbolName)
-    console.log(inputRepr, 'inputRepr')
     if (!inputRepr) {
         return humanInput
     }
+    // Use regex to makes sure the file name is surrounded by spaces and not a substring of another file name
     const fileAsInput = inputRepr.replaceAll(/[$()*+./?[\\\]^{|}-]/g, '\\$&')
     const textToBeReplaced = new RegExp(`\\s*@${fileAsInput}(?![\S#-_])`, 'g')
     const markdownText = `[_@${inputRepr}_](command:${CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID}?${encodeURIComponent(

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -68,10 +68,9 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.locator('span').filter({ hasText: '@index.html:2-10' })).toBeVisible()
     const disabledEditButtons = chatPanel.getByTitle('Cannot Edit Command').locator('i')
     const editLastMessageButton = chatPanel.getByRole('button', { name: /^Edit Last Message / })
-    // Edit button should shows as disabled for all command messages.
-    // Edit Last Message are removed if last submitted message is a command.
-    await expect(disabledEditButtons).toHaveCount(1)
-    await expect(editLastMessageButton).not.toBeVisible()
+    // Edit button and Edit Last Message are shown on all command messages.
+    await expect(disabledEditButtons).toHaveCount(0)
+    await expect(editLastMessageButton).toBeVisible()
 
     // Smell Command
     // Running a command again should reuse the current cursor position
@@ -80,8 +79,8 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByText('Context: 9 lines from 1 file')).toBeVisible()
     await chatPanel.getByText('Context: 9 lines from 1 file').click()
     await expect(chatPanel.locator('span').filter({ hasText: '@index.html:2-10' })).toBeVisible()
-    await expect(disabledEditButtons).toHaveCount(1)
-    await expect(editLastMessageButton).not.toBeVisible()
+    await expect(disabledEditButtons).toHaveCount(0)
+    await expect(editLastMessageButton).toBeVisible()
 })
 
 test.extend<ExpectedEvents>({


### PR DESCRIPTION
enable edits on commands. Replace `the selected code` in the prompt for the explain and smell commands with @-mentioned file with selection range.

<img width="799" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/48760ad2-889e-486f-9e15-ebef311a8533">


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Run the Explain and Smell commands
2. You should see the @-mentioned file in the prompt
3. You should be able to edit the prompt

https://github.com/sourcegraph/cody/assets/68532117/41754c4a-0e2c-40ed-98ac-91e9285deb8e
