### PR TITLE
clean up MessageWithContext, TranscriptJSON, InteractionJSON code

### DIFF
--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -549,7 +549,7 @@ export class TestClient extends MessageHandler {
                     oldChange,
                     newChange,
                     'the request in this test that has no matching recording',
-                    'the closest matchin recording in the recording file.'
+                    'the closest matching recording in the recording file'
                 )
                 console.log(
                     `

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -755,7 +755,7 @@ export class Agent extends MessageHandler {
                 }
             }
             const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
-            await chatHistory.saveChat(authStatus, chatModel.toTranscriptJSON())
+            await chatHistory.saveChat(authStatus, chatModel.toSerializedChatTranscript())
             return this.createChatPanel(
                 Promise.resolve({
                     type: 'chat',

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -210,7 +210,6 @@ describe('Agent', () => {
             expect(lastMessage).toMatchInlineSnapshot(
                 `
               {
-                "contextFiles": [],
                 "displayText": " Hello!",
                 "speaker": "assistant",
                 "text": " Hello!",

--- a/lib/shared/src/chat/chat.ts
+++ b/lib/shared/src/chat/chat.ts
@@ -64,14 +64,17 @@ export class ChatClient {
                   ? messages.concat([{ speaker: 'assistant' }])
                   : messages
 
-        // Strip `file` from any messages that are ContextMessage type, so that we don't send it up.
-        // We only want to send up what's in the prompt text.
-        const messagesWithoutFile = augmentedMessages.map(message => ({ ...message, file: undefined }))
+        // We only want to send up the speaker and prompt text, regardless of whatever other fields
+        // might be on the messages objects (`file`, `displayText`, `contextFiles`, etc.).
+        const messagesToSend = augmentedMessages.map(({ speaker, text }) => ({
+            text,
+            speaker,
+        }))
 
         const completionParams = {
             ...DEFAULT_CHAT_COMPLETION_PARAMETERS,
             ...params,
-            messages: messagesWithoutFile,
+            messages: messagesToSend,
         }
 
         if (useFastPath) {

--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -1,4 +1,3 @@
-import type { ContextItem } from '../../codebase-context/messages'
 import type { ChatMessage } from './messages'
 
 /**
@@ -27,6 +26,7 @@ export interface SerializedChatTranscript {
  */
 export interface SerializedChatInteraction {
     humanMessage: ChatMessage
-    assistantMessage: ChatMessage
-    usedContextFiles: ContextItem[]
+
+    /** `null` if the assistant has not yet replied to the human message. */
+    assistantMessage: ChatMessage | null
 }

--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -1,17 +1,32 @@
-import type { InteractionJSON } from './interaction'
+import type { ContextItem } from '../../codebase-context/messages'
+import type { ChatMessage } from './messages'
 
-interface EnhancedContextJSON {
-    // For enterprise multi-repo search, the manually selected repository names
-    // (for example "github.com/sourcegraph/sourcegraph") and IDs
-    selectedRepos: { id: string; name: string }[]
-}
-
-export interface TranscriptJSON {
-    // This is the timestamp of the first interaction.
+/**
+ * The serialized form of a chat transcript (all data needed to display and recreate a chat
+ * session).
+ */
+export interface SerializedChatTranscript {
+    /** A unique and opaque identifier for this transcript. */
     id: string
+
     chatModel?: string
     chatTitle?: string
-    interactions: InteractionJSON[]
+    interactions: SerializedChatInteraction[]
     lastInteractionTimestamp: string
-    enhancedContext?: EnhancedContextJSON
+    enhancedContext?: {
+        /**
+         * For enterprise multi-repo search, the manually selected repository names (for example
+         * "github.com/sourcegraph/sourcegraph") and IDs.
+         */
+        selectedRepos: { id: string; name: string }[]
+    }
+}
+
+/**
+ * The serialized form of a back-and-forth interaction in a chat transcript.
+ */
+export interface SerializedChatInteraction {
+    humanMessage: ChatMessage
+    assistantMessage: ChatMessage
+    usedContextFiles: ContextItem[]
 }

--- a/lib/shared/src/chat/transcript/interaction.ts
+++ b/lib/shared/src/chat/transcript/interaction.ts
@@ -1,8 +1,0 @@
-import type { ContextItem } from '../../codebase-context/messages'
-import type { ChatMessage } from './messages'
-
-export interface InteractionJSON {
-    humanMessage: ChatMessage
-    assistantMessage: ChatMessage
-    usedContextFiles: ContextItem[]
-}

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -1,7 +1,7 @@
 import type { ContextItem } from '../../codebase-context/messages'
 import type { Message } from '../../sourcegraph-api'
 
-import type { TranscriptJSON } from '.'
+import type { SerializedChatTranscript } from '.'
 import type { DefaultCodyCommands } from '../../commands/types'
 
 export interface ChatMessage extends Message {
@@ -43,7 +43,7 @@ export interface UserLocalHistory {
 }
 
 export interface ChatHistory {
-    [chatID: string]: TranscriptJSON
+    [chatID: string]: SerializedChatTranscript
 }
 
 export interface ChatInputHistory {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -8,8 +8,10 @@ export { ignores, isCodyIgnoredFile } from './cody-ignore/context-filter'
 export { CODY_IGNORE_POSIX_GLOB, type IgnoreFileContent } from './cody-ignore/ignore-helper'
 export { renderCodyMarkdown } from './chat/markdown'
 export { getSimplePreamble } from './chat/preamble'
-export type { TranscriptJSON } from './chat/transcript'
-export type { InteractionJSON } from './chat/transcript/interaction'
+export type {
+    SerializedChatInteraction,
+    SerializedChatTranscript,
+} from './chat/transcript'
 export { errorToChatError } from './chat/transcript/messages'
 export {
     getAtMentionQuery,

--- a/vscode/src/chat/chat-view/ChatHistoryManager.ts
+++ b/vscode/src/chat/chat-view/ChatHistoryManager.ts
@@ -1,7 +1,7 @@
 import type {
     AuthStatus,
     ChatInputHistory,
-    TranscriptJSON,
+    SerializedChatTranscript,
     UserLocalHistory,
 } from '@sourcegraph/cody-shared'
 
@@ -12,14 +12,14 @@ export class ChatHistoryManager {
         return localStorage.getChatHistory(authStatus)
     }
 
-    public getChat(authStatus: AuthStatus, sessionID: string): TranscriptJSON | null {
+    public getChat(authStatus: AuthStatus, sessionID: string): SerializedChatTranscript | null {
         const chatHistory = this.getLocalHistory(authStatus)
         return chatHistory?.chat ? chatHistory.chat[sessionID] : null
     }
 
     public async saveChat(
         authStatus: AuthStatus,
-        chat: TranscriptJSON,
+        chat: SerializedChatTranscript,
         input?: ChatInputHistory
     ): Promise<UserLocalHistory> {
         const history = localStorage.getChatHistory(authStatus)

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -4,9 +4,9 @@ import {
     type ChatError,
     type ChatMessage,
     type ContextItem,
-    type InteractionJSON,
     type Message,
-    type TranscriptJSON,
+    type SerializedChatInteraction,
+    type SerializedChatTranscript,
     errorToChatError,
     isCodyIgnoredFile,
     reformatBotMessageForChat,
@@ -172,16 +172,16 @@ export class SimpleChatModel {
     }
 
     /**
-     * Serializes to the legacy transcript JSON format
+     * Serializes to the transcript JSON format.
      */
-    public toTranscriptJSON(): TranscriptJSON {
-        const interactions: InteractionJSON[] = []
+    public toSerializedChatTranscript(): SerializedChatTranscript {
+        const interactions: SerializedChatInteraction[] = []
         for (let i = 0; i < this.messagesWithContext.length; i += 2) {
             const humanMessage = this.messagesWithContext[i]
             const botMessage = this.messagesWithContext[i + 1]
-            interactions.push(messageToInteractionJSON(humanMessage, botMessage))
+            interactions.push(messageToSerializedChatInteraction(humanMessage, botMessage))
         }
-        const result: TranscriptJSON = {
+        const result: SerializedChatTranscript = {
             id: this.sessionID,
             chatModel: this.modelID,
             chatTitle: this.getCustomChatTitle(),
@@ -197,12 +197,12 @@ export class SimpleChatModel {
     }
 }
 
-function messageToInteractionJSON(
+function messageToSerializedChatInteraction(
     humanMessage: MessageWithContext,
     botMessage: MessageWithContext
-): InteractionJSON {
+): SerializedChatInteraction {
     if (humanMessage?.message?.speaker !== 'human') {
-        throw new Error('SimpleChatModel.toTranscriptJSON: expected human message, got bot')
+        throw new Error('expected human message, got bot')
     }
     return {
         humanMessage: messageToInteractionMessage(humanMessage),

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -1,7 +1,6 @@
 import { findLast } from 'lodash'
 
 import {
-    type ChatError,
     type ChatMessage,
     type ContextItem,
     type Message,
@@ -13,109 +12,78 @@ import {
     toRangeData,
 } from '@sourcegraph/cody-shared'
 
+import { createDisplayTextWithFileLinks } from '../../commands/utils/display-text'
 import type { Repo } from '../../context/repo-fetcher'
 import { getChatPanelTitle } from './chat-helpers'
-
-/**
- * Interface for a chat message with additional context.
- *
- * 🚨 SECURITY: Cody ignored files must be excluded from all context items.
- */
-export interface MessageWithContext {
-    message: Message
-
-    // If set, this should be used as the display text for the message.
-    // Do not access directly, prefer using the getDisplayText function
-    // instead.
-    displayText?: string
-
-    // The additional context items attached to this message (which should not
-    // duplicate any previous context items in the transcript). This should
-    // only be defined on human messages.
-    newContextUsed?: ContextItem[]
-
-    error?: ChatError
-}
 
 export class SimpleChatModel {
     constructor(
         public modelID: string,
-        private messagesWithContext: MessageWithContext[] = [],
+        private messages: ChatMessage[] = [],
         public readonly sessionID: string = new Date(Date.now()).toUTCString(),
         private customChatTitle?: string,
         private selectedRepos?: Repo[]
     ) {}
 
     public isEmpty(): boolean {
-        return this.messagesWithContext.length === 0
+        return this.messages.length === 0
     }
 
-    public setNewContextUsed(newContextUsed: ContextItem[]): void {
-        const lastMessage = this.messagesWithContext.at(-1)
+    public setLastMessageContext(newContextUsed: ContextItem[]): void {
+        const lastMessage = this.messages.at(-1)
         if (!lastMessage) {
             throw new Error('no last message')
         }
-        if (lastMessage.message.speaker !== 'human') {
+        if (lastMessage.speaker !== 'human') {
             throw new Error('Cannot set new context used for bot message')
         }
-        lastMessage.newContextUsed = newContextUsed.filter(c => !isCodyIgnoredFile(c.uri))
+        lastMessage.contextFiles = newContextUsed.filter(c => !isCodyIgnoredFile(c.uri))
     }
 
-    public addHumanMessage(message: Omit<Message, 'speaker'>, displayText?: string): void {
-        if (this.messagesWithContext.at(-1)?.message.speaker === 'human') {
+    public addHumanMessage(message: Omit<Message, 'speaker'>): void {
+        if (this.messages.at(-1)?.speaker === 'human') {
             throw new Error('Cannot add a user message after a user message')
         }
-        this.messagesWithContext.push({
-            displayText,
-            message: {
-                ...message,
-                speaker: 'human',
-            },
-        })
+        this.messages.push({ ...message, speaker: 'human' })
     }
 
     public addBotMessage(message: Omit<Message, 'speaker'>, displayText?: string): void {
-        const lastMessage = this.messagesWithContext.at(-1)?.message
+        const lastMessage = this.messages.at(-1)
         let error: any
         // If there is no text, it could be a placeholder message for an error
         if (lastMessage?.speaker === 'assistant') {
             if (lastMessage?.text) {
                 throw new Error('Cannot add a bot message after a bot message')
             }
-            error = this.messagesWithContext.pop()?.error
+            error = this.messages.pop()?.error
         }
-        this.messagesWithContext.push({
+        this.messages.push({
+            ...message,
+            speaker: 'assistant',
             displayText,
             error,
-            message: {
-                ...message,
-                speaker: 'assistant',
-            },
         })
     }
 
     public addErrorAsBotMessage(error: Error): void {
-        const lastMessage = this.messagesWithContext.at(-1)?.message
+        const lastMessage = this.messages.at(-1)
         // Remove the last assistant message if any
-        const lastAssistantMessage =
-            lastMessage?.speaker === 'assistant' && this.messagesWithContext.pop()
-        const assistantMessage = lastAssistantMessage || { speaker: 'assistant' }
+        const lastAssistantMessage: ChatMessage | undefined =
+            lastMessage?.speaker === 'assistant' ? this.messages.pop() : undefined
         // Then add a new assistant message with error added
-        this.messagesWithContext.push({
+        this.messages.push({
+            ...(lastAssistantMessage ?? {}),
+            speaker: 'assistant',
             error: errorToChatError(error),
-            message: {
-                ...assistantMessage,
-                speaker: 'assistant',
-            },
         })
     }
 
-    public getLastHumanMessage(): MessageWithContext | undefined {
-        return findLast(this.messagesWithContext, message => message.message.speaker === 'human')
+    public getLastHumanMessage(): ChatMessage | undefined {
+        return findLast(this.messages, message => message.speaker === 'human')
     }
 
     public getLastSpeakerMessageIndex(speaker: 'human' | 'assistant'): number | undefined {
-        return this.messagesWithContext.findLastIndex(message => message.message.speaker === speaker)
+        return this.messages.findLastIndex(message => message.speaker === speaker)
     }
 
     /**
@@ -129,7 +97,7 @@ export class SimpleChatModel {
             throw new Error('SimpleChatModel.removeMessagesFromIndex: not message to remove')
         }
 
-        const speakerAtIndex = this.messagesWithContext.at(index)?.message?.speaker
+        const speakerAtIndex = this.messages.at(index)?.speaker
         if (speakerAtIndex !== expectedSpeaker) {
             throw new Error(
                 `SimpleChatModel.removeMessagesFromIndex: expected ${expectedSpeaker}, got ${speakerAtIndex}`
@@ -137,18 +105,19 @@ export class SimpleChatModel {
         }
 
         // Removes everything from the index to the last element
-        this.messagesWithContext.splice(index)
+        this.messages.splice(index)
     }
 
-    public getMessagesWithContext(): MessageWithContext[] {
-        return this.messagesWithContext
+    public getMessages(): readonly ChatMessage[] {
+        return this.messages
     }
 
     public getChatTitle(): string {
         if (this.customChatTitle) {
             return this.customChatTitle
         }
-        const text = this.getLastHumanMessage()?.displayText
+        const lastHumanMessage = this.getLastHumanMessage()
+        const text = lastHumanMessage && getDisplayText(lastHumanMessage)
         if (text) {
             return getChatPanelTitle(text)
         }
@@ -176,10 +145,10 @@ export class SimpleChatModel {
      */
     public toSerializedChatTranscript(): SerializedChatTranscript {
         const interactions: SerializedChatInteraction[] = []
-        for (let i = 0; i < this.messagesWithContext.length; i += 2) {
-            const humanMessage = this.messagesWithContext[i]
-            const botMessage = this.messagesWithContext[i + 1]
-            interactions.push(messageToSerializedChatInteraction(humanMessage, botMessage))
+        for (let i = 0; i < this.messages.length; i += 2) {
+            const humanMessage = this.messages[i]
+            const assistantMessage = this.messages.at(i + 1)
+            interactions.push(messageToSerializedChatInteraction(humanMessage, assistantMessage))
         }
         const result: SerializedChatTranscript = {
             id: this.sessionID,
@@ -198,37 +167,36 @@ export class SimpleChatModel {
 }
 
 function messageToSerializedChatInteraction(
-    humanMessage: MessageWithContext,
-    botMessage: MessageWithContext
+    humanMessage: ChatMessage,
+    assistantMessage?: ChatMessage
 ): SerializedChatInteraction {
-    if (humanMessage?.message?.speaker !== 'human') {
+    if (humanMessage?.speaker !== 'human') {
         throw new Error('expected human message, got bot')
     }
+
+    if (humanMessage.speaker !== 'human') {
+        throw new Error(`expected human message to have speaker == 'human', got ${humanMessage.speaker}`)
+    }
+    if (assistantMessage && assistantMessage.speaker !== 'assistant') {
+        throw new Error(
+            `expected bot message to have speaker == 'assistant', got ${assistantMessage.speaker}`
+        )
+    }
+
+    function toSerializedInteractionMessage(message: ChatMessage): ChatMessage {
+        return { ...message, displayText: getDisplayText(message) }
+    }
     return {
-        humanMessage: messageToInteractionMessage(humanMessage),
-        assistantMessage:
-            botMessage?.message?.speaker === 'assistant'
-                ? messageToInteractionMessage(botMessage)
-                : { speaker: 'assistant' },
-        usedContextFiles: humanMessage.newContextUsed ?? [],
+        humanMessage: toSerializedInteractionMessage(humanMessage),
+        assistantMessage: assistantMessage ? toSerializedInteractionMessage(assistantMessage) : null,
     }
 }
 
-function messageToInteractionMessage(message: MessageWithContext): ChatMessage {
+export function prepareChatMessage(message: ChatMessage): ChatMessage {
     return {
-        speaker: message.message.speaker,
-        text: message.message.text,
+        ...message,
         displayText: getDisplayText(message),
-    }
-}
-
-export function toViewMessage(mwc: MessageWithContext): ChatMessage {
-    const displayText = getDisplayText(mwc)
-    return {
-        ...mwc.message,
-        error: mwc.error,
-        displayText,
-        contextFiles: (mwc.newContextUsed ?? []).map(item => ({
+        contextFiles: message.contextFiles?.map(item => ({
             ...item,
             // De-hydrate because vscode.Range serializes to `[start, end]` in JSON.
             range: toRangeData(item.range),
@@ -236,12 +204,15 @@ export function toViewMessage(mwc: MessageWithContext): ChatMessage {
     }
 }
 
-function getDisplayText(mwc: MessageWithContext): string | undefined {
-    if (mwc.displayText) {
-        return mwc.displayText
+function getDisplayText(message: ChatMessage): string | undefined {
+    if (message.displayText) {
+        return message.displayText
     }
-    if (mwc.message.speaker === 'assistant' && mwc.message.text) {
-        return reformatBotMessageForChat(mwc.message.text, '')
+    if (message.speaker === 'human' && message.text) {
+        return createDisplayTextWithFileLinks(message.text, message.contextFiles ?? [])
     }
-    return mwc.message.text
+    if (message.speaker === 'assistant' && message.text) {
+        return reformatBotMessageForChat(message.text, '')
+    }
+    return message.text
 }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -11,10 +11,10 @@ import {
     FeatureFlag,
     type FeatureFlagProvider,
     type Guardrails,
-    type InteractionJSON,
     type Message,
     ModelProvider,
-    type TranscriptJSON,
+    type SerializedChatInteraction,
+    type SerializedChatTranscript,
     Typewriter,
     featureFlagProvider,
     hydrateAfterPostMessage,
@@ -1055,7 +1055,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private async saveSession(humanInput?: ChatInputHistory): Promise<void> {
         const allHistory = await this.history.saveChat(
             this.authProvider.getAuthStatus(),
-            this.chatModel.toTranscriptJSON(),
+            this.chatModel.toSerializedChatTranscript(),
             humanInput
         )
         if (allHistory) {
@@ -1242,11 +1242,11 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 }
 
 async function newChatModelfromTranscriptJSON(
-    json: TranscriptJSON,
+    json: SerializedChatTranscript,
     modelID: string
 ): Promise<SimpleChatModel> {
     const messages: MessageWithContext[][] = json.interactions.map(
-        (interaction: InteractionJSON): MessageWithContext[] => {
+        (interaction: SerializedChatInteraction): MessageWithContext[] => {
             return [
                 {
                     message: {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -26,7 +26,6 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import type { View } from '../../../webviews/NavBar'
-import { createDisplayTextWithFileLinks } from '../../commands/utils/display-text'
 import { getFullConfig } from '../../configuration'
 import { type RemoteSearch, RepoInclusion } from '../../context/remote-search'
 import {
@@ -78,7 +77,7 @@ import { CodyChatPanelViewType, addWebviewViewHTML } from './ChatManager'
 import type { ChatPanelConfig, ChatViewProviderWebview } from './ChatPanelsManager'
 import { CodebaseStatusProvider } from './CodebaseStatusProvider'
 import { InitDoer } from './InitDoer'
-import { type MessageWithContext, SimpleChatModel, toViewMessage } from './SimpleChatModel'
+import { SimpleChatModel, prepareChatMessage } from './SimpleChatModel'
 import { getChatPanelTitle, openFile } from './chat-helpers'
 import { getEnhancedContext } from './context'
 import { DefaultPrompter, type IPrompter } from './prompt'
@@ -440,11 +439,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     await this.clearAndRestartSession()
                 }
 
-                const displayText = userContextFiles?.length
-                    ? createDisplayTextWithFileLinks(inputText, userContextFiles)
-                    : inputText
-                const promptText = inputText
-                this.chatModel.addHumanMessage({ text: promptText }, displayText)
+                this.chatModel.addHumanMessage({ text: inputText })
                 await this.saveSession({ inputText, inputContextFiles: userContextFiles })
 
                 this.postEmptyMessageInProgress()
@@ -502,7 +497,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                             // the condition below is an additional safeguard measure
                             promptText:
                                 authStatus.endpoint && isDotCom(authStatus.endpoint)
-                                    ? promptText
+                                    ? inputText
                                     : undefined,
                         },
                     })
@@ -708,9 +703,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     private postViewTranscript(messageInProgress?: ChatMessage): void {
-        const messages: ChatMessage[] = this.chatModel
-            .getMessagesWithContext()
-            .map(m => toViewMessage(m))
+        const messages: ChatMessage[] = [...this.chatModel.getMessages()]
         if (messageInProgress) {
             messages.push(messageInProgress)
         }
@@ -719,7 +712,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         // https://github.com/microsoft/vscode/issues/159431
         void this.postMessage({
             type: 'transcript',
-            messages,
+            messages: messages.map(prepareChatMessage),
             isMessageInProgress: !!messageInProgress,
             chatID: this.chatModel.sessionID,
         })
@@ -818,7 +811,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         const { prompt, newContextUsed } = await prompter.makePrompt(this.chatModel, maxChars)
 
         // Update UI based on prompt construction
-        this.chatModel.setNewContextUsed(newContextUsed)
+        this.chatModel.setLastMessageContext(newContextUsed)
 
         if (sendTelemetry) {
             // Create a summary of how many code snippets of each context source are being
@@ -864,14 +857,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             update: content => {
                 measureFirstToken()
                 span.addEvent('update')
-                this.postViewTranscript(
-                    toViewMessage({
-                        message: {
-                            speaker: 'assistant',
-                            text: content,
-                        },
-                    })
-                )
+                this.postViewTranscript({
+                    speaker: 'assistant',
+                    text: content,
+                })
             },
             close: content => {
                 measureFirstToken()
@@ -1236,8 +1225,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     // Convenience function for tests
-    public getViewTranscript(): ChatMessage[] {
-        return this.chatModel.getMessagesWithContext().map(m => toViewMessage(m))
+    public getViewTranscript(): readonly ChatMessage[] {
+        return this.chatModel.getMessages().map(prepareChatMessage)
     }
 }
 
@@ -1247,25 +1236,9 @@ function newChatModelFromSerializedChatTranscript(
 ): SimpleChatModel {
     return new SimpleChatModel(
         json.chatModel || modelID,
-        json.interactions.flatMap((interaction: SerializedChatInteraction): MessageWithContext[] => {
-            return [
-                {
-                    message: {
-                        speaker: 'human',
-                        text: interaction.humanMessage.text,
-                    },
-                    displayText: interaction.humanMessage.displayText,
-                    newContextUsed: interaction.usedContextFiles,
-                },
-                {
-                    message: {
-                        speaker: 'assistant',
-                        text: interaction.assistantMessage.text,
-                    },
-                    displayText: interaction.assistantMessage.displayText,
-                },
-            ]
-        }),
+        json.interactions.flatMap((interaction: SerializedChatInteraction): ChatMessage[] =>
+            [interaction.humanMessage, interaction.assistantMessage].filter(isDefined)
+        ),
         json.id,
         json.chatTitle,
         json.enhancedContext?.selectedRepos

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -18,6 +18,7 @@ import {
     Typewriter,
     featureFlagProvider,
     hydrateAfterPostMessage,
+    isDefined,
     isDotCom,
     isError,
     isFileURI,

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -1,4 +1,4 @@
-import type { ContextItem } from '@sourcegraph/cody-shared'
+import type { ContextItem, Message } from '@sourcegraph/cody-shared'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as vscode from 'vscode'
 import { PromptBuilder } from '../../prompt-builder'
@@ -18,23 +18,21 @@ describe('DefaultPrompter', () => {
             Promise.resolve([])
         ).makePrompt(chat, 100000)
 
-        expect(prompt).toMatchInlineSnapshot(`
-          [
+        expect(prompt).toEqual<Message[]>([
             {
-              "speaker": "human",
-              "text": "You are Cody, an AI coding assistant from Sourcegraph.",
+                speaker: 'human',
+                text: 'You are Cody, an AI coding assistant from Sourcegraph.',
             },
             {
-              "speaker": "assistant",
-              "text": "I am Cody, an AI coding assistant from Sourcegraph.",
+                speaker: 'assistant',
+                text: 'I am Cody, an AI coding assistant from Sourcegraph.',
             },
             {
-              "speaker": "human",
-              "text": "Hello",
+                speaker: 'human',
+                text: 'Hello',
             },
-          ]
-        `)
-        expect(newContextUsed).toMatchInlineSnapshot('[]')
+        ])
+        expect(newContextUsed).toEqual([])
     })
 
     it('adds the cody.chat.preInstruction vscode setting if set', async () => {
@@ -53,23 +51,21 @@ describe('DefaultPrompter', () => {
             Promise.resolve([])
         ).makePrompt(chat, 100000)
 
-        expect(prompt).toMatchInlineSnapshot(`
-          [
+        expect(prompt).toEqual<Message[]>([
             {
-              "speaker": "human",
-              "text": "You are Cody, an AI coding assistant from Sourcegraph. Always respond with 🧀 emojis",
+                speaker: 'human',
+                text: 'You are Cody, an AI coding assistant from Sourcegraph. Always respond with 🧀 emojis',
             },
             {
-              "speaker": "assistant",
-              "text": "I am Cody, an AI coding assistant from Sourcegraph.",
+                speaker: 'assistant',
+                text: 'I am Cody, an AI coding assistant from Sourcegraph.',
             },
             {
-              "speaker": "human",
-              "text": "Hello",
+                speaker: 'human',
+                text: 'Hello',
             },
-          ]
-        `)
-        expect(newContextUsed).toMatchInlineSnapshot('[]')
+        ])
+        expect(newContextUsed).toEqual([])
     })
 
     it('tryAddContext limit should not allow prompt to exceed overall limit', async () => {
@@ -93,6 +89,6 @@ describe('DefaultPrompter', () => {
         expect(used).toEqual([])
 
         const prompt = promptBuilder.build()
-        expect(prompt).toMatchInlineSnapshot('[]')
+        expect(prompt).toEqual([])
     })
 })

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
 import {
+    type ChatMessage,
     type ContextItem,
     type Message,
     getSimplePreamble,
@@ -11,7 +12,7 @@ import { logDebug } from '../../log'
 
 import type { ContextItemWithContent } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { PromptBuilder } from '../../prompt-builder'
-import type { MessageWithContext, SimpleChatModel } from './SimpleChatModel'
+import type { SimpleChatModel } from './SimpleChatModel'
 import { sortContextItems } from './agentContextSorting'
 
 interface PromptInfo {
@@ -57,7 +58,7 @@ export class DefaultPrompter implements IPrompter {
             }
 
             // Add existing transcript messages
-            const reverseTranscript: MessageWithContext[] = [...chat.getMessagesWithContext()].reverse()
+            const reverseTranscript: ChatMessage[] = [...chat.getMessages()].reverse()
             const contextLimitReached = promptBuilder.tryAddMessages(reverseTranscript)
             if (contextLimitReached) {
                 logDebug(
@@ -88,9 +89,7 @@ export class DefaultPrompter implements IPrompter {
             {
                 // Add context from previous messages
                 const { limitReached } = promptBuilder.tryAddContext(
-                    reverseTranscript.flatMap(
-                        (message: MessageWithContext) => message.newContextUsed || []
-                    )
+                    reverseTranscript.flatMap(message => message.contextFiles || [])
                 )
                 if (limitReached) {
                     logDebug(
@@ -102,16 +101,16 @@ export class DefaultPrompter implements IPrompter {
             }
 
             const lastMessage = reverseTranscript[0]
-            if (!lastMessage?.message.text) {
+            if (!lastMessage?.text) {
                 throw new Error('No last message or last message text was empty')
             }
-            if (lastMessage.message.speaker === 'assistant') {
+            if (lastMessage.speaker === 'assistant') {
                 throw new Error('Last message in prompt needs speaker "human", but was "assistant"')
             }
             if (this.getEnhancedContext) {
                 // Add additional context from current editor or broader search
                 const additionalContextItems = await this.getEnhancedContext(
-                    lastMessage.message.text,
+                    lastMessage.text,
                     enhancedContextCharLimit
                 )
                 sortContextItems(additionalContextItems)

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 
 import {
     BotResponseMultiplexer,
+    type ChatMessage,
     type CompletionParameters,
     type EditModel,
     type Message,
@@ -12,7 +13,6 @@ import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { FixupTask } from '../../non-stop/FixupTask'
 import type { EditIntent } from '../types'
 
-import type { MessageWithContext } from '../../chat/chat-view/SimpleChatModel'
 import { PromptBuilder } from '../../prompt-builder'
 import { getContext } from './context'
 import { claude } from './models/claude'
@@ -100,9 +100,9 @@ export const buildInteraction = async ({
     const preamble = getSimplePreamble(model)
     promptBuilder.tryAddToPrefix(preamble)
 
-    const transcript: MessageWithContext[] = [{ message: { speaker: 'human', text: prompt } }]
+    const transcript: ChatMessage[] = [{ speaker: 'human', text: prompt }]
     if (assistantText) {
-        transcript.push({ message: { speaker: 'assistant', text: assistantText } })
+        transcript.push({ speaker: 'assistant', text: assistantText })
     }
     promptBuilder.tryAddMessages(transcript.reverse())
 

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import type { MessageWithContext } from '../chat/chat-view/SimpleChatModel'
+import type { ChatMessage } from '@sourcegraph/cody-shared'
 import { PromptBuilder } from './index'
 
 describe('PromptBuilder', () => {
     describe('tryAddMessages', () => {
         it('adds single valid transcript', () => {
             const builder = new PromptBuilder(100)
-            const transcript: MessageWithContext[] = [{ message: { speaker: 'human', text: 'Hi!' } }]
+            const transcript: ChatMessage[] = [{ speaker: 'human', text: 'Hi!' }]
             builder.tryAddMessages(transcript.reverse())
             const messages = builder.build()
             expect(messages.length).toBe(1)
@@ -16,7 +16,7 @@ describe('PromptBuilder', () => {
 
         it('throw on transcript starts with assistant', () => {
             const builder = new PromptBuilder(100)
-            const transcript: MessageWithContext[] = [{ message: { speaker: 'assistant', text: 'Hi!' } }]
+            const transcript: ChatMessage[] = [{ speaker: 'assistant', text: 'Hi!' }]
             expect(() => {
                 builder.tryAddMessages(transcript)
             }).toThrowError()
@@ -24,11 +24,11 @@ describe('PromptBuilder', () => {
 
         it('adds valid transcript in reverse order', () => {
             const builder = new PromptBuilder(1000)
-            const transcript: MessageWithContext[] = [
-                { message: { speaker: 'human', text: 'Hi assistant!' } },
-                { message: { speaker: 'assistant', text: 'Hello there!' } },
-                { message: { speaker: 'human', text: 'Hi again!' } },
-                { message: { speaker: 'assistant', text: 'Hello there again!' } },
+            const transcript: ChatMessage[] = [
+                { speaker: 'human', text: 'Hi assistant!' },
+                { speaker: 'assistant', text: 'Hello there!' },
+                { speaker: 'human', text: 'Hi again!' },
+                { speaker: 'assistant', text: 'Hello there again!' },
             ]
             builder.tryAddMessages(transcript.reverse())
             const messages = builder.build()
@@ -41,11 +41,11 @@ describe('PromptBuilder', () => {
 
         it('throws on consecutive speakers order', () => {
             const builder = new PromptBuilder(1000)
-            const invalidTranscript: MessageWithContext[] = [
-                { message: { speaker: 'human', text: 'Hi there!' } },
-                { message: { speaker: 'human', text: 'Hello there!' } },
-                { message: { speaker: 'assistant', text: 'How are you?' } },
-                { message: { speaker: 'assistant', text: 'Hello there!' } },
+            const invalidTranscript: ChatMessage[] = [
+                { speaker: 'human', text: 'Hi there!' },
+                { speaker: 'human', text: 'Hello there!' },
+                { speaker: 'assistant', text: 'How are you?' },
+                { speaker: 'assistant', text: 'Hello there!' },
             ]
             expect(() => {
                 builder.tryAddMessages(invalidTranscript)
@@ -54,11 +54,11 @@ describe('PromptBuilder', () => {
 
         it('throws on transcript with human speakers only', () => {
             const builder = new PromptBuilder(1000)
-            const invalidTranscript: MessageWithContext[] = [
-                { message: { speaker: 'human', text: '1' } },
-                { message: { speaker: 'human', text: '2' } },
-                { message: { speaker: 'human', text: '3' } },
-                { message: { speaker: 'human', text: '4' } },
+            const invalidTranscript: ChatMessage[] = [
+                { speaker: 'human', text: '1' },
+                { speaker: 'human', text: '2' },
+                { speaker: 'human', text: '3' },
+                { speaker: 'human', text: '4' },
             ]
             expect(() => {
                 builder.tryAddMessages(invalidTranscript)
@@ -67,18 +67,16 @@ describe('PromptBuilder', () => {
 
         it('stops adding message-pairs when limit has been reached', () => {
             const builder = new PromptBuilder(30)
-            const longTranscript: MessageWithContext[] = [
-                { message: { speaker: 'human', text: 'Hi assistant!' } },
-                { message: { speaker: 'assistant', text: 'Hello there!' } },
-                { message: { speaker: 'human', text: 'Hi again!' } },
+            const longTranscript: ChatMessage[] = [
+                { speaker: 'human', text: 'Hi assistant!' },
+                { speaker: 'assistant', text: 'Hello there!' },
+                { speaker: 'human', text: 'Hi again!' },
                 {
-                    message: {
-                        speaker: 'assistant',
-                        text: 'This is a very long message that should exceed the character limit',
-                    },
+                    speaker: 'assistant',
+                    text: 'This is a very long message that should exceed the character limit',
                 },
                 // Only this message should be added
-                { message: { speaker: 'human', text: 'This should be added.' } },
+                { speaker: 'human', text: 'This should be added.' },
             ]
             const numberOfMessagesIgnored = builder.tryAddMessages(longTranscript.reverse())
             expect(numberOfMessagesIgnored).toBe(4)

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -1,11 +1,11 @@
 import {
+    type ChatMessage,
     type ContextItem,
     type ContextMessage,
     type Message,
     isCodyIgnoredFile,
 } from '@sourcegraph/cody-shared'
 import { SHA256 } from 'crypto-js'
-import type { MessageWithContext } from '../chat/chat-view/SimpleChatModel'
 import { renderContextItem } from './utils'
 
 const isAgentTesting = process.env.CODY_SHIM_TESTING === 'true'
@@ -47,13 +47,13 @@ export class PromptBuilder {
      * Validates that the transcript alternates between human and assistant speakers.
      * Stops adding when the character limit would be exceeded.
      */
-    public tryAddMessages(reverseTranscript: MessageWithContext[]): number {
+    public tryAddMessages(reverseTranscript: ChatMessage[]): number {
         // All Human message is expected to be followed by response from Assistant,
         // except for the Human message at the last index that Assistant hasn't responded yet.
-        const lastHumanMsgIndex = reverseTranscript.findIndex(msg => msg.message?.speaker === 'human')
+        const lastHumanMsgIndex = reverseTranscript.findIndex(msg => msg.speaker === 'human')
         for (let i = lastHumanMsgIndex; i < reverseTranscript.length; i += 2) {
-            const humanMsg = reverseTranscript[i]?.message
-            const assistantMsg = reverseTranscript[i - 1]?.message
+            const humanMsg = reverseTranscript[i]
+            const assistantMsg = reverseTranscript[i - 1]
             if (humanMsg?.speaker !== 'human' || humanMsg?.speaker === assistantMsg?.speaker) {
                 throw new Error(`Invalid transcript order: expected human message at index ${i}`)
             }

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -159,7 +159,7 @@ function contextItem(value: ContextItem | ContextMessage): ContextItem {
     return isContextItem(value) ? value : value.file
 }
 
-export function contextItemId(value: ContextItem | ContextMessage): string {
+function contextItemId(value: ContextItem | ContextMessage): string {
     const item = contextItem(value)
 
     if (item.range) {

--- a/vscode/src/services/HistoryChat.ts
+++ b/vscode/src/services/HistoryChat.ts
@@ -5,6 +5,7 @@ import { getChatPanelTitle } from '../chat/chat-view/chat-helpers'
 
 import type { AuthStatus } from '@sourcegraph/cody-shared'
 import type { ChatMessage } from '@sourcegraph/cody-shared'
+import { prepareChatMessage } from '../chat/chat-view/SimpleChatModel'
 import type { CodySidebarTreeItem } from './tree-views/treeViewItems'
 
 interface GroupedChats {
@@ -62,7 +63,7 @@ export function groupCodyChats(authStatus: AuthStatus | undefined): GroupedChats
         let lastHumanMessage: ChatMessage | undefined = undefined
         // Can use Array.prototype.findLast once we drop Node 16
         for (let index = entry.interactions.length - 1; index >= 0; index--) {
-            lastHumanMessage = entry.interactions[index]?.humanMessage
+            lastHumanMessage = prepareChatMessage(entry.interactions[index]?.humanMessage)
             if (lastHumanMessage) {
                 break
             }

--- a/vscode/src/test-support.ts
+++ b/vscode/src/test-support.ts
@@ -39,7 +39,7 @@ export class TestSupport {
     public chatPanelProvider = new Rendezvous<SimpleChatPanelProvider>()
     public ignoreHelper = new Rendezvous<IgnoreHelper>()
 
-    public async chatMessages(): Promise<ChatMessage[]> {
+    public async chatMessages(): Promise<readonly ChatMessage[]> {
         return (await this.chatPanelProvider.get()).getViewTranscript()
     }
 }

--- a/vscode/test/integration/helpers.ts
+++ b/vscode/test/integration/helpers.ts
@@ -59,7 +59,7 @@ export async function getTranscript(index: number): Promise<ChatMessage> {
     const testSupport = api.exports.testing
     assert.ok(testSupport)
 
-    let transcript: ChatMessage[] | undefined
+    let transcript: readonly ChatMessage[] | undefined
 
     await waitUntil(async () => {
         if (!api.isActive || !api.exports.testing) {

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -11,7 +11,7 @@ import {
     type EnhancedContextContextT,
     GuardrailsPost,
     type ModelProvider,
-    type TranscriptJSON,
+    type SerializedChatTranscript,
 } from '@sourcegraph/cody-shared'
 import type { UserAccountInfo } from './Chat'
 import { EnhancedContextEnabled } from './chat/components/EnhancedContext'
@@ -48,7 +48,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
 
     const [formInput, setFormInput] = useState('')
     const [inputHistory, setInputHistory] = useState<ChatInputHistory[]>([])
-    const [userHistory, setUserHistory] = useState<TranscriptJSON[]>([])
+    const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>([])
     const [chatIDHistory, setChatIDHistory] = useState<string[]>([])
 
     const [contextSelection, setContextSelection] = useState<ContextItem[] | null>(null)

--- a/vscode/webviews/UserContextSelector.tsx
+++ b/vscode/webviews/UserContextSelector.tsx
@@ -12,7 +12,7 @@ const FILE_NO_RESULT = 'No matching files found'
 const SYMBOL_ON_RESULT = 'Search for a symbol to include...'
 const SYMBOL_NO_RESULT = 'No matching symbols found'
 
-export interface UserContextSelectorProps {
+interface UserContextSelectorProps {
     onSelected: (context: ContextItem, queryEndsWithColon?: boolean) => void
     contextSelection?: ContextItem[]
     selected?: number


### PR DESCRIPTION
I am working on #3287, which benefits from having less different data structures that store messages. In working on that PR, I found the following refactors were helpful:

- Remove `MessageWithContext` ([Slack thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1709675835965529))
- Remove `newContextUsed` and `usedContextFiles` fields (that duplicate `ChatMessage#contextFiles`)
- Other code cleanups as a result of these

## Test plan

CI