### PR TITLE
disable unused vscode webview sourcemaps

### DIFF
--- a/vscode/webviews/vite.config.ts
+++ b/vscode/webviews/vite.config.ts
@@ -14,7 +14,7 @@ export default defineProjectWithDefaults(__dirname, {
         target: 'esnext',
         assetsDir: '.',
         minify: false,
-        sourcemap: true,
+        sourcemap: false,
         reportCompressedSize: false,
         rollupOptions: {
             watch: {


### PR DESCRIPTION
These were not being used anyway because VS Code does not support external sourcemaps (https://github.com/microsoft/vscode/issues/115440#issuecomment-778473764).

Using `sourcemap: 'inline'` makes it work, but this increases the size of `dist/webviews/index.js` from 1.5MB to 9MB, which may hurt perf.



## Test plan

CI