### PR TITLE
document and reorganize ContextItem source, title, etc.

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
@@ -24,12 +24,13 @@ sealed class ContextItem {
 data class ContextItemFile(
   val uri: Uri? = null,
   val range: RangeData? = null,
+  val content: String? = null,
   val repoName: String? = null,
   val revision: String? = null,
   val title: String? = null,
-  val source: ContextFileSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
-  val content: String? = null,
+  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
   val type: TypeEnum? = null, // Oneof: file
+  val isTooLarge: Boolean? = null,
 ) : ContextItem() {
 
   enum class TypeEnum {
@@ -40,11 +41,11 @@ data class ContextItemFile(
 data class ContextItemSymbol(
   val uri: Uri? = null,
   val range: RangeData? = null,
+  val content: String? = null,
   val repoName: String? = null,
   val revision: String? = null,
   val title: String? = null,
-  val source: ContextFileSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
-  val content: String? = null,
+  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
   val type: TypeEnum? = null, // Oneof: symbol
   val symbolName: String? = null,
   val kind: SymbolKind? = null, // Oneof: class, function, method

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemSource.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemSource.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-typealias ContextFileSource = String // One of: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
+typealias ContextItemSource = String // One of: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
 

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -3,33 +3,27 @@ import type { URI } from 'vscode-uri'
 import type { RangeData } from '../common/range'
 import type { Message } from '../sourcegraph-api'
 
-// tracked for telemetry purposes. Which context source provided this context file.
-// embeddings: context file returned by the embeddings client
-// user: context file provided by the user explicitly via chat input
-// keyword: the context file returned from local keyword search
-// editor: context file retrieved from the current editor
-// search: context file returned by symf search
-// selection: selected code from the current editor
-// terminal: output from shell terminal
-// unified: remote search
-export type ContextFileSource =
-    | 'embeddings'
-    | 'user'
-    | 'keyword'
-    | 'editor'
-    | 'filename'
-    | 'search'
-    | 'unified'
-    | 'selection'
-    | 'terminal'
-
 export type ContextFileType = 'file' | 'symbol'
 
-export type SymbolKind = 'class' | 'function' | 'method'
-
+/**
+ * Fields that are common to any context item included in chat messages.
+ */
 interface ContextItemCommon {
+    /**
+     * The URI of the document (such as a file) where this context resides.
+     */
     uri: URI
+
+    /**
+     * If only a subset of a file is included as context, the range of that subset.
+     */
     range?: RangeData
+
+    /**
+     * The content, either the entire document or the range subset.
+     */
+    content?: string
+
     repoName?: string
     revision?: string
 
@@ -38,20 +32,75 @@ interface ContextItemCommon {
      */
     title?: string
 
-    source?: ContextFileSource
-    content?: string
+    /**
+     * The source of this context item.
+     */
+    source?: ContextItemSource
 }
 
+/**
+ * The source of this context.
+ */
+export enum ContextItemSource {
+    /** From embeddings search */
+    Embeddings = 'embeddings',
+
+    /** Explicitly @-mentioned by the user in chat */
+    User = 'user',
+
+    /** From local keyword search */
+    Keyword = 'keyword',
+
+    /** From the current editor state and open tabs/documents */
+    Editor = 'editor',
+
+    Filename = 'filename',
+
+    /** From symf search */
+    Search = 'search',
+
+    /** Remote search */
+    Unified = 'unified',
+
+    /** Selected code from the current editor */
+    Selection = 'selection',
+
+    /** Output from the terminal */
+    Terminal = 'terminal',
+}
+
+/**
+ * An item (such as a file or symbol) that is included as context in a chat message.
+ */
 export type ContextItem = ContextItemFile | ContextItemSymbol
-export type ContextItemFile = ContextItemCommon & { type: 'file' }
+
+/**
+ * A file (or a subset of a file given by a range) that is included as context in a chat message.
+ */
+export interface ContextItemFile extends ContextItemCommon {
+    type: 'file'
+
+    /**
+     * Whether the file is too large to be included as context.
+     */
+    isTooLarge?: boolean
+}
+
+/**
+ * A symbol (which is a range within a file) that is included as context in a chat message.
+ */
 export type ContextItemSymbol = ContextItemCommon & {
     type: 'symbol'
 
-    /** The fuzzy name of the symbol (if this represents a symbol). */
+    /** The name of the symbol, used for presentation only (not semantically meaningful). */
     symbolName: string
 
+    /** The kind of symbol, used for presentation only (not semantically meaningful). */
     kind: SymbolKind
 }
+
+/** The valid kinds of a symbol. */
+export type SymbolKind = 'class' | 'function' | 'method'
 
 /** {@link ContextItem} with the `content` field set to the content. */
 export type ContextItemWithContent = ContextItem & Required<Pick<ContextItem, 'content'>>

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -45,7 +45,7 @@ export type {
 export type {
     ContextItem,
     ContextItemFile,
-    ContextFileSource,
+    ContextItemSource as ContextFileSource,
     ContextItemSymbol,
     ContextFileType,
     ContextMessage,

--- a/vscode/src/chat/chat-view/context.test.ts
+++ b/vscode/src/chat/chat-view/context.test.ts
@@ -1,25 +1,26 @@
 import { type ContextItem, testFileUri } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { describe, expect, it } from 'vitest'
 import { fuseContext } from './context'
 
 describe('fuseContext', () => {
     const uri = testFileUri('test.ts')
     const keywordItems: ContextItem[] = [
-        { type: 'file', content: '0', uri, source: 'keyword' },
-        { type: 'file', content: '1', uri, source: 'keyword' },
-        { type: 'file', content: '2', uri, source: 'keyword' },
-        { type: 'file', content: '3', uri, source: 'keyword' },
-        { type: 'file', content: '4', uri, source: 'keyword' },
-        { type: 'file', content: '5', uri, source: 'keyword' },
-        { type: 'file', content: '6', uri, source: 'keyword' },
-        { type: 'file', content: '7', uri, source: 'keyword' },
-        { type: 'file', content: '8', uri, source: 'keyword' },
-        { type: 'file', content: '9', uri, source: 'keyword' },
+        { type: 'file', content: '0', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '1', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '2', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '3', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '4', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '5', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '6', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '7', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '8', uri, source: ContextItemSource.Keyword },
+        { type: 'file', content: '9', uri, source: ContextItemSource.Keyword },
     ]
     const embeddingsItems: ContextItem[] = [
-        { type: 'file', content: 'A', uri, source: 'embeddings' },
-        { type: 'file', content: 'B', uri, source: 'embeddings' },
-        { type: 'file', content: 'C', uri, source: 'embeddings' },
+        { type: 'file', content: 'A', uri, source: ContextItemSource.Embeddings },
+        { type: 'file', content: 'B', uri, source: ContextItemSource.Embeddings },
+        { type: 'file', content: 'C', uri, source: ContextItemSource.Embeddings },
     ]
 
     function joined(items: ContextItem[]): string {
@@ -34,23 +35,28 @@ describe('fuseContext', () => {
 
     it('skips over large items in an attempt to optimize utilization', () => {
         const keywordItems: ContextItem[] = [
-            { type: 'file', content: '0', uri, source: 'keyword' },
-            { type: 'file', content: '1', uri, source: 'keyword' },
-            { type: 'file', content: '2', uri, source: 'keyword' },
-            { type: 'file', content: '3', uri, source: 'keyword' },
-            { type: 'file', content: '4', uri, source: 'keyword' },
-            { type: 'file', content: '5', uri, source: 'keyword' },
-            { type: 'file', content: 'very large keyword item', uri, source: 'keyword' },
-            { type: 'file', content: '6', uri, source: 'keyword' },
-            { type: 'file', content: '7', uri, source: 'keyword' },
-            { type: 'file', content: '8', uri, source: 'keyword' },
-            { type: 'file', content: '9', uri, source: 'keyword' },
+            { type: 'file', content: '0', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '1', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '2', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '3', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '4', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '5', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: 'very large keyword item', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '6', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '7', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '8', uri, source: ContextItemSource.Keyword },
+            { type: 'file', content: '9', uri, source: ContextItemSource.Keyword },
         ]
         const embeddingsItems: ContextItem[] = [
-            { type: 'file', content: 'A', uri, source: 'embeddings' },
-            { type: 'file', content: 'very large embeddings item', uri, source: 'embeddings' },
-            { type: 'file', content: 'B', uri, source: 'embeddings' },
-            { type: 'file', content: 'C', uri, source: 'embeddings' },
+            { type: 'file', content: 'A', uri, source: ContextItemSource.Embeddings },
+            {
+                type: 'file',
+                content: 'very large embeddings item',
+                uri,
+                source: ContextItemSource.Embeddings,
+            },
+            { type: 'file', content: 'B', uri, source: ContextItemSource.Embeddings },
+            { type: 'file', content: 'C', uri, source: ContextItemSource.Embeddings },
         ]
         const maxChars = 10
         const result = fuseContext(keywordItems, embeddingsItems, maxChars)

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -13,6 +13,7 @@ import {
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import type { RemoteSearch } from '../../context/remote-search'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { ContextRankingController } from '../../local-context/context-ranking'
@@ -236,11 +237,11 @@ async function searchRemote(
                 content: result.content,
                 range: new vscode.Range(result.startLine, 0, result.endLine, 0),
                 uri: result.uri,
-                source: 'unified',
+                source: ContextItemSource.Unified,
                 repoName: result.repoName,
                 title: result.path,
                 revision: result.commit,
-            }
+            } satisfies ContextItem
         })
     })
 }
@@ -302,7 +303,7 @@ async function searchSymf(
                         type: 'file',
                         uri: result.file,
                         range,
-                        source: 'search',
+                        source: ContextItemSource.Search,
                         content: text,
                     }
                 }
@@ -341,7 +342,7 @@ async function searchEmbeddingsLocal(
                 uri: result.uri,
                 range,
                 content: result.content,
-                source: 'embeddings',
+                source: ContextItemSource.Embeddings,
             })
         }
         return contextItems
@@ -376,7 +377,7 @@ function getCurrentSelectionContext(editor: VSCodeEditor): ContextItem[] {
             content: selection.selectedText,
             uri: selection.fileUri,
             range,
-            source: 'selection',
+            source: ContextItemSource.Selection,
         },
     ]
 }
@@ -396,7 +397,7 @@ function getVisibleEditorContext(editor: VSCodeEditor): ContextItem[] {
                 type: 'file',
                 text: visible.content,
                 uri: fileUri,
-                source: 'editor',
+                source: ContextItemSource.Editor,
             },
         ]
     })
@@ -519,7 +520,7 @@ async function getReadmeContext(): Promise<ContextItem[]> {
             uri: readmeUri,
             content: truncatedReadmeText,
             range,
-            source: 'editor',
+            source: ContextItemSource.Editor,
         },
     ]
 }

