### PR TITLE
compute ChatMessage.displayText on-demand instead of persisting

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ChatMessage.kt
@@ -6,7 +6,6 @@ import com.google.gson.annotations.SerializedName
 data class ChatMessage(
   val speaker: SpeakerEnum? = null, // Oneof: human, assistant, system
   val text: String? = null,
-  val displayText: String? = null,
   val contextFiles: List<ContextItem>? = null,
   val error: ChatError? = null,
 ) {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -210,7 +210,6 @@ describe('Agent', () => {
             expect(lastMessage).toMatchInlineSnapshot(
                 `
               {
-                "displayText": " Hi there!",
                 "speaker": "assistant",
                 "text": " Hi there!",
               }

--- a/lib/shared/src/chat/transcript/display-text.test.ts
+++ b/lib/shared/src/chat/transcript/display-text.test.ts
@@ -1,11 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
-import {
-    type DisplayPathEnvInfo,
-    setDisplayPathEnvInfo,
-} from '@sourcegraph/cody-shared/src/editor/displayPath'
+import { type DisplayPathEnvInfo, setDisplayPathEnvInfo } from '../../editor/displayPath'
 import { replaceFileNameWithMarkdownLink } from './display-text'
 
 describe('replaceFileNameWithMarkdownLink', () => {
@@ -30,11 +26,10 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
     it('replaces file name with range with markdown link', () => {
         expect(
-            replaceFileNameWithMarkdownLink(
-                'What is @foo.ts:2-2?',
-                URI.file('/foo.ts'),
-                new vscode.Range(1, 0, 2, 0)
-            )
+            replaceFileNameWithMarkdownLink('What is @foo.ts:2-2?', URI.file('/foo.ts'), {
+                start: { line: 1, character: 0 },
+                end: { line: 2, character: 0 },
+            })
         ).toEqual(
             `What is [_@foo.ts:2-2_](command:_cody.vscode.open?${encodeURIComponent(
                 '[{"$mid":1,"path":"/foo.ts","scheme":"file"},{"selection":{"start":{"line":1,"character":0},"end":{"line":2,"character":0}},"preserveFocus":true,"background":false,"preview":true,"viewColumn":-2}]'
@@ -47,7 +42,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
             replaceFileNameWithMarkdownLink(
                 'What is @e2e/cody.ts:2-2#codySymbol?',
                 URI.file('/e2e/cody.ts'),
-                new vscode.Range(1, 0, 2, 0),
+                { start: { line: 1, character: 0 }, end: { line: 2, character: 0 } },
                 'codySymbol'
             )
         ).toEqual(
@@ -112,11 +107,10 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
     it('handles line numbers', () => {
         expect(
-            replaceFileNameWithMarkdownLink(
-                'Error in @test.js:2-2',
-                URI.file('/test.js'),
-                new vscode.Range(1, 0, 2, 0)
-            )
+            replaceFileNameWithMarkdownLink('Error in @test.js:2-2', URI.file('/test.js'), {
+                start: { line: 1, character: 0 },
+                end: { line: 2, character: 0 },
+            })
         ).toEqual(
             `Error in [_@test.js:2-2_](command:_cody.vscode.open?${encodeURIComponent(
                 '[{"$mid":1,"path":"/test.js","scheme":"file"},{"selection":{"start":{"line":1,"character":0},"end":{"line":2,"character":0}},"preserveFocus":true,"background":false,"preview":true,"viewColumn":-2}]'
@@ -126,11 +120,10 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
     it('handles non alphanumeric characters follows the file name in input', () => {
         expect(
-            replaceFileNameWithMarkdownLink(
-                'What is @test.js:2-2?',
-                URI.file('/test.js'),
-                new vscode.Range(1, 0, 2, 0)
-            )
+            replaceFileNameWithMarkdownLink('What is @test.js:2-2?', URI.file('/test.js'), {
+                start: { line: 1, character: 0 },
+                end: { line: 2, character: 0 },
+            })
         ).toEqual(
             `What is [_@test.js:2-2_](command:_cody.vscode.open?${encodeURIComponent(
                 '[{"$mid":1,"path":"/test.js","scheme":"file"},{"selection":{"start":{"line":1,"character":0},"end":{"line":2,"character":0}},"preserveFocus":true,"background":false,"preview":true,"viewColumn":-2}]'
@@ -140,11 +133,10 @@ describe('replaceFileNameWithMarkdownLink', () => {
 
     it('handles edge case where start line at 0 - exclude start line in markdown link', () => {
         expect(
-            replaceFileNameWithMarkdownLink(
-                'Error in @test.js',
-                URI.file('/test.js'),
-                new vscode.Range(0, 0, 0, 0)
-            )
+            replaceFileNameWithMarkdownLink('Error in @test.js', URI.file('/test.js'), {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 0 },
+            })
         ).toEqual(
             `Error in [_@test.js_](command:_cody.vscode.open?${encodeURIComponent(
                 '[{"$mid":1,"path":"/test.js","scheme":"file"},{"selection":{"start":{"line":0,"character":0},"end":{"line":0,"character":0}},"preserveFocus":true,"background":false,"preview":true,"viewColumn":-2}]'
@@ -157,7 +149,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
             replaceFileNameWithMarkdownLink(
                 'Compare and explain @foo.js:2-2 and @bar.js. What does @foo.js:2-2 do?',
                 URI.file('/foo.js'),
-                new vscode.Range(1, 0, 2, 0)
+                { start: { line: 1, character: 0 }, end: { line: 2, character: 0 } }
             )
         ).toEqual(
             `Compare and explain [_@foo.js:2-2_](command:_cody.vscode.open?${encodeURIComponent(
@@ -173,7 +165,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
             replaceFileNameWithMarkdownLink(
                 'Compare and explain @foo.js:2-2 and @bar.js. What does @foo.js:2-2#FooBar() do?',
                 URI.file('/foo.js'),
-                new vscode.Range(1, 0, 2, 0)
+                { start: { line: 1, character: 0 }, end: { line: 2, character: 0 } }
             )
         ).toEqual(
             `Compare and explain [_@foo.js:2-2_](command:_cody.vscode.open?${encodeURIComponent(
@@ -188,7 +180,7 @@ describe('replaceFileNameWithMarkdownLink', () => {
         const result = replaceFileNameWithMarkdownLink(
             text,
             URI.file('/vscode/src/logged-rerank.ts'),
-            new vscode.Range(6, 0, 23, 0),
+            { start: { line: 6, character: 0 }, end: { line: 23, character: 0 } },
             'getRerankWithLog()'
         )
 

--- a/lib/shared/src/chat/transcript/display-text.ts
+++ b/lib/shared/src/chat/transcript/display-text.ts
@@ -1,7 +1,28 @@
-import * as vscode from 'vscode'
+import type * as vscode from 'vscode'
+import type { URI } from 'vscode-uri'
+import type { ContextItem } from '../../codebase-context/messages'
+import type { RangeData } from '../../common/range'
+import { displayPath } from '../../editor/displayPath'
+import { reformatBotMessageForChat } from '../viewHelpers'
+import type { ChatMessage } from './messages'
 
-import { type ContextItem, displayPath } from '@sourcegraph/cody-shared'
-import { trailingNonAlphaNumericRegex } from './test-commands'
+/**
+ * Process the message's text to produce the text that should be displayed to the user. This lets us
+ * fix any unclosed Markdown code blocks, remove any erroneous `Human:` suffixes, and do any other
+ * cleanup that we determine to be necessary from LLM outputs.
+ */
+export function getDisplayText(message: ChatMessage): string {
+    if (!message.text) {
+        return ''
+    }
+    if (message.speaker === 'human') {
+        return createDisplayTextWithFileLinks(message.text, message.contextFiles ?? [])
+    }
+    if (message.speaker === 'assistant') {
+        return reformatBotMessageForChat(message.text)
+    }
+    throw new Error(`unable to get display text for message with speaker '${message.speaker}'`)
+}
 
 /**
  * VS Code intentionally limits what `command:vscode.open?ARGS` can have for args (see
@@ -15,7 +36,7 @@ export const CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID = '_cody.vscode.open'
 /**
  * Creates display text for the given context files by replacing file names with markdown links.
  */
-export function createDisplayTextWithFileLinks(humanInput: string, files: ContextItem[]): string {
+function createDisplayTextWithFileLinks(humanInput: string, files: ContextItem[]): string {
     let formattedText = humanInput
     for (const file of files) {
         // +1 on the end line numbers because we want to make sure to include everything on the end line by
@@ -23,7 +44,12 @@ export function createDisplayTextWithFileLinks(humanInput: string, files: Contex
         formattedText = replaceFileNameWithMarkdownLink(
             formattedText,
             file.uri,
-            file.range && new vscode.Range(file.range.start.line, 0, file.range.end.line + 1, 0),
+            file.range
+                ? {
+                      start: { line: file.range.start.line, character: 0 },
+                      end: { line: file.range.end.line + 1, character: 0 },
+                  }
+                : undefined,
             file.type === 'symbol' ? file.symbolName : undefined
         )
     }
@@ -36,8 +62,8 @@ export function createDisplayTextWithFileLinks(humanInput: string, files: Contex
  */
 export function replaceFileNameWithMarkdownLink(
     humanInput: string,
-    file: vscode.Uri,
-    range?: vscode.Range,
+    file: URI,
+    range?: RangeData,
     symbolName?: string
 ): string {
     const inputRepr = inputRepresentation(humanInput, file, range, symbolName)
@@ -55,7 +81,7 @@ export function replaceFileNameWithMarkdownLink(
                 preserveFocus: true,
                 background: false,
                 preview: true,
-                viewColumn: vscode.ViewColumn.Beside,
+                viewColumn: -2 satisfies vscode.ViewColumn.Beside,
             },
         ])
     )})`
@@ -67,14 +93,16 @@ export function replaceFileNameWithMarkdownLink(
     return (text + trailingNonAlphanum).trim()
 }
 
+const trailingNonAlphaNumericRegex = /[^\d#@A-Za-z]+$/
+
 /**
  * Generates a string representation of the given file, range, and symbol name
  * to use when linking to locations in code.
  */
 function inputRepresentation(
     humanInput: string,
-    file: vscode.Uri,
-    range?: vscode.Range,
+    file: URI,
+    range?: RangeData,
     symbolName?: string
 ): string {
     const fileName = displayPath(file)

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -5,7 +5,6 @@ import type { SerializedChatTranscript } from '.'
 import type { DefaultCodyCommands } from '../../commands/types'
 
 export interface ChatMessage extends Message {
-    displayText?: string
     contextFiles?: ContextItem[]
     error?: ChatError
 }

--- a/lib/shared/src/chat/viewHelpers.test.ts
+++ b/lib/shared/src/chat/viewHelpers.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { reformatBotMessageForChat } from './viewHelpers'
+
+describe('reformatBotMessageForChat', () => {
+    it('trims Human stop sequence', () => {
+        expect(reformatBotMessageForChat('Here is some info Human:')).toBe('Here is some info ')
+    })
+
+    it('fixes unclosed markdown code block', () => {
+        expect(reformatBotMessageForChat('Here is some code ```console.log("hello")')).toBe(
+            'Here is some code ```console.log("hello")\n```'
+        )
+    })
+})

--- a/lib/shared/src/chat/viewHelpers.ts
+++ b/lib/shared/src/chat/viewHelpers.ts
@@ -1,9 +1,10 @@
-// If the bot message ends with some prefix of the `Human:` stop
-// sequence, trim if from the end.
 const STOP_SEQUENCE_REGEXP = /(H|Hu|Hum|Huma|Human|Human:)$/
 
-export function reformatBotMessageForChat(text: string, prefix: string): string {
-    let reformattedMessage = prefix + text.trimEnd()
+/**
+ * If the bot message ends with some prefix of the `Human:` stop sequence, trim if from the end.
+ */
+export function reformatBotMessageForChat(text: string): string {
+    let reformattedMessage = text.trimEnd()
 
     const stopSequenceMatch = reformattedMessage.match(STOP_SEQUENCE_REGEXP)
     if (stopSequenceMatch) {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -29,6 +29,7 @@ export type {
     ChatMessage,
     UserLocalHistory,
 } from './chat/transcript/messages'
+export { getDisplayText, CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID } from './chat/transcript/display-text'
 export { Typewriter } from './chat/typewriter'
 export { reformatBotMessageForChat } from './chat/viewHelpers'
 export type {

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -33,7 +33,7 @@ export class PromptMixin {
             .join('\n\n')
         if (mixins) {
             // Stuff the prompt mixins at the start of the human text.
-            // Note we do not reflect them in displayText.
+            // Note we do not reflect them in `text`.
             return { ...humanMessage, text: `${mixins}${humanMessage.text}` }
         }
         return humanMessage

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -4,13 +4,13 @@ import * as vscode from 'vscode'
 
 import {
     type AuthStatus,
+    CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID,
     type ChatClient,
     type Guardrails,
     ModelProvider,
 } from '@sourcegraph/cody-shared'
 
 import type { View } from '../../../webviews/NavBar'
-import { CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID } from '../../commands/utils/display-text'
 import { isRunningInsideAgent } from '../../jsonrpc/isRunningInsideAgent'
 import type { LocalEmbeddingsController } from '../../local-context/local-embeddings'
 import type { SymfRunner } from '../../local-context/symf'

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -212,7 +212,7 @@ function getDisplayText(message: ChatMessage): string | undefined {
         return createDisplayTextWithFileLinks(message.text, message.contextFiles ?? [])
     }
     if (message.speaker === 'assistant' && message.text) {
-        return reformatBotMessageForChat(message.text, '')
+        return reformatBotMessageForChat(message.text)
     }
     return message.text
 }

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -8,11 +8,9 @@ import {
     type SerializedChatTranscript,
     errorToChatError,
     isCodyIgnoredFile,
-    reformatBotMessageForChat,
     toRangeData,
 } from '@sourcegraph/cody-shared'
 
-import { createDisplayTextWithFileLinks } from '../../commands/utils/display-text'
 import type { Repo } from '../../context/repo-fetcher'
 import { getChatPanelTitle } from './chat-helpers'
 
@@ -47,7 +45,7 @@ export class SimpleChatModel {
         this.messages.push({ ...message, speaker: 'human' })
     }
 
-    public addBotMessage(message: Omit<Message, 'speaker'>, displayText?: string): void {
+    public addBotMessage(message: Omit<Message, 'speaker'>): void {
         const lastMessage = this.messages.at(-1)
         let error: any
         // If there is no text, it could be a placeholder message for an error
@@ -60,7 +58,6 @@ export class SimpleChatModel {
         this.messages.push({
             ...message,
             speaker: 'assistant',
-            displayText,
             error,
         })
     }
@@ -117,11 +114,7 @@ export class SimpleChatModel {
             return this.customChatTitle
         }
         const lastHumanMessage = this.getLastHumanMessage()
-        const text = lastHumanMessage && getDisplayText(lastHumanMessage)
-        if (text) {
-            return getChatPanelTitle(text)
-        }
-        return 'New Chat'
+        return getChatPanelTitle(lastHumanMessage?.text ?? '')
     }
 
     public getCustomChatTitle(): string | undefined {
@@ -183,36 +176,16 @@ function messageToSerializedChatInteraction(
         )
     }
 
-    function toSerializedInteractionMessage(message: ChatMessage): ChatMessage {
-        return { ...message, displayText: getDisplayText(message) }
-    }
-    return {
-        humanMessage: toSerializedInteractionMessage(humanMessage),
-        assistantMessage: assistantMessage ? toSerializedInteractionMessage(assistantMessage) : null,
-    }
+    return { humanMessage, assistantMessage: assistantMessage ?? null }
 }
 
 export function prepareChatMessage(message: ChatMessage): ChatMessage {
     return {
         ...message,
-        displayText: getDisplayText(message),
         contextFiles: message.contextFiles?.map(item => ({
             ...item,
             // De-hydrate because vscode.Range serializes to `[start, end]` in JSON.
             range: toRangeData(item.range),
         })),
     }
-}
-
-function getDisplayText(message: ChatMessage): string | undefined {
-    if (message.displayText) {
-        return message.displayText
-    }
-    if (message.speaker === 'human' && message.text) {
-        return createDisplayTextWithFileLinks(message.text, message.contextFiles ?? [])
-    }
-    if (message.speaker === 'assistant' && message.text) {
-        return reformatBotMessageForChat(message.text)
-    }
-    return message.text
 }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -961,15 +961,15 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
      * Finalizes adding a bot message to the chat model and triggers an update to the view.
      */
     private addBotMessage(requestID: string, rawResponse: string): void {
-        const displayText = reformatBotMessageForChat(rawResponse)
-        this.chatModel.addBotMessage({ text: rawResponse }, displayText)
+        const messageText = reformatBotMessageForChat(rawResponse)
+        this.chatModel.addBotMessage({ text: messageText })
         void this.saveSession()
         this.postViewTranscript()
 
         const authStatus = this.authProvider.getAuthStatus()
 
         // Count code generated from response
-        const codeCount = countGeneratedCode(rawResponse)
+        const codeCount = countGeneratedCode(messageText)
         if (codeCount?.charCount) {
             // const metadata = lastInteraction?.getHumanMessage().metadata
             telemetryService.log(
@@ -991,7 +991,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     // V2 telemetry exports privateMetadata only for DotCom users
                     // the condition below is an aditional safegaurd measure
                     responseText:
-                        authStatus.endpoint && isDotCom(authStatus.endpoint) ? rawResponse : undefined,
+                        authStatus.endpoint && isDotCom(authStatus.endpoint) ? messageText : undefined,
                 },
             })
         }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -961,7 +961,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
      * Finalizes adding a bot message to the chat model and triggers an update to the view.
      */
     private addBotMessage(requestID: string, rawResponse: string): void {
-        const displayText = reformatBotMessageForChat(rawResponse, '')
+        const displayText = reformatBotMessageForChat(rawResponse)
         this.chatModel.addBotMessage({ text: rawResponse }, displayText)
         void this.saveSession()
         this.postViewTranscript()

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import type { RangeData } from '@sourcegraph/cody-shared'
+import { type RangeData, getDisplayText } from '@sourcegraph/cody-shared'
 
 export async function openFile(
     uri: vscode.Uri,
@@ -22,16 +22,18 @@ export async function openFile(
     })
 }
 
-export function getChatPanelTitle(lastDisplayText?: string, truncateTitle = true): string {
-    if (!lastDisplayText) {
+export function getChatPanelTitle(lastHumanText?: string, truncateTitle = true): string {
+    if (!lastHumanText) {
         return 'New Chat'
     }
+
+    let displayText = getDisplayText({ speaker: 'human', text: lastHumanText })
     // Regex to remove the markdown formatted links with this format: '[_@FILENAME_]()'
     const MARKDOWN_LINK_REGEX = /\[_(.+?)_]\((.+?)\)/g
-    lastDisplayText = lastDisplayText.replaceAll(MARKDOWN_LINK_REGEX, '$1')?.trim()
+    displayText = displayText.replaceAll(MARKDOWN_LINK_REGEX, '$1')?.trim()
     if (!truncateTitle) {
-        return lastDisplayText
+        return displayText
     }
     // truncate title that is too long
-    return lastDisplayText.length > 25 ? `${lastDisplayText.slice(0, 25).trim()}...` : lastDisplayText
+    return displayText.length > 25 ? `${displayText.slice(0, 25).trim()}...` : displayText
 }

--- a/vscode/src/commands/utils/test-commands.ts
+++ b/vscode/src/commands/utils/test-commands.ts
@@ -30,9 +30,6 @@ export function isValidTestFile(uri: URI): boolean {
     return fileNameWithoutExt.startsWith('test_') || suffixTest.test(fileNameWithoutExt)
 }
 
-// REGEX for trailing non-alphanumeric characters
-export const trailingNonAlphaNumericRegex = /[^\d#@A-Za-z]+$/
-
 /**
  * Checks if the given test file path matches the path of the original file
  * by comparing stripped down versions of the paths.

--- a/vscode/src/services/HistoryChat.ts
+++ b/vscode/src/services/HistoryChat.ts
@@ -68,9 +68,9 @@ export function groupCodyChats(authStatus: AuthStatus | undefined): GroupedChats
                 break
             }
         }
-        if (lastHumanMessage?.displayText && lastHumanMessage?.text) {
-            const lastDisplayText = lastHumanMessage.displayText.split('\n')[0]
-            const chatTitle = chats[id].chatTitle || getChatPanelTitle(lastDisplayText, false)
+        if (lastHumanMessage?.text) {
+            const lastHumanText = lastHumanMessage.text.split('\n')[0]
+            const chatTitle = chats[id].chatTitle || getChatPanelTitle(lastHumanText, false)
 
             const lastInteractionTimestamp = new Date(entry.lastInteractionTimestamp)
             let groupLabel = 'N months ago'

--- a/vscode/test/integration/single-root/chat.test.ts
+++ b/vscode/test/integration/single-root/chat.test.ts
@@ -28,9 +28,9 @@ suite('Chat', function () {
         const chatView = await getChatViewProvider()
         await chatView.handleUserMessageSubmission('test', 'hello from the human', 'user', [], false)
 
-        assert.match((await getTranscript(0)).displayText || '', /^hello from the human$/)
+        assert.match((await getTranscript(0)).text || '', /^hello from the human$/)
         await waitUntil(async () =>
-            /^hello from the assistant$/.test((await getTranscript(1)).displayText || '')
+            /^hello from the assistant$/.test((await getTranscript(1)).text || '')
         )
     })
 
@@ -42,9 +42,9 @@ suite('Chat', function () {
         await chatView.handleUserMessageSubmission('test', 'hello from the human', 'user', [], false)
 
         // Display text should include file link at the end of message
-        assert.match((await getTranscript(0)).displayText || '', /^hello from the human$/)
+        assert.match((await getTranscript(0)).text || '', /^hello from the human$/)
         await waitUntil(async () =>
-            /^hello from the assistant$/.test((await getTranscript(1)).displayText || '')
+            /^hello from the assistant$/.test((await getTranscript(1)).text || '')
         )
     })
 })

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -147,7 +147,7 @@ export const Transcript: React.FunctionComponent<
 
     const lastHumanMessageIndex = findLastIndex(
         transcript,
-        message => message.speaker === 'human' && message.displayText !== undefined
+        message => message.speaker === 'human' && message.text !== undefined
     )
     let earlierMessages: ChatMessage[] = []
     let lastInteractionMessages = transcript
@@ -159,7 +159,7 @@ export const Transcript: React.FunctionComponent<
     const messageToTranscriptItem =
         (offset: number) =>
         (message: ChatMessage, index: number): JSX.Element | null => {
-            if (!message?.displayText && !message.error) {
+            if (!message.text && !message.error) {
                 return null
             }
             const offsetIndex = index + offset === earlierMessages.length
@@ -174,11 +174,12 @@ export const Transcript: React.FunctionComponent<
                         index={keyIndex}
                         key={keyIndex}
                         message={message}
-                        inProgress={
+                        inProgress={Boolean(
                             offsetIndex &&
-                            messageInProgress?.speaker === 'assistant' &&
-                            !messageInProgress?.displayText
-                        }
+                                messageInProgress &&
+                                messageInProgress.speaker === 'assistant' &&
+                                !messageInProgress.text
+                        )}
                         showEditButton={message.speaker === 'human'}
                         beingEdited={messageBeingEdited}
                         setBeingEdited={setMessageBeingEdited}
@@ -205,7 +206,7 @@ export const Transcript: React.FunctionComponent<
         }
 
     const welcomeTranscriptMessage = useMemo(
-        (): ChatMessage => ({ speaker: 'assistant', displayText: welcomeText({ welcomeMessage }) }),
+        (): ChatMessage => ({ speaker: 'assistant', text: welcomeText({ welcomeMessage }) }),
         [welcomeMessage]
     )
 

--- a/vscode/webviews/chat/TranscriptItem.tsx
+++ b/vscode/webviews/chat/TranscriptItem.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import classNames from 'classnames'
 
-import type { ChatMessage, Guardrails } from '@sourcegraph/cody-shared'
+import { type ChatMessage, type Guardrails, getDisplayText } from '@sourcegraph/cody-shared'
 
 import type { UserAccountInfo } from '../Chat'
 import type { ChatButtonProps } from '../Chat'
@@ -89,6 +89,12 @@ export const TranscriptItem: React.FunctionComponent<
     // A boolean indicating whether the current transcript item is the one being edited.
     const isItemBeingEdited = beingEdited === index
 
+    // Memoize based on the content, not the object reference, so that the displayText is not
+    // recomputed each time any other message in the parent transcript changes.
+    const messageJSON = useMemo((): string => JSON.stringify(message), [message])
+    // biome-ignore lint/correctness/useExhaustiveDependencies: Our use of `message` is safe because we depend on `messageJSON`.
+    const displayText = useMemo((): string => getDisplayText(message), [messageJSON])
+
     return (
         <div
             className={classNames(
@@ -139,9 +145,9 @@ export const TranscriptItem: React.FunctionComponent<
                 )
             ) : null}
             <div className={classNames(styles.contentPadding, styles.content)}>
-                {message.displayText ? (
+                {displayText ? (
                     <CodeBlocks
-                        displayText={message.displayText}
+                        displayText={displayText}
                         copyButtonClassName={codeBlocksCopyButtonClassName}
                         copyButtonOnSubmit={copyButtonOnSubmit}
                         insertButtonClassName={codeBlocksInsertButtonClassName}

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -5,46 +5,44 @@ import type { ChatMessage } from '@sourcegraph/cody-shared'
 export const FIXTURE_TRANSCRIPT: Record<
     'simple' | 'simple2' | 'codeQuestion' | 'explainCode',
     ChatMessage[]
-> = setOtherChatMessageFields({
+> = {
     simple: [
-        { speaker: 'human', displayText: 'Hello, world!' },
-        { speaker: 'assistant', displayText: 'Thank you' },
+        { speaker: 'human', text: 'Hello, world!' },
+        { speaker: 'assistant', text: 'Thank you' },
     ],
     simple2: [
         {
             speaker: 'human',
-            displayText: 'What planet are we on?',
+            text: 'What planet are we on?',
         },
         {
             speaker: 'assistant',
-            displayText: 'Earth',
+            text: 'Earth',
         },
         {
             speaker: 'human',
-            displayText: 'What color is the sky?',
+            text: 'What color is the sky?',
             contextFiles: [{ type: 'file', uri: URI.file('/foo.js') }],
         },
         {
             speaker: 'assistant',
-            displayText: 'Blue.',
+            text: 'Blue.',
         },
     ],
     codeQuestion: [
         {
             speaker: 'human',
-            displayText: 'What does `document.getSelection()?.isCollapsed` mean?',
+            text: 'What does `document.getSelection()?.isCollapsed` mean?',
         },
         {
             speaker: 'assistant',
-            displayText:
-                '`document.getSelection()?.isCollapsed` means that the current selection in the document is collapsed, meaning it is a caret (no text is selected).\n\nThe `?.` operator is optional chaining - it will return `undefined` if `document.getSelection()` returns `null` or `undefined`.\n\nSo in short, that line is checking if there is currently a text selection in the document, and if not, focusing the textarea.\n\n',
+            text: '`document.getSelection()?.isCollapsed` means that the current selection in the document is collapsed, meaning it is a caret (no text is selected).\n\nThe `?.` operator is optional chaining - it will return `undefined` if `document.getSelection()` returns `null` or `undefined`.\n\nSo in short, that line is checking if there is currently a text selection in the document, and if not, focusing the textarea.\n\n',
         },
     ],
     explainCode: [
         {
             speaker: 'human',
-            displayText:
-                "Explain the following code at a high level:\n\n```\nprivate getNonce(): string {\n  let text = ''\n  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n```",
+            text: "Explain the following code at a high level:\n\n```\nprivate getNonce(): string {\n  let text = ''\n  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n```",
             contextFiles: [
                 { type: 'file', uri: URI.file('/vscode/src/chat/ChatViewProvider.ts') },
                 { type: 'file', uri: URI.file('/lib/shared/src/timestamp.ts') },
@@ -52,31 +50,15 @@ export const FIXTURE_TRANSCRIPT: Record<
         },
         {
             speaker: 'assistant',
-            displayText:
-                'This code generates a random 32-character string (nonce) using characters A-Z, a-z, and 0-9.',
+            text: 'This code generates a random 32-character string (nonce) using characters A-Z, a-z, and 0-9.',
         },
         {
             speaker: 'human',
-            displayText: 'Rewrite it to only use hexadecimal encoding.',
+            text: 'Rewrite it to only use hexadecimal encoding.',
         },
         {
             speaker: 'assistant',
-            displayText:
-                "Here is the rewritten code using only hexadecimal encoding:\n\n```\nprivate getNonce(): string {\n  let text = ''\n  const possible = '0123456789ABCDEF'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n```",
+            text: "Here is the rewritten code using only hexadecimal encoding:\n\n```\nprivate getNonce(): string {\n  let text = ''\n  const possible = '0123456789ABCDEF'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n```",
         },
     ],
-})
-
-// Some things require the `text` field to be set.
-function setOtherChatMessageFields<K extends string>(
-    data: Record<K, ChatMessage[]>
-): Record<K, ChatMessage[]> {
-    for (const chatMessages of Object.values(data) as ChatMessage[][]) {
-        for (const chatMessage of chatMessages) {
-            if (!chatMessage.text) {
-                chatMessage.text = chatMessage.displayText
-            }
-        }
-    }
-    return data
 }


### PR DESCRIPTION
Previously, `ChatMessage.displayText?: string` was set in multiple places, and the logic for getting the title of a chat was defined in 2 different places (and uses the `displayText`). Now, we never persist `displayText` and instead compute it at display time, which is possible because it uses only data that is available in the `ChatMessage` value.

Also simplify and test reformatBotMessageForChat.

This is a refactor to clear the way for #3287.

## Test plan

CI. Also manually test that chat titles are set based on the last human message in a new chat, and that editing a chat title in the sidebar updates the title in the sidebar and the tab title bars.