### PR TITLE
Custom Commands: display commands in sidebar

### DIFF
--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -15,7 +15,7 @@ import type { SymfRunner } from '../../local-context/symf'
 import { logDebug } from '../../log'
 import { telemetryService } from '../../services/telemetry'
 import { telemetryRecorder } from '../../services/telemetry-v2'
-import { TreeViewProvider } from '../../services/TreeViewProvider'
+import { TreeViewProvider } from '../../services/tree-views/TreeViewProvider'
 import type { MessageProviderOptions } from '../MessageProvider'
 import type { AuthStatus, ExtensionMessage } from '../protocol'
 
@@ -56,7 +56,6 @@ export class ChatPanelsManager implements vscode.Disposable {
     public treeView
 
     public supportTreeViewProvider = new TreeViewProvider('support', featureFlagProvider)
-    public commandTreeViewProvider = new TreeViewProvider('command', featureFlagProvider)
 
     // We keep track of the currently authenticated account and dispose open chats when it changes
     private currentAuthAccount: undefined | { endpoint: string; primaryEmail: string; username: string }
@@ -92,16 +91,7 @@ export class ChatPanelsManager implements vscode.Disposable {
             vscode.window.registerTreeDataProvider(
                 'cody.support.tree.view',
                 this.supportTreeViewProvider
-            ),
-            vscode.window.registerTreeDataProvider(
-                'cody.commands.tree.view',
-                this.commandTreeViewProvider
-            ),
-            vscode.workspace.onDidChangeConfiguration(async event => {
-                if (event.affectsConfiguration('cody')) {
-                    await this.commandTreeViewProvider.refresh()
-                }
-            })
+            )
         )
     }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -46,7 +46,7 @@ import type { AuthProvider } from '../../services/AuthProvider'
 import { getProcessInfo } from '../../services/LocalAppDetector'
 import { telemetryService } from '../../services/telemetry'
 import { telemetryRecorder } from '../../services/telemetry-v2'
