### PR TITLE
Chat: Remove welcome message after first chat

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -206,6 +206,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         return <LoadingPage />
     }
 
+    const noChatHistory = !userHistory.filter(chat => chat.interactions.length)?.length
+
     return (
         <div className="outer-container">
             {view === 'login' || !authStatus.isLoggedIn ? (
@@ -217,12 +219,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 />
             ) : (
                 <>
-                    <Notices
-                        probablyNewInstall={
-                            !userHistory.filter(chat => chat.interactions.length)?.length
-                        }
-                        vscodeAPI={vscodeAPI}
-                    />
+                    <Notices probablyNewInstall={noChatHistory} vscodeAPI={vscodeAPI} />
                     {errorMessages && (
                         <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />
                     )}
@@ -260,7 +257,8 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                                         isTranscriptError={isTranscriptError}
                                         chatModels={chatModels}
                                         setChatModels={setChatModels}
-                                        welcomeMessage={getWelcomeMessageByOS(config?.os)}
+                                        // Only shows welcome message for the first chat submitted.
+                                        welcomeMessage={getWelcomeMessageByOS(config?.os, noChatHistory)}
                                         guardrails={attributionEnabled ? guardrails : undefined}
                                         chatIDHistory={chatIDHistory}
                                         isWebviewActive={isWebviewActive}
@@ -294,7 +292,7 @@ const ErrorBanner: React.FunctionComponent<{ errors: string[]; setErrors: (error
         </div>
     )
 
-function getWelcomeMessageByOS(os: string): string {
+function getWelcomeMessageByOS(os: string, noChatHistory: boolean): string | undefined {
     const welcomeMessageMarkdown = `Welcome to Cody! Start writing code and Cody will autocomplete lines and entire functions for you.
 
 To run [Cody Commands](command:cody.menu.commands) use the keyboard shortcut <span class="keyboard-shortcut"><span>${
@@ -307,5 +305,5 @@ You can start a new chat at any time with <span class="keyboard-shortcut"><span>
 
 For more tips and tricks, see the [Getting Started Guide](command:cody.welcome) and [docs](https://sourcegraph.com/docs/cody).
 `
-    return welcomeMessageMarkdown
+    return noChatHistory ? welcomeMessageMarkdown : undefined
 }

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -743,8 +743,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         <div className={classNames(styles.innerContainer)}>
             {
                 <Transcript
-                    // Remove welcome message after the first message is submitted
-                    transcript={transcript.length ? transcript : transcriptWithWelcome}
+                    // Only shows welcome message for the first chat submitted.
+                    // Assume this is the first chat if there is not chat history.
+                    transcript={chatIDHistory.length ? transcript : transcriptWithWelcome}
                     messageInProgress={messageInProgress}
                     messageBeingEdited={messageBeingEdited}
                     setMessageBeingEdited={setEditMessageState}

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -743,9 +743,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         <div className={classNames(styles.innerContainer)}>
             {
                 <Transcript
-                    // Only shows welcome message for the first chat submitted.
-                    // Assume this is the first chat if there is not chat history.
-                    transcript={chatIDHistory.length ? transcript : transcriptWithWelcome}
+                    transcript={welcomeMessage ? transcriptWithWelcome : transcript}
                     messageInProgress={messageInProgress}
                     messageBeingEdited={messageBeingEdited}
                     setMessageBeingEdited={setEditMessageState}


### PR DESCRIPTION
Follow up on https://github.com/sourcegraph/cody/pull/3341#issuecomment-1984793796

Display the welcome message on the first chat ever created based on local chat history, instead of first chat message submitted in a single chat session.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

<img width="1999" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/e8dffa57-4b07-4bb4-910d-1535f80025ad">
