### PR TITLE
Update symf index when stale

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Commands: Updated the prompts for the `Explain Code` and `Find Code Smell` commands to include file ranges. [pull/3243](https://github.com/sourcegraph/cody/pull/3243)
 - Custom Command: All custom commands are now listed individually under the `Custom Commands` section in the Cody sidebar. [pull/3245](https://github.com/sourcegraph/cody/pull/3245)
 - Custom Commands: You can now assign keybindings to individual custom commands. Simply search for `cody.command.custom.{CUSTOM_COMMAND_NAME}` (e.g. `cody.command.custom.commit`) in the Keyboard Shortcuts editor to add keybinding. [pull/3242](https://github.com/sourcegraph/cody/pull/3242)
+- Chat/Search: Local indexes are rebuilt automatically on a daily cadence when they are stale. Staleness is determined by checking whether files have changed across Git commits and in the set of working file updates not yet committed. [pull/3261](https://github.com/sourcegraph/cody/pull/3261)
 
 ### Fixed
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -649,7 +649,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private async handleSymfIndex(): Promise<void> {
         const codebase = await this.codebaseStatusProvider.currentCodebase()
         if (codebase && isFileURI(codebase.localFolder)) {
-            await this.symf?.ensureIndex(codebase.localFolder, { hard: true })
+            await this.symf?.ensureIndex(codebase.localFolder, { retryIfLastAttemptFailed: true })
         }
     }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -649,7 +649,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private async handleSymfIndex(): Promise<void> {
         const codebase = await this.codebaseStatusProvider.currentCodebase()
         if (codebase && isFileURI(codebase.localFolder)) {
-            await this.symf?.ensureIndex(codebase.localFolder, { retryIfLastAttemptFailed: true })
+            await this.symf?.ensureIndex(codebase.localFolder, {
+                retryIfLastAttemptFailed: true,
+                ignoreExisting: false,
+            })
         }
     }
 

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -265,7 +265,7 @@ async function searchSymf(
 
         const indexExists = await symf.getIndexStatus(workspaceRoot)
         if (indexExists !== 'ready' && !blockOnIndex) {
-            void symf.ensureIndex(workspaceRoot, { hard: false })
+            void symf.ensureIndex(workspaceRoot, { retryIfLastAttemptFailed: false })
             return []
         }
 

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -265,9 +265,15 @@ async function searchSymf(
 
         const indexExists = await symf.getIndexStatus(workspaceRoot)
         if (indexExists !== 'ready' && !blockOnIndex) {
-            void symf.ensureIndex(workspaceRoot, { retryIfLastAttemptFailed: false })
+            void symf.ensureIndex(workspaceRoot, {
+                retryIfLastAttemptFailed: false,
+                ignoreExisting: false,
+            })
             return []
         }
+
+        // trigger background reindex if the index is stale
+        void symf?.reindexIfStale(workspaceRoot)
 
         const r0 = (await symf.getResults(userText, [workspaceRoot])).flatMap(async results => {
             const items = (await results).flatMap(

--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -11,7 +11,7 @@ import { logDebug } from '../log'
 import { getOSArch } from '../os'
 import { captureException } from '../services/sentry/sentry'
 
-const symfVersion = 'v0.0.6'
+const symfVersion = 'v0.0.7'
 
 /**
  * Get the path to `symf`. If the symf binary is not found, download it.

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -228,6 +228,15 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         }
     }
 
+    /**
+     * Triggers indexing for a scopeDir.
+     *
+     * Options:
+     * - retryIfLastAttemptFailed: if the last indexing run ended in failure, we don't retry
+     *   unless this value is true.
+     * - ignoreExisting: if an index already exists, we don't reindex unless this value is true.
+     *   This should be set to true when we want to update an index because files have changed.
+     */
     public async ensureIndex(
         scopeDir: FileURI,
         options: IndexOptions = { retryIfLastAttemptFailed: false, ignoreExisting: false }

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -115,7 +115,7 @@ class IndexManager implements vscode.Disposable {
     private async forceRefreshIndex(scopeDir: FileURI): Promise<void> {
         try {
             await this.symf.deleteIndex(scopeDir)
-            await this.symf.ensureIndex(scopeDir, { hard: true })
+            await this.symf.ensureIndex(scopeDir, { retryIfLastAttemptFailed: true })
         } catch (error) {
             if (!(error instanceof vscode.CancellationError)) {
                 void vscode.window.showErrorMessage(
@@ -177,7 +177,7 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
         if (vscode.workspace.workspaceFolders) {
             for (const folder of vscode.workspace.workspaceFolders) {
                 if (isFileURI(folder.uri)) {
-                    void this.symfRunner.ensureIndex(folder.uri, { hard: false })
+                    void this.symfRunner.ensureIndex(folder.uri, { retryIfLastAttemptFailed: false })
                 }
             }
         }
@@ -186,7 +186,7 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
                 for (const folder of event.added) {
                     if (isFileURI(folder.uri)) {
                         void this.symfRunner.ensureIndex(folder.uri, {
-                            hard: false,
+                            retryIfLastAttemptFailed: false,
                         })
                     }
                 }

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -88,7 +88,7 @@ class IndexManager implements vscode.Disposable {
         void vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: `Building Cody search index for ${displayPath(scopeDir)}`,
+                title: `Updating Cody search index for ${displayPath(scopeDir)}`,
                 cancellable: true,
             },
             async (_progress, token) => {
@@ -115,7 +115,10 @@ class IndexManager implements vscode.Disposable {
     private async forceRefreshIndex(scopeDir: FileURI): Promise<void> {
         try {
             await this.symf.deleteIndex(scopeDir)
-            await this.symf.ensureIndex(scopeDir, { retryIfLastAttemptFailed: true })
+            await this.symf.ensureIndex(scopeDir, {
+                retryIfLastAttemptFailed: true,
+                ignoreExisting: false,
+            })
         } catch (error) {
             if (!(error instanceof vscode.CancellationError)) {
                 void vscode.window.showErrorMessage(
@@ -177,7 +180,10 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
         if (vscode.workspace.workspaceFolders) {
             for (const folder of vscode.workspace.workspaceFolders) {
                 if (isFileURI(folder.uri)) {
-                    void this.symfRunner.ensureIndex(folder.uri, { retryIfLastAttemptFailed: false })
+                    void this.symfRunner.ensureIndex(folder.uri, {
+                        retryIfLastAttemptFailed: false,
+                        ignoreExisting: false,
+                    })
                 }
             }
         }
@@ -187,6 +193,7 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
                     if (isFileURI(folder.uri)) {
                         void this.symfRunner.ensureIndex(folder.uri, {
                             retryIfLastAttemptFailed: false,
+                            ignoreExisting: false,
                         })
                     }
                 }


### PR DESCRIPTION
Local indexes are rebuilt automatically on a daily cadence when they are stale. Staleness is determined by checking whether files have changed across Git commits and in the set of working file updates not yet committed. If the indexed directories is not in a Git repository, then reindex every day.

## Test plan

- [x] Test chat context still works
- [x] Change the update frequency from [1 day](https://github.com/sourcegraph/cody/pull/3261/files#diff-0299d8549e3068ffd8c6bce70122b88f7cc9871455aff5bdd90572a8c44eb636R28) to 1 second and test that the index is rebuilt when files are changed and a new chat question is asked.