### PR TITLE
Harden the GH actions by pinning the release

### DIFF
--- a/.github/workflows/agent-bindings.yml
+++ b/.github/workflows/agent-bindings.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         id: pnpm-install
         with:
           version: 8.6.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .tool-versions
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .tool-versions
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
       - id: auth
         uses: google-github-actions/auth@v0
         # Skip auth if PR is from a fork
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .tool-versions
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
       - id: auth
         uses: google-github-actions/auth@v0
         # Skip auth if PR is from a fork
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .tool-versions
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
       - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
         shell: bash
         id: pnpm-cache

--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         id: pnpm-install
         with:
           version: 8.6.7

--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .tool-versions
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         with:
           run_install: true
       - run: pnpm build
@@ -32,7 +32,7 @@ jobs:
           VSCODE_OPENVSX_TOKEN: ${{ secrets.VSCODE_OPENVSX_TOKEN }}
       - name: Slack Notification
         if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@b24d75fe0e728a4bf9fc42ee217caa686d141ee8 # SECURITY: pin third-party action hashes
         env:
           SLACK_CHANNEL: wg-cody-vscode
           SLACK_ICON: https://github.com/sourcegraph.png?size=48

--- a/.github/workflows/vscode-stable-release.yml
+++ b/.github/workflows/vscode-stable-release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .tool-versions
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         with:
           run_install: true
       - name: get release version


### PR DESCRIPTION
This PRs pins the 3rd party GitHub actions to their release commit. This prevents potential supply chain attacks. See https://github.com/sourcegraph/security-issues/issues/377 for more information.

## Test plan
See if CI still runs as expected.

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