--- a/vscode/src/commands/context/current-file.ts
+++ b/vscode/src/commands/context/current-file.ts
@@ -5,6 +5,7 @@ import {
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import * as vscode from 'vscode'
 import { getEditor } from '../../editor/active-editor'
 
@@ -35,9 +36,9 @@ export async function getContextFileFromCurrentFile(): Promise<ContextItem[]> {
                     type: 'file',
                     uri: document.uri,
                     content: truncateText(content, MAX_CURRENT_FILE_TOKENS),
-                    source: 'editor',
+                    source: ContextItemSource.Editor,
                     range: selection,
-                } as ContextItem,
+                } satisfies ContextItem,
             ]
         } catch (error) {
             logError('getContextFileFromCurrentFile', 'failed', { verbose: error })

--- a/vscode/src/commands/context/directory.ts
+++ b/vscode/src/commands/context/directory.ts
@@ -5,6 +5,7 @@ import {
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import * as vscode from 'vscode'
 import { type URI, Utils } from 'vscode-uri'
 import { getEditor } from '../../editor/active-editor'
@@ -59,15 +60,13 @@ export async function getContextFileFromDirectory(directory?: URI): Promise<Cont
                 const truncatedContent = truncateText(decoded, MAX_CURRENT_FILE_TOKENS)
                 const range = new vscode.Range(0, 0, truncatedContent.split('\n').length - 1 || 0, 0)
 
-                const contextFile = {
+                contextFiles.push({
                     type: 'file',
                     uri: fileUri,
                     content: truncatedContent,
-                    source: 'editor',
+                    source: ContextItemSource.Editor,
                     range,
-                } as ContextItem
-
-                contextFiles.push(contextFile)
+                })
 
                 // Limit the number of files to 10
                 const maxResults = 10

--- a/vscode/src/commands/context/file-path.ts
+++ b/vscode/src/commands/context/file-path.ts
@@ -5,6 +5,7 @@ import {
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 
@@ -28,10 +29,10 @@ export async function getContextFileFromUri(file: URI): Promise<ContextItem[]> {
                     type: 'file',
                     content: decoded,
                     uri: file,
-                    source: 'editor',
+                    source: ContextItemSource.Editor,
                     range,
                 },
-            ]
+            ] satisfies ContextItem[]
         } catch (error) {
             logError('getContextFileFromUri', 'failed', { verbose: error })
             return []

--- a/vscode/src/commands/context/selection.ts
+++ b/vscode/src/commands/context/selection.ts
@@ -5,6 +5,7 @@ import {
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { getEditor } from '../../editor/active-editor'
 import { getSmartSelection } from '../../editor/utils'
 
@@ -40,9 +41,9 @@ export async function getContextFileFromCursor(): Promise<ContextItem[]> {
                     type: 'file',
                     uri: document.uri,
                     content: truncateText(content, MAX_CURRENT_FILE_TOKENS),
-                    source: 'selection',
+                    source: ContextItemSource.Selection,
                     range: selection,
-                } as ContextItem,
+                } satisfies ContextItem,
             ]
         } catch (error) {
             logError('getContextFileFromCursor', 'failed', { verbose: error })

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -13,6 +13,7 @@ import {
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 
 const _exec = promisify(exec)
 
@@ -50,8 +51,8 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
                 content: truncateText(context, MAX_CURRENT_FILE_TOKENS),
                 title: 'Terminal Output',
                 uri: vscode.Uri.file('terminal-output'),
-                source: 'terminal',
-            } as ContextItem
+                source: ContextItemSource.Terminal,
+            } satisfies ContextItem
 
             return [file]
         } catch (error) {

--- a/vscode/src/commands/utils/create-context-file.ts
+++ b/vscode/src/commands/utils/create-context-file.ts
@@ -1,4 +1,5 @@
 import { type ContextItem, MAX_CURRENT_FILE_TOKENS, truncateText } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 
 import * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
@@ -13,9 +14,9 @@ export async function createContextFile(file: URI, content: string): Promise<Con
             type: 'file',
             uri: file,
             content: truncatedContent,
-            source: 'editor',
+            source: ContextItemSource.Editor,
             range,
-        } as ContextItem
+        } satisfies ContextItem
     } catch (error) {
         console.error(error)
     }

