### PR TITLE
fix App story

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -220,6 +220,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         probablyNewInstall={
                             !userHistory.filter(chat => chat.interactions.length)?.length
                         }
+                        vscodeAPI={vscodeAPI}
                     />
                     {errorMessages && (
                         <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />

--- a/vscode/webviews/Notices/OnboardingAutocompleteNotice.tsx
+++ b/vscode/webviews/Notices/OnboardingAutocompleteNotice.tsx
@@ -1,18 +1,20 @@
 import type React from 'react'
 import { useEffect, useState } from 'react'
 
-import { getVSCodeAPI } from '../utils/VSCodeApi'
+import type { VSCodeWrapper } from '../utils/VSCodeApi'
 
 import { Notice } from './Notice'
 
 import styles from './OnboardingAutocompleteNotice.module.css'
 
-export const OnboardingAutocompleteNotice: React.FunctionComponent = () => {
+export const OnboardingAutocompleteNotice: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({
+    vscodeAPI,
+}) => {
     const [showNotice, setShowNotice] = useState<boolean>(false)
 
     // On first render we set up a listener for messages from ChatViewProvider
     useEffect(() => {
-        const cleanup = getVSCodeAPI().onMessage(message => {
+        const cleanup = vscodeAPI.onMessage(message => {
             if (message.type === 'notice' && message.notice.key === 'onboarding-autocomplete') {
                 setShowNotice(true)
             }
@@ -21,7 +23,7 @@ export const OnboardingAutocompleteNotice: React.FunctionComponent = () => {
         return () => {
             cleanup()
         }
-    }, [])
+    }, [vscodeAPI])
 
     if (!showNotice) {
         return undefined

--- a/vscode/webviews/Notices/index.tsx
+++ b/vscode/webviews/Notices/index.tsx
@@ -1,3 +1,4 @@
+import type { VSCodeWrapper } from '../utils/VSCodeApi'
 import { OnboardingAutocompleteNotice } from './OnboardingAutocompleteNotice'
 import { VersionUpdatedNotice } from './VersionUpdatedNotice'
 
@@ -5,11 +6,12 @@ import styles from './index.module.css'
 
 interface NoticesProps {
     probablyNewInstall: boolean
+    vscodeAPI: VSCodeWrapper
 }
 
-export const Notices: React.FunctionComponent<NoticesProps> = ({ probablyNewInstall }) => (
+export const Notices: React.FunctionComponent<NoticesProps> = ({ probablyNewInstall, vscodeAPI }) => (
     <div className={styles.notices}>
         <VersionUpdatedNotice probablyNewInstall={probablyNewInstall} />
-        <OnboardingAutocompleteNotice />
+        <OnboardingAutocompleteNotice vscodeAPI={vscodeAPI} />
     </div>
 )


### PR DESCRIPTION
The `vscodeAPI` should be passed down from App to avoid global state, which makes the App story in the storybook work again.


## Test plan

CI