### PR TITLE
Edit: Fix missing context for instruction-based inputs

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -18,6 +18,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Auth: Logging in via redirect should now work in Cursor. This requires Sourcegraph 5.3.2 or later. [pull/3241](https://github.com/sourcegraph/cody/pull/3241)
 - Chat: Fixed error `found consecutive messages with the same speaker 'assistant'` that occurred when prompt length exceeded limit. [pull/3228](https://github.com/sourcegraph/cody/pull/3228)
+- Edit: Fixed an issue where preceding and following text would not be included for instruction-based Edits. [pull/3309](https://github.com/sourcegraph/cody/pull/3309)
 
 ### Changed
 

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -150,7 +150,7 @@ export const getContext = async ({
     contextMessages,
     ...options
 }: GetContextOptions): Promise<ContextItem[]> => {
-    if (contextMessages) {
+    if (contextMessages && contextMessages.length > 0) {
         return extractContextItemsFromContextMessages(contextMessages)
     }
 

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -151,6 +151,9 @@ export const getContext = async ({
     ...options
 }: GetContextOptions): Promise<ContextItem[]> => {
     if (contextMessages && contextMessages.length > 0) {
+        // TODO: We currently use `contextMessages` as a way to programmatically provide specific context
+        // for test files and attach this context to the `FixupTask`.
+        // We should move this logic to `getContextFromIntent` and add `test` as an Edit intent
         return extractContextItemsFromContextMessages(contextMessages)
     }
 

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -153,7 +153,7 @@ export const getContext = async ({
     if (contextMessages && contextMessages.length > 0) {
         // TODO: We currently use `contextMessages` as a way to programmatically provide specific context
         // for test files and attach this context to the `FixupTask`.
-        // We should move this logic to `getContextFromIntent` and add `test` as an Edit intent
+        // We should move this logic to `getContextFromIntent`
         return extractContextItemsFromContextMessages(contextMessages)
     }
 

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import {
     type ContextItem,
     type Message,
@@ -10,10 +11,22 @@ import {
 } from '@sourcegraph/cody-shared'
 import { URI } from 'vscode-uri'
 
+function sha256(input: string): string {
+    return crypto.createHash('sha256').update(input).digest('hex')
+}
+
 export function contextItemId(contextItem: ContextItem): string {
-    return contextItem.range
-        ? `${contextItem.uri.toString()}#${contextItem.range.start.line}:${contextItem.range.end.line}`
-        : contextItem.uri.toString()
+    const uri = contextItem.uri.toString()
+
+    if (contextItem.range) {
+        return `${uri}#${contextItem.range.start.line}:${contextItem.range.end.line}`
+    }
+
+    if (contextItem.content) {
+        return `${uri}#${sha256(contextItem.content)}`
+    }
+
+    return uri
 }
 
 export function renderContextItem(contextItem: ContextItem): Message[] {

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto'
 import {
     type ContextItem,
     type Message,
@@ -9,11 +8,8 @@ import {
     populateCurrentSelectedCodeContextTemplate,
     populateMarkdownContextTemplate,
 } from '@sourcegraph/cody-shared'
+import { SHA256 } from 'crypto-js'
 import { URI } from 'vscode-uri'
-
-function sha256(input: string): string {
-    return crypto.createHash('sha256').update(input).digest('hex')
-}
 
 export function contextItemId(contextItem: ContextItem): string {
     const uri = contextItem.uri.toString()
@@ -23,7 +19,7 @@ export function contextItemId(contextItem: ContextItem): string {
     }
 
     if (contextItem.content) {
-        return `${uri}#${sha256(contextItem.content)}`
+        return `${uri}#${SHA256(contextItem.content).toString()}`
     }
 
     return uri


### PR DESCRIPTION
## Description

@philipp-spiess noticed that Edit was not including context, which it should have been doing.

Recent work around commands + context improvements introduced a couple of bugs that weren't obvious:
- `contextMessages` are defaulted to `[]` from the Edit input, we had a bad check for these
- `range` is an optional value for `ContextItem`, but we rely on it to generate unique IDs for content within a file. This adds an extra ID mechanism to uniquely hash the `content` of the item alongside the file URI (if available)

## Test plan

1. Create an edit,
2. Check preceding code and following code are included as context

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
