### PR TITLE
[HACKATHON] [Proof-of-Concept] Added Client side PII scrubber for Cody Telemetry 

### DIFF
--- a/lib/shared/src/telemetry/EventLogger.ts
+++ b/lib/shared/src/telemetry/EventLogger.ts
@@ -159,27 +159,21 @@ export class EventLogger {
             /sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}/, // V3 Sourcegraph Access token
             /sgp_[a-fA-F0-9]{40}/, // V2 Sourcegraph Access token
             /[a-fA-F0-9]{40}/, // v1 Sourcegraph Access token
-            /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/ // Dora - email regex
-         ]
+            /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/, // Dora - email regex
+        ]
 
         PII_REGEX.find(regex => {
-            const match = publicArgument['serverEndpoint'].match(regex);
-            if(match) {
-                logDebug(
-                    `logEvent${
-                        ':alert: (PII DETECTED) in ' + eventName
-                    }`,
-                    eventName,
-                    {
-                        verbose: {
-                            details: ':alert: Telemetry string contains PII info',
-                            publicArgument,
-                        },
-                    }
-                )
-                publicArgument['serverEndpoint'] = publicArgument['serverEndpoint'].replace(regex, "REDACTED");
+            const match = publicArgument.promptText.match(regex)
+            if (match) {
+                logDebug(`logEvent${':alert: (PII DETECTED) in ' + eventName}`, eventName, {
+                    verbose: {
+                        details: ':alert: Telemetry string contains PII info',
+                        publicArgument,
+                    },
+                })
+                publicArgument.promptText = publicArgument.promptText.replace(regex, 'REDACTED')
             }
-        });
+        })
         // prompts for enterprise cody customers
 
         // techncally this isn't applicable for V1 events
@@ -187,31 +181,24 @@ export class EventLogger {
         // check if promptText is not null
         // check if promptText is not empty
         const allowedEndpoints = [
-            "sourcegraph.com",
-            "localhost:3080",
-            "www.sourcegraph.com",
-            "https://sourcegraph.com/",
-            "https://sourcegraph.com",
-            "sourcegraph.test:3443",
-            "demo.sourcegraph.com",
-        ];
+            'sourcegraph.com',
+            'localhost:3080',
+            'www.sourcegraph.com',
+            'https://sourcegraph.com/',
+            'https://sourcegraph.com',
+            'sourcegraph.test:3443',
+            'demo.sourcegraph.com',
+        ]
 
-        if (
-            !allowedEndpoints.includes(publicArgument["serverEndpoint"]) &&
-            publicArgument["promptText"]
-        ) {
-            logDebug(
-                `logEvent${":alert: (PII DETECTED) in " + eventName}`,
-                eventName,
-                {
-                    verbose: {
-                        details: ":alert: Telemetry string contains PII info",
-                        publicArgument,
-                    },
-                }
-            );
+        if (!allowedEndpoints.includes(publicArgument.promptText) && publicArgument.promptText) {
+            logDebug(`logEvent${':alert: (PII DETECTED) in ' + eventName}`, eventName, {
+                verbose: {
+                    details: ':alert: Telemetry string contains PII info',
+                    publicArgument,
+                },
+            })
 
-            publicArgument["promptText"] = "REDACTED";
+            publicArgument.promptText = 'REDACTED'
         }
 
         return JSON.parse(publicArgument)

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -190,13 +190,17 @@ export function splitSafeMetadata<Properties extends { [key: string]: any }>(
                     safe[`${key}.${nestedKey}`] = value as number
                 }
                 // Preserve the entire original value in unsafe
-                unsafe[key] = value
+                if(!verifyEventProperties(key, value)) {
+                    unsafe[key] = value
+                }
                 break
             }
 
             // By default, treat as potentially unsafe.
             default:
-                unsafe[key] = value
+                if(!verifyEventProperties(key, value)) {
+                    unsafe[key] = value
+                }
         }
     }
     return {
@@ -206,4 +210,33 @@ export function splitSafeMetadata<Properties extends { [key: string]: any }>(
         metadata: safe as { [key in KeysWithNumericValues<Properties>]: number },
         privateMetadata: unsafe,
     }
+}
+
+function verifyEventProperties(keyName: string, keyValue: string): boolean {
+    const PII_REGEX = [
+        /sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}/, // V3 Sourcegraph Access token
+        /sgp_[a-fA-F0-9]{40}/, // V2 Sourcegraph Access token
+        /[a-fA-F0-9]{40}/, // v1 Sourcegraph Access token
+        /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/ // Dora - email regex
+     ]
+
+     let matchFound = false;
+
+    PII_REGEX.find((regex) => {
+        const match = keyValue.match(regex);
+        if (match) {
+            logDebug(
+                `logEvent${":alert: (PII DETECTED) in v2 telemetry" + keyName}`,
+                keyValue,
+                {
+                    verbose: {
+                        details: ":alert: Telemetry string contains PII info",
+                        keyValue,
+                    },
+                }
+            );
+            matchFound = true;
+        }
+    });
+    return matchFound;
 }

--- a/vscode/src/services/telemetry-v2.ts
+++ b/vscode/src/services/telemetry-v2.ts
@@ -190,15 +190,18 @@ export function splitSafeMetadata<Properties extends { [key: string]: any }>(
                     safe[`${key}.${nestedKey}`] = value as number
                 }
                 // Preserve the entire original value in unsafe
-                if(!verifyEventProperties(key, value)) {
-                    unsafe[key] = value
-                }
+                unsafe[key] = value
                 break
             }
 
             // By default, treat as potentially unsafe.
             default:
-                if(!verifyEventProperties(key, value)) {
+                logDebug(`logEvent${':alert: (PII DETECTED) in v2 telemetry'}`, 'testdata', {
+                    verbose: {
+                        details: ':alert: Telemetry string contains PII info',
+                    },
+                })
+                if (!verifyEventProperties(key, value)) {
                     unsafe[key] = value
                 }
         }
@@ -217,26 +220,22 @@ function verifyEventProperties(keyName: string, keyValue: string): boolean {
         /sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}/, // V3 Sourcegraph Access token
         /sgp_[a-fA-F0-9]{40}/, // V2 Sourcegraph Access token
         /[a-fA-F0-9]{40}/, // v1 Sourcegraph Access token
-        /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/ // Dora - email regex
-     ]
+        /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/, // Dora - email regex
+    ]
 
-     let matchFound = false;
+    let matchFound = false
 
-    PII_REGEX.find((regex) => {
-        const match = keyValue.match(regex);
+    PII_REGEX.find(regex => {
+        const match = keyValue.match(regex)
         if (match) {
-            logDebug(
-                `logEvent${":alert: (PII DETECTED) in v2 telemetry" + keyName}`,
-                keyValue,
-                {
-                    verbose: {
-                        details: ":alert: Telemetry string contains PII info",
-                        keyValue,
-                    },
-                }
-            );
-            matchFound = true;
+            logDebug(`logEvent${':alert: (PII DETECTED) in v2 telemetry' + keyName}`, keyValue, {
+                verbose: {
+                    details: ':alert: Telemetry string contains PII info',
+                    keyValue,
+                },
+            })
+            matchFound = true
         }
-    });
-    return matchFound;
+    })
+    return matchFound
 }


### PR DESCRIPTION
As Hackathon project, I attempted to add client side PII scrubber for Cody telemetry (proof-of-concept) helps to identify sourcegraph tokens, emails and additionally verified prompt text in telemetry events

## Test plan

- Proof-of-concept
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
