### PR TITLE
Custom Command: Fix shell command as context on Windows

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Custom Commands: Fixed an issue that blocked shell commands from running on Windows. [pull/3333](https://github.com/sourcegraph/cody/pull/3333)
+
 ### Changed
 
 ## [1.8.0]

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -33,14 +33,10 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
 
         // Expand the ~/ in command with the home directory if any of the substring starts with ~/ with a space before it
         const filteredCommand = command.replaceAll(/(\s~\/)/g, ` ${rootDir}${path.sep}`)
-        const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri?.path
+        // NOTE: Use fsPath to get path with platform specific path separator
+        const cwd = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath
         try {
-            const { stdout, stderr } = await _exec(filteredCommand, {
-                cwd: wsRoot,
-                encoding: 'utf8',
-            })
-
-            // stringify the output of the command first
+            const { stdout, stderr } = await _exec(filteredCommand, { cwd, encoding: 'utf8' })
             const output = stdout ?? stderr
             const outputString = JSON.stringify(output.trim())
             if (!outputString) {

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -56,10 +56,9 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
             return [file]
         } catch (error) {
             // Handles errors and empty output
-            console.error('getContextFileFromShell > failed', error)
             logError('getContextFileFromShell', 'failed', { verbose: error })
             void vscode.window.showErrorMessage('Command Failed: Make sure the command works locally.')
-            return []
+            throw new Error('Failed to get shell output for Custom Command.')
         }
     })
 }

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -306,12 +306,10 @@ test.extend<ExpectedEvents>({
 
 testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
-
-    // Open the Source Control view
+    // Open the Source Control View to confirm this is a git workspace
+    // Check the change is showing as a Git file in the sidebar
     const sourceControlView = page.getByLabel(/Source Control/).nth(2)
     await sourceControlView.click()
-
-    // Check the change is showing as a Git file in the sidebar
     await page.getByRole('heading', { name: 'Source Control' }).hover()
     await page.getByText('index.js').hover()
     await page.locator('a').filter({ hasText: 'index.js' }).click()
@@ -321,11 +319,13 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
     const menuInputBox = page.getByPlaceholder('Search for a command or enter your question here...')
     await expect(menuInputBox).toBeVisible()
     await menuInputBox.fill('shellOutput')
-    await expect(page.getByText('Get output from a shell command.')).toBeVisible()
     await page.keyboard.press('Enter')
 
-    const chatPanel = getChatPanel(page)
-    await expect(chatPanel.getByText('✨ Context: 1 line from 2 files')).toBeVisible()
-    await chatPanel.getByText('✨ Context: 1 line from 2 files').click()
-    await expect(chatPanel.getByRole('button', { name: '@/terminal-output' })).toBeVisible()
+    // Check the context list to confirm the terminal output is added as file
+    const panel = getChatPanel(page)
+    await expect(panel.getByText('✨ Context: 1 line from 2 files')).toBeVisible()
+    await panel.getByText('✨ Context: 1 line from 2 files').click()
+    await expect(
+        panel.getByRole('button', { name: withPlatformSlashes('@/terminal-output') })
+    ).toBeVisible()
 })

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -1,4 +1,4 @@
-import { type Frame, type Locator, type Page, expect } from '@playwright/test'
+import { type Frame, type FrameLocator, type Locator, type Page, expect } from '@playwright/test'
 
 import { SERVER_URL, VALID_TOKEN } from '../fixtures/mock-server'
 import { executeCommandInPalette } from './helpers'
@@ -25,11 +25,19 @@ export const sidebarSignin = async (
 }
 
 // Selector for the Explorer button in the sidebar that would match on Mac and Linux
-const sidebarExplorerRole = { name: /Explorer.*/ }
-export const sidebarExplorer = (page: Page): Locator => page.getByRole('tab', sidebarExplorerRole)
+export const sidebarExplorer = (page: Page): Locator => page.getByRole('tab', { name: /Explorer.*/ })
 
