### PR TITLE
Autocomplete: upgrade tree-sitter and expand language support

### DIFF
--- a/agent/src/cli/evaluate-autocomplete/AutocompleteMatcher.ts
+++ b/agent/src/cli/evaluate-autocomplete/AutocompleteMatcher.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import type { Tree, default as Parser } from 'web-tree-sitter'
 
-import { SupportedLanguage, getParseLanguage } from '../../../../vscode/src/tree-sitter/grammars'
+import { SupportedLanguage, isSupportedLanguage } from '../../../../vscode/src/tree-sitter/grammars'
 import { createParser } from '../../../../vscode/src/tree-sitter/parser'
 
 import { EvaluationDocument, type EvaluationDocumentParams } from './EvaluationDocument'
@@ -30,15 +30,16 @@ export class AutocompleteMatcher {
     ) {}
     private ifSyntax(language: SupportedLanguage): string {
         switch (language) {
-            case SupportedLanguage.Go:
+            case SupportedLanguage.go:
                 return 'if  '
             default:
                 return 'if ()'
         }
     }
     public async matches(text: string): Promise<AutocompleteMatch[] | undefined> {
-        const language = getParseLanguage(this.params.languageid)
-        if (!language) {
+        const { languageid: language } = this.params
+
+        if (!isSupportedLanguage(language)) {
             return undefined
         }
         this.parser = await createParser({ language, grammarDirectory: this.grammarDirectory })

--- a/agent/src/cli/evaluate-autocomplete/Queries.ts
+++ b/agent/src/cli/evaluate-autocomplete/Queries.ts
@@ -101,7 +101,7 @@ function compileQuery(query: UncompiledQuery, parser: Parser): CompiledQuery {
 }
 
 const grammarInheritance: Partial<Record<SupportedLanguage, SupportedLanguage[]>> = {
-    [SupportedLanguage.TypeScript]: [SupportedLanguage.JavaScript],
-    [SupportedLanguage.JSX]: [SupportedLanguage.JavaScript],
-    [SupportedLanguage.TSX]: [SupportedLanguage.TypeScript, SupportedLanguage.JavaScript],
+    [SupportedLanguage.typescript]: [SupportedLanguage.javascript],
+    [SupportedLanguage.javascriptreact]: [SupportedLanguage.javascript],
+    [SupportedLanguage.typescriptreact]: [SupportedLanguage.typescript, SupportedLanguage.javascript],
 }

--- a/agent/src/cli/evaluate-autocomplete/strategy-bfg.ts
+++ b/agent/src/cli/evaluate-autocomplete/strategy-bfg.ts
@@ -4,7 +4,7 @@ import * as fspromises from 'fs/promises'
 
 import * as vscode from 'vscode'
 
-import { getParseLanguage } from '../../../../vscode/src/tree-sitter/grammars'
+import { isSupportedLanguage } from '../../../../vscode/src/tree-sitter/grammars'
 import type { MessageHandler } from '../../jsonrpc-alias'
 import { getLanguageForFileName } from '../../language'
 
@@ -56,8 +56,7 @@ export async function evaluateBfgStrategy(
             }
             const content = (await fspromises.readFile(filePath)).toString()
             const languageid = getLanguageForFileName(file)
-            const language = getParseLanguage(languageid)
-            if (!language) {
+            if (!isSupportedLanguage(languageid)) {
                 continue
             }
             if (

--- a/agent/src/cli/evaluate-autocomplete/testParse.test.ts
+++ b/agent/src/cli/evaluate-autocomplete/testParse.test.ts
@@ -9,37 +9,37 @@ import { testParses } from './testParse'
 
 const tests: { language: SupportedLanguage; okText: string; errorText: string }[] = [
     {
-        language: SupportedLanguage.TypeScript,
+        language: SupportedLanguage.typescript,
         okText: 'const x = 42\n',
         errorText: 'const x =\n',
     },
     {
-        language: SupportedLanguage.Go,
+        language: SupportedLanguage.go,
         okText: 'type Person struct {\n\tName string\n}\n',
         errorText: 'type Person struct {\n',
     },
     {
-        language: SupportedLanguage.Java,
+        language: SupportedLanguage.java,
         okText: 'class Foo {}\n',
         errorText: 'class Foo {\n',
     },
     {
-        language: SupportedLanguage.Python,
+        language: SupportedLanguage.python,
         okText: 'def foo():\n    pass\n',
         errorText: 'def foo(\n',
     },
     {
-        language: SupportedLanguage.Cpp,
+        language: SupportedLanguage.cpp,
         okText: 'int main() {\n\treturn 0;\n}\n',
         errorText: 'int main() {\n',
     },
     {
-        language: SupportedLanguage.CSharp,
+        language: SupportedLanguage.csharp,
         okText: 'class Foo {\n\tpublic void Bar() {}\n}\n',
         errorText: 'class Foo {\n',
     },
     {
-        language: SupportedLanguage.Php,
+        language: SupportedLanguage.php,
         okText: '<?php\nfunction foo() {\n\treturn 0;\n}\n',
         errorText: '<?php\nfunction foo() {\n',
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
       socks-proxy-agent:
         specifier: ^8.0.1
         version: 8.0.1
+      tree-sitter-wasms:
+        specifier: ^0.1.7
+        version: 0.1.7
       unzipper:
         specifier: ^0.10.14
         version: 0.10.14
@@ -363,8 +366,8 @@ importers:
         specifier: ^3.0.7
         version: 3.0.7
       web-tree-sitter:
-        specifier: ^0.20.8
-        version: 0.20.8
+        specifier: ^0.21.0
+        version: 0.21.0
       wink-nlp-utils:
         specifier: ^2.1.0
         version: 2.1.0
@@ -13627,6 +13630,10 @@ packages:
     hasBin: true
     dev: true
 
+  /tree-sitter-wasms@0.1.7:
+    resolution: {integrity: sha512-/EnmSDDqEnSnIuCqVhSOc14T8r792LmiztqlZMFSRg+4ACrgUWNLvEr2AUP1K76XCJrvuH8liSWfkdQpK41hIA==}
+    dev: false
+
   /trim-newlines@4.1.1:
     resolution: {integrity: sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==}
     engines: {node: '>=12'}
@@ -14208,8 +14215,8 @@ packages:
       defaults: 1.0.4
     dev: true
 
-  /web-tree-sitter@0.20.8:
-    resolution: {integrity: sha512-weOVgZ3aAARgdnb220GqYuh7+rZU0Ka9k9yfKtGAzEYMa6GgiCzW9JjQRJyCJakvibQW+dfjJdihjInKuuCAUQ==}
+  /web-tree-sitter@0.21.0:
+    resolution: {integrity: sha512-iJ+QJ6ikN9D9cG7Kh6q3KtAstYFUQbYZ8OjuPEJYWfj2kLrmp5I3C2n6WjE1Y3jvj7nJbkcrJytJGWUEhCxn+g==}
     dev: false
 
   /webidl-conversions@3.0.1:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1152,11 +1152,12 @@
     "mkdirp": "^3.0.1",
     "os-browserify": "^0.3.0",
     "socks-proxy-agent": "^8.0.1",
+    "tree-sitter-wasms": "^0.1.7",
     "unzipper": "^0.10.14",
     "uuid": "^9.0.0",
     "vscode-languageserver-textdocument": "^1.0.8",
     "vscode-uri": "^3.0.7",
-    "web-tree-sitter": "^0.20.8",
+    "web-tree-sitter": "^0.21.0",
     "wink-nlp-utils": "^2.1.0"
   },
   "devDependencies": {

--- a/vscode/scripts/download-wasm-modules.ts
+++ b/vscode/scripts/download-wasm-modules.ts
@@ -1,8 +1,5 @@
-import fs, { copyFileSync, existsSync, mkdirSync, readdirSync, type WriteStream } from 'fs'
-import http from 'https'
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'fs'
 import path from 'path'
-
-import ProgressBar from 'progress'
 
 const DIST_DIRECTORY = path.join(__dirname, '../dist')
 const WASM_DIRECTORY = path.join(__dirname, '../resources/wasm')
@@ -14,21 +11,8 @@ const WASM_DIRECTORY = path.join(__dirname, '../resources/wasm')
 // https://github.com/tree-sitter/tree-sitter/discussions/1680
 const TREE_SITTER_WASM_FILE = 'tree-sitter.wasm'
 const TREE_SITTER_WASM_PATH = require.resolve(`web-tree-sitter/${TREE_SITTER_WASM_FILE}`)
-
-const urls = [
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-javascript.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-typescript.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-tsx.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-c_sharp.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-cpp.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-go.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-python.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-ruby.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-rust.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-java.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-dart.wasm',
-    'https://storage.googleapis.com/sourcegraph-assets/cody-wasm/tree-sitter-php.wasm',
-]
+const JS_GRAMMAR_PATH = require.resolve('tree-sitter-wasms/out/tree-sitter-javascript.wasm')
+const GRAMMARS_PATH = path.dirname(JS_GRAMMAR_PATH)
 
 export async function main(): Promise<void> {
     const hasStoreDir = existsSync(WASM_DIRECTORY)
@@ -37,23 +21,7 @@ export async function main(): Promise<void> {
         mkdirSync(WASM_DIRECTORY)
     }
 
-    const filesToDownload = getMissingFiles(urls)
-
-    if (filesToDownload.length === 0) {
-        copyFilesToDistDir()
-        console.log('All wasm modules are in place, have a good day!')
-        return
-    }
-
-    console.log(`We are missing ${filesToDownload.length} files.`)
-
     try {
-        await Promise.all(filesToDownload.map(downloadFile))
-
-        // HACK(sqs): Wait for files to be written. Otherwise sometimes the files are copied before
-        // they are complete, which causes failures in AutocompleteMatcher.test.ts.
-        await new Promise(resolve => setTimeout(resolve, 500))
-
         copyFilesToDistDir()
         console.log('All files were successful downloaded, check resources/wasm directory')
     } catch (error) {
@@ -71,62 +39,14 @@ function copyFilesToDistDir(): void {
         mkdirSync(DIST_DIRECTORY)
     }
 
-    const files = readdirSync(WASM_DIRECTORY)
+    const files = readdirSync(GRAMMARS_PATH)
 
     for (const file of files) {
-        copyFileSync(path.join(WASM_DIRECTORY, file), path.join(DIST_DIRECTORY, file))
+        const grammarFilePath = path.join(GRAMMARS_PATH, file)
+
+        copyFileSync(grammarFilePath, path.join(WASM_DIRECTORY, file))
+        copyFileSync(grammarFilePath, path.join(DIST_DIRECTORY, file))
     }
 
     copyFileSync(TREE_SITTER_WASM_PATH, path.join(DIST_DIRECTORY, TREE_SITTER_WASM_FILE))
-}
-
-function getMissingFiles(urls: string[]): string[] {
-    const missingFiles = []
-
-    for (const url of urls) {
-        const filePath = getFilePathFromURL(url)
-        if (!existsSync(path.resolve(WASM_DIRECTORY, filePath))) {
-            missingFiles.push(url)
-        }
-    }
-
-    return missingFiles
-}
-
-function getFilePathFromURL(url: string): string {
-    const parts = url.split('/')
-    return parts.at(-1)!
-}
-
-function downloadFile(url: string): Promise<WriteStream> {
-    const fileName = getFilePathFromURL(url)
-
-    const file = fs.createWriteStream(path.join(WASM_DIRECTORY, fileName))
-
-    return new Promise((resolve, reject) => {
-        http.get(url).on('response', res => {
-            const contentLength = res.headers?.['content-length'] ?? '0'
-            const totalLength = parseInt(contentLength, 10)
-
-            const progress = new ProgressBar(`-> ${fileName} [:bar] :rate/bps :percent :etas`, {
-                width: 40,
-                complete: '=',
-                incomplete: ' ',
-                renderThrottle: 1,
-                total: totalLength,
-            })
-
-            res.on('data', (chunk): void => {
-                file.write(chunk)
-                progress.tick(chunk.length)
-            })
-                .on('end', () => {
-                    resolve(file.end())
-                })
-                .on('error', err => {
-                    console.log('\n')
-                    reject(err)
-                })
-        })
-    })
 }

--- a/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/multiline-truncation.test.ts
@@ -18,7 +18,7 @@ for (const isTreeSitterEnabled of cases) {
         describe('python', () => {
             beforeAll(async () => {
                 if (isTreeSitterEnabled) {
-                    await initTreeSitterParser(SupportedLanguage.Python)
+                    await initTreeSitterParser(SupportedLanguage.python)
                 }
             })
 

--- a/vscode/src/completions/get-inline-completions-tests/post-processing.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/post-processing.test.ts
@@ -195,7 +195,7 @@ for (const isTreeSitterEnabled of cases) {
             it('adds parse info to single-line completions', async () => {
                 const completions = await getCompletionItems('function sort(█', [
                     'array) {}',
-                    'array) new',
+                    'array new',
                 ])
 
                 expect(completions.map(c => Boolean(c.parseErrorCount))).toEqual([false, true])
@@ -204,7 +204,7 @@ for (const isTreeSitterEnabled of cases) {
             it('respects completion insert ranges', async () => {
                 const completions = await getCompletionItems('function sort(█)', [
                     'array) {}',
-                    'array) new',
+                    'array new',
                 ])
 
                 expect(completions.map(c => Boolean(c.parseErrorCount))).toEqual([false, true])

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -121,7 +121,7 @@ describe('InlineCompletionItemProvider', () => {
             const { document, position } = documentAndPosition('// █', 'typescript')
 
             await initTreeSitterParser()
-            const parser = getParser(SupportedLanguage.TypeScript)
+            const parser = getParser(SupportedLanguage.typescript)
             if (parser) {
                 updateParseTreeCache(document, parser)
             }

--- a/vscode/src/completions/text-processing/truncate-parsed-completion.ts
+++ b/vscode/src/completions/text-processing/truncate-parsed-completion.ts
@@ -64,6 +64,7 @@ export function truncateParsedCompletion(context: CompletionContext): TruncatePa
     addAutocompleteDebugEvent('truncate', {
         currentLinePrefix: docContext.currentLinePrefix,
         text: insertText,
+        position: points.trigger || points.start,
     })
 
     let fixedCompletion = completion
@@ -90,7 +91,9 @@ export function truncateParsedCompletion(context: CompletionContext): TruncatePa
     )
 
     let textToInsert =
-        nodeToInsert?.id === fixedCompletion.tree!.rootNode.id ? 'root' : nodeToInsert?.text
+        nodeToInsert?.grammarId === fixedCompletion.tree!.rootNode.grammarId
+            ? 'root'
+            : nodeToInsert?.text
     if (textToInsert && document.getText().endsWith(textToInsert.slice(-100))) {
         textToInsert = 'till the end of the document'
     }
@@ -124,7 +127,7 @@ export function findLastAncestorOnTheSameRow(root: SyntaxNode, position: Point):
 
     while (
         current?.parent?.startPosition.row === initial?.startPosition.row &&
-        current.parent.id !== root.id
+        current.parent.grammarId !== root.grammarId
     ) {
         current = current.parent
     }

--- a/vscode/src/tree-sitter/grammars.ts
+++ b/vscode/src/tree-sitter/grammars.ts
@@ -7,23 +7,73 @@
  * TODO: Decouple language detect to make it editor agnostic
  */
 export enum SupportedLanguage {
-    JavaScript = 'javascript',
-    JSX = 'javascriptreact',
-    TypeScript = 'typescript',
-    TSX = 'typescriptreact',
-    Java = 'java',
-    Go = 'go',
-    Python = 'python',
-    Dart = 'dart',
-    Cpp = 'cpp',
-    CSharp = 'csharp',
-    Php = 'php',
+    'objective-c' = 'objective-c',
+    c = 'c',
+    cpp = 'cpp',
+    csharp = 'csharp',
+    css = 'css',
+    elixir = 'elixir',
+    elm = 'elm',
+    go = 'go',
+    html = 'html',
+    java = 'java',
+    javascript = 'javascript',
+    javascriptreact = 'javascriptreact',
+    json = 'json',
+    kotlin = 'kotlin',
+    elisp = 'elisp',
+    lua = 'lua',
+    ocaml = 'ocaml',
+    php = 'php',
+    python = 'python',
+    rescript = 'rescript',
+    ruby = 'ruby',
+    rust = 'rust',
+    scala = 'scala',
+    shellscript = 'bash',
+    swift = 'swift',
+    toml = 'toml',
+    typescript = 'typescript',
+    typescriptreact = 'typescriptreact',
+    vue = 'vue',
+    yaml = 'yaml',
 }
 
-export const getParseLanguage = (languageId: string): SupportedLanguage | null => {
-    const matchedLang = Object.entries(SupportedLanguage).find(
-        ([key, value]) => value === (languageId as SupportedLanguage)
-    )
+export const DOCUMENT_LANGUAGE_TO_GRAMMAR = {
+    [SupportedLanguage['objective-c']]: 'tree-sitter-objc.wasm',
+    [SupportedLanguage.c]: 'tree-sitter-c.wasm',
+    [SupportedLanguage.cpp]: 'tree-sitter-cpp.wasm',
+    [SupportedLanguage.csharp]: 'tree-sitter-c_sharp.wasm',
+    [SupportedLanguage.css]: 'tree-sitter-css.wasm',
+    [SupportedLanguage.elisp]: 'tree-sitter-elisp.wasm',
+    [SupportedLanguage.elixir]: 'tree-sitter-elixir.wasm',
+    [SupportedLanguage.elm]: 'tree-sitter-elm.wasm',
+    [SupportedLanguage.go]: 'tree-sitter-go.wasm',
+    [SupportedLanguage.html]: 'tree-sitter-html.wasm',
+    [SupportedLanguage.java]: 'tree-sitter-java.wasm',
+    [SupportedLanguage.javascript]: 'tree-sitter-javascript.wasm',
+    [SupportedLanguage.javascriptreact]: 'tree-sitter-javascript.wasm',
+    [SupportedLanguage.json]: 'tree-sitter-json.wasm',
+    [SupportedLanguage.kotlin]: 'tree-sitter-kotlin.wasm',
+    [SupportedLanguage.lua]: 'tree-sitter-lua.wasm',
+    [SupportedLanguage.ocaml]: 'tree-sitter-ocaml.wasm',
+    [SupportedLanguage.php]: 'tree-sitter-php.wasm',
+    [SupportedLanguage.python]: 'tree-sitter-python.wasm',
+    [SupportedLanguage.rescript]: 'tree-sitter-rescript.wasm',
+    [SupportedLanguage.ruby]: 'tree-sitter-ruby.wasm',
+    [SupportedLanguage.rust]: 'tree-sitter-rust.wasm',
+    [SupportedLanguage.scala]: 'tree-sitter-scala.wasm',
+    [SupportedLanguage.shellscript]: 'tree-sitter-bash.wasm',
+    [SupportedLanguage.swift]: 'tree-sitter-swift.wasm',
+    [SupportedLanguage.toml]: 'tree-sitter-toml.wasm',
+    [SupportedLanguage.typescript]: 'tree-sitter-typescript.wasm',
+    [SupportedLanguage.typescriptreact]: 'tree-sitter-tsx.wasm',
+    [SupportedLanguage.vue]: 'tree-sitter-vue.wasm',
+    [SupportedLanguage.yaml]: 'tree-sitter-yaml.wasm',
+} as const
 
-    return matchedLang ? (languageId as SupportedLanguage) : null
+export const isSupportedLanguage = (
+    documentLanguageId: string
+): documentLanguageId is SupportedLanguage => {
+    return documentLanguageId in SupportedLanguage
 }

--- a/vscode/src/tree-sitter/grammars.ts
+++ b/vscode/src/tree-sitter/grammars.ts
@@ -39,7 +39,7 @@ export enum SupportedLanguage {
     yaml = 'yaml',
 }
 
-export const DOCUMENT_LANGUAGE_TO_GRAMMAR = {
+export const DOCUMENT_LANGUAGE_TO_GRAMMAR: Record<SupportedLanguage, string> = {
     [SupportedLanguage['objective-c']]: 'tree-sitter-objc.wasm',
     [SupportedLanguage.c]: 'tree-sitter-c.wasm',
     [SupportedLanguage.cpp]: 'tree-sitter-cpp.wasm',

--- a/vscode/src/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/tree-sitter/parse-tree-cache.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import type { TextDocument } from 'vscode'
 import type { Tree, default as Parser } from 'web-tree-sitter'
 
-import { type SupportedLanguage, getParseLanguage } from './grammars'
+import { type SupportedLanguage, isSupportedLanguage } from './grammars'
 import { createParser, getParser } from './parser'
 
 const parseTreesPerFile = new LRUCache<string, Tree>({
@@ -55,7 +55,7 @@ export function updateParseTreeCache(document: TextDocument, parser: Parser): vo
 }
 
 function getLanguageIfTreeSitterEnabled(document: TextDocument): SupportedLanguage | null {
-    const parseLanguage = getParseLanguage(document.languageId)
+    const { languageId } = document
 
     /**
      * 1. Do not use tree-sitter for unsupported languages.
@@ -65,8 +65,8 @@ function getLanguageIfTreeSitterEnabled(document: TextDocument): SupportedLangua
      *
      *    Needs more testing to figure out if we need it. Playing it safe for the initial integration.
      */
-    if (document.lineCount <= 10_000 && parseLanguage) {
-        return parseLanguage
+    if (document.lineCount <= 10_000 && isSupportedLanguage(languageId)) {
+        return languageId
     }
 
     return null

--- a/vscode/src/tree-sitter/parser.ts
+++ b/vscode/src/tree-sitter/parser.ts
@@ -3,12 +3,12 @@ import path from 'path'
 import * as vscode from 'vscode'
 import type Parser from 'web-tree-sitter'
 
-import { SupportedLanguage } from './grammars'
+import { DOCUMENT_LANGUAGE_TO_GRAMMAR, type SupportedLanguage } from './grammars'
 import { initQueries } from './query-sdk'
 const ParserImpl = require('web-tree-sitter') as typeof Parser
 
 /*
- * Loading wasm grammar and creation parser instance everytime we trigger
+ * Loading wasm grammar and creation parser instance every time we trigger
  * pre- and post-process might be a performance problem, so we create instance
  * and load language grammar only once, first time we need parser for a specific
  * language, next time we read it from this cache.
@@ -53,7 +53,7 @@ export async function createParser(settings: ParserSettings): Promise<Parser | u
         return cachedParser
     }
 
-    const wasmPath = path.resolve(grammarDirectory, SUPPORTED_LANGUAGES[language])
+    const wasmPath = path.resolve(grammarDirectory, DOCUMENT_LANGUAGE_TO_GRAMMAR[language])
     if (!(await isRegularFile(vscode.Uri.file(wasmPath)))) {
         return undefined
     }
@@ -64,35 +64,12 @@ export async function createParser(settings: ParserSettings): Promise<Parser | u
     const languageGrammar = await ParserImpl.Language.load(wasmPath)
 
     parser.setLanguage(languageGrammar)
+    // stop parsing after 50ms to avoid infinite loops
+    // if that happens, tree-sitter throws an error so we can catch and address it
+    parser.setTimeoutMicros(50_000)
     PARSERS_LOCAL_CACHE[language] = parser
 
     initQueries(languageGrammar, language, parser)
 
     return parser
-}
-
-// TODO: Add grammar type autogenerate script
-// see https://github.com/asgerf/dts-tree-sitter
-type GrammarPath = string
-
-/**
- * Map language to wasm grammar path modules, usually we would have
- * used node bindings for grammar packages, but since VSCode editor
- * runtime doesn't support this we have to work with wasm modules.
- *
- * Note: make sure that dist folder contains these modules when you
- * run VSCode extension.
- */
-const SUPPORTED_LANGUAGES: Record<SupportedLanguage, GrammarPath> = {
-    [SupportedLanguage.JavaScript]: 'tree-sitter-javascript.wasm',
-    [SupportedLanguage.JSX]: 'tree-sitter-javascript.wasm',
-    [SupportedLanguage.TypeScript]: 'tree-sitter-typescript.wasm',
-    [SupportedLanguage.TSX]: 'tree-sitter-tsx.wasm',
-    [SupportedLanguage.Java]: 'tree-sitter-java.wasm',
-    [SupportedLanguage.Go]: 'tree-sitter-go.wasm',
-    [SupportedLanguage.Python]: 'tree-sitter-python.wasm',
-    [SupportedLanguage.Dart]: 'tree-sitter-dart.wasm',
-    [SupportedLanguage.Cpp]: 'tree-sitter-cpp.wasm',
-    [SupportedLanguage.CSharp]: 'tree-sitter-c_sharp.wasm',
-    [SupportedLanguage.Php]: 'tree-sitter-php.wasm',
 }

--- a/vscode/src/tree-sitter/queries/go.ts
+++ b/vscode/src/tree-sitter/queries/go.ts
@@ -4,7 +4,7 @@ import { SupportedLanguage } from '../grammars'
 import type { QueryName } from '../queries'
 
 export const goQueries = {
-    [SupportedLanguage.Go]: {
+    [SupportedLanguage.go]: {
         singlelineTriggers: dedent`
             (struct_type (field_declaration_list ("{") @block_start)) @trigger
             (interface_type ("{") @block_start) @trigger

--- a/vscode/src/tree-sitter/queries/javascript.ts
+++ b/vscode/src/tree-sitter/queries/javascript.ts
@@ -26,7 +26,7 @@ const JS_INTENTS_QUERY = dedent`
         parameters: (formal_parameters ("(") @function.parameters.cursor) @function.parameters
         body: (statement_block ("{") @function.body.cursor) @function.body)
 
-    (function
+    (function_expression
         name: (identifier) @function.name!
         parameters: (formal_parameters ("(") @function.parameters.cursor) @function.parameters
         body: (statement_block ("{") @function.body.cursor) @function.body)
@@ -107,7 +107,7 @@ const TS_INTENTS_QUERY = dedent`
 
     (interface_declaration
         name: (type_identifier) @type_declaration.name!
-        body: (object_type ("{") @type_declaration.body.cursor) @type_declaration.body)
+        body: (interface_body ("{") @type_declaration.body.cursor) @type_declaration.body)
 
     (type_alias_declaration
         name: (type_identifier) @type_declaration.name!
@@ -121,7 +121,7 @@ const TSX_INTENTS_QUERY = dedent`
 `
 
 const TS_SINGLELINE_TRIGGERS_QUERY = dedent`
-    (interface_declaration (object_type ("{") @block_start)) @trigger
+    (interface_declaration (interface_body ("{") @block_start)) @trigger
     (type_alias_declaration (object_type ("{") @block_start)) @trigger
 `
 
@@ -155,11 +155,11 @@ const TS_DOCUMENTABLE_NODES_QUERY = dedent`
     ;--------------------------------
     ((call_signature) @signature)
     (interface_declaration
-        (object_type
+        (interface_body
             (property_signature
                 name: (property_identifier) @signature.property)))
     (interface_declaration
-        (object_type
+        (interface_body
             (method_signature
                 name: (property_identifier) @signature.property)))
     (type_alias_declaration
@@ -169,22 +169,22 @@ const TS_DOCUMENTABLE_NODES_QUERY = dedent`
 `
 
 export const javascriptQueries = {
-    [SupportedLanguage.JavaScript]: {
+    [SupportedLanguage.javascript]: {
         singlelineTriggers: '',
         intents: JS_INTENTS_QUERY,
         documentableNodes: JS_DOCUMENTABLE_NODES_QUERY,
     },
-    [SupportedLanguage.JSX]: {
+    [SupportedLanguage.javascriptreact]: {
         singlelineTriggers: '',
         intents: JSX_INTENTS_QUERY,
         documentableNodes: JS_DOCUMENTABLE_NODES_QUERY,
     },
-    [SupportedLanguage.TypeScript]: {
+    [SupportedLanguage.typescript]: {
         singlelineTriggers: TS_SINGLELINE_TRIGGERS_QUERY,
         intents: TS_INTENTS_QUERY,
         documentableNodes: TS_DOCUMENTABLE_NODES_QUERY,
     },
-    [SupportedLanguage.TSX]: {
+    [SupportedLanguage.typescriptreact]: {
         singlelineTriggers: TS_SINGLELINE_TRIGGERS_QUERY,
         intents: TSX_INTENTS_QUERY,
         documentableNodes: TS_DOCUMENTABLE_NODES_QUERY,

--- a/vscode/src/tree-sitter/queries/python.ts
+++ b/vscode/src/tree-sitter/queries/python.ts
@@ -4,7 +4,7 @@ import { SupportedLanguage } from '../grammars'
 import type { QueryName } from '../queries'
 
 export const pythonQueries = {
-    [SupportedLanguage.Python]: {
+    [SupportedLanguage.python]: {
         singlelineTriggers: '',
         intents: dedent`
             ; Cursor dependent intents

--- a/vscode/src/tree-sitter/query-sdk.test.ts
+++ b/vscode/src/tree-sitter/query-sdk.test.ts
@@ -28,7 +28,7 @@ describe('getDocumentQuerySDK', () => {
         expect(sdk?.queries.intents).toBeTruthy()
     })
 
-    it.only.each([
+    it.each([
         { languageId: SupportedLanguage.csharp },
         { languageId: SupportedLanguage.cpp },
         { languageId: SupportedLanguage.csharp },

--- a/vscode/src/tree-sitter/query-sdk.test.ts
+++ b/vscode/src/tree-sitter/query-sdk.test.ts
@@ -11,12 +11,12 @@ describe('getDocumentQuerySDK', () => {
     })
 
     it.each([
-        { languageId: SupportedLanguage.JavaScript },
-        { languageId: SupportedLanguage.TypeScript },
-        { languageId: SupportedLanguage.JSX },
-        { languageId: SupportedLanguage.TSX },
-        { languageId: SupportedLanguage.Go },
-        { languageId: SupportedLanguage.Python },
+        { languageId: SupportedLanguage.javascript },
+        { languageId: SupportedLanguage.typescript },
+        { languageId: SupportedLanguage.javascriptreact },
+        { languageId: SupportedLanguage.typescriptreact },
+        { languageId: SupportedLanguage.go },
+        { languageId: SupportedLanguage.python },
     ])('returns valid SDK for $languageId', async ({ languageId }) => {
         const nonInitializedSDK = getDocumentQuerySDK(languageId)
         expect(nonInitializedSDK).toBeNull()
@@ -28,11 +28,11 @@ describe('getDocumentQuerySDK', () => {
         expect(sdk?.queries.intents).toBeTruthy()
     })
 
-    it.each([
-        { languageId: SupportedLanguage.CSharp },
-        { languageId: SupportedLanguage.Cpp },
-        { languageId: SupportedLanguage.Dart },
-        { languageId: SupportedLanguage.Php },
+    it.only.each([
+        { languageId: SupportedLanguage.csharp },
+        { languageId: SupportedLanguage.cpp },
+        { languageId: SupportedLanguage.csharp },
+        { languageId: SupportedLanguage.php },
     ])('returns null for $languageId because queries are not defined', async ({ languageId }) => {
         const nonInitializedSDK = getDocumentQuerySDK(languageId)
         expect(nonInitializedSDK).toBeNull()

--- a/vscode/src/tree-sitter/query-sdk.ts
+++ b/vscode/src/tree-sitter/query-sdk.ts
@@ -9,7 +9,7 @@ import type {
     default as Parser,
 } from 'web-tree-sitter'
 
-import { type SupportedLanguage, getParseLanguage } from './grammars'
+import { type SupportedLanguage, isSupportedLanguage } from './grammars'
 import { getCachedParseTreeForDocument } from './parse-tree-cache'
 import { getParser } from './parser'
 import { type CompletionIntent, type QueryName, intentPriority, languages } from './queries'
@@ -65,16 +65,15 @@ export interface DocumentQuerySDK {
 
 /**
  * Returns the query SDK only if the language has queries defined and
- * the relevant laguage parser is initialized.
+ * the relevant language parser is initialized.
  */
 export function getDocumentQuerySDK(language: string): DocumentQuerySDK | null {
-    const supportedLanguage = getParseLanguage(language)
-    if (!supportedLanguage) {
+    if (!isSupportedLanguage(language)) {
         return null
     }
 
-    const parser = getParser(supportedLanguage)
-    const queries = QUERIES_LOCAL_CACHE[supportedLanguage]
+    const parser = getParser(language)
+    const queries = QUERIES_LOCAL_CACHE[language]
 
     if (!parser || !queries) {
         return null
@@ -83,7 +82,7 @@ export function getDocumentQuerySDK(language: string): DocumentQuerySDK | null {
     return {
         parser,
         queries,
-        language: supportedLanguage,
+        language,
     }
 }
 
@@ -344,7 +343,7 @@ export function execQueryWrapper<T extends keyof QueryWrappers>(
     queryWrapper: T
 ): ReturnType<QueryWrappers[T]> | never[] {
     const parseTreeCache = getCachedParseTreeForDocument(document)
-    const documentQuerySDK = getDocumentQuerySDK(document.languageId)
+    const documentQuerySDK = getDocumentQuerySDK(document.languageId as SupportedLanguage)
 
     const { startPoint, endPoint } = positionToQueryPoints(position)
 

--- a/vscode/src/tree-sitter/query-tests/annotate-and-match-snapshot.ts
+++ b/vscode/src/tree-sitter/query-tests/annotate-and-match-snapshot.ts
@@ -133,6 +133,7 @@ function annotateSnippets(params: AnnotateSnippetsParams): string {
     const tree = parser.parse(linesWithoutCursorComment.join('\n'))
     const capturedNodes = captures(tree.rootNode, caretPoint, {
         ...caretPoint,
+        row: caretPoint.row + 1,
         column: caretPoint.column + 1,
     })
 
@@ -205,7 +206,7 @@ function annotateSnippets(params: AnnotateSnippetsParams): string {
 
     let annotatedCodeSnippet = result.filter(line => !isCursorPositionLine(line, delimiter)).join('\n')
 
-    // Add extra line betwee the annotated code and node types annotations if needed.
+    // Add extra line between the annotated code and node types annotations if needed.
     if (!annotatedCodeSnippet.endsWith('\n\n')) {
         annotatedCodeSnippet += '\n'
     }
@@ -245,7 +246,7 @@ export async function annotateAndMatchSnapshot(params: AnnotateAndMatchParams): 
     // Get the source code and split into snippets.
     const code = fs.readFileSync(path.join(__dirname, sourcesPath), 'utf8')
     // Queries are used on specific parts of the source code (e.g., range of the inserted multiline completion).
-    // Snippets are required to mimick such behavior and test the order of returned captures.
+    // Snippets are required to mimic such behavior and test the order of returned captures.
     const snippets = code.split(separator)
     // Support "// only" to focus on one code sample at a time
     const onlySnippet = findLast(snippets, snippet => snippet.startsWith(`${delimiter} only`))

--- a/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
+++ b/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { SupportedLanguage } from '../grammars'
 import { initTreeSitterSDK } from '../test-helpers'
 
+import { SupportedLanguage } from '../grammars'
 import { annotateAndMatchSnapshot } from './annotate-and-match-snapshot'
 
 describe('getDocumentableNode', () => {
     it('typescript', async () => {
-        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.TypeScript)
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.typescript)
 
         await annotateAndMatchSnapshot({
             parser,

--- a/vscode/src/tree-sitter/query-tests/intents.test.ts
+++ b/vscode/src/tree-sitter/query-tests/intents.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'vitest'
 
-import { SupportedLanguage } from '../grammars'
 import { initTreeSitterSDK } from '../test-helpers'
 
+import { SupportedLanguage } from '../grammars'
 import { annotateAndMatchSnapshot } from './annotate-and-match-snapshot'
 
 describe('getIntent', () => {
     it('typescript', async () => {
-        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.TypeScript)
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.typescript)
 
         await annotateAndMatchSnapshot({
             parser,
@@ -18,7 +18,7 @@ describe('getIntent', () => {
     })
 
     it('typescript incomplete code', async () => {
-        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.TypeScript)
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.typescript)
 
         await annotateAndMatchSnapshot({
             parser,
@@ -29,7 +29,7 @@ describe('getIntent', () => {
     })
 
     it('javascriptreact', async () => {
-        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.JSX)
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.javascriptreact)
 
         await annotateAndMatchSnapshot({
             parser,
@@ -40,7 +40,7 @@ describe('getIntent', () => {
     })
 
     it('typescriptreact', async () => {
-        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.TSX)
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.typescriptreact)
 
         await annotateAndMatchSnapshot({
             parser,
@@ -51,7 +51,7 @@ describe('getIntent', () => {
     })
 
     it('python', async () => {
-        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.Python)
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.python)
 
         await annotateAndMatchSnapshot({
             parser,

--- a/vscode/src/tree-sitter/query-tests/node-at-cursor-and-parents.test.ts
+++ b/vscode/src/tree-sitter/query-tests/node-at-cursor-and-parents.test.ts
@@ -9,11 +9,11 @@ import { annotateAndMatchSnapshot } from './annotate-and-match-snapshot'
 
 describe('getNodeAtCursorAndParents', () => {
     beforeAll(async () => {
-        await initTreeSitterParser(SupportedLanguage.TypeScript)
+        await initTreeSitterParser(SupportedLanguage.typescript)
     })
 
     it('typescript', async () => {
-        const { language, parser } = getDocumentQuerySDK(SupportedLanguage.TypeScript)!
+        const { language, parser } = getDocumentQuerySDK(SupportedLanguage.typescript)!
 
         await annotateAndMatchSnapshot({
             parser,

--- a/vscode/src/tree-sitter/query-tests/singleline-triggers.test.ts
+++ b/vscode/src/tree-sitter/query-tests/singleline-triggers.test.ts
@@ -8,8 +8,8 @@ import { annotateAndMatchSnapshot } from './annotate-and-match-snapshot'
 
 describe('singlelineTriggers', () => {
     it('typescript', async () => {
-        await initTreeSitterParser(SupportedLanguage.TypeScript)
-        const { language, parser, queries } = getDocumentQuerySDK(SupportedLanguage.TypeScript)!
+        await initTreeSitterParser(SupportedLanguage.typescript)
+        const { language, parser, queries } = getDocumentQuerySDK(SupportedLanguage.typescript)!
 
         await annotateAndMatchSnapshot({
             parser,
@@ -20,8 +20,8 @@ describe('singlelineTriggers', () => {
     })
 
     it('go', async () => {
-        await initTreeSitterParser(SupportedLanguage.Go)
-        const { language, parser, queries } = getDocumentQuerySDK(SupportedLanguage.Go)!
+        await initTreeSitterParser(SupportedLanguage.go)
+        const { language, parser, queries } = getDocumentQuerySDK(SupportedLanguage.go)!
 
         await annotateAndMatchSnapshot({
             parser,

--- a/vscode/src/tree-sitter/query-tests/test-data/intents.snap.ts
+++ b/vscode/src/tree-sitter/query-tests/test-data/intents.snap.ts
@@ -133,7 +133,7 @@
 //^ end type_declaration.body[1]
 
 // Nodes types:
-// type_declaration.body[1]: object_type
+// type_declaration.body[1]: interface_body
 
 // ------------------------------------
 

--- a/vscode/src/tree-sitter/query-tests/test-data/parents.snap.ts
+++ b/vscode/src/tree-sitter/query-tests/test-data/parents.snap.ts
@@ -56,7 +56,7 @@
 //^ end parents[3]
 // Nodes types:
 // at_cursor[1]: {
-// parents[1]: object_type
+// parents[1]: interface_body
 // parents[2]: interface_declaration
 // parents[3]: program
 

--- a/vscode/src/tree-sitter/test-helpers.ts
+++ b/vscode/src/tree-sitter/test-helpers.ts
@@ -12,7 +12,7 @@ const CUSTOM_WASM_LANGUAGE_DIR = path.join(__dirname, '../../resources/wasm')
  * Should be used in tests only.
  */
 export function initTreeSitterParser(
-    language = SupportedLanguage.TypeScript
+    language = SupportedLanguage.typescript
 ): Promise<Parser | undefined> {
     return createParser({
         language,
@@ -24,7 +24,7 @@ export function initTreeSitterParser(
  * Should be used in tests only.
  */
 export async function initTreeSitterSDK(
-    language = SupportedLanguage.TypeScript
+    language = SupportedLanguage.typescript
 ): Promise<DocumentQuerySDK> {
     await initTreeSitterParser(language)
     const sdk = getDocumentQuerySDK(language)


### PR DESCRIPTION
## Context

- Upgrade tree-sitter from `0.20.8` to `0.21.0` and update the code based on breaking changes.
- Migrate from custom S3-hosted grammars to the latest grammars from `npm` via [tree-sitter-wasms](https://github.com/Gregoor/tree-sitter-wasms). This expands the tree-sitter language support and improves grammars error tolerance.
    - Follow-up issue https://github.com/sourcegraph/cody/issues/3374
- Add timeout to the tree-sitter parse method to avoid freezing users' editor instances in case of unexpected errors.
- Refactor how tree-sitter edits are calculated to paste completions into the existing document. This fixes the issue described in [the Slack thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1709892644622649?thread_ts=1709891165.036869&cid=C05AGQYD528).
- Updated the `SupportedLanguage` enum to keep all keys and values equal to the possible `document.languageId` values.

## Test plan

- I could not repro the infinite loop parsing issue in our integration tests environment.
- CI and manual tests from [the Slack thread](https://sourcegraph.slack.com/archives/C05AGQYD528/p1709892644622649?thread_ts=1709891165.036869&cid=C05AGQYD528).