--- a/vscode/src/context/remote-search.ts
+++ b/vscode/src/context/remote-search.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode'
 
 import {
     type ContextGroup,
+    type ContextItem,
     type ContextItemFile,
     type ContextSearchResult,
     type ContextStatusProvider,
@@ -11,6 +12,7 @@ import {
     isError,
 } from '@sourcegraph/cody-shared'
 
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import type { URI } from 'vscode-uri'
 import { getCodebaseFromWorkspaceUri } from '../repository/repositoryHelpers'
 import type * as repofetcher from './repo-fetcher'
@@ -134,23 +136,26 @@ export class RemoteSearch implements ContextStatusProvider, IRemoteSearch {
         if (isError(results)) {
             throw results
         }
-        return (results || []).map(result => ({
-            type: 'file',
-            uri: result.uri,
-            repoName: result.repoName,
-            revision: result.commit,
-            source: 'unified',
-            content: result.content,
-            range: {
-                start: {
-                    line: result.startLine,
-                    character: 0,
-                },
-                end: {
-                    line: result.endLine,
-                    character: 0,
-                },
-            },
-        }))
+        return (results || []).map(
+            result =>
+                ({
+                    type: 'file',
+                    uri: result.uri,
+                    repoName: result.repoName,
+                    revision: result.commit,
+                    source: ContextItemSource.Unified,
+                    content: result.content,
+                    range: {
+                        start: {
+                            line: result.startLine,
+                            character: 0,
+                        },
+                        end: {
+                            line: result.endLine,
+                            character: 0,
+                        },
+                    },
+                }) satisfies ContextItem
+        )
     }
 }

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -14,6 +14,7 @@ import {
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { EditIntent } from '../types'
 
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { fillInContextItemContent } from '../../editor/utils/editor-context'
 import { PROMPT_TOPICS } from './constants'
 
@@ -57,7 +58,7 @@ const getContextFromIntent = async ({
                         uri,
                         PROMPT_TOPICS.OUTPUT
                     ),
-                    file: { type: 'file', uri, source: 'editor' },
+                    file: { type: 'file', uri, source: ContextItemSource.Editor },
                 },
             ]
         }
