### PR TITLE
VS Code: Release 1.8.2

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -2442,7 +2442,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1e412d292db108b0d91617d63ff34f19
+    - _id: d4359c67ff24d596934bf24e9c3487f7
       _order: 0
       cache: {}
       request:
@@ -2497,7 +2497,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2512,7 +2512,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:26 GMT
+            value: Fri, 08 Mar 2024 19:49:27 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -2540,7 +2540,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-03-07T17:52:26.328Z
+      startedDateTime: 2024-03-08T19:49:27.478Z
       time: 0
       timings:
         blocked: -1
@@ -2550,7 +2550,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 86ba1f1eb45fca769b524857f0ff14d9
+    - _id: d1cd4f4795ab1636fe0d989450f29fa3
       _order: 0
       cache: {}
       request:
@@ -2606,7 +2606,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2627,7 +2627,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:27 GMT
+            value: Fri, 08 Mar 2024 19:49:27 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2658,7 +2658,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-07T17:52:26.406Z
+      startedDateTime: 2024-03-08T19:49:27.524Z
       time: 0
       timings:
         blocked: -1
@@ -2668,7 +2668,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c1c227ce3d7b418dcc1087683e00457a
+    - _id: e9c38ab66f404a55958836052f4f794c
       _order: 0
       cache: {}
       request:
@@ -2724,7 +2724,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2745,7 +2745,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:26 GMT
+            value: Fri, 08 Mar 2024 19:49:27 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2776,7 +2776,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-07T17:52:26.411Z
+      startedDateTime: 2024-03-08T19:49:27.527Z
       time: 0
       timings:
         blocked: -1
@@ -2786,7 +2786,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 0730ea6a80347eab2f91f7f7b29f830f
+    - _id: 018a011dee81a2af9225a289f91b320b
       _order: 0
       cache: {}
       request:
@@ -2842,7 +2842,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2863,7 +2863,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:26 GMT
+            value: Fri, 08 Mar 2024 19:49:27 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2894,7 +2894,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-07T17:52:26.412Z
+      startedDateTime: 2024-03-08T19:49:27.528Z
       time: 0
       timings:
         blocked: -1
@@ -2904,7 +2904,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: deb9badc31d020f49fdb1e58b76e0572
+    - _id: 052d6130f6ee1fca4da31d8ee177f1d7
       _order: 0
       cache: {}
       request:
@@ -2960,7 +2960,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2981,7 +2981,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:26 GMT
+            value: Fri, 08 Mar 2024 19:49:27 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3012,7 +3012,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-07T17:52:26.566Z
+      startedDateTime: 2024-03-08T19:49:27.679Z
       time: 0
       timings:
         blocked: -1
@@ -3022,7 +3022,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a49b5b729435d4afad65a239fee2498a
+    - _id: 41bdb98bccf33cf50c4c28b3100c6498
       _order: 0
       cache: {}
       request:
@@ -3078,7 +3078,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3099,7 +3099,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:26 GMT
+            value: Fri, 08 Mar 2024 19:49:27 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3130,7 +3130,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-07T17:52:26.578Z
+      startedDateTime: 2024-03-08T19:49:27.691Z
       time: 0
       timings:
         blocked: -1
@@ -3140,7 +3140,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: d1cc0353479f98105727433a0f55103f
+    - _id: ad9a41686e8b9bd8d94a0f30156ab6cd
       _order: 0
       cache: {}
       request:
@@ -3196,7 +3196,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3217,7 +3217,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:26 GMT
+            value: Fri, 08 Mar 2024 19:49:27 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3248,7 +3248,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-07T17:52:26.581Z
+      startedDateTime: 2024-03-08T19:49:27.695Z
       time: 0
       timings:
         blocked: -1
@@ -3258,7 +3258,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a8fe4331f22d08c2f29655ea1c95d076
+    - _id: 88760d8b30b22a204a5400aedbfc64ec
       _order: 0
       cache: {}
       request:
@@ -3314,7 +3314,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3335,7 +3335,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:26 GMT
+            value: Fri, 08 Mar 2024 19:49:27 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3366,7 +3366,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-07T17:52:26.583Z
+      startedDateTime: 2024-03-08T19:49:27.697Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -552,7 +552,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8971263d9acc43cb65ef0fc99b2a4d66
+    - _id: 126497b9739b7acf8c73db372d6a0b57
       _order: 0
       cache: {}
       request:
