### PR TITLE
Chat: Wrap pasted code blocks in backticks

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,7 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Chat: Welcome message is only shown on new chat panel. [pull/3341](https://github.com/sourcegraph/cody/pull/3341)
-- Chat: Wrap pasted code blocks in triple-backtick automatically. [pull/3357](https://github.com/sourcegraph/cody/pull/3357)
+- Chat: Wrap pasted code blocks in triple-backticks automatically. [pull/3357](https://github.com/sourcegraph/cody/pull/3357)
 
 ## [1.8.1]
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Chat: Welcome message is only shown on new chat panel. [pull/3341](https://github.com/sourcegraph/cody/pull/3341)
+- Chat: Wrap pasted code blocks in triple-backtick automatically. [pull/3357](https://github.com/sourcegraph/cody/pull/3357)
 
 ## [1.8.1]
 

--- a/vscode/webviews/chat/TextArea.tsx
+++ b/vscode/webviews/chat/TextArea.tsx
@@ -114,7 +114,7 @@ export const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
 
                     const text = clipboardData.getData('text/plain')
                     if (text.split('\n').length > 1) {
-                        const newText = '```\n' + text.replace(/\n/g, '\n\n') + '\n```\n'
+                        const newText = '```\n' + text.replace(/\r\n/g, '\n') + '\n```\n'
 
                         const startPos = textarea.selectionStart
                         const endPos = textarea.selectionEnd

--- a/vscode/webviews/chat/TextArea.tsx
+++ b/vscode/webviews/chat/TextArea.tsx
@@ -109,11 +109,10 @@ export const TextArea: React.FunctionComponent<ChatUITextAreaProps> = ({
                 const language = parseEditorData(clipboardData.getData('vscode-editor-data'))
 
                 if (language) {
-                    event.preventDefault()
-                    event.stopPropagation()
-
                     const text = clipboardData.getData('text/plain')
                     if (text.split('\n').length > 1) {
+                        event.preventDefault()
+                        event.stopPropagation()
                         const newText = '```\n' + text.replace(/\r\n/g, '\n') + '\n```\n'
 
                         const startPos = textarea.selectionStart


### PR DESCRIPTION
This PR makes it so that when we paste code into the chat box, it will wrap it in triple backticks.

This improves a few things:
- If someone pasts html/tsx, the code will now no longer be hidden once the request is sent (since it would be escaped otherwise)
- Any pasted code will now be showing with the right indentation after submitting the search query
- LLMs like Opus will not be confused by missing code block delimiters causing the response to also skip code block delimiters.

## Test plan

https://github.com/sourcegraph/cody/assets/458591/6dfe67f4-fe0d-4269-a85c-fecdf8da85a0

