### PR TITLE
Debug: Enable debug mode from setting menu

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Debug: Added new commands (`Cody Debug: Enable Debug Mode` and `Cody Debug: Open Output Channel`) to the editor Command Palette and the `Settings & Support` sidebar to streamline the process of getting started with debugging Cody. [pull/3342](https://github.com/sourcegraph/cody/pull/3342)
+
 ### Fixed
 
 ### Changed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -503,9 +503,15 @@
       {
         "command": "cody.debug.export.logs",
         "category": "Cody",
-        "group": "Cody",
+        "group": "Debug",
         "title": "Export Logs…",
         "when": "config.cody.debug.enable"
+      },
+      {
+        "command": "cody.open.outputChannel",
+        "category": "Cody",
+        "group": "Debug",
+        "title": "Open Output Channel"
       }
     ],
     "keybindings": [
@@ -718,7 +724,12 @@
         {
           "command": "cody.debug.export.logs",
           "when": "view == cody.support.tree.view",
-          "group": "7_cody@0"
+          "group": "8_cody@0"
+        },
+        {
+          "command": "cody.open.outputChannel",
+          "when": "view == cody.support.tree.view",
+          "group": "8_cody@1"
         },
         {
           "command": "cody.search.index-update",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -38,7 +38,12 @@
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
-  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": [
+    "Programming Languages",
+    "Machine Learning",
+    "Snippets",
+    "Education"
+  ],
   "keywords": [
     "ai",
     "openai",
@@ -89,7 +94,11 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
+  "activationEvents": [
+    "onLanguage",
+    "onStartupFinished",
+    "onWebviewPanel:cody.chatPanel"
+  ],
   "contributes": {
     "walkthroughs": [
       {
@@ -811,12 +820,20 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": [
+            "https://github.com/sourcegraph/cody",
+            "ssh://git@github.com/sourcegraph/cody"
+          ]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": ["embeddings", "keyword", "blended", "none"],
+          "enum": [
+            "embeddings",
+            "keyword",
+            "blended",
+            "none"
+          ],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -880,7 +897,9 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages. (E.g., \"Answer all my questions in Spanish.\")",
-          "examples": ["Answer all my questions in Spanish."]
+          "examples": [
+            "Answer all my questions in Spanish."
+          ]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -945,15 +964,27 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
+          "enum": [
+            "all",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "Disables all extension telemetry."
+          ],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": null,
-          "enum": [null, "anthropic", "fireworks", "unstable-openai", "experimental-ollama"],
+          "enum": [
+            null,
+            "anthropic",
+            "fireworks",
+            "unstable-openai",
+            "experimental-ollama"
+          ],
           "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."
         },
         "cody.autocomplete.advanced.serverEndpoint": {
@@ -967,7 +998,12 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [null, "starcoder-16b", "starcoder-7b", "llama-code-13b"],
+          "enum": [
+            null,
+            "starcoder-16b",
+            "starcoder-7b",
+            "llama-code-13b"
+          ],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -987,7 +1023,10 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": ["lsp", "indentation-based"],
+          "enum": [
+            "lsp",
+            "indentation-based"
+          ],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1018,7 +1057,11 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "bfg", "bfg-mixed"],
+          "enum": [
+            null,
+            "bfg",
+            "bfg-mixed"
+          ],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.ollamaOptions": {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -508,7 +508,8 @@
         "command": "cody.debug.enable.all",
         "category": "Cody Debug",
         "group": "Debug",
-        "title": "Enable Debug Mode"
+        "title": "Enable Debug Mode",
+        "when": "!config.cody.debug.verbose"
       }
     ],
     "keybindings": [
@@ -721,12 +722,17 @@
         {
           "command": "cody.debug.export.logs",
           "when": "view == cody.support.tree.view",
+          "group": "8_cody@1"
+        },
+        {
+          "command": "cody.debug.enable.all",
+          "when": "view == cody.support.tree.view && !config.cody.debug.verbose",
           "group": "8_cody@0"
         },
         {
           "command": "cody.debug.outputChannel",
           "when": "view == cody.support.tree.view",
-          "group": "8_cody@1"
+          "group": "8_cody@2"
         },
         {
           "command": "cody.search.index-update",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -38,12 +38,7 @@
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
-  "categories": [
-    "Programming Languages",
-    "Machine Learning",
-    "Snippets",
-    "Education"
-  ],
+  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "ai",
     "openai",
@@ -94,11 +89,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": [
-    "onLanguage",
-    "onStartupFinished",
-    "onWebviewPanel:cody.chatPanel"
-  ],
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
   "contributes": {
     "walkthroughs": [
       {
@@ -502,16 +493,22 @@
       },
       {
         "command": "cody.debug.export.logs",
-        "category": "Cody",
+        "category": "Cody Debug",
         "group": "Debug",
         "title": "Export Logs…",
         "when": "config.cody.debug.enable"
       },
       {
-        "command": "cody.open.outputChannel",
-        "category": "Cody",
+        "command": "cody.debug.outputChannel",
+        "category": "Cody Debug",
         "group": "Debug",
         "title": "Open Output Channel"
+      },
+      {
+        "command": "cody.debug.enable.all",
+        "category": "Cody Debug",
+        "group": "Debug",
+        "title": "Enable Debug Mode"
       }
     ],
     "keybindings": [
@@ -727,7 +724,7 @@
           "group": "8_cody@0"
         },
         {
-          "command": "cody.open.outputChannel",
+          "command": "cody.debug.outputChannel",
           "when": "view == cody.support.tree.view",
           "group": "8_cody@1"
         },
@@ -808,20 +805,12 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": [
-            "https://github.com/sourcegraph/cody",
-            "ssh://git@github.com/sourcegraph/cody"
-          ]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "embeddings",
-            "keyword",
-            "blended",
-            "none"
-          ],
+          "enum": ["embeddings", "keyword", "blended", "none"],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -885,9 +874,7 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages. (E.g., \"Answer all my questions in Spanish.\")",
-          "examples": [
-            "Answer all my questions in Spanish."
-          ]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -952,27 +939,15 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "all",
-            "off"
-          ],
-          "enumDescriptions": [
-            "Sends usage data and errors.",
-            "Disables all extension telemetry."
-          ],
+          "enum": ["all", "off"],
+          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "anthropic",
-            "fireworks",
-            "unstable-openai",
-            "experimental-ollama"
-          ],
+          "enum": [null, "anthropic", "fireworks", "unstable-openai", "experimental-ollama"],
           "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."
         },
         "cody.autocomplete.advanced.serverEndpoint": {
@@ -986,12 +961,7 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "starcoder-16b",
-            "starcoder-7b",
-            "llama-code-13b"
-          ],
+          "enum": [null, "starcoder-16b", "starcoder-7b", "llama-code-13b"],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1011,10 +981,7 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": [
-            "lsp",
-            "indentation-based"
-          ],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1045,11 +1012,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "bfg",
-            "bfg-mixed"
-          ],
+          "enum": [null, "bfg", "bfg-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.ollamaOptions": {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -519,7 +519,7 @@ const register = async (
             void vscode.commands.executeCommand(command, [source])
         }),
         ...setUpCodyIgnore(initialConfig),
-        // Debugging
+        // For debugging
         vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri)),
         vscode.commands.registerCommand('cody.debug.outputChannel', () => openCodyOutputChannel()),
         vscode.commands.registerCommand('cody.debug.enable.all', () => enableDebugMode())

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -60,7 +60,7 @@ import { setUpCodyIgnore } from './services/cody-ignore'
 import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
 import { onTextDocumentChange } from './services/utils/codeblock-action-tracker'