+/**
+ * Use the command to toggle DND mode because the UI differs on Windows/non-Windows since 1.86 with
+ * macOS appearing to use a native menu where Windows uses a VS Code-drawn menu.
+ */
 async function disableNotifications(page: Page): Promise<void> {
-    // Use the command to toggle DND mode because the UI differs on Windows/non-Windows since 1.86 with
-    // macOS appearing to use a native menu where Windows uses a VS Code-drawn menu.
     await executeCommandInPalette(page, 'notifications: toggle do not disturb')
+}
+
+/**
+ * Gets the chat panel frame locator.
+ */
+export function getChatPanel(page: Page): FrameLocator {
+    return page.frameLocator('iframe.webview').frameLocator('iframe[title="New Chat"]')
 }

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -10,6 +10,7 @@ import * as uuid from 'uuid'
 import { MockServer, loggedEvents, resetLoggedEvents, sendTestInfo } from '../fixtures/mock-server'
 
 import { installVsCode } from './install-deps'
+import { buildCustomCommandConfigFile } from './utils/buildCustomCommands'
 
 // Playwright test extension: The workspace directory to run the test in.
 export interface WorkspaceDirectory {
@@ -107,7 +108,7 @@ export const test = base
             )
 
             await buildWorkSpaceSettings(workspaceDirectory, extraWorkspaceSettings)
-            await buildCodyJson(workspaceDirectory)
+            await buildCustomCommandConfigFile(workspaceDirectory)
 
             sendTestInfo(testInfo.title, testInfo.testId, uuid.v4())
 
