### PR TITLE
standardize on display{Line,}Range funcs

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -10186,7 +10186,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 834f361490e61829331277ac569b4a9e
+    - _id: 85d89f9192841e2bca16f2c4b1825ef8
       _order: 0
       cache: {}
       request:
@@ -10232,7 +10232,7 @@ log:
               - speaker: assistant
                 text: Ok.
               - speaker: human
-                text: "Explain what @src/animal.ts:1-7  does in simple terms. Assume the
+                text: "Explain what @src/animal.ts:1-6  does in simple terms. Assume the
                   audience is a beginner programmer who has just learned the
                   language features and basic syntax. Focus on explaining: 1)
                   The purpose of the code 2) What input(s) it takes 3) What
@@ -13516,7 +13516,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: f4eedc092e77005e22f1f2f602fd98d0
+    - _id: c90629f685d5bb3bf2e042a6bacb0017
       _order: 0
       cache: {}
       request:
@@ -13562,7 +13562,7 @@ log:
               - speaker: assistant
                 text: Ok.
               - speaker: human
-                text: Please review and analyze @src/animal.ts:1-7  and identify potential areas
+                text: Please review and analyze @src/animal.ts:1-6  and identify potential areas
                   for improvement related to code smells, readability,
                   maintainability, performance, security, etc. Do not list
                   issues already addressed in the given code. Focus on providing

