### PR TITLE
Add documentation for CODY_RELEASE_TYPE environment variable

### DIFF
--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -79,6 +79,7 @@ It can be helpful to build and run the packaged extension locally to replicate a
 
 To do this:
 
+1. Set the environment variable `CODY_RELEASE_TYPE` to one of the following values:	`stable`, `insiders`
 1. Run `pnpm install` (see [repository setup instructions](../doc/dev/index.md) if you don't have `pnpm`).
 1. Run `pnpm release:dry-run`
 1. Uninstall any existing Cody extension from VS Code.

--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -79,9 +79,8 @@ It can be helpful to build and run the packaged extension locally to replicate a
 
 To do this:
 
-1. Set the environment variable `CODY_RELEASE_TYPE` to one of the following values:	`stable`, `insiders`
 1. Run `pnpm install` (see [repository setup instructions](../doc/dev/index.md) if you don't have `pnpm`).
-1. Run `pnpm release:dry-run`
+1. Run `CODY_RELEASE_TYPE=stable pnpm release:dry-run`
 1. Uninstall any existing Cody extension from VS Code.
 1. Run `code --install-extension dist/cody.vsix`
 


### PR DESCRIPTION
This PR adds documentation for the `CODY_RELEASE_TYPE` environment variable to the `CONTRIBUTING.md` file.

The `CODY_RELEASE_TYPE` environment variable is required to build the extension locally successfully. It specifies the type of release, which can be either `stable` or `insiders`.

By adding this documentation, we can ensure that contributors are aware of the requirements for building the extension locally and can avoid errors during the build process. 
The error that appears due to not setting the environment variable is:

> Invalid release type undefined. Valid values are: ["stable","insiders"]. Specify a a release type in the CODY_RELEASE_TYPE env var.
> ELIFECYCLE  Command failed with exit code 1.

## Test plan

Docs only change
