### PR TITLE
Autocomplete: add `kotlin` multiline support

### DIFF
--- a/vscode/src/completions/detect-multiline.ts
+++ b/vscode/src/completions/detect-multiline.ts
@@ -45,6 +45,7 @@ const LANGUAGES_WITH_MULTILINE_SUPPORT = [
     'java',
     'javascript',
     'javascriptreact',
+    'kotlin',
     'php',
     'python',
     'rust',

--- a/vscode/src/tree-sitter/language.ts
+++ b/vscode/src/tree-sitter/language.ts
@@ -16,6 +16,7 @@ export function getLanguageConfig(languageId: string): LanguageConfig | null {
         case 'java':
         case 'javascript':
         case 'javascriptreact':
+        case 'kotlin':
         case 'php':
         case 'rust':
         case 'svelte':


### PR DESCRIPTION
## Context

- Adds `kotlin` support for multiline completions.
- Closes https://github.com/sourcegraph/cody/issues/3303

## Test plan

- CI
- Added unit test