@@ -272,58 +273,6 @@ async function buildWorkSpaceSettings(
     })
     await new Promise<void>((resolve, reject) => {
         writeFile(workspaceSettingsPath, JSON.stringify(settings), error => {
-            if (error) {
-                reject(error)
-            } else {
-                resolve()
-            }
-        })
-    })
-}
-
-// Build a cody.json file for testing custom commands and context fetching
-async function buildCodyJson(workspaceDirectory: string): Promise<void> {
-    const codyJson = {
-        currentDir: {
-            description:
-                "Should have 4 context files from the current directory. Files start with '.' are skipped by default.",
-            prompt: 'Add four context files from the current directory.',
-            context: {
-                selection: false,
-                currentDir: true,
-            },
-        },
-        filePath: {
-            prompt: 'Add lib/batches/env/var.go as context.',
-            context: {
-                filePath: 'lib/batches/env/var.go',
-            },
-        },
-        directoryPath: {
-            description: 'Get files from directory.',
-            prompt: 'Directory has one context file.',
-            context: {
-                directoryPath: 'lib/batches/env',
-            },
-        },
-        openTabs: {
-            description: 'Get files from open tabs.',
-            prompt: 'Open tabs as context.',
-            context: {
-                selection: false,
-                openTabs: true,
-            },
-        },
-        invalid: {
-            description: 'Command without prompt should not break the custom command menu.',
-            note: 'This is used for validating the custom command UI to avoid cases where an invalid command entry prevents all custom commands from showing up in the menu.',
-        },
-    }
-
-    // add file to the .vscode directory created in the buildWorkSpaceSettings step
-    const codyJsonPath = path.join(workspaceDirectory, '.vscode', 'cody.json')
-    await new Promise<void>((resolve, reject) => {
-        writeFile(codyJsonPath, JSON.stringify(codyJson), error => {
             if (error) {
                 reject(error)
             } else {

--- a/vscode/test/e2e/utils/buildCustomCommands.ts
+++ b/vscode/test/e2e/utils/buildCustomCommands.ts
@@ -1,0 +1,21 @@
+import { writeFile } from 'fs'
+import { join } from 'path'
+import * as codyJson from './commands.json'
+
+/**
+ * Builds a cody.json file for testing custom commands and context fetching in e2e test.
+ *
+ * The file is written to the .vscode directory created in the buildWorkSpaceSettings step
+ */
+export async function buildCustomCommandConfigFile(workspaceDirectory: string): Promise<void> {
+    const codyJsonPath = join(workspaceDirectory, '.vscode', 'cody.json')
+    await new Promise<void>((resolve, reject) => {
+        writeFile(codyJsonPath, JSON.stringify(codyJson), error => {
+            if (error) {
+                reject(error)
+            } else {
+                resolve()
+            }
+        })
+    })
+}

--- a/vscode/test/e2e/utils/commands.json
+++ b/vscode/test/e2e/utils/commands.json
@@ -1,0 +1,42 @@
+{
+  "currentDir": {
+    "description": "Should have 4 context files from the current directory. Files start with '.' are skipped by default.",
+    "prompt": "Add four context files from the current directory.",
+    "context": {
+      "selection": false,
+      "currentDir": true
+    }
+  },
+  "filePath": {
+    "prompt": "Add lib/batches/env/var.go as context.",
+    "context": {
+      "filePath": "lib/batches/env/var.go"
+    }
+  },
+  "directoryPath": {
+    "description": "Get files from directory.",
+    "prompt": "Directory has one context file.",
+    "context": {
+      "directoryPath": "lib/batches/env"
+    }
+  },
+  "openTabs": {
+    "description": "Get files from open tabs.",
+    "prompt": "Open tabs as context.",
+    "context": {
+      "selection": false,
+      "openTabs": true
+    }
+  },
+  "shellOutput": {
+    "description": "Get output from a shell command.",
+    "prompt": "Shell command output as context.",
+    "context": {
+      "command": "git diff"
+    }
+  },
+  "invalid": {
+    "description": "Command without prompt should not break the custom command menu.",
+    "note": "This is used for validating the custom command UI to avoid cases where an invalid command entry prevents all custom commands from showing up in the menu."
+  }
+}

--- a/vscode/test/e2e/utils/gitWorkspace.ts
+++ b/vscode/test/e2e/utils/gitWorkspace.ts
@@ -1,0 +1,58 @@
+import { spawn } from 'child_process'
+import { promises as fs } from 'fs'
+import * as mockServer from '../../fixtures/mock-server'
+
+import path from 'path'
+import {
+    type DotcomUrlOverride,
+    type WorkspaceDirectory,
+    test as baseTest,
+    withTempDir,
+} from '../helpers'
+
+// Reconfigured test with Git enabled
+export const testGitWorkspace = baseTest
+    .extend<DotcomUrlOverride>({
+        dotcomUrl: mockServer.SERVER_URL,
+    })
+    .extend<WorkspaceDirectory>({
+        // biome-ignore lint/correctness/noEmptyPattern: Playwright needs empty pattern to specify "no dependencies".
+        workspaceDirectory: async ({}, use) => {
+            await withTempDir(async dir => {
+                // Initialize a git repository there
+                await runGit(['init'], { cwd: dir })
+                await runGit(['config', 'user.name', 'Test User'], { cwd: dir })
+                await runGit(['config', 'user.email', 'test@example.host'], { cwd: dir })
+
+                // Add Cody ignore
+                await fs.mkdir(path.join(dir, '.cody'), { recursive: true })
+                await fs.writeFile(path.join(dir, '.cody', 'ignore'), 'ignored.js')
+
+                // Add empty files to change later
+                await Promise.all([
+                    fs.writeFile(path.join(dir, 'index.js'), ''),
+                    fs.writeFile(path.join(dir, 'ignored.js'), ''),
+                ])
+
+                // Commit initial files
+                await runGit(['add', '.'], { cwd: dir })
+                await runGit(['commit', '-m', 'Initial commit'], {
+                    cwd: dir,
+                })
+
+                // Add some content to try to commit in our tests
+                await Promise.all([
+                    fs.writeFile(path.join(dir, 'index.js'), '// Hello World'),
+                    fs.writeFile(path.join(dir, 'ignored.js'), '// Ignore me!'),
+                ])
+
+                await use(dir)
+            })
+        },
+    })
+
+/** Run 'git' and wait for the process to exit. */
+export async function runGit(args: string[], options?: any) {
+    const proc = spawn('git', args, options)
+    return new Promise(resolve => proc.on('close', resolve))
+}

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -13,6 +13,7 @@
     "test/fixtures",
     "playwright.config.ts",
     "test/e2e",
+    "test/e2e/utils/commands.json",
     "webviews",
     "webviews/*.d.ts",
     "package.json"
@@ -28,6 +29,6 @@
   "references": [
     {
       "path": "../lib/shared"
-    },
+    }
   ]
 }


### PR DESCRIPTION
FIX https://github.com/sourcegraph/cody/issues/3328

This PR fixes an issue where Cody is unable to use output from a shell command as context for Custom Command.

Root cause: we would run the command from the workspace root using the path of the URI, which doesn't return the path with the correct format on Windows (forward slashes vs backward slashes). 

Proposed fix: Replacing path with fsPath which returns the path with the correct format base on platform works.

Added a new e2e test to ensure shell context can be used across platforms.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Start Cody from this branch on Windows
2. Runs a custom command that uses command output as context
3. You should see that Cody is able to get the output from the command instead of showing the `Command Failed: Make sure the command works locally` error 