### PR TITLE
handle incorrectly serialized vscode.Range values in toRangeData

### DIFF
--- a/lib/shared/src/common/range.test.ts
+++ b/lib/shared/src/common/range.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { toRangeData } from './range'
+
+describe('toRangeData', () => {
+    test('converts Range to RangeData', () => {
+        expect(
+            toRangeData({ start: { line: 1, character: 2 }, end: { line: 3, character: 4 } })
+        ).toEqual({
+            start: { line: 1, character: 2 },
+            end: { line: 3, character: 4 },
+        })
+    })
+
+    test('handles array input', () => {
+        expect(
+            toRangeData([
+                { line: 1, character: 2 },
+                { line: 3, character: 4 },
+            ])
+        ).toEqual({
+            start: { line: 1, character: 2 },
+            end: { line: 3, character: 4 },
+        })
+    })
+
+    test('handles undefined input', () => {
+        expect(toRangeData(undefined)).toBeUndefined()
+    })
+})

--- a/lib/shared/src/common/range.ts
+++ b/lib/shared/src/common/range.ts
@@ -14,11 +14,21 @@ export interface RangeData {
  */
 export function toRangeData<R extends RangeData>(range: R): RangeData
 export function toRangeData<R extends RangeData>(range: R | undefined): RangeData | undefined
-export function toRangeData<R extends RangeData>(range: R | undefined): RangeData | undefined {
-    return range
+export function toRangeData(
+    badVSCodeSerializedRange: [{ line: number; character: number }, { line: number; character: number }]
+): RangeData
+export function toRangeData<R extends RangeData>(
+    range: R | [{ line: number; character: number }, { line: number; character: number }] | undefined
+): RangeData | undefined {
+    // HACK: Handle if the `vscode.Range` value was accidentally JSON-serialized as [start, end],
+    // which `vscode.Range` instances do when JSON-serialized because of their `toJSON()` method
+    // that misleading and not represented in the type system).
+    const data = Array.isArray(range) ? { start: range[0], end: range[1] } : range
+
+    return data
         ? {
-              start: { line: range.start.line, character: range.start.character },
-              end: { line: range.end.line, character: range.end.character },
+              start: { line: data.start.line, character: data.start.character },
+              end: { line: data.end.line, character: data.end.character },
           }
         : undefined
 }

--- a/vscode/src/common/range.ts
+++ b/vscode/src/common/range.ts
@@ -1,13 +1,16 @@
 import type { RangeData } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 
-export function toVSCodeRange(range?: RangeData): vscode.Range | undefined {
+export function toVSCodeRange(
+    range?: RangeData | [{ line: number; character: number }, { line: number; character: number }]
+): vscode.Range | undefined {
     if (!range) {
         return undefined
     }
 
-    // HACK: If value was accidentally serialized as [start, end] (which `vscode.Range` instances do
-    // when JSON-serialized), handle it.
+    // HACK: Handle if the `vscode.Range` value was accidentally JSON-serialized as [start, end],
+    // which `vscode.Range` instances do when JSON-serialized because of their `toJSON()` method
+    // that misleading and not represented in the type system).
     if (Array.isArray(range)) {
         return new vscode.Range(range[0].line, range[0].character, range[1].line, range[1].character)
     }


### PR DESCRIPTION
We should fix the source of any bugs like this, but it's also helpful to handle them gracefully.



## Test plan

CI