-import { exportOutputLog } from './services/utils/export-logs'
+import { exportOutputLog, openCodyOutputChannel } from './services/utils/export-logs'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
 
 /**
@@ -519,7 +519,8 @@ const register = async (
             void vscode.commands.executeCommand(command, [source])
         }),
         ...setUpCodyIgnore(initialConfig),
-        vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri))
+        vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri)),
+        vscode.commands.registerCommand('cody.open.outputChannel', () => openCodyOutputChannel())
     )
 
     /**

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -60,7 +60,7 @@ import { setUpCodyIgnore } from './services/cody-ignore'
 import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
 import { onTextDocumentChange } from './services/utils/codeblock-action-tracker'
-import { exportOutputLog, openCodyOutputChannel } from './services/utils/export-logs'
+import { enableDebugMode, exportOutputLog, openCodyOutputChannel } from './services/utils/export-logs'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
 
 /**
@@ -519,8 +519,10 @@ const register = async (
             void vscode.commands.executeCommand(command, [source])
         }),
         ...setUpCodyIgnore(initialConfig),
+        // Debugging
         vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri)),
-        vscode.commands.registerCommand('cody.open.outputChannel', () => openCodyOutputChannel())
+        vscode.commands.registerCommand('cody.debug.outputChannel', () => openCodyOutputChannel()),
+        vscode.commands.registerCommand('cody.debug.enable.all', () => enableDebugMode())
     )
 
     /**

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -201,7 +201,7 @@ export function createStatusBar(): CodyStatusBar {
         quickPick.buttons = [
             {
                 iconPath: new vscode.ThemeIcon('bug'),
-                tooltip: 'Turn on Debug Mode',
+                tooltip: config.debugEnable ? 'Check Debug Logs' : 'Turn on Debug Mode',
                 onClick: () => enableDebugMode(),
             } as vscode.QuickInputButton,
         ]

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -6,7 +6,7 @@ import { getConfiguration } from '../configuration'
 
 import { getGhostHintEnablement } from '../commands/GhostHintDecorator'
 import { FeedbackOptionItems } from './FeedbackOptions'
-import { openCodyOutputChannel } from './utils/export-logs'
+import { enableDebugMode } from './utils/export-logs'
 
 interface StatusBarError {
     title: string
@@ -202,19 +202,7 @@ export function createStatusBar(): CodyStatusBar {
             {
                 iconPath: new vscode.ThemeIcon('bug'),
                 tooltip: 'Turn on Debug Mode',
-                onClick: () => {
-                    void workspaceConfig.update(
-                        'cody.debug.enable',
-                        true,
-                        vscode.ConfigurationTarget.Global
-                    )
-                    void workspaceConfig.update(
-                        'cody.debug.verbose',
-                        true,
-                        vscode.ConfigurationTarget.Global
-                    )
-                    openCodyOutputChannel()
-                },
+                onClick: () => enableDebugMode(),
             } as vscode.QuickInputButton,
         ]
         quickPick.onDidTriggerButton(async item => {

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -6,6 +6,7 @@ import { getConfiguration } from '../configuration'
 
 import { getGhostHintEnablement } from '../commands/GhostHintDecorator'
 import { FeedbackOptionItems } from './FeedbackOptions'
+import { openCodyOutputChannel } from './utils/export-logs'
 
 interface StatusBarError {
     title: string
@@ -194,6 +195,31 @@ export function createStatusBar(): CodyStatusBar {
         quickPick.onDidTriggerItemButton(item => {
             // @ts-ignore: onClick is a custom extension to the QuickInputButton
             item?.button?.onClick?.()
+            quickPick.hide()
+        })
+        // Debug Mode
+        quickPick.buttons = [
+            {
+                iconPath: new vscode.ThemeIcon('bug'),
+                tooltip: 'Turn on Debug Mode',
+                onClick: () => {
+                    void workspaceConfig.update(
+                        'cody.debug.enable',
+                        true,
+                        vscode.ConfigurationTarget.Global
+                    )
+                    void workspaceConfig.update(
+                        'cody.debug.verbose',
+                        true,
+                        vscode.ConfigurationTarget.Global
+                    )
+                    openCodyOutputChannel()
+                },
+            } as vscode.QuickInputButton,
+        ]
+        quickPick.onDidTriggerButton(async item => {
+            // @ts-ignore: onClick is a custom extension to the QuickInputButton
+            item?.onClick?.()
             quickPick.hide()
         })
     })

--- a/vscode/src/services/utils/export-logs.ts
+++ b/vscode/src/services/utils/export-logs.ts
@@ -54,9 +54,13 @@ export async function exportOutputLog(logUri: vscode.Uri): Promise<void> {
             })
     } catch (error) {
         // Open the output channel instead
-        void vscode.commands.executeCommand(
-            'workbench.action.output.show.extension-output-sourcegraph.cody-ai-#1-Cody by Sourcegraph'
-        )
+        openCodyOutputChannel()
         console.error(error)
     }
+}
+
+export function openCodyOutputChannel(): void {
+    void vscode.commands.executeCommand(
+        'workbench.action.output.show.extension-output-sourcegraph.cody-ai-#1-Cody by Sourcegraph'
+    )
 }

--- a/vscode/src/services/utils/export-logs.ts
+++ b/vscode/src/services/utils/export-logs.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import { CODY_OUTPUT_CHANNEL } from '../../log'
+import { CODY_OUTPUT_CHANNEL, outputChannel } from '../../log'
 
 /**
  * Exports the output log file to a specified location.
@@ -70,7 +70,7 @@ export function openCodyOutputChannel(): void {
  */
 export function enableDebugMode(): void {
     const workspaceConfig = vscode.workspace.getConfiguration()
-    void workspaceConfig.update('cody.debug.enable', true, vscode.ConfigurationTarget.Global)
+    void workspaceConfig.update('cody.debug.enable', undefined, vscode.ConfigurationTarget.Global)
     void workspaceConfig.update('cody.debug.verbose', true, vscode.ConfigurationTarget.Global)
     openCodyOutputChannel()
 }

