### PR TITLE
do not crash initialization if chat history somehow lacks `displayText`

### DIFF
--- a/vscode/src/commands/utils/display-text.ts
+++ b/vscode/src/commands/utils/display-text.ts
@@ -49,7 +49,7 @@ export function replaceFileNameWithMarkdownLink(
     const textToBeReplaced = new RegExp(`\\s*@${fileAsInput}(?![\S#-_])`, 'g')
     const markdownText = `[_@${inputRepr}_](command:${CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID}?${encodeURIComponent(
         JSON.stringify([
-            file.toJSON(),
+            file,
             {
                 selection: range,
                 preserveFocus: true,


### PR DESCRIPTION
If chat history lacks `displayText` (which should never happen, only if you have a local dev extension that writes chat history without that field, as I did), then Cody initialization will crash and Cody is completely unusable. This is because Cody attempts to synthesize the `displayText` but assumes that the value contains classes (including a `vscode.Uri` value on which it calls `toJSON()`), but actually the value was just serialized from JSON and does not have any nested class instances.

This would cause the following error message at initialization:

```
TypeError: file.toJSON is not a function
	at replaceFileNameWithMarkdownLink (/home/sqs/.vscode/extensions/sourcegraph.cody-ai-1.8.2/dist/extension.node.js:124096:12)
```

(But again, nobody should experience this. Still, this fix is worthwhile for now, and https://github.com/sourcegraph/cody/pull/3363 will help further.)



## Test plan

Build extension locally and ensure that the crash described above does not happen.