### PR TITLE
UserContextSelector: remove duplicative prop formInput

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -60,7 +60,7 @@ export type {
     SymbolKind,
 } from './codebase-context/messages'
 export type { CodyCommand, CodyCommandContext, CodyCommandType } from './commands/types'
-export { DefaultCodyCommands, DefaultChatCommands } from './commands/types'
+export { type DefaultCodyCommands, DefaultChatCommands } from './commands/types'
 export { dedupeWith, isDefined, isErrorLike, pluralize } from './common'
 export {
     ProgrammingLanguage,
@@ -204,4 +204,4 @@ export type { ExtensionDetails } from './telemetry/EventLogger'
 export { testFileUri } from './test/path-helpers'
 export { addTraceparent, getActiveTraceAndSpanId, wrapInActiveSpan } from './tracing'
 export { convertGitCloneURLToCodebaseName, isError } from './utils'
-export { CurrentUserCodySubscription } from './sourcegraph-api/graphql/client'
+export type { CurrentUserCodySubscription } from './sourcegraph-api/graphql/client'

--- a/lib/ui/src/Chat.tsx
+++ b/lib/ui/src/Chat.tsx
@@ -167,7 +167,6 @@ export interface ChatCommandsProps {
 
 export interface UserContextSelectorProps {
     onSelected: (context: ContextFile, queryEndsWithColon?: boolean) => void
-    formInput: string
     contextSelection?: ContextFile[]
     selected?: number
     onSubmit: (input: string, inputType: 'user') => void
@@ -866,7 +865,6 @@ export const Chat: React.FunctionComponent<ChatProps> = ({
                                 selected={selectedChatContext}
                                 onSelected={onChatContextSelected}
                                 contextSelection={contextSelection}
-                                formInput={'@' + currentChatContextQuery}
                                 onSubmit={onSubmit}
                                 setSelectedChatContext={setSelectedChatContext}
                                 contextQuery={currentChatContextQuery ?? ''}

--- a/vscode/webviews/UserContextSelector.story.tsx
+++ b/vscode/webviews/UserContextSelector.story.tsx
@@ -29,7 +29,7 @@ export const FileSearchEmpty: StoryObj<typeof UserContextSelectorComponent> = {
     args: {
         contextSelection: undefined,
         selected: 0,
-        formInput: '@',
+        contextQuery: '',
     },
 }
 
@@ -37,7 +37,7 @@ export const FileSearchNoMatches: StoryObj<typeof UserContextSelectorComponent> 
     args: {
         contextSelection: [],
         selected: 0,
-        formInput: '@missing',
+        contextQuery: 'missing',
     },
 }
 
@@ -49,7 +49,7 @@ export const FileSearchMatches: StoryObj<typeof UserContextSelectorComponent> = 
             type: 'file',
         })),
         selected: 0,
-        formInput: '@file',
+        contextQuery: 'file',
     },
 }
 
@@ -57,7 +57,7 @@ export const SymbolSearchNoMatchesWarning: StoryObj<typeof UserContextSelectorCo
     args: {
         contextSelection: [],
         selected: 0,
-        formInput: '@#a',
+        contextQuery: '#a',
     },
 }
 
@@ -109,6 +109,6 @@ export const SymbolSearchMatches: StoryObj<typeof UserContextSelectorComponent> 
             },
         ],
         selected: 0,
-        formInput: '@#login',
+        contextQuery: '#login',
     },
 }

--- a/vscode/webviews/UserContextSelector.tsx
+++ b/vscode/webviews/UserContextSelector.tsx
@@ -15,7 +15,7 @@ const SYMBOL_NO_RESULT = 'No matching symbols found'
 
 export const UserContextSelectorComponent: React.FunctionComponent<
     React.PropsWithChildren<UserContextSelectorProps>
-> = ({ onSelected, contextSelection, formInput, selected, setSelectedChatContext, contextQuery }) => {
+> = ({ onSelected, contextSelection, selected, setSelectedChatContext, contextQuery }) => {
     const selectionRef = useRef<HTMLButtonElement>(null)
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: we want this to refresh
@@ -49,7 +49,7 @@ export const UserContextSelectorComponent: React.FunctionComponent<
         return SYMBOL_NO_RESULT
     }, [contextQuery, contextSelection?.length])
 
-    if (formInput.endsWith(' ')) {
+    if (contextQuery.endsWith(' ')) {
         return null
     }
 
@@ -114,7 +114,7 @@ export const UserContextSelectorComponent: React.FunctionComponent<
                 unavailable, so we take a guess: there should be some symbols
                 that exist for any given one or two letters, and if not, we give
                 them some help to debug the situation themselves */}
-            {formInput.match(/@#.{1,2}$/) && !contextSelection?.length ? (
+            {contextQuery.match(/#.{1,2}$/) && !contextSelection?.length ? (
                 <p className={styles.emptySymbolSearchTip}>
                     <i className="codicon codicon-info" /> VS Code may require you to open files and
                     install language extensions for accurate results


### PR DESCRIPTION
The props `contextQuery` and `formInput` were the same, except the latter had `@` prepended.


## Test plan

CI