-import type { TreeViewProvider } from '../../services/TreeViewProvider'
+import type { TreeViewProvider } from '../../services/tree-views/TreeViewProvider'
 import {
     handleCodeFromInsertAtCursor,
     handleCodeFromSaveToNewFile,

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -1,4 +1,4 @@
-import type * as vscode from 'vscode'
+import * as vscode from 'vscode'
 
 import { logDebug } from '../log'
 
@@ -23,7 +23,13 @@ class CommandsController implements vscode.Disposable {
     public init(provider?: CommandsProvider) {
         if (provider) {
             this.provider = provider
-            this.disposables.push(this.provider)
+            this.disposables.push(
+                this.provider,
+                vscode.window.registerTreeDataProvider(
+                    'cody.commands.tree.view',
+                    this.provider.treeViewProvider
+                )
+            )
         }
     }
 

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -1,4 +1,4 @@
-import type { CodySidebarTreeItem } from '../services/treeViewItems'
+import type { CodySidebarTreeItem } from '../services/tree-views/treeViewItems'
 import { isMac } from '@sourcegraph/cody-shared/src/common/platform'
 
 const osIcon = isMac() ? '⌥' : 'Alt+'

--- a/vscode/src/commands/index.ts
+++ b/vscode/src/commands/index.ts
@@ -1,4 +1,3 @@
-import type { CodySidebarTreeItem } from '../services/tree-views/treeViewItems'
 import { isMac } from '@sourcegraph/cody-shared/src/common/platform'
 
 const osIcon = isMac() ? '⌥' : 'Alt+'
@@ -69,13 +68,3 @@ export const CodyCommandMenuItems = [
         type: 'default',
     },
 ]
-
-export function getCommandTreeItems(): CodySidebarTreeItem[] {
-    return CodyCommandMenuItems.map(item => {
-        return {
-            ...item,
-            title: item.description,
-            description: item.keybinding,
-        }
-    })
-}

--- a/vscode/src/commands/services/custom-commands.ts
+++ b/vscode/src/commands/services/custom-commands.ts
@@ -14,6 +14,8 @@ import { buildCodyCommandMap } from '../utils/get-commands'
 import { CustomCommandType } from '@sourcegraph/cody-shared/src/commands/types'
 import { getConfiguration } from '../../configuration'
 import { isMac } from '@sourcegraph/cody-shared/src/common/platform'
+import type { TreeViewProvider } from '../../services/tree-views/TreeViewProvider'
+import { getCommandTreeItems } from '../../services/tree-views/commands'
 
 const isTesting = process.env.CODY_TESTING === 'true'
 const isMacOS = isMac()
@@ -41,7 +43,7 @@ export class CustomCommandsManager implements vscode.Disposable {
         return Utils.joinPath(workspaceRoot, this.configFileName)
     }
 
-    constructor() {
+    constructor(private sidebar: TreeViewProvider) {
         // TODO (bee) Migrate to use .cody/commands.json for VS Code
         // Right now agent is using .cody/commands.json for Custom Commands,
         // .vscode/cody.json in VS Code.
@@ -121,6 +123,7 @@ export class CustomCommandsManager implements vscode.Disposable {
         } catch (error) {
             logError('CustomCommandsProvider:refresh', 'failed', { verbose: error })
         }
+        this.sidebar.setTreeNodes(getCommandTreeItems([...this.customCommandsMap.values()]))
         return { commands: this.customCommandsMap }
     }
 

--- a/vscode/src/services/HistoryChat.ts
+++ b/vscode/src/services/HistoryChat.ts
@@ -4,7 +4,7 @@ import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 import { chatHistory } from '../chat/chat-view/ChatHistoryManager'
 import type { AuthStatus } from '../chat/protocol'
 
-import type { CodySidebarTreeItem } from './treeViewItems'
+import type { CodySidebarTreeItem } from './tree-views/treeViewItems'
 import type { InteractionMessage } from '@sourcegraph/cody-shared'
 
 interface GroupedChats {

--- a/vscode/src/services/tree-views/TreeItemProvider.ts
+++ b/vscode/src/services/tree-views/TreeItemProvider.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode'
+
+export class CodyTreeItem extends vscode.TreeItem {
+    public children: CodyTreeItem[] | undefined
+
+    constructor(
+        public readonly id: string,
+        title: string,
+        icon?: string,
+        command?: {
+            command: string
+            args?: string[] | { [key: string]: string }[]
+        },
+        contextValue?: string,
+        collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.None,
+        children?: CodyTreeItem[]
+    ) {
+        super(title, collapsibleState)
+        this.id = id
+        if (icon) {
+            this.iconPath = new vscode.ThemeIcon(icon)
+        }
+        if (command) {
+            this.command = {
+                command: command.command,
+                title,
+                arguments: command.args,
+            }
+        }
+        if (contextValue) {
+            this.contextValue = contextValue
+        }
+        this.children = children
+    }
+    public async loadChildNodes(): Promise<CodyTreeItem[] | undefined> {
+        await Promise.resolve()
+        return this.children
+    }
+}

--- a/vscode/src/services/tree-views/TreeItemProvider.ts
+++ b/vscode/src/services/tree-views/TreeItemProvider.ts
@@ -9,7 +9,7 @@ export class CodyTreeItem extends vscode.TreeItem {
         icon?: string,
         command?: {
             command: string
-            args?: string[] | { [key: string]: string }[]
+            args?: any[]
         },
         contextValue?: string,
         collapsibleState: vscode.TreeItemCollapsibleState = vscode.TreeItemCollapsibleState.None,

--- a/vscode/src/services/tree-views/TreeViewProvider.test.ts
+++ b/vscode/src/services/tree-views/TreeViewProvider.test.ts
@@ -3,8 +3,8 @@ import type * as vscode from 'vscode'
 
 import { DOTCOM_URL, isDotCom } from '@sourcegraph/cody-shared'
 
-import { newAuthStatus } from '../chat/utils'
-import { emptyMockFeatureFlagProvider, vsCodeMocks } from '../testutils/mocks'
+import { newAuthStatus } from '../../chat/utils'
+import { emptyMockFeatureFlagProvider, vsCodeMocks } from '../../testutils/mocks'
 
 import { TreeViewProvider } from './TreeViewProvider'
 

--- a/vscode/src/services/tree-views/chat-history.ts
+++ b/vscode/src/services/tree-views/chat-history.ts
@@ -1,0 +1,53 @@
+import * as vscode from 'vscode'
+import type { AuthStatus } from '../../chat/protocol'
+import { groupCodyChats } from '../HistoryChat'
+import { CodyTreeItem } from './TreeItemProvider'
+
+/**
+ * Method to initialize the grouped chats for the History items
+ */
+export async function initializeGroupedChats(authStatus?: AuthStatus): Promise<CodyTreeItem[]> {
+    const groupedChats = groupCodyChats(authStatus)
+    if (!authStatus || !groupedChats) {
+        void vscode.commands.executeCommand('setContext', 'cody.hasChatHistory', 0)
+        return []
+    }
+
+    const treeNodes = []
+    let firstGroup = true
+
+    // Create a CodyTreeItem for each group and add to treeNodes
+    for (const [groupLabel, chats] of Object.entries(groupedChats)) {
+        // only display the group in the treeview for which chat exists
+        if (!chats.length) {
+            continue
+        }
+        const collapsibleState = firstGroup
+            ? vscode.TreeItemCollapsibleState.Expanded
+            : vscode.TreeItemCollapsibleState.Collapsed
+
+        const groupItem = new CodyTreeItem(
+            groupLabel,
+            groupLabel,
+            undefined,
+            undefined,
+            undefined,
+            collapsibleState,
+            chats.map(
+                chat =>
+                    new CodyTreeItem(
+                        chat.id as string,
+                        chat.title,
+                        chat.icon,
+                        chat.command,
+                        'cody.chats'
+                    )
+            )
+        )
+        treeNodes.push(groupItem)
+        firstGroup = false
+    }
+
+    void vscode.commands.executeCommand('setContext', 'cody.hasChatHistory', treeNodes.length)
+    return treeNodes
+}

--- a/vscode/src/services/tree-views/commands.ts
+++ b/vscode/src/services/tree-views/commands.ts
@@ -21,6 +21,7 @@ export function getCommandTreeItems(customCommands: CodyCommand[]): CodyTreeItem
                 ? vscode.TreeItemCollapsibleState.Expanded
                 : vscode.TreeItemCollapsibleState.None
         )
+        treeItem.description = item.keybinding
 
         if (item.key === 'custom' && customCommands?.length) {
             try {

--- a/vscode/src/services/tree-views/commands.ts
+++ b/vscode/src/services/tree-views/commands.ts
@@ -4,32 +4,24 @@ import { CodyCommandMenuItems } from '../../commands'
 import type { CodyCommand } from '@sourcegraph/cody-shared'
 
 /**
- * Method to initialize the grouped chats for the Commands items
+ * Method to get items for the Commands sidebar
  */
 export function getCommandTreeItems(customCommands: CodyCommand[]): CodyTreeItem[] {
     const treeNodes = []
 
     // Create a CodyTreeItem for each group and add to treeNodes
     for (const item of CodyCommandMenuItems) {
-        const treeItem = new CodyTreeItem(
-            item.key,
-            item.description,
-            item.icon,
-            item.command,
-            undefined,
-            item.key === 'custom'
-                ? vscode.TreeItemCollapsibleState.Expanded
-                : vscode.TreeItemCollapsibleState.None
-        )
+        const treeItem = new CodyTreeItem(item.key, item.description, item.icon, item.command)
         treeItem.description = item.keybinding
 
         if (item.key === 'custom' && customCommands?.length) {
+            treeItem.collapsibleState = vscode.TreeItemCollapsibleState.Expanded
             try {
                 treeItem.children = customCommands.map(
                     command =>
-                        new CodyTreeItem(command.key as string, command.key, 'tools', {
+                        new CodyTreeItem(command.key, command.key, 'tools', {
                             command: 'cody.action.command',
-                            args: [command.key],
+                            args: [command.key, { source: 'sidebar' }],
                         })
                 )
             } catch (e) {

--- a/vscode/src/services/tree-views/commands.ts
+++ b/vscode/src/services/tree-views/commands.ts
@@ -1,0 +1,44 @@
+import * as vscode from 'vscode'
+import { CodyTreeItem } from './TreeItemProvider'
+import { CodyCommandMenuItems } from '../../commands'
+import type { CodyCommand } from '@sourcegraph/cody-shared'
+
+/**
+ * Method to initialize the grouped chats for the Commands items
+ */
+export function getCommandTreeItems(customCommands: CodyCommand[]): CodyTreeItem[] {
+    const treeNodes = []
+
+    // Create a CodyTreeItem for each group and add to treeNodes
+    for (const item of CodyCommandMenuItems) {
+        const treeItem = new CodyTreeItem(
+            item.key,
+            item.description,
+            item.icon,
+            item.command,
+            undefined,
+            item.key === 'custom'
+                ? vscode.TreeItemCollapsibleState.Expanded
+                : vscode.TreeItemCollapsibleState.None
+        )
+
+        if (item.key === 'custom' && customCommands?.length) {
+            try {
+                treeItem.children = customCommands.map(
+                    command =>
+                        new CodyTreeItem(command.key as string, command.key, 'tools', {
+                            command: 'cody.action.command',
+                            args: [command.key],
+                        })
+                )
+            } catch (e) {
+                console.error('Error creating custom command tree items', e)
+                treeItem.children = [new CodyTreeItem(e as string, e as string, 'bug')]
+            }
+        }
+        treeNodes.push(treeItem)
+    }
+
+    void vscode.commands.executeCommand('setContext', 'cody.hasChatHistory', treeNodes.length)
+    return treeNodes
+}

--- a/vscode/src/services/tree-views/treeViewItems.ts
+++ b/vscode/src/services/tree-views/treeViewItems.ts
@@ -1,8 +1,7 @@
 import type { FeatureFlag } from '@sourcegraph/cody-shared'
 
-import { releaseType } from '../release'
-import { version } from '../version'
-import { getCommandTreeItems } from '../commands'
+import { releaseType } from '../../release'
+import { version } from '../../version'
 
 export type CodyTreeItemType = 'command' | 'support' | 'search' | 'chat'
 
@@ -26,8 +25,6 @@ export interface CodySidebarTreeItem {
  */
 export function getCodyTreeItems(type: CodyTreeItemType): CodySidebarTreeItem[] {
     switch (type) {
-        case 'command':
-            return getCommandTreeItems()
         case 'support':
             return supportItems
         default:

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -97,8 +97,14 @@ test.extend<ExpectedEvents>({
     await page.click('.badge[aria-label="Cody"]')
     await page.getByLabel('Custom Commands').locator('a').click()
     await expect(page.getByText('Cody: Custom Commands (Beta)')).toBeVisible()
-    await expect(page.getByText(commandName)).toBeVisible()
-    await page.getByText(commandName).click()
+    const newCommandMenuItem = page.getByLabel('tools  ATestCommand, The test command has been created')
+    const newCommandSidebarItem = page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a')
+    await expect(page.getByText(commandName)).toHaveCount(2) // one in sidebar, and one in menu
+    await newCommandMenuItem.hover()
+    await expect(newCommandMenuItem).toBeVisible()
+    await newCommandSidebarItem.hover()
+    await expect(newCommandSidebarItem).toBeVisible()
+    await newCommandMenuItem.click()
 
     // Confirm the command prompt is displayed in the chat panel on execution
     const chatPanel = page.frameLocator('iframe.webview').last().frameLocator('iframe')
@@ -272,6 +278,7 @@ test.extend<ExpectedEvents>({
     await expect(page.getByRole('list').getByLabel(/cody.json(.*)Deleted$/)).toBeVisible()
 
     // Open the cody.json from User Settings
+    // NOTE: This is expected to fail locally if you currently have User commands configured
     await customCommandSidebar.click()
     await page.locator('a').filter({ hasText: 'Open User Settings (JSON)' }).hover()
     await page.getByRole('button', { name: 'Open or Create Settings File' }).hover()


### PR DESCRIPTION
PR add custom commands to sidebar as discussed with @toolmantim

![image](https://github.com/sourcegraph/cody/assets/68532117/3c5baf9a-46ef-4872-9536-238aa0d5e18d)

- move the TreeViewProvider registration process for commands to the command provider as that's the service that manages the commands
- reorganize tree-views items into its own folder
- refactor TreeViewProvider to make sure methods are not one-type-specificed

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

e2e test for custom commands has been updated accordingly.

1. Check the sidebar to see if your custom commands are showing up there
2. Clicking on the custom command in sidebar should work as expected

https://github.com/sourcegraph/cody/assets/68532117/0bc58b64-ba2a-4d7e-add1-3def062ed366


### After

![image](https://github.com/sourcegraph/cody/assets/68532117/96b3f412-e42d-4e74-9544-fd677714ad83)

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/4f4b5420-f4b2-4d63-86b7-425cf1cc00bd)
