### PR TITLE
Chat: Shows welcome message on empty chat only

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Chat: Welcome message is only shown on new chat panel. [pull/3341](https://github.com/sourcegraph/cody/pull/3341)
+
 ## [1.8.1]
 
 ### Added

--- a/vscode/test/e2e/command-menu.test.ts
+++ b/vscode/test/e2e/command-menu.test.ts
@@ -33,7 +33,7 @@ test('Start a new chat from Cody Command Menu', async ({ page, sidebar }) => {
 
     // the question should show up in the chat panel on submit
     const chatPanel = page.frameLocator('iframe.webview').last().frameLocator('iframe')
-    await chatPanel.getByText('new chat submitted from command menu').click()
+    await chatPanel.getByText('hello from the assistant').hover()
 
     const expectedEvents = [
         'CodyVSCodeExtension:menu:command:default:clicked',

--- a/vscode/test/e2e/update-notice.test.ts
+++ b/vscode/test/e2e/update-notice.test.ts
@@ -56,10 +56,11 @@ test('existing installs should show the update toast when the last dismissed ver
     await page.locator('*[aria-label="Tab actions"] *[aria-label~="Close"]').click()
 
     // Reopen the chat; the update notice should be visible.
+    // Welcome message is removed.
     await chatHistoryEntry.click()
     chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
     const introChat = chatFrame.getByText(greetingChatText)
-    await expect(introChat).toBeVisible()
+    await expect(introChat).not.toBeVisible()
     const chatNotice = chatFrame.getByText(updateToastText)
     await expect(chatNotice).toBeVisible()
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -743,7 +743,8 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         <div className={classNames(styles.innerContainer)}>
             {
                 <Transcript
-                    transcript={transcriptWithWelcome}
+                    // Remove welcome message after the first message is submitted
+                    transcript={transcript.length ? transcript : transcriptWithWelcome}
                     messageInProgress={messageInProgress}
                     messageBeingEdited={messageBeingEdited}
                     setMessageBeingEdited={setEditMessageState}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -155,20 +155,16 @@ export const Transcript: React.FunctionComponent<
             if (!message?.displayText && !message.error) {
                 return null
             }
-            // The key index includes the Cody welcome message added to the transcript in the webview
-            // as it is not included in the transcript returned from the server, the key index is
-            // offset by 1 to account for this.
             const offsetIndex = index + offset === earlierMessages.length
             const keyIndex = index + offset
-            const transcriptIndex = keyIndex - 1
 
-            const isItemBeingEdited = messageBeingEdited === transcriptIndex
+            const isItemBeingEdited = messageBeingEdited === keyIndex
 
             return (
                 <div key={index}>
                     {isItemBeingEdited && <div ref={itemBeingEditedRef} />}
                     <TranscriptItem
-                        index={transcriptIndex}
+                        index={keyIndex}
                         key={keyIndex}
                         message={message}
                         inProgress={


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/2461

![image](https://github.com/sourcegraph/cody/assets/68532117/4ebb82e1-7f4f-46c6-8eb9-f1035f703a9c)

This PR removes the welcome message after the first question has been submitted.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Open a new chat to confirm welcome message is displayed
2. Submit a question / execute a command
3. the welcome message should disappear

## Before

![image](https://github.com/sourcegraph/cody/assets/68532117/de430f25-a36e-4929-9d81-ad6bd38677df)