@@ -76,14 +77,14 @@ const getContextFromIntent = async ({
                 contextMessages.push({
                     speaker: 'human',
                     text: populateCodeContextTemplate(truncatedPrecedingText, uri, undefined, 'edit'),
-                    file: { type: 'file', uri, source: 'editor' },
+                    file: { type: 'file', uri, source: ContextItemSource.Editor },
                 })
             }
             if (truncatedFollowingText.trim().length > 0) {
                 contextMessages.push({
                     speaker: 'human',
                     text: populateCodeContextTemplate(truncatedFollowingText, uri, undefined, 'edit'),
-                    file: { type: 'file', uri, source: 'editor' },
+                    file: { type: 'file', uri, source: ContextItemSource.Editor },
                 })
             }
             return contextMessages
@@ -105,7 +106,7 @@ const getContextFromIntent = async ({
                         ({
                             speaker: 'human' as const,
                             text: populateCurrentEditorDiagnosticsTemplate(diagnostic, uri),
-                            file: { type: 'file', uri, source: 'editor' },
+                            file: { type: 'file', uri, source: ContextItemSource.Editor },
                         }) satisfies ContextMessage
                 ),
                 ...[truncatedPrecedingText, truncatedFollowingText]
@@ -115,7 +116,7 @@ const getContextFromIntent = async ({
                             ({
                                 speaker: 'human' as const,
                                 text: populateCodeContextTemplate(text, uri, undefined, 'edit'),
-                                file: { type: 'file', uri, source: 'editor' },
+                                file: { type: 'file', uri, source: ContextItemSource.Editor },
                             }) satisfies ContextMessage
                     ),
             ]

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -138,14 +138,14 @@ describe('getFileContextFiles', () => {
 
 describe('filterLargeFiles', () => {
     it('filters out files larger than 1MB', async () => {
-        const largeFile = {
+        const largeFile: ContextItemFile = {
             uri: vscode.Uri.file('/large-file.txt'),
             type: 'file',
-        } as ContextItemFile
+        }
         vscode.workspace.fs.stat = vi.fn().mockResolvedValueOnce({
             size: 1000001,
             type: vscode.FileType.File,
-        } as any)
+        } as vscode.FileStat)
 
         const filtered = await filterLargeFiles([largeFile])
 
@@ -153,33 +153,37 @@ describe('filterLargeFiles', () => {
     })
 
     it('filters out non-text files', async () => {
-        const binaryFile = {
+        const binaryFile: ContextItemFile = {
             uri: vscode.Uri.file('/binary.bin'),
             type: 'file',
-        } as ContextItemFile
+        }
         vscode.workspace.fs.stat = vi.fn().mockResolvedValueOnce({
             size: 100,
             type: vscode.FileType.SymbolicLink,
-        } as any)
+        } as vscode.FileStat)
 
         const filtered = await filterLargeFiles([binaryFile])
 
         expect(filtered).toEqual([])
     })
 
-    it('sets title to large-file for files exceeding token limit', async () => {
-        const largeTextFile = {
+    it('sets isTooLarge for files exceeding token limit', async () => {
+        const largeTextFile: ContextItemFile = {
             uri: vscode.Uri.file('/large-text.txt'),
             type: 'file',
-        } as ContextItemFile
+        }
         vscode.workspace.fs.stat = vi.fn().mockResolvedValueOnce({
             size: MAX_CURRENT_FILE_TOKENS * CHARS_PER_TOKEN + 1,
             type: vscode.FileType.File,
-        } as any)
+        } as vscode.FileStat)
 
         const filtered = await filterLargeFiles([largeTextFile])
 
-        expect(filtered[0].title).toEqual('large-file')
+        expect(filtered[0]).toEqual<ContextItem>({
+            type: 'file',
+            uri: largeTextFile.uri,
+            isTooLarge: true,
+        })
     })
 })
 

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -19,7 +19,10 @@ import {
     isWindows,
 } from '@sourcegraph/cody-shared'
 
-import type { ContextItemWithContent } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import {
+    ContextItemSource,
+    type ContextItemWithContent,
+} from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { CHARS_PER_TOKEN } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { getOpenTabsUris, getWorkspaceSymbols } from '.'
 import { toVSCodeRange } from '../../common/range'
@@ -115,7 +118,7 @@ export async function getFileContextFiles(
                 new Intl.Collator(undefined, { numeric: true }).compare(a.obj.uri.path, b.obj.uri.path)
             )
         })
