### PR TITLE
Add Mixtral model to code edit feature

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -50,6 +50,6 @@ export const DEFAULT_DOT_COM_MODELS = [
         default: false,
         codyProOnly: true,
         // TODO: Improve prompt for Mixtral + Edit to see if we can use it there too.
-        usage: [ModelUsage.Chat],
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
     },
 ] as const satisfies ModelProvider[]

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -17,6 +17,7 @@ import { PromptBuilder } from '../../prompt-builder'
 import { getContext } from './context'
 import { claude } from './models/claude'
 import { openai } from './models/openai'
+import { mixtral } from './models/mixtral'
 import type { EditLLMInteraction, GetLLMInteractionOptions, LLMInteraction } from './type'
 
 const INTERACTION_MODELS: Record<EditModel, EditLLMInteraction> = {
@@ -25,6 +26,7 @@ const INTERACTION_MODELS: Record<EditModel, EditLLMInteraction> = {
     'anthropic/claude-instant-1.2': claude,
     'openai/gpt-3.5-turbo': openai,
     'openai/gpt-4-1106-preview': openai,
+    'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct': mixtral
 } as const
 
 const getInteractionArgsFromIntent = (

--- a/vscode/src/edit/prompt/models/mixtral.ts
+++ b/vscode/src/edit/prompt/models/mixtral.ts
@@ -1,0 +1,49 @@
+import { PROMPT_TOPICS } from '../constants'
+import type { EditLLMInteraction } from '../type'
+import { buildGenericPrompt } from './generic'
+
+const RESPONSE_PREFIX = `<${PROMPT_TOPICS.OUTPUT}>\n`
+const SHARED_PARAMETERS = {
+    responseTopic: PROMPT_TOPICS.OUTPUT,
+    stopSequences: [`</${PROMPT_TOPICS.OUTPUT}>`],
+    assistantText: RESPONSE_PREFIX,
+    assistantPrefix: RESPONSE_PREFIX,
+}
+
+export const mixtral: EditLLMInteraction = {
+    getEdit(options) {
+        return {
+            ...SHARED_PARAMETERS,
+            prompt: buildGenericPrompt('edit', options),
+        }
+    },
+    getDoc(options) {
+        return {
+            ...SHARED_PARAMETERS,
+            prompt: buildGenericPrompt('doc', options),
+        }
+    },
+    getFix(options) {
+        return {
+            ...SHARED_PARAMETERS,
+            prompt: buildGenericPrompt('fix', options),
+        }
+    },
+    getAdd(options) {
+        let assistantPreamble = ''
+        if (options.precedingText) {
+            assistantPreamble = `<${PROMPT_TOPICS.PRECEDING}>${options.precedingText}</${PROMPT_TOPICS.PRECEDING}>`
+        }
+        return {
+            ...SHARED_PARAMETERS,
+            assistantText: `${assistantPreamble}${RESPONSE_PREFIX}`,
+            prompt: buildGenericPrompt('add', options),
+        }
+    },
+    getTest(options) {
+        return {
+            ...SHARED_PARAMETERS,
+            prompt: buildGenericPrompt('test', options),
+        }
+    },
+}


### PR DESCRIPTION
This PR adds the Mixtral model to the code edit feature.

The code edit feature allows users to ask Cody to edit code according to their instructions, giving them the chance to retry the edit with a new prompt, undo, or accept the change.

With this PR, users can now select the Mixtral model when using the code edit feature. This may improve the quality of the code edits for certain use cases.

Here's a summary of the changes:

- Adds a new file `mixtral.ts` in the 'models' directory, which exports a `mixtral` object that contains various methods for generating prompts for the Mixtral model.
- The `mixtral` object includes methods for generating prompts for editing, documenting, fixing, adding, and testing code.
- The `mixtral` object is added to the `INTERACTION_MODELS` object in the `index.ts` file, which maps model names to `EditLLMInteraction` objects.
- The `mixtral` object is associated with the `fireworks/accounts/fireworks/models/mixtral-8x7b-instruct` model name.

I've tested the changes thoroughly and ensured that the Mixtral model works as expected with the code edit feature.

Please let me know if you have any questions or concerns.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