--- a/lib/shared/src/common/range.test.ts
+++ b/lib/shared/src/common/range.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { toRangeData } from './range'
+import { displayLineRange, displayRange, toRangeData } from './range'
 
 describe('toRangeData', () => {
     test('converts Range to RangeData', () => {
@@ -26,4 +26,45 @@ describe('toRangeData', () => {
     test('handles undefined input', () => {
         expect(toRangeData(undefined)).toBeUndefined()
     })
+})
+
+describe('displayRangeLines', () => {
+    test('multi-line range', () =>
+        expect(
+            displayLineRange({ start: { line: 1, character: 2 }, end: { line: 4, character: 5 } })
+        ).toBe('2-5'))
+
+    test('range ending at character 0', () =>
+        expect(
+            displayLineRange({ start: { line: 1, character: 2 }, end: { line: 4, character: 0 } })
+        ).toBe('2-4'))
+
+    test('single line only', () => {
+        expect(
+            displayLineRange({ start: { line: 1, character: 0 }, end: { line: 1, character: 0 } })
+        ).toBe('2')
+        expect(
+            displayLineRange({ start: { line: 1, character: 0 }, end: { line: 1, character: 17 } })
+        ).toBe('2')
+        expect(
+            displayLineRange({ start: { line: 1, character: 2 }, end: { line: 2, character: 0 } })
+        ).toBe('2')
+    })
+})
+
+describe('displayRange', () => {
+    test('same line', () =>
+        expect(displayRange({ start: { line: 1, character: 2 }, end: { line: 1, character: 5 } })).toBe(
+            '2:3-6'
+        ))
+
+    test('empty', () =>
+        expect(displayRange({ start: { line: 1, character: 2 }, end: { line: 1, character: 2 } })).toBe(
+            '2:3'
+        ))
+
+    test('multi-line range', () =>
+        expect(displayRange({ start: { line: 1, character: 2 }, end: { line: 3, character: 4 } })).toBe(
+            '2:3-4:5'
+        ))
 })

--- a/lib/shared/src/common/range.ts
+++ b/lib/shared/src/common/range.ts
@@ -3,6 +3,8 @@
  * use {@link vscode.Range} when serializing to JSON because it serializes to an array `[start,
  * end]`, which is impossible to deserialize correctly without knowing that the value is for a
  * {@link vscode.Range}.
+ *
+ * The line and character numbers are 0-indexed.
  */
 export interface RangeData {
     start: { line: number; character: number }
@@ -31,4 +33,43 @@ export function toRangeData<R extends RangeData>(
               end: { line: data.end.line, character: data.end.character },
           }
         : undefined
+}
+
+/**
+ * Return the display text for the line range, such as `1-3` (meaning lines 1 through 3, which we
+ * assume humans interpret as an inclusive range) or just `2` (meaning just line 2). Callers that
+ * need the characters in the returned string should use {@link displayRange}.
+ *
+ * If the range ends on a line at character 0, it's assumed to only include the prior line.
+ *
+ * `RangeData` is 0-indexed but humans use 1-indexed line ranges.
+ */
+export function displayLineRange(range: RangeData): string {
+    const startLine = range.start.line + 1
+    const endLine =
+        range.end.line + (range.end.line !== range.start.line && range.end.character === 0 ? 0 : 1)
+    if (endLine === startLine) {
+        return startLine.toString()
+    }
+    return `${startLine}-${endLine}`
+}
+
+/**
+ * Return the display text for the range, such as `1:2-3:4` (meaning from character 2 on line 1 to
+ * character 4 on line 3), `1:2-3` (meaning from character 2 to 3 on line 1), or `1:2` (meaning an
+ * empty range that starts and ends at character 2 on line 1). Callers that need only the lines in
+ * the returned string should use {@link displayLineRange}.
+ *
+ * `RangeData` is 0-indexed but humans use 1-indexed line ranges.
+ */
+export function displayRange(range: RangeData): string {
+    if (range.end.line === range.start.line) {
+        if (range.end.character === range.start.character) {
+            return `${range.start.line + 1}:${range.start.character + 1}`
+        }
+        return `${range.start.line + 1}:${range.start.character + 1}-${range.end.character + 1}`
+    }
+    return `${range.start.line + 1}:${range.start.character + 1}-${range.end.line + 1}:${
+        range.end.character + 1
+    }`
 }

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -54,7 +54,7 @@ export type {
 export type { CodyCommand, CodyCommandContext, CodyCommandType } from './commands/types'
 export { type DefaultCodyCommands, DefaultChatCommands } from './commands/types'
 export { dedupeWith, isDefined, isErrorLike, pluralize } from './common'
-export { type RangeData, toRangeData } from './common/range'
+export { type RangeData, toRangeData, displayLineRange, displayRange } from './common/range'
 export {
     ProgrammingLanguage,
     languageFromFilename,

--- a/vscode/src/commands/execute/explain.ts
+++ b/vscode/src/commands/execute/explain.ts
@@ -1,4 +1,4 @@
-import { type ContextItem, displayPath, logDebug } from '@sourcegraph/cody-shared'
+import { type ContextItem, displayLineRange, displayPath, logDebug } from '@sourcegraph/cody-shared'
 import { DefaultChatCommands } from '@sourcegraph/cody-shared/src/commands/types'
 import { defaultCommands } from '.'
 import type { ChatCommandResult } from '../../main'
@@ -40,7 +40,7 @@ async function explainCommand(
 
     const cs = currentSelection[0] ?? currentFile[0]
     if (cs) {
-        const range = cs.range && `:${cs.range.start.line + 1}-${cs.range.end.line + 1}`
+        const range = cs.range && `:${displayLineRange(cs.range)}`
         prompt = prompt.replace('the selected code', `@${displayPath(cs.uri)}${range ?? ''} `)
     }
 

--- a/vscode/src/commands/execute/smell.ts
+++ b/vscode/src/commands/execute/smell.ts
@@ -1,4 +1,4 @@
-import { type ContextItem, displayPath, logDebug } from '@sourcegraph/cody-shared'
+import { type ContextItem, displayLineRange, displayPath, logDebug } from '@sourcegraph/cody-shared'
 import { DefaultChatCommands } from '@sourcegraph/cody-shared/src/commands/types'
 import { defaultCommands } from '.'
 import type { ChatCommandResult } from '../../main'
@@ -32,7 +32,7 @@ async function smellCommand(span: Span, args?: Partial<CodyCommandArgs>): Promis
 
     const cs = currentSelection[0]
     if (cs) {
-        const range = cs.range && `:${cs.range.start.line + 1}-${cs.range.end.line + 1}`
+        const range = cs.range && `:${displayLineRange(cs.range)}`
         prompt = prompt.replace('the selected code', `@${displayPath(cs.uri)}${range ?? ''} `)
     }
 

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import { displayPath, isDefined, renderMarkdown } from '@sourcegraph/cody-shared'
+import { displayPath, displayRange, isDefined, renderMarkdown } from '@sourcegraph/cody-shared'
 
 import {
     SectionHistoryRetriever,
@@ -313,20 +313,8 @@ ${
 }`
 }
 
-function rangeDescription(range: vscode.Range): string {
-    // The VS Code extension API uses 0-indexed lines and columns, but the UI (and humans) use
-    // 1-indexed lines and columns. Show the latter.
-    return `${range.start.line + 1}:${range.start.character + 1}${
-        range.isEmpty
-            ? ''
-            : `-${range.end.line === range.start.line ? '' : `${range.end.line + 1}:`}${
-                  range.end.character + 1
-              }`
-    }`
-}
-
 function rangeDescriptionWithCurrentText(range: vscode.Range, document?: vscode.TextDocument): string {
-    return `${rangeDescription(range)} (${
+    return `${displayRange(range)} (${
         range.isEmpty
             ? 'empty'
             : document

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -1,4 +1,9 @@
-import type { ChatEventSource, ContextItem, EditModel } from '@sourcegraph/cody-shared'
+import {
+    type ChatEventSource,
+    type ContextItem,
+    type EditModel,
+    displayLineRange,
+} from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 
 import { ACCOUNT_UPGRADE_URL } from '../../chat/protocol'
@@ -22,7 +27,7 @@ import { getTestInputItems } from './get-items/test'
 import type { EditModelItem, EditRangeItem } from './get-items/types'
 import { getMatchingContext } from './get-matching-context'
 import { createQuickPick } from './quick-pick'
-import { fetchDocumentSymbols, getLabelForContextItem, getTitleRange, removeAfterLastAt } from './utils'
+import { fetchDocumentSymbols, getLabelForContextItem, removeAfterLastAt } from './utils'
 
 interface QuickPickInput {
     /** The user provided instruction */
@@ -103,8 +108,7 @@ export const getInput = async (
     const relativeFilePath = vscode.workspace.asRelativePath(document.uri.fsPath)
     let activeTitle: string
     const updateActiveTitle = (newRange: vscode.Range) => {
-        const fileRange = getTitleRange(newRange)
-        activeTitle = `Edit ${relativeFilePath}:${fileRange} with Cody`
+        activeTitle = `Edit ${relativeFilePath}:${displayLineRange(newRange)} with Cody`
     }
     updateActiveTitle(activeRange)
 

--- a/vscode/src/edit/input/utils.ts
+++ b/vscode/src/edit/input/utils.ts
@@ -1,4 +1,4 @@
-import { type ContextItem, displayPath } from '@sourcegraph/cody-shared'
+import { type ContextItem, displayLineRange, displayPath } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { QUICK_PICK_ITEM_CHECKED_PREFIX, QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX } from './constants'
 
@@ -21,30 +21,11 @@ export function removeAfterLastAt(str: string): string {
  */
 export function getLabelForContextItem(item: ContextItem): string {
     const isFileType = item.type === 'file'
-    const rangeLabel = item.range ? `:${item.range?.start.line}-${item.range?.end.line}` : ''
+    const rangeLabel = item.range ? `:${displayLineRange(item.range)}` : ''
     if (isFileType) {
         return `${displayPath(item.uri)}${rangeLabel}`
     }
     return `${displayPath(item.uri)}${rangeLabel}#${item.symbolName}`
-}
-
-/**
- * Returns a string representation of the given range, formatted as "{startLine}:{endLine}".
- * If startLine and endLine are the same, returns just the line number.
- */
-export function getTitleRange(range: vscode.Range): string {
-    if (range.isEmpty) {
-        // No selected range, return just active line
-        return `${range.start.line + 1}`
-    }
-
-    const endLine = range.end.character === 0 ? range.end.line - 1 : range.end.line
-    if (range.start.line === endLine) {
-        // Range only encompasses a single line
-        return `${range.start.line + 1}`
-    }
-
-    return `${range.start.line + 1}:${endLine + 1}`
 }
 
 /**

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -179,11 +179,11 @@ test.extend<ExpectedEvents>({
     await chatPanel.getByText('✨ Context: 61 lines from 5 files').click()
     // Display the context files to confirm no hidden files are included
     await expect(chatPanel.locator('span').filter({ hasText: '@.mydotfile:1-2' })).not.toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@error.ts:1-10' })).toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@Main.java:1-10' })).toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@buzz.test.ts:1-13' })).toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@buzz.ts:1-16' })).toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@index.html:1-12' })).toBeVisible()
+    await expect(chatPanel.locator('span').filter({ hasText: '@error.ts:1-9' })).toBeVisible()
+    await expect(chatPanel.locator('span').filter({ hasText: '@Main.java:1-9' })).toBeVisible()
+    await expect(chatPanel.locator('span').filter({ hasText: '@buzz.test.ts:1-12' })).toBeVisible()
+    await expect(chatPanel.locator('span').filter({ hasText: '@buzz.ts:1-15' })).toBeVisible()
+    await expect(chatPanel.locator('span').filter({ hasText: '@index.html:1-11' })).toBeVisible()
 
     /* Test: context.filePath with filePath command */
 
@@ -207,11 +207,11 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByText('✨ Context: 14 lines from 2 file')).toBeVisible()
     await chatPanel.getByText('✨ Context: 14 lines from 2 file').click()
     await expect(
-        chatPanel.locator('span').filter({ hasText: withPlatformSlashes('@lib/batches/env/var.go:1-2') })
+        chatPanel.locator('span').filter({ hasText: withPlatformSlashes('@lib/batches/env/var.go:1') })
     ).toBeVisible()
     // Click on the file link should open the 'var.go file in the editor
     await chatPanel
-        .getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1-2') })
+        .getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
         .click()
     await expect(page.getByRole('tab', { name: 'var.go' })).toBeVisible()
 
@@ -226,9 +226,9 @@ test.extend<ExpectedEvents>({
     // The files from the open tabs should be added as context
     await expect(chatPanel.getByText('✨ Context: 14 lines from 2 files')).toBeVisible()
     await chatPanel.getByText('✨ Context: 14 lines from 2 files').click()
-    await expect(chatPanel.getByRole('button', { name: '@index.html:1-12' })).toBeVisible()
+    await expect(chatPanel.getByRole('button', { name: '@index.html:1-11' })).toBeVisible()
     await expect(
-        chatPanel.getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1-2') })
+        chatPanel.getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
     ).toBeVisible()
 })
 

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 
-import { displayPath } from '@sourcegraph/cody-shared'
+import { displayLineRange, displayPath } from '@sourcegraph/cody-shared'
 import type { FileLinkProps } from '../chat/components/EnhancedContext'
 
 import { getVSCodeAPI } from '../utils/VSCodeApi'
@@ -19,9 +19,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
         // This is a remote search result.
         const repoShortName = repoName?.slice(repoName.lastIndexOf('/') + 1)
         const pathToDisplay = `${repoShortName} ${title}`
-        const pathWithRange = range
-            ? `${pathToDisplay}:${range.start.line + 1}-${range.end.line}`
-            : pathToDisplay
+        const pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
         const tooltip = `${repoName} @${revision}\nincluded via Search`
         return (
             <a
@@ -36,13 +34,8 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
         )
     }
 
-    // +1 because selection range starts at 0 but editor line number starts at 1
-    const startLine = (range?.start.line ?? 0) + 1
-    const endLine = (range?.end.line ?? -1) + 1
-    const hasValidRange = startLine <= endLine
-
     const pathToDisplay = `@${displayPath(uri)}`
-    const pathWithRange = hasValidRange ? `${pathToDisplay}:${startLine}-${endLine}` : pathToDisplay
+    const pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
     const tooltip = source ? `${pathWithRange} included via ${source}` : pathWithRange
     return (
         <button

--- a/vscode/webviews/UserContextSelector.tsx
+++ b/vscode/webviews/UserContextSelector.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef } from 'react'
 
 import classNames from 'classnames'
 
-import { type ContextItem, displayPath } from '@sourcegraph/cody-shared'
+import { type ContextItem, displayLineRange, displayPath } from '@sourcegraph/cody-shared'
 
 import styles from './UserContextSelector.module.css'
 
@@ -139,9 +139,7 @@ export const UserContextSelectorComponent: React.FunctionComponent<
                                   ? 'symbol-structure'
                                   : 'symbol-method'
                         const title = match.type === 'file' ? displayPath(match.uri) : match.symbolName
-                        const range = match.range
-                            ? `:${match.range.start.line + 1}-${match.range.end.line + 1}`
-                            : ''
+                        const range = match.range ? `:${displayLineRange(match.range)}` : ''
                         const description =
                             match.type === 'file' ? undefined : displayPath(match.uri) + range
                         const warning =


### PR DESCRIPTION
Several places had slightly different logic for rendering ranges and line ranges. Now, anywhere that a range string (such as `1:2-3:4`) or line range string (such as `1-2`) is presented, it uses `displayRange` or `displayLineRange`, respectively.

Refactor related to https://github.com/sourcegraph/cody/pull/3287.

## Test plan

CI