### PR TITLE
ignore index.scip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 playwright/**/*.webm
 **/*.iml
 **/*.vsix
+index.scip


### PR DESCRIPTION
This file is created when you regenerate the Kotlin agent bindings and should not be committed to Git.



## Test plan

CI