### PR TITLE
Autocomplete: add `StarCoder2` ollama support

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1007,7 +1007,7 @@
             "model": {
               "type": "string",
               "default": "deepseek-coder:6.7b-base-q4_K_M",
-              "examples": ["codellama:7b-code", "codellama:13b-code", "deepseek-coder:6.7b-base-q4_K_M"]
+              "examples": ["codellama:7b-code", "codellama:13b-code", "deepseek-coder:6.7b-base-q4_K_M", "starcoder2:7b", "starcoder2:15b"]
             },
             "parameters": {
               "type": "object",

--- a/vscode/src/completions/providers/ollama-models.ts
+++ b/vscode/src/completions/providers/ollama-models.ts
@@ -129,6 +129,16 @@ class CodeLlama extends DefaultOllamaModel {
     }
 }
 
+class StarCoder extends DefaultOllamaModel {
+    getPrompt(ollamaPrompt: OllamaPromptContext): string {
+        const { context, currentFileNameComment, prefix, suffix } = ollamaPrompt
+
+        const infillPrefix = context + currentFileNameComment + prefix
+
+        return `<fim_prefix>${infillPrefix}<fim_suffix>${suffix}<fim_middle>`
+    }
+}
+
 export function getModelHelpers(model: string) {
     if (model.includes('codellama')) {
         return new CodeLlama()
@@ -136,6 +146,10 @@ export function getModelHelpers(model: string) {
 
     if (model.includes('deepseek-coder')) {
         return new DeepseekCoder()
+    }
+
+    if (model.includes('starcoder')) {
+        return new StarCoder()
     }
 
     return new DefaultOllamaModel()


### PR DESCRIPTION
## Context

- Adds [StarCoder2](https://ollama.com/library/starcoder2) support for autocomplete via Ollama.

## Test plan

- Install the pre-release Ollama version https://github.com/ollama/ollama/releases/tag/v0.1.28
- `ollama pull starcoder2:7b` or `ollama pull starcoder2:15b`
- Update user settings:

```json
{
  "cody.autocomplete.experimental.ollamaOptions": {
    "url": "http://localhost:11434",
    "model": "starcoder2:7b"
  },
  "cody.autocomplete.advanced.provider": "experimental-ollama",
}
```
