### PR TITLE
escapeHTML that does not use the DOM

### DIFF
--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -5,12 +5,15 @@ import { marked } from 'marked'
 // TODO(sqs): copied from sourcegraph/sourcegraph. should dedupe.
 
 /**
- * Escapes HTML by replacing characters like `<` with their HTML escape sequences like `&lt;`
+ * Escapes HTML by replacing characters like `<` with their HTML escape sequences like `&lt;`.
  */
-const escapeHTML = (html: string): string => {
-    const span = document.createElement('span')
-    span.textContent = html
-    return span.innerHTML
+export function escapeHTML(html: string): string {
+    return html
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#039;')
 }
 
 /**


### PR DESCRIPTION
This is an equivalent implementation of `escapeHTML` that just uses regexps and not the DOM, so it's usable in non-DOM contexts.

These replacements are sufficient and match the OWASP recommendation for characters to encode: https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-for-html-contexts.

## Test plan

CI