### PR TITLE
sourcegraph-api: always include anonymous UID

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -759,7 +759,8 @@ export class SourcegraphGraphQLAPIClient {
         headers.set('Content-Type', 'application/json; charset=utf-8')
         if (this.config.accessToken) {
             headers.set('Authorization', `token ${this.config.accessToken}`)
-        } else if (this.anonymousUserID) {
+        }
+        if (this.anonymousUserID) {
             headers.set('X-Sourcegraph-Actor-Anonymous-UID', this.anonymousUserID)
         }
 


### PR DESCRIPTION
Updates the condition for including `X-Sourcegraph-Actor-Anonymous-UID` to always do it, instead of only doing it on unauthenticated users.

## Test plan

n/a

