### PR TITLE
ensure symf is only downloaded once

### DIFF
--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -49,19 +49,18 @@ export async function _getSymfPath(
         )
         return null
     }
+    // Releases (eg at https://github.com/sourcegraph/symf/releases) are named with the Zig platform
+    // identifier (linux-musl, windows-gnu, macos).
+    const zigPlatform =
+        platform === 'linux' ? 'linux-musl' : platform === 'windows' ? 'windows-gnu' : platform
 
     const symfFilename = `symf-${symfVersion}-${arch}-${platform}`
-    const symfUnzippedFilename = `symf-${arch}-${platform}` // the filename inside the zip
+    const symfUnzippedFilename = `symf-${arch}-${zigPlatform}` // the filename inside the zip
     const symfPath = path.join(symfContainingDir, symfFilename)
     if (await fileExists(symfPath)) {
         logDebug('symf', `using downloaded symf "${symfPath}"`)
         return symfPath
     }
-
-    // Releases (eg at https://github.com/sourcegraph/symf/releases) are named with the Zig platform
-    // identifier (linux-musl, windows-gnu, macos).
-    const zigPlatform =
-        platform === 'linux' ? 'linux-musl' : platform === 'windows' ? 'windows-gnu' : platform
 
     const symfURL = `https://github.com/sourcegraph/symf/releases/download/${symfVersion}/symf-${arch}-${zigPlatform}.zip`
 

--- a/vscode/src/local-context/symf.test.ts
+++ b/vscode/src/local-context/symf.test.ts
@@ -4,7 +4,12 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { startPollyRecording } from '../testutils/polly'
 
+import { _getSymfPath } from './download-symf'
 import { symfExpandQuery } from './symfExpandQuery'
+
+import { tmpdir } from 'os'
+import path from 'path'
+import { mkdtemp, open, rmdir } from 'fs/promises'
 
 describe('symf', () => {
     const client = new SourcegraphNodeCompletionsClient({
@@ -57,6 +62,35 @@ describe('symf', () => {
         )
         afterAll(async () => {
             await polly.stop()
+        })
+    })
+
+    describe('download', () => {
+        it('no parallel download', async () => {
+            const dir = await mkdtemp(path.join(tmpdir(), 'symf-'))
+            try {
+                const makeEmptyFile = async (filePath: string) => {
+                    const file = await open(filePath, 'w')
+                    await file.close()
+                }
+
+                let mockDownloadSymfCalled = 0
+                const mockDownloadSymf = async (op: {
+                    symfPath: string
+                    symfFilename: string
+                    symfURL: string
+                }): Promise<void> => {
+                    mockDownloadSymfCalled++
+                    await makeEmptyFile(op.symfPath)
+                }
+                const symfPaths = await Promise.all(
+                    [...Array(10).keys()].map(() => _getSymfPath(dir, mockDownloadSymf))
+                )
+                expect(symfPaths.every(p => p === symfPaths[0])).toBeTruthy()
+                expect(mockDownloadSymfCalled).toEqual(1)
+            } finally {
+                await rmdir(dir, { recursive: true })
+            }
         })
     })
 })


### PR DESCRIPTION
Previously, it was possible to have 2 parallel symf downloads if `getSymfPath` was called twice before the first download completed. Sometimes, these appeared to interfere with one another.

## Test plan

See added unit test.
