### PR TITLE
VS Code: Release 1.8.0

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -2699,7 +2699,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.6.1
+                    clientVersion: 1.8.1
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2817,7 +2817,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.6.1
+                    clientVersion: 1.8.1
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2935,7 +2935,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.6.1
+                    clientVersion: 1.8.1
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3053,7 +3053,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.6.1
+                    clientVersion: 1.8.1
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3171,7 +3171,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.6.1
+                    clientVersion: 1.8.1
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3289,7 +3289,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.6.1
+                    clientVersion: 1.8.1
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3407,7 +3407,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.6.1
+                    clientVersion: 1.8.1
         queryString:
           - name: RecordTelemetryEvents
             value: null

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -2699,7 +2699,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2817,7 +2817,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2935,7 +2935,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3053,7 +3053,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3171,7 +3171,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3289,7 +3289,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3407,7 +3407,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.0
         queryString:
           - name: RecordTelemetryEvents
             value: null

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -2643,7 +2643,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 627921aecef7f81ad3eced27ed298560
+    - _id: f7d661532c6712bfc5b6aa473be89de8
       _order: 0
       cache: {}
       request:
@@ -2720,7 +2720,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 08:51:32 GMT
+            value: Wed, 06 Mar 2024 23:46:52 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2751,7 +2751,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T08:51:32.205Z
+      startedDateTime: 2024-03-06T23:46:52.634Z
       time: 0
       timings:
         blocked: -1
@@ -2761,7 +2761,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 16f0bc26c451237b8ad4bf3c0643db6d
+    - _id: b656fa8b4a7bf9f6055a3cd2bb5829b8
       _order: 0
       cache: {}
       request:
@@ -2838,7 +2838,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 08:51:32 GMT
+            value: Wed, 06 Mar 2024 23:46:53 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2869,7 +2869,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T08:51:32.213Z
+      startedDateTime: 2024-03-06T23:46:52.669Z
       time: 0
       timings:
         blocked: -1
@@ -2879,7 +2879,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1b15851ff16d88768aa910634072814a
+    - _id: 0651bd1ac11f26c328e6c84e300c548e
       _order: 0
       cache: {}
       request:
@@ -2956,7 +2956,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 08:51:32 GMT
+            value: Wed, 06 Mar 2024 23:46:53 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2987,7 +2987,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T08:51:32.214Z
+      startedDateTime: 2024-03-06T23:46:52.670Z
       time: 0
       timings:
         blocked: -1
@@ -2997,7 +2997,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b9ea7097f1ce3852ff06bead29540c92
+    - _id: dc482c3bddc864b4b6450112dad79a31
       _order: 0
       cache: {}
       request:
@@ -3074,7 +3074,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 08:51:34 GMT
+            value: Wed, 06 Mar 2024 23:46:53 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3105,7 +3105,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T08:51:33.818Z
+      startedDateTime: 2024-03-06T23:46:52.819Z
       time: 0
       timings:
         blocked: -1
@@ -3115,7 +3115,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: aa8c3e28cdacdf38879f212b54a42679
+    - _id: acaaab5bba099cb56a2935493c6f397e
       _order: 0
       cache: {}
       request:
@@ -3192,7 +3192,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 08:51:38 GMT
+            value: Wed, 06 Mar 2024 23:46:53 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3223,7 +3223,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T08:51:38.310Z
+      startedDateTime: 2024-03-06T23:46:52.830Z
       time: 0
       timings:
         blocked: -1
@@ -3233,7 +3233,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 369e417e1dc33ddc74c9decbdc5ac9a2
+    - _id: 12f01789446e073746df1a886bdc0a13
       _order: 0
       cache: {}
       request:
@@ -3310,7 +3310,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 08:51:38 GMT
+            value: Wed, 06 Mar 2024 23:46:53 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3341,7 +3341,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T08:51:38.315Z
+      startedDateTime: 2024-03-06T23:46:52.834Z
       time: 0
       timings:
         blocked: -1
@@ -3351,7 +3351,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 4c92e4e12b5040a9e19f92768cf0e975
+    - _id: 00ce0a526f87250d2bf7e97c929071f3
       _order: 0
       cache: {}
       request:
@@ -3428,7 +3428,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 08:51:38 GMT
+            value: Wed, 06 Mar 2024 23:46:53 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3459,7 +3459,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T08:51:38.317Z
+      startedDateTime: 2024-03-06T23:46:52.837Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -754,7 +754,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 38505f96e0a8bea9859d860b34dc55b6
+    - _id: d79ae221eac441b2c43b972276ea858b
       _order: 0
       cache: {}
       request:
@@ -831,7 +831,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 08:53:30 GMT
+            value: Wed, 06 Mar 2024 23:46:54 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -862,7 +862,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T08:53:30.168Z
+      startedDateTime: 2024-03-06T23:46:54.359Z
       time: 0
       timings:
         blocked: -1
@@ -1388,114 +1388,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 497016b346576225fa3857c9ca66af24
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 243
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_ad28238383af71357085701263df7766e6f7f8ad1afc344d71aaf69a07143677
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseMainBranchClient / v1
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "243"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - _fromType: array
-            name: connection
-            value: close
-          - name: host
-            value: sourcegraph.sourcegraph.com
-        headersSize: 380
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query SnippetAttribution($snippet: String!) {
-                  snippetAttribution(snippet: $snippet) {
-                      limitHit
-                      nodes {
-                          repositoryName
-                      }
-                  }
-              }
-            variables:
-              snippet: sourcegraph.Location(new URL
-        queryString:
-          - name: SnippetAttribution
-            value: null
-        url: https://sourcegraph.sourcegraph.com/.api/graphql?SnippetAttribution
-      response:
-        bodySize: 231
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 231
-          text: "[\"H4sIAAAAAAAAA4SNMQrDMAxF76I5aXZv3Tr1AqWD4whHEEvGkqEl+O4lU10IdPt83uPts\
-            Hjz4HZQppzRrmaF5mokfLwbJbIbGTgrFQdgWVDBPXYomEXJpLzv\",\"PiE4iGRrnS9\
-            B0qRSS8BYfF77DW048Tj/CrNXCmOQBUdiw+3c6mvRUG1KGP2B/ee72Dcz4suQlYQV2r\
-            O19gEAAP//AwAoEJKNGwEAAA==\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Sat, 27 Jan 2024 14:35:00 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: close
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1244
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-06T08:53:30.186Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: b635aa83c2f05439f124938c5856379f
       _order: 0
       cache: {}
@@ -1598,6 +1490,114 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-03-06T07:55:59.314Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 497016b346576225fa3857c9ca66af24
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 243
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_ad28238383af71357085701263df7766e6f7f8ad1afc344d71aaf69a07143677
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "243"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - _fromType: array
+            name: connection
+            value: close
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 380
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |-
+              
+              query SnippetAttribution($snippet: String!) {
+                  snippetAttribution(snippet: $snippet) {
+                      limitHit
+                      nodes {
+                          repositoryName
+                      }
+                  }
+              }
+            variables:
+              snippet: sourcegraph.Location(new URL
+        queryString:
+          - name: SnippetAttribution
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?SnippetAttribution
+      response:
+        bodySize: 231
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 231
+          text: "[\"H4sIAAAAAAAAA4SNMQrDMAxF76I5aXZv3Tr1AqWD4whHEEvGkqEl+O4lU10IdPt83uPts\
+            Hjz4HZQppzRrmaF5mokfLwbJbIbGTgrFQdgWVDBPXYomEXJpLzv\",\"PiE4iGRrnS9\
+            B0qRSS8BYfF77DW048Tj/CrNXCmOQBUdiw+3c6mvRUG1KGP2B/ee72Dcz4suQlYQV2r\
+            O19gEAAP//AwAoEJKNGwEAAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Sat, 27 Jan 2024 14:35:00 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: close
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1244
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-06T08:53:30.186Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -810,7 +810,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.0
         queryString:
           - name: RecordTelemetryEvents
             value: null

--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -810,7 +810,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.6.1
+                    clientVersion: 1.8.1
         queryString:
           - name: RecordTelemetryEvents
             value: null

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [1.8.0]
+
+### Added
+
 - Chat: Adds experimental support for local Ollama chat models. Simply start the Ollama app. You should be able to find the models you have pulled from Ollama in the model dropdown list in your chat panel after restarting VS Code. For detailed instructions, see [pull/3282](https://github.com/sourcegraph/cody/pull/3282)
 - Chat: Adds support for line ranges with @-mentioned files (Example: `Explain @src/README.md:1-5`). [pull/3174](https://github.com/sourcegraph/cody/pull/3174)
 - Chat: Command prompts are now editable and compatible with @ mentions. [pull/3243](https://github.com/sourcegraph/cody/pull/3243)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.6.1",
+  "version": "1.8.0",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
VS Code: Release 1.8.0 - Stable Release.

Blog post: https://github.com/sourcegraph/about/pull/6791

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Version bump
- [x] vscode/changelog.md
- [x] vscode/package.json 
- [x] agent recordings 