### PR TITLE
use `page.waitForTimeout` instead of custom `sleep`

### DIFF
--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test'
 
-import { sleep } from '../../src/completions/utils'
 import { sidebarSignin } from './common'
 import { type ExpectedEvents, test } from './helpers'
 
@@ -68,14 +67,14 @@ test.extend<ExpectedEvents>({
     await heyTreeItem.hover()
     await heyTreeItem.getByLabel('Delete Chat').hover()
     await heyTreeItem.getByLabel('Delete Chat').click()
-    await sleep(100)
+    await page.waitForTimeout(100)
     expect(heyTreeItem).not.toBeVisible()
     await expect(page.getByRole('tab', { name: 'Hey' })).not.toBeVisible()
 
     await holaTreeItem.hover()
     await holaTreeItem.getByLabel('Delete Chat').hover()
     await holaTreeItem.getByLabel('Delete Chat').click()
-    await sleep(100)
+    await page.waitForTimeout(100)
     expect(holaTreeItem).not.toBeVisible()
     await expect(page.getByRole('tab', { name: 'Hola' })).not.toBeVisible()
 

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test'
 import * as mockServer from '../fixtures/mock-server'
 
-import { sleep } from '../../src/completions/utils'
 import { sidebarExplorer, sidebarSignin } from './common'
 import {
     type DotcomUrlOverride,
@@ -280,7 +279,7 @@ test.extend<ExpectedEvents>({
 
     // Open the cody.json from User Settings
     // NOTE: This is expected to fail locally if you currently have User commands configured
-    await sleep(100)
+    await page.waitForTimeout(100)
     await customCommandSidebar.click()
     await page.locator('a').filter({ hasText: 'Open User Settings (JSON)' }).hover()
     await page.getByRole('button', { name: 'Open or Create Settings File' }).hover()

--- a/vscode/test/e2e/context-settings.test.ts
+++ b/vscode/test/e2e/context-settings.test.ts
@@ -4,7 +4,6 @@ import { sidebarSignin } from './common'
 import { type ExpectedEvents, newChat, test } from './helpers'
 
 import type { RepoListResponse } from '@sourcegraph/cody-shared/src/sourcegraph-api/graphql/client'
-import { sleep } from '../../src/completions/utils'
 
 test.extend<ExpectedEvents>({
     // list of events we expect this test to log, add to this list as needed
@@ -100,7 +99,7 @@ test('enterprise context selector can pick repos', async ({ page, sidebar, serve
     // Choosing should dismiss the repo picker, but not the enhanced context
     // settings widget.
     await repoFoo.click()
-    await sleep(100)
+    await page.waitForTimeout(100)
     await page.keyboard.type('\n')
     await expect(repoPicker).not.toBeVisible()
     await expect(chooseReposButton).toBeVisible()


### PR DESCRIPTION
Playwright provides `page.waitForTimeout`, so we should use it instead of our own `sleep` for consistency.



## Test plan

CI