### PR TITLE
preserve trailing non-alphanum chars in chat message

### DIFF
--- a/vscode/src/commands/utils/display-text.test.ts
+++ b/vscode/src/commands/utils/display-text.test.ts
@@ -198,4 +198,14 @@ describe('replaceFileNameWithMarkdownLink', () => {
             )}) what does this do`
         )
     })
+
+    it('preserves trailing non-alphanum', () => {
+        expect(
+            replaceFileNameWithMarkdownLink('Hello @path/to/test.js :-)', URI.file('/path/to/test.js'))
+        ).toEqual(
+            `Hello [_@path/to/test.js_](command:_cody.vscode.open?${encodeURIComponent(
+                '[{"$mid":1,"path":"/path/to/test.js","scheme":"file"},{"preserveFocus":true,"background":false,"preview":true,"viewColumn":-2}]'
+            )}) :-)`
+        )
+    })
 })

--- a/vscode/src/commands/utils/display-text.ts
+++ b/vscode/src/commands/utils/display-text.ts
@@ -63,8 +63,8 @@ export function replaceFileNameWithMarkdownLink(
     const text = humanInput
         .replace(trailingNonAlphaNumericRegex, '')
         .replace(textToBeReplaced, ` ${markdownText}`)
-    const lastChar = trailingNonAlphaNumericRegex.test(humanInput) ? humanInput.slice(-1) : ''
-    return (text + lastChar).trim()
+    const trailingNonAlphanum = humanInput.match(trailingNonAlphaNumericRegex)?.[0] ?? ''
+    return (text + trailingNonAlphanum).trim()
 }
 
 /**


### PR DESCRIPTION
Given a chat message like `Explain @my/file.go :)`, all but the last non-alphanum char was dropped, so the resulting message as seen in the transcript would be `Explain @my/file.go)`. The handling of trailing non-alphanum was to not get tripped up by question marks, but it incorrectly assumed there would only be a single such character. This approach can be fixed more robustly by using a rich editor (https://github.com/sourcegraph/cody/pull/3287), but this is a quick fix for now.



## Test plan

CI