-        .flatMap(result => createContextFileFromUri(result.obj.uri, 'user', 'file'))
+        .flatMap(result => createContextFileFromUri(result.obj.uri, ContextItemSource.User, 'file'))
 
     // TODO(toolmantim): Add fuzzysort.highlight data to the result so we can show it in the UI
 
@@ -164,7 +167,7 @@ export async function getSymbolContextFiles(
     for (const symbol of symbols) {
         const contextFile = createContextFileFromUri(
             symbol.location.uri,
-            'user',
+            ContextItemSource.User,
             'symbol',
             symbol.location.range,
             // TODO(toolmantim): Update the kinds to match above
@@ -185,7 +188,7 @@ export async function getOpenTabsContextFile(): Promise<ContextItemFile[]> {
     return await filterLargeFiles(
         getOpenTabsUris()
             .filter(uri => !isCodyIgnoredFile(uri))
-            .flatMap(uri => createContextFileFromUri(uri, 'user', 'file'))
+            .flatMap(uri => createContextFileFromUri(uri, ContextItemSource.User, 'file'))
     )
 }
 
@@ -250,7 +253,7 @@ function createContextFileRange(selectionRange: vscode.Range): ContextItem['rang
 
 /**
  * Filters the given context files to remove files larger than 1MB and non-text files.
- * Sets the title to 'large-file' for files contains more characters than the token limit.
+ * Sets {@link ContextItemFile.isTooLarge} for files contains more characters than the token limit.
  */
 export async function filterLargeFiles(contextFiles: ContextItemFile[]): Promise<ContextItemFile[]> {
     const filtered = []
@@ -265,10 +268,10 @@ export async function filterLargeFiles(contextFiles: ContextItemFile[]): Promise
             continue
         }
         // Check if file contains more characters than the token limit based on fileStat.size
-        // and set the title of the result as 'large-file' for webview to display file size
+        // and set {@link ContextItemFile.isTooLarge} for webview to display file size
         // warning.
         if (fileStat.size > CHARS_PER_TOKEN * MAX_CURRENT_FILE_TOKENS) {
-            cf.title = 'large-file'
+            cf.isTooLarge = true
         }
         filtered.push(cf)
     }

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -5,6 +5,7 @@ import {
     type Message,
     isCodyIgnoredFile,
 } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { SHA256 } from 'crypto-js'
 import { renderContextItem } from './utils'
 
@@ -107,7 +108,9 @@ export class PromptBuilder {
             // the last context item to be read by the LLM to avoid confusions where
             // other files also include the selection text in test files.
             const selectionContext = contextItemsAndMessages.find(
-                item => (isContextItem(item) ? item.source : item.file.source) === 'selection'
+                item =>
+                    (isContextItem(item) ? item.source : item.file.source) ===
+                    ContextItemSource.Selection
             )
             if (selectionContext) {
                 contextItemsAndMessages.splice(contextItemsAndMessages.indexOf(selectionContext), 1)

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -8,6 +8,7 @@ import {
     populateCurrentSelectedCodeContextTemplate,
     populateMarkdownContextTemplate,
 } from '@sourcegraph/cody-shared'
+import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 
 import { URI } from 'vscode-uri'
 
@@ -17,15 +18,18 @@ export function renderContextItem(contextItem: ContextItem): ContextMessage | nu
         return null
     }
     let messageText: string
-    const uri = contextItem.source === 'unified' ? URI.parse(contextItem.title || '') : contextItem.uri
-    if (contextItem.source === 'selection') {
+    const uri =
+        contextItem.source === ContextItemSource.Unified
+            ? URI.parse(contextItem.title || '')
+            : contextItem.uri
+    if (contextItem.source === ContextItemSource.Selection) {
         messageText = populateCurrentSelectedCodeContextTemplate(contextItem.content, uri)
-    } else if (contextItem.source === 'editor') {
+    } else if (contextItem.source === ContextItemSource.Editor) {
         // This template text works best with prompts in our commands
         // Using populateCodeContextTemplate here will cause confusion to Cody
         const templateText = 'Codebase context from file path {fileName}: '
         messageText = populateContextTemplateFromText(templateText, contextItem.content, uri)
-    } else if (contextItem.source === 'terminal') {
+    } else if (contextItem.source === ContextItemSource.Terminal) {
         messageText = contextItem.content
     } else if (languageFromFilename(uri) === ProgrammingLanguage.Markdown) {
         messageText = populateMarkdownContextTemplate(contextItem.content, uri, contextItem.repoName)

--- a/vscode/webviews/UserContextSelector.tsx
+++ b/vscode/webviews/UserContextSelector.tsx
@@ -145,7 +145,7 @@ export const UserContextSelectorComponent: React.FunctionComponent<
                         const description =
                             match.type === 'file' ? undefined : displayPath(match.uri) + range
                         const warning =
-                            match.type === 'file' && match.title === 'large-file'
+                            match.type === 'file' && match.isTooLarge
                                 ? 'File too large. Type @# to choose a symbol'
                                 : undefined
                         return (


### PR DESCRIPTION
Mostly just adds docs. Makes `ContextItemSource` an enum because each item had relevant documentation.

Also now uses `isTooLarge?: boolean` instead of `title === 'large-file'` to indicate the file is too large.

## Test plan

CI