--- a/vscode/src/services/utils/export-logs.ts
+++ b/vscode/src/services/utils/export-logs.ts
@@ -64,3 +64,15 @@ export function openCodyOutputChannel(): void {
         'workbench.action.output.show.extension-output-sourcegraph.cody-ai-#1-Cody by Sourcegraph'
     )
 }
+
+/**
+ * Enables debug mode by updating workspace configuration settings.
+ * Sets 'cody.debug.enable' and 'cody.debug.verbose' to true globally.
+ * Opens the Cody output channel.
+ */
+export function enableDebugMode(): void {
+    const workspaceConfig = vscode.workspace.getConfiguration()
+    void workspaceConfig.update('cody.debug.enable', true, vscode.ConfigurationTarget.Global)
+    void workspaceConfig.update('cody.debug.verbose', true, vscode.ConfigurationTarget.Global)
+    openCodyOutputChannel()
+}

--- a/vscode/src/services/utils/export-logs.ts
+++ b/vscode/src/services/utils/export-logs.ts
@@ -60,9 +60,7 @@ export async function exportOutputLog(logUri: vscode.Uri): Promise<void> {
 }
 
 export function openCodyOutputChannel(): void {
-    void vscode.commands.executeCommand(
-        'workbench.action.output.show.extension-output-sourcegraph.cody-ai-#1-Cody by Sourcegraph'
-    )
+    outputChannel.show()
 }
 
 /**


### PR DESCRIPTION
Part of Better debugging facilities for enterprise issues

New commands to make debugging Cody easier:
- `cody.debug.outputChannel`
  - open the Cody output channel
- `cody.debug.enable.all`
  - enable both `cody.debug.enable` and `cody.debug.verbose` and open output channel with one click

New sidebar menu item to open output channel

![image](https://github.com/sourcegraph/cody/assets/68532117/0ad57b24-69b3-46f9-82fa-a4ede0d4e5d5)

New button in the Cody Setting menu to enable debug mode and open output channel on click

![image](https://github.com/sourcegraph/cody/assets/68532117/675e8b17-ef11-437c-9fb2-64bf2d9a2396)

All debug commands are also grouped together and are available through the command palette

![image](https://github.com/sourcegraph/cody/assets/68532117/33a777f0-bd70-4d35-898b-863a7fdbb01b)



## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->


https://github.com/sourcegraph/cody/assets/68532117/3ec5a97b-8d09-4b72-92a5-d08f17bad72a


