### PR TITLE
stricter timeouts for vscode e2e tests

### DIFF
--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -5,4 +5,8 @@ export default defineConfig({
     // Give failing tests a second chance
     retries: 2,
     testDir: 'test/e2e',
+    timeout: 20000,
+    expect: {
+        timeout: 3000,
+    },
 })


### PR DESCRIPTION
These make it so that test failures will be returned faster, and so that flaky/slow UI behavior must be explicitly accounted for in tests (such as by including `{ timeout: X }` in a `.toBeVisible()` call).



## Test plan

CI