### PR TITLE
Prevent auth block when another auth is ongoing

### DIFF
--- a/vscode/src/chat/chat-view/SidebarViewController.ts
+++ b/vscode/src/chat/chat-view/SidebarViewController.ts
@@ -72,9 +72,7 @@ export class SidebarViewController implements vscode.WebviewViewProvider {
                     if (this.startTokenReceiver) {
                         logExposure()
                         if (branch === OnboardingExperimentBranch.RemoveAuthenticationStep) {
-                            if (isAuthProgressInProgress()) {
-                                return
-                            }
+                            closeAuthProgressIndicator()
                             startAuthProgressIndicator()
                             tokenReceiverUrl = await this.startTokenReceiver(
                                 endpoint,


### PR DESCRIPTION
Initially we thought that while another sign in is in progress, we want to avoid starting a new flow. However, this turned out to be confusing (see https://sourcegraph.slack.com/archives/C05AGQYD528/p1709828514131439) and also buggy (if you cancel the dialog it was still impossible to open another link). So let's remove this logic and allow opening multiple flows.

## Test plan

https://github.com/sourcegraph/cody/assets/458591/c28fa737-a08b-4905-ada0-adf51dc26de5

