### PR TITLE
Command: do not refresh sidebar on config change

### DIFF
--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -35,12 +35,7 @@ export class CommandsProvider implements vscode.Disposable {
             vscode.commands.registerCommand('cody.menu.commands', () => this?.menu('default')),
             vscode.commands.registerCommand('cody.menu.custom-commands', () => this?.menu('custom')),
             vscode.commands.registerCommand('cody.menu.commands-settings', () => this?.menu('config')),
-            vscode.commands.registerCommand('cody.commands.open.doc', () => openCustomCommandDocsLink()),
-            vscode.workspace.onDidChangeConfiguration(async event => {
-                if (event.affectsConfiguration('cody')) {
-                    await this.treeViewProvider.refresh()
-                }
-            })
+            vscode.commands.registerCommand('cody.commands.open.doc', () => openCustomCommandDocsLink())
         )
 
         this.customCommandsStore.init()


### PR DESCRIPTION
FIX bug where command sidebar disappears on configuration change ([slack](https://sourcegraph.slack.com/archives/C05AGQYD528/p1709745282681469))

![image](https://github.com/sourcegraph/cody/assets/68532117/3e8fbac5-1518-43ae-8c76-fb0b70cccef1)

Root cause: Introduced in https://github.com/sourcegraph/cody/pull/3245 by me 😅 , the tree view provider for commands is refreshed without tree items provided on configuration change, causing the sidebar view to be empty

Proposed fix: Since commands are not configurable, there is no need to refresh the sidebar on configuration change. This PR removes the aforementioned code. 

Note: Changelog entry is not required as the change has not been released

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Start Cody from this branch
2. Update any of your Cody extension settings
3. Confirm the command sidebar is not empty
4. Update any of your Custom Command
5. Confirm the change is reflected in the sidebar

https://github.com/sourcegraph/cody/assets/68532117/441234d8-4b37-4ae7-84fa-a7d820aebb03


