### PR TITLE
fix counting of context lines (don't count lines w/no chars included)

### DIFF
--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -47,7 +47,7 @@ test.extend<ExpectedEvents>({
     // When no selection is made, we will try to create smart selection from the cursor position
     // If there is no cursor position, we will use the visible content of the editor
     // NOTE: Core commands context should not start with ✨
-    await chatPanel.getByText('Context: 12 lines from 1 file').click()
+    await chatPanel.getByText('Context: 11 lines from 1 file').click()
 
     // Check if assistant responsed
     await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
@@ -64,7 +64,7 @@ test.extend<ExpectedEvents>({
     await page.getByText('<title>Hello Cody</title>').click()
     await expect(page.getByText('Explain Code')).toBeVisible()
     await page.getByText('Explain Code').click()
-    await chatPanel.getByText('Context: 21 lines from 1 file').click()
+    await chatPanel.getByText('Context: 20 lines from 1 file').click()
     await expect(chatPanel.locator('span').filter({ hasText: '@index.html:2-10' })).toBeVisible()
     const disabledEditButtons = chatPanel.getByTitle('Cannot Edit Command').locator('i')
     const editLastMessageButton = chatPanel.getByRole('button', { name: /^Edit Last Message / })

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -175,8 +175,8 @@ test.extend<ExpectedEvents>({
 
     await expect(chatPanel.getByText('Add four context files from the current directory.')).toBeVisible()
     // Show the current file numbers used as context
-    await expect(chatPanel.getByText('✨ Context: 61 lines from 5 files')).toBeVisible()
-    await chatPanel.getByText('✨ Context: 61 lines from 5 files').click()
+    await expect(chatPanel.getByText('✨ Context: 56 lines from 5 files')).toBeVisible()
+    await chatPanel.getByText('✨ Context: 56 lines from 5 files').click()
     // Display the context files to confirm no hidden files are included
     await expect(chatPanel.locator('span').filter({ hasText: '@.mydotfile:1-2' })).not.toBeVisible()
     await expect(chatPanel.locator('span').filter({ hasText: '@error.ts:1-9' })).toBeVisible()
@@ -194,7 +194,7 @@ test.extend<ExpectedEvents>({
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Add lib/batches/env/var.go as context.')).toBeVisible()
     // Should show 2 files with current file added as context
-    await expect(chatPanel.getByText('✨ Context: 14 lines from 2 files')).toBeVisible()
+    await expect(chatPanel.getByText('✨ Context: 12 lines from 2 files')).toBeVisible()
 
     /* Test: context.directory with directory command */
 
@@ -204,8 +204,8 @@ test.extend<ExpectedEvents>({
     await page.getByPlaceholder('Search command to run...').fill('directory')
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Directory has one context file.')).toBeVisible()
-    await expect(chatPanel.getByText('✨ Context: 14 lines from 2 file')).toBeVisible()
-    await chatPanel.getByText('✨ Context: 14 lines from 2 file').click()
+    await expect(chatPanel.getByText('✨ Context: 12 lines from 2 file')).toBeVisible()
+    await chatPanel.getByText('✨ Context: 12 lines from 2 file').click()
     await expect(
         chatPanel.locator('span').filter({ hasText: withPlatformSlashes('@lib/batches/env/var.go:1') })
     ).toBeVisible()
@@ -224,8 +224,8 @@ test.extend<ExpectedEvents>({
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Open tabs as context.')).toBeVisible()
     // The files from the open tabs should be added as context
-    await expect(chatPanel.getByText('✨ Context: 14 lines from 2 files')).toBeVisible()
-    await chatPanel.getByText('✨ Context: 14 lines from 2 files').click()
+    await expect(chatPanel.getByText('✨ Context: 12 lines from 2 files')).toBeVisible()
+    await chatPanel.getByText('✨ Context: 12 lines from 2 files').click()
     await expect(chatPanel.getByRole('button', { name: '@index.html:1-11' })).toBeVisible()
     await expect(
         chatPanel.getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })

--- a/vscode/webviews/chat/components/EnhancedContext.tsx
+++ b/vscode/webviews/chat/components/EnhancedContext.tsx
@@ -41,7 +41,14 @@ export const EnhancedContext: React.FunctionComponent<{
     // It checks if file.range exists first before accessing start and end.
     // If range doesn't exist, it adds 0 lines for that file.
     const lineCount = contextFiles.reduce(
-        (total, file) => total + (file.range ? file.range?.end?.line - file.range?.start?.line + 1 : 0),
+        (total, file) =>
+            total +
+            (file.range
+                ? // Don't count a line with no characters included (character == 0).
+                  (file.range.end.character === 0 ? file.range.end.line - 1 : file.range.end.line) -
+                  file.range.start?.line +
+                  1
+                : 0),
         0
     )
     const fileCount = new Set(contextFiles.map(file => file.uri.toString())).size


### PR DESCRIPTION
In the context summary in chat, `✨ Context: 56 lines from 5 files` previously counted lines even if no characters on that line were included. For example, a range from line 5 character 10 to line 7 character 0, which is rendered as `5-6`, was counted as 3 lines. It should be counted as 2 lines.



## Test plan

CI