### PR TITLE
context ranker: adding sentence transformer embeddings as a context r…

### DIFF
--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -67,6 +67,9 @@ export enum ContextItemSource {
 
     /** Output from the terminal */
     Terminal = 'terminal',
+
+    /** Embeddings from the sentence transformers */
+    RankerSentenceTransformerEmbedding = 'ranker-sentence-transformer-embedding',
 }
 
 /**

--- a/vscode/src/jsonrpc/context-ranking-protocol.ts
+++ b/vscode/src/jsonrpc/context-ranking-protocol.ts
@@ -1,3 +1,5 @@
+import { QueryResultSet } from './embeddings-protocol'
+
 interface InitializeParams {
     indexPath: string
     accessToken: string
@@ -8,7 +10,7 @@ interface ComputeFeaturesParams {
 }
 
 export interface RankContextItem {
-    document_id: number
+    documentId: number
     filePath?: string
     content: string
     source?: string
@@ -25,9 +27,15 @@ interface RankerPredictions {
 }
 
 export interface RankerPrediction {
-    //todo: Change to camel case, when changing the protocol on bfg.
-    document_id: number
+    documentId: number
     score: number
+}
+
+export interface EmbeddingModelQueryParams {
+    repoPath: string
+    query: string
+    modelName: string
+    numResults: number
 }
 
 export type Requests = {
@@ -35,4 +43,5 @@ export type Requests = {
     'context-ranking/initialize': [InitializeParams, string]
     'context-ranking/compute-features': [ComputeFeaturesParams, string]
     'context-ranking/rank-items': [RankItemsParams, RankerPredictions]
+    'context-ranking/context-retriver-embedding': [EmbeddingModelQueryParams, QueryResultSet]
 }

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -18,7 +18,7 @@ interface QueryParams {
     query: string
 }
 
-interface QueryResultSet {
+export interface QueryResultSet {
     results: QueryResult[]
 }
 


### PR DESCRIPTION
# Context

## Features
1. Adding sentence transformer embeddings as a context retrival source. Caller can specify the type of embedding model to use as a context source.

2. Adding the support for logging which logs the ranker features, 
- Embedding health checks
- BM25 score detailed breakdown
- All possible embeddings with overlapping stats (such as # lines overlapping etc) -- can be used for offline analysis of embedding selection strategy. 
- bm25 explanations, overlapping embeddings for selection etc. 
- ranker features and final payload sent
- ranker prediction scores
- latencies such as ranker e2e latency.

3. Support for getting variable number of context items from the local embeddings

## Optimizations
1. gRPC support 
2. Adding the triton ranking client for inference
3. multi-region end point support for ranker call
4.  Pre-computing the query embedding (in parallel to fetching context from symf, local-embeddings etc.)

# Dependent PR
1. https://github.com/sourcegraph/cody/pull/3323
2. https://github.com/sourcegraph/symf-private/pull/10

# Test Plan

```
cargo test --package context-ranking
```