### PR TITLE
Auth: supports codium and cursor for enterprise instances

### DIFF
--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -28,6 +28,7 @@ import { localStorage } from './LocalStorageProvider'
 import { secretStorage } from './SecretStorageProvider'
 import { telemetryService } from './telemetry'
 import { telemetryRecorder } from './telemetry-v2'
+import { getAuthReferralCode } from './AuthProviderSimplified'
 
 type Listener = (authStatus: AuthStatus) => void
 type Unsubscribe = () => void
@@ -396,10 +397,7 @@ export class AuthProvider {
         }
 
         const newTokenCallbackUrl = new URL('/user/settings/tokens/new/callback', endpoint)
-        newTokenCallbackUrl.searchParams.append(
-            'requestFrom',
-            this.appScheme === 'vscode-insiders' ? 'CODY_INSIDERS' : 'CODY'
-        )
+        newTokenCallbackUrl.searchParams.append('requestFrom', getAuthReferralCode())
         this.authStatus.endpoint = endpoint
         void vscode.env.openExternal(vscode.Uri.parse(newTokenCallbackUrl.href))
     }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -36,7 +36,6 @@ type Unsubscribe = () => void
 export class AuthProvider {
     private endpointHistory: string[] = []
 
-    private appScheme = vscode.env.uriScheme
     private client: SourcegraphGraphQLAPIClient | null = null
 
     private authStatus: AuthStatus = defaultAuthStatus

--- a/vscode/src/services/AuthProviderSimplified.ts
+++ b/vscode/src/services/AuthProviderSimplified.ts
@@ -22,19 +22,26 @@ export class AuthProviderSimplified {
     }
 }
 
+/**
+ * Returns a known referral code to use based on the current VS Code environment.
+ */
+export function getAuthReferralCode(): string {
+    return (
+        {
+            'vscode-insiders': 'CODY_INSIDERS',
+            vscodium: 'CODY_VSCODIUM',
+            cursor: 'CODY_CURSOR',
+        }[vscode.env.uriScheme] || 'CODY'
+    )
+}
+
 // Opens authentication URLs for simplified onboarding.
 async function openExternalAuthUrl(provider: AuthMethod): Promise<boolean> {
     // Create the chain of redirects:
     // 1. Specific login page (GitHub, etc.) redirects to the post-sign up survey
     // 2. Post-sign up survery redirects to the new token page
     // 3. New token page redirects back to the extension with the new token
-    const uriScheme = vscode.env.uriScheme
-    const referralCode =
-        {
-            'vscode-insiders': 'CODY_INSIDERS',
-            vscodium: 'CODY_VSCODIUM',
-            cursor: 'CODY_CURSOR',
-        }[uriScheme] || 'CODY'
+    const referralCode = getAuthReferralCode()
     const newTokenUrl = `/user/settings/tokens/new/callback?requestFrom=${referralCode}`
     const postSignUpSurveyUrl = `/post-sign-up?returnTo=${newTokenUrl}`
     const site = DOTCOM_URL.toString() // Note, ends with the path /


### PR DESCRIPTION
Adds `getAuthReferralCode` function to streamline the referral code retrieval process for both simplified onboarding and AuthProvider. 

This also addresses the compatibility issue where the `cursor` and `codium` schemes added in https://github.com/sourcegraph/cody/pull/3241 & https://github.com/sourcegraph/cody/pull/3167 are currently not working for enterprise users as AuthProviderSimplified is only used by dot com users, while `AuthProvider menu` is used by our enterprise users. By consolidating the referral code logic into a single function shared by both AuthProvider and AuthProviderSimplified, future updates for additional scheme support can be easily implemented without duplicating code. This also ensures a consistent experience across all supported schemes and simplifies maintenance efforts in the long run.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->


<img width="2047" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/2382c0fc-b8d4-49a5-9323-a9a065596155">

1. Open the build of this branch in Cursor
2. in the Auth page, select `Sign in to your Enterprise instance`
3. select the first option and then enter `https://demo.sourcegraph.com` as your sourcegraph instance URL
4. You should see a pop up with the redirect link that contains the correct referral code based on your current environment, which should be CURSOR in this case


### After

Redirect link includes the CURSOR referral code in cursor

<img width="1456" alt="Screenshot 2024-02-23 at 5 41 25 PM" src="https://github.com/sourcegraph/cody/assets/68532117/06840883-1908-4073-9537-acfa8f1a1dd8">


https://github.com/sourcegraph/cody/assets/68532117/56d575d6-932c-4e51-9aa0-8528d81aeb96



### Before


Redirect link includes the CODY referral code in cursor

<img width="1372" alt="Screenshot 2024-02-23 at 5 41 52 PM" src="https://github.com/sourcegraph/cody/assets/68532117/cfe25da8-61a7-48a1-9d53-73b22e4e42e0">


https://github.com/sourcegraph/cody/assets/68532117/d3d5e4d4-598e-439d-92a3-74217e1f0a44

