### PR TITLE
more generous retries and timeouts for windows e2e tests to de-flake

### DIFF
--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -1,12 +1,14 @@
 import { defineConfig } from '@playwright/test'
 
+const isWin = process.platform.startsWith('win')
+
 export default defineConfig({
     workers: 1,
-    // Give failing tests a second chance
-    retries: 2,
+    // Give failing tests more chances
+    retries: isWin ? 4 : 2,
     testDir: 'test/e2e',
-    timeout: 20000,
+    timeout: isWin ? 30000 : 20000,
     expect: {
-        timeout: 3000,
+        timeout: isWin ? 5000 : 3000,
     },
 })


### PR DESCRIPTION
I don't love it, but this seems to make Windows e2e tests pass more reliably.

On this branch, test-e2e on Windows passed 4/4 times (https://github.com/sourcegraph/cody/actions/runs/8259801441/job/22596572234?pr=3390), compared to a pass rate of about 50% looking at `main` (https://github.com/sourcegraph/cody/commits/main/).

## Test plan

CI