### PR TITLE
cody.experimental.showChatScores setting

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 nodejs 20.4.0
 pnpm 8.6.7
+yarn 1.22.10

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ConfigParams.kt
@@ -4,6 +4,7 @@ package com.sourcegraph.cody.protocol_generated
 data class ConfigParams(
   val debugEnable: Boolean? = null,
   val experimentalGuardrails: Boolean? = null,
+  val experimentalShowChatScores: Boolean? = null,
   val serverEndpoint: String? = null,
   val os: String? = null,
   val arch: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
@@ -29,6 +29,7 @@ data class ContextItemFile(
   val revision: String? = null,
   val title: String? = null,
   val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
+  val metadata: ContextItemMetadata? = null,
   val type: TypeEnum? = null, // Oneof: file
   val isTooLarge: Boolean? = null,
 ) : ContextItem() {
@@ -46,6 +47,7 @@ data class ContextItemSymbol(
   val revision: String? = null,
   val title: String? = null,
   val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
+  val metadata: ContextItemMetadata? = null,
   val type: TypeEnum? = null, // Oneof: symbol
   val symbolName: String? = null,
   val kind: SymbolKind? = null, // Oneof: class, function, method

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemMetadata.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemMetadata.kt
@@ -1,0 +1,9 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class ContextItemMetadata(
+  val expandedQuery: String? = null,
+  val blugeScore: Int? = null,
+  val otherDisplayInfo: String? = null,
+)
+

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -36,6 +36,28 @@ interface ContextItemCommon {
      * The source of this context item.
      */
     source?: ContextItemSource
+
+    metadata?: ContextItemMetadata
+}
+
+/**
+ * Metadata associated with a context item, such as an expanded search query or relevance score.
+ */
+export interface ContextItemMetadata {
+    /**
+     * The expanded keyword query that was used to generate this context item.
+     */
+    expandedQuery?: string
+
+    /**
+     * The relevance score of the context item from Bluge (bubbled up from symf)
+     */
+    blugeScore?: number
+
+    /**
+     * Other information relevant to the ranking of this context item
+     */
+    otherDisplayInfo?: string
 }
 
 /**

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -48,6 +48,7 @@ export interface Configuration {
      */
     experimentalGuardrails: boolean
     experimentalSymfContext: boolean
+    experimentalShowChatScores: boolean
     experimentalTracing: boolean
     experimentalSimpleChatContext: boolean
     experimentalChatContextRanker: boolean | undefined

--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -35,7 +35,7 @@ interface Range {
     endPoint: Point
 }
 
-export interface Result {
+export interface Result extends ResultMetadata {
     fqname: string
     name: string
     type: string
@@ -47,8 +47,26 @@ export interface Result {
     summary: string
 }
 
+export interface ResultMetadata {
+    blugeScore: number
+    blugeExplanation?: BlugeExplanation
+    heuristicBoostID?: string
+}
+
+interface BlugeExplanation {
+    value: number
+    message: string
+    children?: BlugeExplanation[]
+}
+
 export interface IndexedKeywordContextFetcher {
-    getResults(query: string, scopeDirs: URI[]): Promise<Promise<Result[]>[]>
+    getResults(
+        query: string,
+        scopeDirs: URI[]
+    ): {
+        expandedQuery: Promise<string>
+        results: Promise<Promise<Result[]>[]>
+    }
 }
 
 /**

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- New experimental flag `cody.experimental.showChatScores` that shows the search scores of chat context items when enabled.
+
 ### Fixed
 
 ### Changed

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -876,6 +876,12 @@
           "default": false,
           "markdownDescription": "Experimental feature for internal use."
         },
+        "cody.experimental.showChatScores": {
+          "order": 9,
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Experimental feature to show context scores in chat."
+        },
         "cody.chat.preInstruction": {
           "order": 6,
           "type": "string",

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -36,6 +36,7 @@ export type Config = Pick<
     | 'commandCodeLenses'
     | 'experimentalSimpleChatContext'
     | 'experimentalSymfContext'
+    | 'experimentalShowChatScores'
     | 'editorTitleCommandIcon'
     | 'internalUnstable'
     | 'experimentalChatContextRanker'
@@ -192,6 +193,7 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
                 debugEnable: this.config.debugEnable,
                 serverEndpoint: this.config.serverEndpoint,
                 experimentalGuardrails: this.config.experimentalGuardrails,
+                experimentalShowChatScores: this.config.experimentalShowChatScores,
             }
             const workspaceFolderUris =
                 vscode.workspace.workspaceFolders?.map(folder => folder.uri.toString()) ?? []

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -352,6 +352,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             debugEnable: config.debugEnable,
             serverEndpoint: config.serverEndpoint,
             experimentalGuardrails: config.experimentalGuardrails,
+            experimentalShowChatScores: config.experimentalShowChatScores,
         }
         const workspaceFolderUris =
             vscode.workspace.workspaceFolders?.map(folder => folder.uri.toString()) ?? []

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -276,7 +276,8 @@ async function searchSymf(
         // trigger background reindex if the index is stale
         void symf?.reindexIfStale(workspaceRoot)
 
-        const r0 = (await symf.getResults(userText, [workspaceRoot])).flatMap(async results => {
+        const { results, expandedQuery } = symf.getResults(userText, [workspaceRoot])
+        const r0 = (await results).flatMap(async results => {
             const items = (await results).flatMap(
                 async (result: Result): Promise<ContextItem[] | ContextItem> => {
                     const range = new vscode.Range(
@@ -299,12 +300,18 @@ async function searchSymf(
                         )
                         return []
                     }
+                    const metadata = {
+                        blugeScore: result.blugeScore,
+                        otherDisplayInfo: result.heuristicBoostID && `boost:${result.heuristicBoostID}`,
+                        expandedQuery: await expandedQuery,
+                    }
                     return {
                         type: 'file',
                         uri: result.file,
                         range,
                         source: ContextItemSource.Search,
                         content: text,
+                        metadata,
                     }
                 }
             )

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -173,7 +173,7 @@ export interface ExtensionTranscriptMessage {
 export interface ConfigurationSubsetForWebview
     extends Pick<
         ConfigurationWithAccessToken,
-        'debugEnable' | 'experimentalGuardrails' | 'serverEndpoint'
+        'debugEnable' | 'experimentalGuardrails' | 'experimentalShowChatScores' | 'serverEndpoint'
     > {}
 
 /**

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -22,6 +22,7 @@ const getVSCodeConfigurationWithAccessToken = (
     ...config,
     serverEndpoint: 'https://example.com',
     accessToken: 'foobar',
+    experimentalShowChatScores: config.experimentalShowChatScores || false,
 })
 
 const dummyCodeCompletionsClient: CodeCompletionsClient = {

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -104,6 +104,8 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.experimental.chatContextRanker':
                         return false
+                    case 'cody.experimental.showChatScores':
+                        return false
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -125,6 +127,7 @@ describe('getConfiguration', () => {
             commandCodeLenses: true,
             experimentalSimpleChatContext: true,
             experimentalSymfContext: true,
+            experimentalShowChatScores: false,
             experimentalTracing: true,
             editorTitleCommandIcon: true,
             experimentalGuardrails: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -123,6 +123,7 @@ export function getConfiguration(
         experimentalSymfContext: getHiddenSetting('experimental.symfContext', true),
 
         experimentalGuardrails: getHiddenSetting('experimental.guardrails', isTesting),
+        experimentalShowChatScores: getHiddenSetting('experimental.showChatScores', false),
         experimentalTracing: getHiddenSetting('experimental.tracing', false),
 
         experimentalOllamaChat: getHiddenSetting('experimental.ollamaChat', false),

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -311,8 +311,8 @@ export class SearchViewProvider implements vscode.WebviewViewProvider, vscode.Di
         await vscode.window.withProgress({ location: { viewId: 'cody.search' } }, async () => {
             const cumulativeResults: SearchPanelFile[] = []
             this.indexManager.showMessageIfIndexingInProgress(scopeDirs)
-            const resultSets = await symf.getResults(query, scopeDirs)
-            for (const resultSet of resultSets) {
+            const { results: resultSets } = symf.getResults(query, scopeDirs)
+            for (const resultSet of await resultSets) {
                 try {
                     cumulativeResults.push(...(await resultsToDisplayResults(await resultSet)))
                     await this.webview?.postMessage({

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -818,6 +818,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     experimentalOllamaChat: false,
     experimentalSymfContext: true,
     experimentalTracing: false,
+    experimentalShowChatScores: false,
     codeActions: true,
     commandHints: false,
     isRunningInsideAgent: false,

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -33,6 +33,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 uiKindIsWeb: false,
                 extensionVersion: '0.0.0',
                 experimentalGuardrails: false,
+                experimentalShowChatScores: false,
             },
             authStatus: {
                 ...defaultAuthStatus,

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -14,7 +14,7 @@ import {
     type SerializedChatTranscript,
 } from '@sourcegraph/cody-shared'
 import type { UserAccountInfo } from './Chat'
-import { EnhancedContextEnabled } from './chat/components/EnhancedContext'
+import { EnhancedContextEnabled, IncludeScores } from './chat/components/EnhancedContext'
 
 import type { AuthMethod, LocalEnv } from '../src/chat/protocol'
 
@@ -32,7 +32,9 @@ import { updateDisplayPathEnvInfoForWebview } from './utils/displayPathEnvInfo'
 import { createWebviewTelemetryService } from './utils/telemetry'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
-    const [config, setConfig] = useState<(Pick<Configuration, 'debugEnable'> & LocalEnv) | null>(null)
+    const [config, setConfig] = useState<
+        (Pick<Configuration, 'debugEnable' | 'experimentalShowChatScores'> & LocalEnv) | null
+    >(null)
     const [view, setView] = useState<View | undefined>()
     // If the current webview is active (vs user is working in another editor tab)
     const [isWebviewActive, setIsWebviewActive] = useState<boolean>(true)
@@ -242,29 +244,31 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         >
                             <EnhancedContextContext.Provider value={enhancedContextStatus}>
                                 <EnhancedContextEnabled.Provider value={enhancedContextEnabled}>
-                                    <Chat
-                                        chatEnabled={chatEnabled}
-                                        userInfo={userAccountInfo}
-                                        messageInProgress={messageInProgress}
-                                        messageBeingEdited={messageBeingEdited}
-                                        setMessageBeingEdited={setMessageBeingEdited}
-                                        transcript={transcript}
-                                        contextSelection={contextSelection}
-                                        setContextSelection={setContextSelection}
-                                        formInput={formInput}
-                                        setFormInput={setFormInput}
-                                        inputHistory={inputHistory}
-                                        setInputHistory={setInputHistory}
-                                        vscodeAPI={vscodeAPI}
-                                        telemetryService={telemetryService}
-                                        isTranscriptError={isTranscriptError}
-                                        chatModels={chatModels}
-                                        setChatModels={setChatModels}
-                                        welcomeMessage={getWelcomeMessageByOS(config?.os)}
-                                        guardrails={attributionEnabled ? guardrails : undefined}
-                                        chatIDHistory={chatIDHistory}
-                                        isWebviewActive={isWebviewActive}
-                                    />
+                                    <IncludeScores.Provider value={config.experimentalShowChatScores}>
+                                        <Chat
+                                            chatEnabled={chatEnabled}
+                                            userInfo={userAccountInfo}
+                                            messageInProgress={messageInProgress}
+                                            messageBeingEdited={messageBeingEdited}
+                                            setMessageBeingEdited={setMessageBeingEdited}
+                                            transcript={transcript}
+                                            contextSelection={contextSelection}
+                                            setContextSelection={setContextSelection}
+                                            formInput={formInput}
+                                            setFormInput={setFormInput}
+                                            inputHistory={inputHistory}
+                                            setInputHistory={setInputHistory}
+                                            vscodeAPI={vscodeAPI}
+                                            telemetryService={telemetryService}
+                                            isTranscriptError={isTranscriptError}
+                                            chatModels={chatModels}
+                                            setChatModels={setChatModels}
+                                            welcomeMessage={getWelcomeMessageByOS(config?.os)}
+                                            guardrails={attributionEnabled ? guardrails : undefined}
+                                            chatIDHistory={chatIDHistory}
+                                            isWebviewActive={isWebviewActive}
+                                        />
+                                    </IncludeScores.Provider>
                                 </EnhancedContextEnabled.Provider>
                             </EnhancedContextContext.Provider>
                         </EnhancedContextEventHandlers.Provider>

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -184,7 +184,6 @@ export const Transcript: React.FunctionComponent<
                         beingEdited={messageBeingEdited}
                         setBeingEdited={setMessageBeingEdited}
                         EditButtonContainer={EditButtonContainer}
-                        fileLinkComponent={fileLinkComponent}
                         codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
                         codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
                         transcriptItemClassName={transcriptItemClassName}
@@ -232,7 +231,6 @@ export const Transcript: React.FunctionComponent<
                         message={welcomeTranscriptMessage}
                         beingEdited={undefined}
                         inProgress={false}
-                        fileLinkComponent={fileLinkComponent}
                         setBeingEdited={() => {}}
                         showEditButton={false}
                         showFeedbackButtons={false}
@@ -249,7 +247,6 @@ export const Transcript: React.FunctionComponent<
                         inProgress={!!transcript[earlierMessages.length].contextFiles}
                         beingEdited={messageBeingEdited}
                         setBeingEdited={setMessageBeingEdited}
-                        fileLinkComponent={fileLinkComponent}
                         codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
                         codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
                         transcriptItemClassName={transcriptItemClassName}

--- a/vscode/webviews/chat/TranscriptItem.tsx
+++ b/vscode/webviews/chat/TranscriptItem.tsx
@@ -14,7 +14,7 @@ import type { CodeBlockActionsProps } from './CodeBlocks'
 import { BlinkingCursor, LoadingContext } from './BlinkingCursor'
 import { CodeBlocks } from './CodeBlocks'
 import { ErrorItem, RequestErrorItem } from './ErrorItem'
-import { EnhancedContext, type FileLinkProps } from './components/EnhancedContext'
+import { EnhancedContext } from './components/EnhancedContext'
 
 import styles from './TranscriptItem.module.css'
 
@@ -42,7 +42,6 @@ export const TranscriptItem: React.FunctionComponent<
         setBeingEdited: (index?: number) => void
         EditButtonContainer?: React.FunctionComponent<EditButtonProps>
         showEditButton: boolean
-        fileLinkComponent: React.FunctionComponent<FileLinkProps>
         FeedbackButtonsContainer?: React.FunctionComponent<FeedbackButtonsProps>
         feedbackButtonsOnSubmit?: (text: string) => void
         showFeedbackButtons: boolean
@@ -63,7 +62,6 @@ export const TranscriptItem: React.FunctionComponent<
     inProgress,
     beingEdited,
     setBeingEdited,
-    fileLinkComponent,
     transcriptItemClassName,
     humanTranscriptItemClassName,
     transcriptItemParticipantClassName,
@@ -164,7 +162,6 @@ export const TranscriptItem: React.FunctionComponent<
                     {message.contextFiles && message.contextFiles.length > 0 ? (
                         <EnhancedContext
                             contextFiles={message.contextFiles}
-                            fileLinkComponent={fileLinkComponent}
                             className={transcriptActionClassName}
                         />
                     ) : (

--- a/vscode/webviews/chat/components/EnhancedContext.tsx
+++ b/vscode/webviews/chat/components/EnhancedContext.tsx
@@ -4,12 +4,20 @@ import type { URI } from 'vscode-uri'
 
 import type { ContextItem, RangeData } from '@sourcegraph/cody-shared'
 
+import type { ContextItemMetadata } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { FileLink } from '../../Components/FileLink'
 import { TranscriptAction } from '../actions/TranscriptAction'
 
 export const EnhancedContextEnabled: React.Context<boolean> = React.createContext(true)
 
 export function useEnhancedContextEnabled(): boolean {
     return React.useContext(EnhancedContextEnabled)
+}
+
+export const IncludeScores: React.Context<boolean> = React.createContext(false)
+
+export function useIncludeScores(): boolean {
+    return React.useContext(IncludeScores)
 }
 
 export interface FileLinkProps {
@@ -19,13 +27,13 @@ export interface FileLinkProps {
     source?: string
     range?: RangeData
     title?: string
+    metadata?: ContextItemMetadata
 }
 
 export const EnhancedContext: React.FunctionComponent<{
     contextFiles: ContextItem[]
-    fileLinkComponent: React.FunctionComponent<FileLinkProps>
     className?: string
-}> = React.memo(function ContextFilesContent({ contextFiles, fileLinkComponent: FileLink, className }) {
+}> = React.memo(function ContextFilesContent({ contextFiles, className }) {
     if (!contextFiles.length) {
         return
     }
@@ -66,6 +74,7 @@ export const EnhancedContext: React.FunctionComponent<{
                         source={file.source}
                         range={file.range}
                         title={file.title}
+                        metadata={file.metadata}
                     />
                 ),
             }))}


### PR DESCRIPTION
Shows the search scores of chat context items when enabled. This is in preparation for adjusting the chat context engine to take better advantage of the combination of (1) symf, (2) Sourcegraph search, (3) embeddings produced by the new model, (4) the reranker (which currently keys off of embeddings and BM25 signals).

<img width="924" alt="image" src="https://github.com/sourcegraph/cody/assets/1646931/b46b6cb7-9ef5-478b-86ef-733bfffdc2a2">


## Test plan

Test locally. Should not affect regular use. When the flag is turned on, it should only modify the display of enhanced context links.