### PR TITLE
disable model selector after 1st chat message is sent

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -16,7 +16,6 @@ import {
     getContextFileDisplayText,
     isAtMention,
     isAtRange,
-    isDefined,
     isMacOS,
 } from '@sourcegraph/cody-shared'
 
@@ -723,25 +722,14 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         ]
     )
 
-    const transcriptWithWelcome = useMemo<ChatMessage[]>(
-        () => [
-            {
-                speaker: 'assistant',
-                displayText: welcomeText({ welcomeMessage }),
-            },
-            ...transcript,
-        ],
-        [welcomeMessage, transcript]
-    )
-
     const [isEnhancedContextOpen, setIsEnhancedContextOpen] = useState(false)
 
     return (
         <div className={classNames(styles.innerContainer)}>
             {
                 <Transcript
-                    // Remove welcome message after the first message is submitted
-                    transcript={transcript.length ? transcript : transcriptWithWelcome}
+                    transcript={transcript}
+                    welcomeMessage={welcomeMessage}
                     messageInProgress={messageInProgress}
                     messageBeingEdited={messageBeingEdited}
                     setMessageBeingEdited={setEditMessageState}
@@ -1031,20 +1019,6 @@ const FeedbackButtonsContainer: React.FunctionComponent<FeedbackButtonsProps> = 
             )}
         </div>
     )
-}
-
-interface WelcomeTextOptions {
-    /** Provide users with a way to quickly access Cody docs/help.*/
-    helpMarkdown?: string
-    /** Provide additional content to supplement the original message. Example: tips, privacy policy. */
-    welcomeMessage?: string
-}
-
-function welcomeText({
-    helpMarkdown = 'See [Cody documentation](https://sourcegraph.com/docs/cody) for help and tips.',
-    welcomeMessage,
-}: WelcomeTextOptions): string {
-    return [helpMarkdown, welcomeMessage].filter(isDefined).join('\n\n')
 }
 
 export interface UserAccountInfo {

--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -91,6 +91,7 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
                 className={styles.dropdownContainer}
                 onChange={handleChange}
                 selectedIndex={currentModelIndex}
+                aria-label="Choose a model"
                 {...(!disabled && enabledDropdownProps)}
             >
                 {models?.map((option, index) => (

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -1,8 +1,13 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 
 import classNames from 'classnames'
 
-import type { ChatMessage, Guardrails, ModelProvider } from '@sourcegraph/cody-shared'
+import {
+    type ChatMessage,
+    type Guardrails,
+    type ModelProvider,
+    isDefined,
+} from '@sourcegraph/cody-shared'
 
 import type { UserAccountInfo } from '../Chat'
 import type { ChatButtonProps } from '../Chat'
@@ -20,6 +25,7 @@ import styles from './Transcript.module.css'
 export const Transcript: React.FunctionComponent<
     {
         transcript: ChatMessage[]
+        welcomeMessage?: string
         messageInProgress: ChatMessage | null
         messageBeingEdited: number | undefined
         setMessageBeingEdited: (index?: number) => void
@@ -41,6 +47,7 @@ export const Transcript: React.FunctionComponent<
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptContent({
     transcript,
+    welcomeMessage,
     messageInProgress,
     messageBeingEdited,
     setMessageBeingEdited,
@@ -197,6 +204,11 @@ export const Transcript: React.FunctionComponent<
             )
         }
 
+    const welcomeTranscriptMessage = useMemo(
+        (): ChatMessage => ({ speaker: 'assistant', displayText: welcomeText({ welcomeMessage }) }),
+        [welcomeMessage]
+    )
+
     return (
         <div ref={transcriptContainerRef} className={classNames(className, styles.container)}>
             <div ref={scrollAnchoredContainerRef} className={classNames(styles.scrollAnchoredContainer)}>
@@ -207,11 +219,25 @@ export const Transcript: React.FunctionComponent<
                     userInfo.isDotComUser && (
                         <ChatModelDropdownMenu
                             models={chatModels}
-                            disabled={transcript.length > 1}
+                            disabled={transcript.length > 0}
                             onCurrentChatModelChange={onCurrentChatModelChange}
                             userInfo={userInfo}
                         />
                     )}
+                {transcript.length === 0 && (
+                    // Show welcome message only when the chat is empty.
+                    <TranscriptItem
+                        index={0}
+                        message={welcomeTranscriptMessage}
+                        beingEdited={undefined}
+                        inProgress={false}
+                        fileLinkComponent={fileLinkComponent}
+                        setBeingEdited={() => {}}
+                        showEditButton={false}
+                        showFeedbackButtons={false}
+                        userInfo={userInfo}
+                    />
+                )}
                 {earlierMessages.map(messageToTranscriptItem(0))}
                 <div ref={lastHumanMessageTopRef} />
                 {lastInteractionMessages.map(messageToTranscriptItem(earlierMessages.length))}
@@ -253,4 +279,18 @@ function findLastIndex<T>(array: T[], predicate: (value: T) => boolean): number 
         }
     }
     return -1
+}
+
+interface WelcomeTextOptions {
+    /** Provide users with a way to quickly access Cody docs/help.*/
+    helpMarkdown?: string
+    /** Provide additional content to supplement the original message. Example: tips, privacy policy. */
+    welcomeMessage?: string
+}
+
+function welcomeText({
+    helpMarkdown = 'See [Cody documentation](https://sourcegraph.com/docs/cody) for help and tips.',
+    welcomeMessage,
+}: WelcomeTextOptions): string {
+    return [helpMarkdown, welcomeMessage].filter(isDefined).join('\n\n')
 }


### PR DESCRIPTION
In https://github.com/sourcegraph/cody/pull/3341 the behavior changed so that the welcome message goes away when you chat. (Which I love!) But there's a minor bug in that the model selector remains enabled after the 1st message is sent now (because the existing logic assumed that the welcome message was always the 1st message and so checked for `>1` messages to disable the model selector).

Also adds an e2e test for the model selector.

## Test plan

e2e test covers the following test plan: Open new chat. Ensure model selector is enabled. Send a message. Ensure the model selector becomes immediately disabled.