### PR TITLE
Debug: enable debug logging by default

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -25,6 +25,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Debug: The `cody.debug.enabled` setting is now set to `true` by default. [pull/](https://github.com/sourcegraph/cody/pull/)
+
 ## [1.6.1]
 
 ### Changed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -906,7 +906,8 @@
         "cody.debug.enable": {
           "order": 99,
           "type": "boolean",
-          "markdownDescription": "Turns on debug output (visible in the VS Code Output panel under \"Cody by Sourcegraph\")"
+          "markdownDescription": "Turns on debug output (visible in the VS Code Output panel under \"Cody by Sourcegraph\")",
+          "default": true
         },
         "cody.debug.verbose": {
           "order": 99,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -87,7 +87,7 @@ export function getConfiguration(
         codebase: sanitizeCodebase(config.get(CONFIG_KEY.codebase)),
         customHeaders: config.get<object>(CONFIG_KEY.customHeaders, {}) as Record<string, string>,
         useContext: config.get<ConfigurationUseContext>(CONFIG_KEY.useContext) || 'embeddings',
-        debugEnable: config.get<boolean>(CONFIG_KEY.debugEnable, false),
+        debugEnable: config.get<boolean>(CONFIG_KEY.debugEnable, true),
         debugVerbose: config.get<boolean>(CONFIG_KEY.debugVerbose, false),
         debugFilter: debugRegex,
         telemetryLevel: config.get<'all' | 'off'>(CONFIG_KEY.telemetryLevel, 'all'),

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -822,7 +822,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     commandHints: false,
     isRunningInsideAgent: false,
     agentIDE: undefined,
-    debugEnable: false,
+    debugEnable: true,
     debugVerbose: false,
     debugFilter: null,
     telemetryLevel: 'all',


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/3256

Context: https://sourcegraph.slack.com/archives/C05AGQYD528/p1708722669252619

This PR updates to enable `cody.debug.enable` by default that allows basic debug logging, which would be helpful with the `Export Logs` feature introduced in https://github.com/sourcegraph/cody/pull/3256

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

No feature change. Green CI.