@@ -607,7 +607,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -622,7 +622,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:29 GMT
+            value: Fri, 08 Mar 2024 19:49:28 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -650,7 +650,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-03-07T17:52:27.879Z
+      startedDateTime: 2024-03-08T19:49:28.610Z
       time: 0
       timings:
         blocked: -1
@@ -660,7 +660,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 45fa5ca0b5c473ba1a8c4dd1a384fe6c
+    - _id: 73399d451ae841eb293cab5a3c36ea70
       _order: 0
       cache: {}
       request:
@@ -716,7 +716,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.8.1
+                    clientVersion: 1.8.2
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -737,7 +737,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 07 Mar 2024 17:52:29 GMT
+            value: Fri, 08 Mar 2024 19:49:28 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -768,7 +768,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-07T17:52:27.919Z
+      startedDateTime: 2024-03-08T19:49:28.649Z
       time: 0
       timings:
         blocked: -1

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [1.8.2]
+
+### Added
+
 - Debug: Added new commands (`Cody Debug: Enable Debug Mode` and `Cody Debug: Open Output Channel`) to the editor Command Palette and the `Settings & Support` sidebar to streamline the process of getting started with debugging Cody. [pull/3342](https://github.com/sourcegraph/cody/pull/3342)
 
 ### Fixed
@@ -15,10 +23,10 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
-- Chat: Welcome message is only shown on new chat panel. [pull/3341](https://github.com/sourcegraph/cody/pull/3341)
-- Command: You can now choose a LLM model for the Generate Unit Test command. [pull/3343](https://github.com/sourcegraph/cody/pull/3343)
-- Chat: Wrap pasted code blocks in triple-backticks automatically. [pull/3357](https://github.com/sourcegraph/cody/pull/3357)
 - Autocomplete: Improved the stop sequences list for Ollama models. [pull/3352](https://github.com/sourcegraph/cody/pull/3352)
+- Chat: Welcome message is only shown on new chat panel. [pull/3341](https://github.com/sourcegraph/cody/pull/3341)
+- Chat: Wrap pasted code blocks in triple-backticks automatically. [pull/3357](https://github.com/sourcegraph/cody/pull/3357)
+- Command: You can now choose a LLM model for the Generate Unit Test command. [pull/3343](https://github.com/sourcegraph/cody/pull/3343)
 
 ## [1.8.1]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",
@@ -38,12 +38,7 @@
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
-  "categories": [
-    "Programming Languages",
-    "Machine Learning",
-    "Snippets",
-    "Education"
-  ],
+  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "ai",
     "openai",
@@ -94,11 +89,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": [
-    "onLanguage",
-    "onStartupFinished",
-    "onWebviewPanel:cody.chatPanel"
-  ],
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
   "contributes": {
     "walkthroughs": [
       {
@@ -820,20 +811,12 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": [
-            "https://github.com/sourcegraph/cody",
-            "ssh://git@github.com/sourcegraph/cody"
-          ]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "embeddings",
-            "keyword",
-            "blended",
-            "none"
-          ],
+          "enum": ["embeddings", "keyword", "blended", "none"],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -897,9 +880,7 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages. (E.g., \"Answer all my questions in Spanish.\")",
-          "examples": [
-            "Answer all my questions in Spanish."
-          ]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -964,27 +945,15 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "all",
-            "off"
-          ],
-          "enumDescriptions": [
-            "Sends usage data and errors.",
-            "Disables all extension telemetry."
-          ],
+          "enum": ["all", "off"],
+          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "anthropic",
-            "fireworks",
-            "unstable-openai",
-            "experimental-ollama"
-          ],
+          "enum": [null, "anthropic", "fireworks", "unstable-openai", "experimental-ollama"],
           "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."
         },
         "cody.autocomplete.advanced.serverEndpoint": {
@@ -998,12 +967,7 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "starcoder-16b",
-            "starcoder-7b",
-            "llama-code-13b"
-          ],
+          "enum": [null, "starcoder-16b", "starcoder-7b", "llama-code-13b"],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1023,10 +987,7 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": [
-            "lsp",
-            "indentation-based"
-          ],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1057,11 +1018,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "bfg",
-            "bfg-mixed"
-          ],
+          "enum": [null, "bfg", "bfg-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.ollamaOptions": {


### PR DESCRIPTION
VS Code: Release 1.8.2 - Stable

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Version bump
- [x] vscode/changelog.md
- [x] vscode/package.json 
- [x] agent recordings 