### PR TITLE
standardize on a single prompt format for codebase context

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -2841,515 +2841,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7d426108a93308149c0d6c9b3a4066af
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3151
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                  const foo = 42
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      constructor(private shouldGreet: boolean) {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  "My selected TypeScript code from file `src/animal.ts`:
-                  <selected>
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Write a class Dog that implements the Animal interface in my workspace.
-                  Show the code only, no explanation needed.
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 10503
-        content:
-          mimeType: text/event-stream
-          size: 10503
-          text: >+
-            event: completion
-
-            data: {"completion":" ```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```types","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string)","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  make","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound()","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Wo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isM","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isMam","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isMammal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isMammal =","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isMammal = true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isMammal = true;","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isMammal = true;\n}","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isMammal = true;\n}\n```","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" ```typescript\nexport class Dog implements Animal {\n  name: string;\n  \n  constructor(name: string) {\n    this.name = name;\n  }\n\n  makeAnimalSound() {\n    return \"Woof!\";\n  }\n\n  isMammal = true;\n}\n```","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 14 Mar 2024 23:44:19 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-14T23:44:17.439Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: e57db4d79e10dedf9c63eea18a391057
       _order: 0
       cache: {}
@@ -4427,778 +3918,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-03-14T23:44:20.911Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: bd898e06e8a7e9a9472546d1171d2dba
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 880
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/squirrel.ts`:
-                  ```typescript
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `src/squirrel.ts`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is Squirrel?
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 50662
-        content:
-          mimeType: text/event-stream
-          size: 50662
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Source","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Source","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Source","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does not represent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does not represent an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does not represent an actual","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does not represent an actual squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does not represent an actual squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does not represent an actual squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippet and comment provided, Squirrel is an interface that has nothing to do with actual squirrels. It is related to implementing precise code navigation in Sourcegraph. Specifically:\n\n- It is an empty interface exported from the file `src/squirrel.ts`\n- The comment states it is used to \"mock something completely unrelated to squirrels\" \n- The comment further explains it is related to \"the implementation of precise code navigation in Sourcegraph\"\n\nSo in summary, Squirrel is an interface used for mocking/testing purposes in implementing code navigation functionality in Sourcegraph, and does not represent an actual squirrel.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 14 Mar 2024 23:44:24 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-14T23:44:23.500Z
       time: 0
       timings:
         blocked: -1
@@ -7492,314 +6211,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e5535b2d2ff40de4c581d882a29fc2c3
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1248
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What files contain SELECTION_START?
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 4649
-        content:
-          mimeType: text/event-stream
-          size: 4649
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SE","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.ts\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.ts\n- src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.ts\n- src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.ts\n- src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.ts\n- src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.ts\n- src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets provided, SELECTION_START is contained in the following files:\n\n- src/multiple-selections.ts\n- src/animal.ts","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 14 Mar 2024 23:44:42 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-14T23:44:40.437Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 38f46564b22ecb1aceb5bc9e77fb9371
       _order: 0
       cache: {}
@@ -9376,358 +7787,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-03-14T23:44:47.621Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: b62bae1fcea22270e514e73404939da8
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1795
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file
-                  `src/multiple-selections.ts`:
-
-                  <selected>
-
-
-                  function anotherFunction() {}
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 252
-        content:
-          mimeType: text/event-stream
-          size: 252
-          text: |+
-            event: completion
-            data: {"completion":" another","stopReason":""}
-
-            event: completion
-            data: {"completion":" anotherFunction","stopReason":""}
-
-            event: completion
-            data: {"completion":" anotherFunction","stopReason":"stop_sequence"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 14 Mar 2024 23:44:52 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-14T23:44:50.115Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: a2e4f6f96e177424b3b48637e51accf8
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1800
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/TestClass.ts`:
-                  ```typescript
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `src/multiple-selections.ts`:
-
-                  ```typescript
-
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Use the following code snippet from file `src/animal.ts`:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  "My selected TypeScript code from file
-                  `src/multiple-selections.ts`:
-
-                  <selected>
-
-                      return function inner() {}
-
-                      
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 165
-        content:
-          mimeType: text/event-stream
-          size: 165
-          text: |+
-            event: completion
-            data: {"completion":" inner","stopReason":""}
-
-            event: completion
-            data: {"completion":" inner","stopReason":"stop_sequence"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 14 Mar 2024 23:44:56 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-14T23:44:54.667Z
       time: 0
       timings:
         blocked: -1
@@ -14049,992 +12108,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: fae3f423a0498c2384922c2ea6c038fc
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2880
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |+
-                  Use the following code snippet from file: src/TestClass.ts:
-                  const foo = 42
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  - You are an AI programming assistant who is an expert in
-                  updating code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-
-
-                  This is part of the file: src/TestClass.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>    public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }</SELECTEDCODE7662>
-
-
-                  The user wants you to geneerate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-2.0
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 2617
-        content:
-          mimeType: text/event-stream
-          size: 2617
-          text: >+
-            event: completion
-
-            data: {"completion":"\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If should","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldG","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs '","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!'","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.\n     */","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.\n     */\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.\n     */\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 14 Mar 2024 23:45:33 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-14T23:45:30.874Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 45f91eda4fe2c18d8dcf54a6d9b4da31
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2887
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |+
-                  Use the following code snippet from file: src/TestLogger.ts:
-                  const foo = 42
-
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  - You are an AI programming assistant who is an expert in
-                  updating code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-
-
-                  This is part of the file: src/TestLogger.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to geneerate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-2.0
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 5218
-        content:
-          mimeType: text/event-stream
-          size: 5218
-          text: >+
-            event: completion
-
-            data: {"completion":"\n/**","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `record","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write the first","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write the first log","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write the first log message","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write the first log message.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write the first log message.\n */","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write the first log message.\n */\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Starts logging by performing setup actions like initializing variables, \n * then calls an internal `recordLog()` function to write the first log message.\n */\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 14 Mar 2024 23:45:37 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-14T23:45:34.480Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 2370ba873fdebfedec27ad141a84698a
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3109
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |+
-                  Use the following code snippet from file: src/example.test.ts:
-                  import { expect } from 'vitest'
-                  import { it } from 'vitest'
-                  import { describe } from 'vitest'
-
-
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  - You are an AI programming assistant who is an expert in
-                  updating code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-
-
-                  This is part of the file: src/example.test.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to geneerate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-2.0
-            stopSequences:
-              - </CODE5711>
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 8577
-        content:
-          mimeType: text/event-stream
-          size: 8577
-          text: >+
-            event: completion
-
-            data: {"completion":"\n/**","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will error","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will error due","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will error due to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will error due to missing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will error due to missing params","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will error due to missing params\n*/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will error due to missing params\n*/\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * A test block that contains 3 tests:\n * - Test 1 verifies that true equals true\n * - Test 2 verifies that true equals true \n * - Test 3 verifies usage of performance.now but will error due to missing params\n*/\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Thu, 14 Mar 2024 23:45:41 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-14T23:45:38.549Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 27775a25b941931c77d25895426ffe5e
       _order: 0
       cache: {}
@@ -17926,6 +14999,2733 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-03-14T23:46:02.530Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 36bcdb23e7fb6ac27ff0a0894e957932
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3196
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/TestClass.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/TestClass.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  const foo = 42
+
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/TestClass.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  const foo = 42
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/TestClass.tsin repository
+                  undefined:
+
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/TestClass.tsin repository
+                  undefined:
+
+                  ```typescript
+                      constructor(private shouldGreet: boolean) {}
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/squirrel.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/squirrel.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/animal.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/animal.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  /* SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  "My selected TypeScript code from file `src/animal.ts`:
+                  <selected>
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Show the code only, no explanation needed.
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 6480
+        content:
+          mimeType: text/event-stream
+          size: 6480
+          text: >+
+            event: completion
+
+            data: {"completion":" ```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```types","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  make","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound():","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"B","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\";","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isM","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMam","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal: boolean","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal: boolean =","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal: boolean = true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal: boolean = true;","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal: boolean = true;\n}","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal: boolean = true;\n}\n```","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" ```typescript\nclass Dog implements Animal {\n  name: string;\n\n  makeAnimalSound(): string {\n    return \"Bark!\"; \n  }\n\n  isMammal: boolean = true;\n}\n```","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:54:57 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:54:55.225Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: da9cd3d452a3c1428c9b530aeda6e2e6
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 890
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/squirrel.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/squirrel.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is Squirrel?
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 37879
+        content:
+          mimeType: text/event-stream
+          size: 37879
+          text: >+
+            event: completion
+
+            data: {"completion":" Based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a wh","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whims","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent actual","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent actual squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent actual squirrels","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent actual squirrels in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent actual squirrels in any","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent actual squirrels in any way","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent actual squirrels in any way.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the code and comments provided, Squirrel is an interface that does not actually have anything to do with squirrels. The comment states it is related to the implementation of precise code navigation in Sourcegraph. So Squirrel appears to be an interface used internally by Sourcegraph, but the name was likely chosen arbitrarily or as a whimsical reference. The interface itself is empty, so there are no specific details about what it represents in Sourcegraph's codebase. But it does not model or represent actual squirrels in any way.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:55:00 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:54:59.021Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 2b185d7bf230f06153c02aa4e166e0a7
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1263
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/multiple-selections.tsin
+                  repository undefined:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/animal.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/animal.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  /* SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What files contain SELECTION_START?
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 7269
+        content:
+          mimeType: text/event-stream
+          size: 7269
+          text: >+
+            event: completion
+
+            data: {"completion":" Based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SE","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SE","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is found","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is found in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is found in both","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is found in both of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is found in both of these","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is found in both of these files","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is found in both of these files.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided, the files that contain SELECTION_START are:\n\n- src/multiple-selections.ts\n- src/animal.ts\n\nThe SELECTION_START comment is found in both of these files.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:55:05 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:55:04.322Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: fce8129dee01be937d5396d835f044d0
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1815
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/TestClass.tsin repository
+                  undefined:
+
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/multiple-selections.tsin
+                  repository undefined:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/animal.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/animal.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  /* SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+
+                  function anotherFunction() {}
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 252
+        content:
+          mimeType: text/event-stream
+          size: 252
+          text: |+
+            event: completion
+            data: {"completion":" another","stopReason":""}
+
+            event: completion
+            data: {"completion":" anotherFunction","stopReason":""}
+
+            event: completion
+            data: {"completion":" anotherFunction","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:55:08 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:55:07.338Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 427970be8116e7a0f0f69e4671445726
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 1820
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/TestClass.tsin repository
+                  undefined:
+
+                  ```typescript
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/multiple-selections.tsin
+                  repository undefined:
+
+                  ```typescript
+
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/animal.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/animal.tsin repository
+                  undefined:
+
+                  ```typescript
+
+                  /* SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  "My selected TypeScript code from file
+                  `src/multiple-selections.ts`:
+
+                  <selected>
+
+                      return function inner() {}
+
+                      
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is the name of the function that I have selected? Only answer with
+                  the name of the function, nothing else
+              - speaker: assistant
+            model: anthropic/claude-2.0
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 165
+        content:
+          mimeType: text/event-stream
+          size: 165
+          text: |+
+            event: completion
+            data: {"completion":" inner","stopReason":""}
+
+            event: completion
+            data: {"completion":" inner","stopReason":"stop_sequence"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:55:11 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:55:08.909Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: eeb3e6125a15decc381dd09babdb87ef
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2886
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >+
+                  Codebase context from file src/TestClass.tsin repository
+                  undefined:
+
+                  const foo = 42
+
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  - You are an AI programming assistant who is an expert in
+                  updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+
+
+                  This is part of the file: src/TestClass.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>    public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }</SELECTEDCODE7662>
+
+
+                  The user wants you to geneerate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-2.0
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 2617
+        content:
+          mimeType: text/event-stream
+          size: 2617
+          text: >+
+            event: completion
+
+            data: {"completion":"\n   ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If should","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldG","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs '","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!'","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.\n    ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.\n     */","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.\n     */\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n    /**\n     * If shouldGreet is true, logs 'Hello World!' to the console.\n     */\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:55:15 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:55:12.319Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: e25bb63a4cd6e406d7ef6d4f8d4c485e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2893
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >
+                  Codebase context from file src/TestLogger.tsin repository
+                  undefined:
+
+                  const foo = 42
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  - You are an AI programming assistant who is an expert in
+                  updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+
+
+                  This is part of the file: src/TestLogger.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>export const TestLogger = {
+                      startLogging: () => {
+                          // Do some stuff
+
+                          function recordLog() {
+                              console.log(/* CURSOR */ 'Recording the log')
+                          }
+
+                          recordLog()
+                      },
+                  }
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to geneerate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-2.0
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 1416
+        content:
+          mimeType: text/event-stream
+          size: 1416
+          text: >+
+            event: completion
+
+            data: {"completion":"\n/**","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the console","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the console for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the console for testing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the console for testing purposes","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the console for testing purposes.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the console for testing purposes.\n */","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the console for testing purposes.\n */\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Logs messages to the console for testing purposes.\n */\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:55:18 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:55:15.654Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 07baa82ea035f9d44512b677aebf7dfb
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3115
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 263
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >+
+                  Codebase context from file src/example.test.tsin repository
+                  undefined:
+
+                  import { expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  - You are an AI programming assistant who is an expert in
+                  updating code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+
+
+                  This is part of the file: src/example.test.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>describe('test block', () => {
+                      it('does 1', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does 2', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does something else', () => {
+                          // This line will error due to incorrect usage of `performance.now`
+                          const startTime = performance.now(/* CURSOR */)
+                      })
+                  })
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to geneerate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-2.0
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 6257
+        content:
+          mimeType: text/event-stream
+          size: 6257
+          text: >+
+            event: completion
+
+            data: {"completion":"\n/**","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage of","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage of performance","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage of performance.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage of performance.now","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage of performance.now().","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage of performance.now().\n*/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage of performance.now().\n*/\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"\n/**\n * Test suite with 3 test cases.\n * The first 2 test cases assert true equals true. \n * The 3rd test case will error due to incorrect usage of performance.now().\n*/\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:55:21 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:55:18.523Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -102,11 +102,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a9664e40a303b139e2ef31626a8d4fb8
+    - _id: 541a40f5b0b77d7ada0eb8181cfe9b71
       _order: 0
       cache: {}
       request:
-        bodySize: 10762
+        bodySize: 3115
         cookies: []
         headers:
           - name: content-type
@@ -133,1242 +133,16 @@ log:
                 text: You are Cody, an AI coding assistant from Sourcegraph.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/internal/symbols/client.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  	client, err := grpcClient.LocalCodeIntel(ctx, &protoArgs)
-                  	if err != nil {
-                  		if status.Code(err) == codes.Unimplemented {
-                  			// This ignores errors from LocalCodeIntel to match the behavior found here:
-                  			// https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a1631d58604815917096acc3356447c55baebf22/-/blob/cmd/symbols/squirrel/http_handlers.go?L57-57
-                  			//
-                  			// This is weird, and maybe not intentional, but things break if we return an error.
-                  			return nil, nil
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Use the following text from file `/doc/cloud/index.md` in
-                  repository `github.com/sourcegraph/sourcegraph`:
-
-
-                  The below are for example purposes only:
-
-
-                  In the case of things like Code Search, latency is directly correlated with user input / shape of the query, ex. on our public [sourcegraph.com](https://sourcegraph.com/search) instance:
-
-
-                  - searching for “squirrel” in the [sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph) repo takes 30ms and returns 163 results
-
-                  - searching for “squirrel” in all OSS repos, but only requesting 1000 matches takes 540ms
-
-                  - searching for all matches of “squirrel” in all OSS repos returns 1.7million results in 30000ms
-
-                  - In the case of other features, latency of Sourcegraph directly depends on latency / uptime / rate-limits of customer managed systems, ex. for:
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Use the following text from file
-                  `/doc/admin/deploy/kubernetes/troubleshoot.md` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  SYMBOLS_URL=http:symbols:3184
-
-                  ```
-
-
-                  > WARNING: **This option is recommended only for symbols with a single replica**. Enabling this option will negatively impact the performance of the symbols service when it has multiple replicas, as it will no longer be able to distribute requests by repository/commit.
-
-
-                  #### Squirrel.LocalCodeIntel http status 502
-
-
-                  <img class="screenshot w-100" src="https://user-images.githubusercontent.com/68532117/212374098-dc2dfe69-4d26-4f5e-a78b-37a53c19ef22.png"/>
-
-                  The issue described is related to the Code Intel hover feature, where it may get stuck in a loading state or return a 502 error with the message `Squirrel.LocalCodeIntel http status 502`. This is caused by the same issue described in [Symbols sidebar and hovers are not working](#symbols-sidebar-and-hovers-are-not-working"). See that section for solution.
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/util.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  package squirrel
-
-
-                  import (
-                  	"context"
-                  	"fmt"
-                  	"path/filepath"
-                  	"runtime"
-                  	"strings"
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/service.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  package squirrel
-
-
-                  import (
-                  	"context"
-                  	"fmt"
-                  	"os"
-                  	"runtime"
-                  	"strconv"
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/service_test.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  package squirrel
-
-
-                  import (
-                  	"context"
-                  	"os"
-                  	"path/filepath"
-                  	"slices"
-                  	"sort"
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Use the following text from file
-                  `/cmd/symbols/squirrel/README.md` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  # Squirrel
-
-
-                  Squirrel is an HTTP server for fast and precise local code intelligence using tree-sitter.
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/lang_starlark.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  package squirrel
-
-
-                  import (
-                  	"context"
-                  	"path/filepath"
-                  	"strings"
-
-                  	sitter "github.com/smacker/go-tree-sitter"
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/lang_python.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  package squirrel
-
-
-                  import (
-                  	"context"
-                  	"fmt"
-                  	"path/filepath"
-                  	"strings"
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/lang_java.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  package squirrel
-
-
-                  import (
-                  	"context"
-                  	"fmt"
-                  	"path/filepath"
-                  	"sort"
-                  	"strings"
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/hover_test.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  package squirrel
-
-
-                  import (
-                  	"context"
-                  	"strings"
-                  	"testing"
-
-                  	"github.com/sourcegraph/sourcegraph/internal/types"
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/BUILD.bazel` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```bazel
-
-                  load("//dev:go_defs.bzl", "go_test")
-
-                  load("@io_bazel_rules_go//go:def.bzl", "go_library")
-
-
-                  go_library(
-                      name = "squirrel",
-                      srcs = [
-                          "breadcrumbs.go",
-                          "hover.go",
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/squirrel/breadcrumbs.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-
-                  package squirrel
-
-
-                  import (
-                  	"context"
-                  	"fmt"
-                  	"os"
-                  	"strings"
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/cmd/symbols/internal/api/handler_cgo.go` in repository
-                  `github.com/sourcegraph/sourcegraph`:
-
-                  ```go
-                  	proto "github.com/sourcegraph/sourcegraph/internal/symbols/v1"
-                  	internaltypes "github.com/sourcegraph/sourcegraph/internal/types"
-                  	"github.com/sourcegraph/sourcegraph/lib/errors"
-                  )
-
-
-                  func convertSquirrelErrorToGrpcError(err error) *status.Status {
-                  	if errors.Is(err, squirrel.UnrecognizedFileExtensionError) {
-                  		return status.New(codes.InvalidArgument, err.Error())
-                  	}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.ts`
-                  in repository `github.com/sourcegraph/sourcegraph`:
-
-                  ```typescript
-                              }))
-                      }
-                      return
-                  }
-
-
-                  async function searchBasedReferencesViaSquirrel(
-                      options: UseSearchBasedCodeIntelOptions
-                  ): Promise<Location[] | undefined> {
-                      const { repo, position, path, commit, fileContent } = options
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/client/shared/src/codeintel/legacy-extensions/search/providers.ts`
-                  in repository `github.com/sourcegraph/sourcegraph`:
-
-                  ```typescript
-
-                  import { getConfig } from './config'
-
-                  import { type Result, resultToLocation, searchResultToResults } from './conversion'
-
-                  import { findDocstring } from './docstrings'
-
-                  import { wrapIndentationInCodeBlocks } from './markdown'
-
-                  import { definitionQuery, referencesQuery } from './queries'
-
-                  import { mkSquirrel } from './squirrel'
-
-                  import { findSearchToken } from './tokens'
-
-
-                  /** The number of files whose content can be cached at once. */
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file `/.bazelignore` in
-                  repository `github.com/sourcegraph/sourcegraph`:
-
-                  ```
-
-                  client/web/node_modules
-
-                  client/web-sveltekit/node_modules
-
-                  client/wildcard/node_modules
-
-                  dev/release/node_modules
-
-
-                  cmd/symbols/squirrel/test_repos/starlark
-
-
-                  # Generated by local tools
-
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Use the following code snippet from file
-                  `/agent/src/__tests__/example-ts/src/squirrel.ts` in
-                  repository `github.com/sourcegraph/cody`:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-
-                  ```
-              - speaker: assistant
-                text: Ok.
               - speaker: human
                 text: >+
-                  Use the following text from file `/agent/README.md` in
-                  repository `github.com/sourcegraph/cody`:
+                  Codebase context from file src/example.test.tsin repository
+                  undefined:
 
-                  | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-
-                  | `pnpm test agent/src/index.test.ts`                                                                                  | Run agent tests in replay mode                                                                                                                                |
-
-                  | `source agent/scripts/export-cody-http-recording-tokens.sh`                                                          | Export access tokens to enable recording mode                                                                                                                 |
-
-                  | `pnpm update-agent-tests`                                                                                            | Update HTTP recordings for all tests. Run this before opening a PR                                                                                            |
-
-                  | `CODY_KEEP_UNUSED_RECORDINGS=true CODY_RECORD_IF_MISSING=true pnpm run test agent/src/index.test.ts`                 | Run this when iterating on a feature and you only want to run an individual test via `it.only`. Remember to run `pnpm update-agent-tests` before sending a PR |
-
-                  | `CODY_KEEP_UNUSED_RECORDINGS=true CODY_RECORD_IF_MISSING=true npx vitest agent/src/index.test.ts -t 'squirrel test'` | Run only a single test without making changes to the code                                                                                                     |
-
-
-                  ## Debugging the agent
-
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is Squirrel?
-              - speaker: assistant
-            model: anthropic/claude-2
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://demo.sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 61396
-        content:
-          mimeType: text/event-stream
-          size: 61396
-          text: >+
-            event: completion
-
-            data: {"completion":" Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-s","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide ho","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Source","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Inter","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Source","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mock","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Source","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interf","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing with tree","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing with tree-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing with tree-s","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing with tree-sitter","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing with tree-sitter parsers","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing with tree-sitter parsers.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":" Based on the code snippets and text you asked me to reference, Squirrel seems to be:\n\n- An HTTP server for providing local code intelligence using tree-sitter, as described in the README.md\n- Used to provide hovers, definitions, references etc for code navigation in Sourcegraph, as referenced in several client code files.\n- Interfaces with Sourcegraph's code intelligence features to provide this local code navigation.\n- Mocked in an example test file in the cody repo, implying it's an important component that needs to be tested against.\n\nSo in summary, Squirrel is a service used by Sourcegraph to enable fast and precise code intelligence for code navigation by interfacing with tree-sitter parsers.","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 06 Mar 2024 08:52:23 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1214
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-03-06T08:52:19.460Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 55053fe9d89428c51f89486b98638610
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3109
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - name: user-agent
-            value: enterpriseClient / v1
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 265
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 1000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |+
-                  Use the following code snippet from file: src/example.test.ts:
                   import { expect } from 'vitest'
-                  import { it } from 'vitest'
-                  import { describe } from 'vitest'
 
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
 
               - speaker: assistant
                 text: Ok.
@@ -1437,10 +211,10 @@ log:
         queryString: []
         url: https://demo.sourcegraph.com/.api/completions/stream
       response:
-        bodySize: 7147
+        bodySize: 6248
         content:
           mimeType: text/event-stream
-          size: 7147
+          size: 6248
           text: >+
             event: completion
 
@@ -1544,127 +318,107 @@ log:
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  ","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n *","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n *","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * -","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * -","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attemp","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of `","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of `performance","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of `performance.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of `performance.now","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of `","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of `performance.now`","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of `performance","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of `performance.now`\n*/","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of `performance.","stopReason":""}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of `performance.now`\n*/\n","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of `performance.now","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of `performance.now()`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of `performance.now()`\n*/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of `performance.now()`\n*/\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2  \n * - Attempts to do something else but will error due to invalid usage of `performance.now()`\n*/\n","stopReason":"stop_sequence"}
+            data: {"completion":"\n/**\n * Test block that contains 3 test cases:\n * - Does test 1\n * - Does test 2 \n * - Does something else that errors due to incorrect usage of `performance.now`\n*/\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -1674,7 +428,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 06 Mar 2024 19:48:38 GMT
+            value: Thu, 14 Mar 2024 23:55:29 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -1703,7 +457,1362 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-03-06T19:48:35.723Z
+      startedDateTime: 2024-03-14T23:55:26.860Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 04a003a70be4dca9be6480df34125967
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 10467
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - name: user-agent
+            value: enterpriseClient / v1
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 265
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 1000
+            messages:
+              - speaker: human
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Codebase context from file /internal/symbols/client.goin
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  	client, err := grpcClient.LocalCodeIntel(ctx, &protoArgs)
+                  	if err != nil {
+                  		if status.Code(err) == codes.Unimplemented {
+                  			// This ignores errors from LocalCodeIntel to match the behavior found here:
+                  			// https://sourcegraph.com/github.com/sourcegraph/sourcegraph@a1631d58604815917096acc3356447c55baebf22/-/blob/cmd/symbols/squirrel/http_handlers.go?L57-57
+                  			//
+                  			// This is weird, and maybe not intentional, but things break if we return an error.
+                  			return nil, nil
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file /doc/cloud/index.mdin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```markdown
+
+
+                  The below are for example purposes only:
+
+
+                  In the case of things like Code Search, latency is directly correlated with user input / shape of the query, ex. on our public [sourcegraph.com](https://sourcegraph.com/search) instance:
+
+
+                  - searching for “squirrel” in the [sourcegraph/sourcegraph](https://sourcegraph.com/github.com/sourcegraph/sourcegraph) repo takes 30ms and returns 163 results
+
+                  - searching for “squirrel” in all OSS repos, but only requesting 1000 matches takes 540ms
+
+                  - searching for all matches of “squirrel” in all OSS repos returns 1.7million results in 30000ms
+
+                  - In the case of other features, latency of Sourcegraph directly depends on latency / uptime / rate-limits of customer managed systems, ex. for:
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /doc/admin/deploy/kubernetes/troubleshoot.mdin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```markdown
+
+                  SYMBOLS_URL=http:symbols:3184
+
+                  ```
+
+
+                  > WARNING: **This option is recommended only for symbols with a single replica**. Enabling this option will negatively impact the performance of the symbols service when it has multiple replicas, as it will no longer be able to distribute requests by repository/commit.
+
+
+                  #### Squirrel.LocalCodeIntel http status 502
+
+
+                  <img class="screenshot w-100" src="https://user-images.githubusercontent.com/68532117/212374098-dc2dfe69-4d26-4f5e-a78b-37a53c19ef22.png"/>
+
+                  The issue described is related to the Code Intel hover feature, where it may get stuck in a loading state or return a 502 error with the message `Squirrel.LocalCodeIntel http status 502`. This is caused by the same issue described in [Symbols sidebar and hovers are not working](#symbols-sidebar-and-hovers-are-not-working"). See that section for solution.
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file /cmd/symbols/squirrel/util.goin
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"fmt"
+                  	"path/filepath"
+                  	"runtime"
+                  	"strings"
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file /cmd/symbols/squirrel/service.goin
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"fmt"
+                  	"os"
+                  	"runtime"
+                  	"strconv"
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/squirrel/service_test.goin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"os"
+                  	"path/filepath"
+                  	"slices"
+                  	"sort"
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file /cmd/symbols/squirrel/README.mdin
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```markdown
+
+                  # Squirrel
+
+
+                  Squirrel is an HTTP server for fast and precise local code intelligence using tree-sitter.
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/squirrel/lang_starlark.goin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"path/filepath"
+                  	"strings"
+
+                  	sitter "github.com/smacker/go-tree-sitter"
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/squirrel/lang_python.goin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"fmt"
+                  	"path/filepath"
+                  	"strings"
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/squirrel/lang_java.goin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"fmt"
+                  	"path/filepath"
+                  	"sort"
+                  	"strings"
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/squirrel/hover_test.goin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"strings"
+                  	"testing"
+
+                  	"github.com/sourcegraph/sourcegraph/internal/types"
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file /cmd/symbols/squirrel/BUILD.bazelin
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```bazel
+
+                  load("//dev:go_defs.bzl", "go_test")
+
+                  load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+
+                  go_library(
+                      name = "squirrel",
+                      srcs = [
+                          "breadcrumbs.go",
+                          "hover.go",
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/squirrel/breadcrumbs.goin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+
+                  package squirrel
+
+
+                  import (
+                  	"context"
+                  	"fmt"
+                  	"os"
+                  	"strings"
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /cmd/symbols/internal/api/handler_cgo.goin repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```go
+                  	proto "github.com/sourcegraph/sourcegraph/internal/symbols/v1"
+                  	internaltypes "github.com/sourcegraph/sourcegraph/internal/types"
+                  	"github.com/sourcegraph/sourcegraph/lib/errors"
+                  )
+
+
+                  func convertSquirrelErrorToGrpcError(err error) *status.Status {
+                  	if errors.Is(err, squirrel.UnrecognizedFileExtensionError) {
+                  		return status.New(codes.InvalidArgument, err.Error())
+                  	}
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /client/web/src/enterprise/codeintel/useSearchBasedCodeIntel.tsin
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```typescript
+                              }))
+                      }
+                      return
+                  }
+
+
+                  async function searchBasedReferencesViaSquirrel(
+                      options: UseSearchBasedCodeIntelOptions
+                  ): Promise<Location[] | undefined> {
+                      const { repo, position, path, commit, fileContent } = options
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /client/shared/src/codeintel/legacy-extensions/search/providers.tsin
+                  repository github.com/sourcegraph/sourcegraph:
+
+                  ```typescript
+
+                  import { getConfig } from './config'
+
+                  import { type Result, resultToLocation, searchResultToResults } from './conversion'
+
+                  import { findDocstring } from './docstrings'
+
+                  import { wrapIndentationInCodeBlocks } from './markdown'
+
+                  import { definitionQuery, referencesQuery } from './queries'
+
+                  import { mkSquirrel } from './squirrel'
+
+                  import { findSearchToken } from './tokens'
+
+
+                  /** The number of files whose content can be cached at once. */
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file /.bazelignorein repository
+                  github.com/sourcegraph/sourcegraph:
+
+                  ```
+
+                  client/web/node_modules
+
+                  client/web-sveltekit/node_modules
+
+                  client/wildcard/node_modules
+
+                  dev/release/node_modules
+
+
+                  cmd/symbols/squirrel/test_repos/starlark
+
+
+                  # Generated by local tools
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file
+                  /agent/src/__tests__/example-ts/src/squirrel.tsin repository
+                  github.com/sourcegraph/cody:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file /agent/README.mdin repository
+                  github.com/sourcegraph/cody:
+
+                  ```markdown
+
+                  | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+
+                  | `pnpm test agent/src/index.test.ts`                                                                                  | Run agent tests in replay mode                                                                                                                                |
+
+                  | `source agent/scripts/export-cody-http-recording-tokens.sh`                                                          | Export access tokens to enable recording mode                                                                                                                 |
+
+                  | `pnpm update-agent-tests`                                                                                            | Update HTTP recordings for all tests. Run this before opening a PR                                                                                            |
+
+                  | `CODY_KEEP_UNUSED_RECORDINGS=true CODY_RECORD_IF_MISSING=true pnpm run test agent/src/index.test.ts`                 | Run this when iterating on a feature and you only want to run an individual test via `it.only`. Remember to run `pnpm update-agent-tests` before sending a PR |
+
+                  | `CODY_KEEP_UNUSED_RECORDINGS=true CODY_RECORD_IF_MISSING=true npx vitest agent/src/index.test.ts -t 'squirrel test'` | Run only a single test without making changes to the code                                                                                                     |
+
+
+                  ## Debugging the agent
+
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: What is Squirrel?
+              - speaker: assistant
+            model: anthropic/claude-2
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString: []
+        url: https://demo.sourcegraph.com/.api/completions/stream
+      response:
+        bodySize: 85717
+        content:
+          mimeType: text/event-stream
+          size: 85717
+          text: >+
+            event: completion
+
+            data: {"completion":" Based","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSqu","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-s","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like ho","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Star","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starl","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by lever","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-s","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"prec","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\"","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Source","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's code navigation","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's code navigation/","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's code navigation/product","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's code navigation/productivity","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's code navigation/productivity features","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's code navigation/productivity features.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":" Based on the context provided:\n\nSquirrel is an HTTP server developed by Sourcegraph for providing fast and precise local code intelligence using tree-sitter. \n\nSome key things about Squirrel:\n\n- It is used to power code intelligence features in Sourcegraph like hovers, definitions, references etc. by analyzing code locally.\n\n- It supports multiple languages like Java, Python, Starlark etc.\n\n- It surfaces code intelligence by leveraging tree-sitter parsers.\n\n- There are multiple references to it being used to provide \"precise code navigation\" in Sourcegraph.\n\n- There are tests and other infrastructure set up around Squirrel in the Sourcegraph codebase.\n\nSo in summary, Squirrel is Sourcegraph's internal tool for enabling accurate and fast code intelligence for various languages. It powers Sourcegraph's code navigation/productivity features.","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 14 Mar 2024 23:55:32 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1214
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-03-14T23:55:29.878Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -346,18 +346,14 @@ describe('Agent', () => {
             // is not a git directory and symf reports some git-related error.
             expect(trimEndOfLine(lastMessage?.text ?? '')).toMatchInlineSnapshot(`
               " \`\`\`typescript
-              export class Dog implements Animal {
+              class Dog implements Animal {
                 name: string;
 
-                constructor(name: string) {
-                  this.name = name;
+                makeAnimalSound(): string {
+                  return "Bark!";
                 }
 
-                makeAnimalSound() {
-                  return "Woof!";
-                }
-
-                isMammal = true;
+                isMammal: boolean = true;
               }
               \`\`\`"
             `)
@@ -900,8 +896,7 @@ describe('Agent', () => {
                     expect(obtained).toMatchInlineSnapshot(`
                       "const foo = 42
                       /**
-                       * Starts logging by performing setup actions like initializing variables,
-                       * then calls an internal \`recordLog()\` function to write the first log message.
+                       * Logs messages to the console for testing purposes.
                        */
                       export const TestLogger = {
                           startLogging: () => {
@@ -929,10 +924,9 @@ describe('Agent', () => {
                       import { describe } from 'vitest'
 
                       /**
-                       * A test block that contains 3 tests:
-                       * - Test 1 verifies that true equals true
-                       * - Test 2 verifies that true equals true
-                       * - Test 3 verifies usage of performance.now but will error due to missing params
+                       * Test suite with 3 test cases.
+                       * The first 2 test cases assert true equals true.
+                       * The 3rd test case will error due to incorrect usage of performance.now().
                       */
                       describe('test block', () => {
                           it('does 1', () => {
@@ -1282,7 +1276,7 @@ describe('Agent', () => {
                    * Test block that contains 3 test cases:
                    * - Does test 1
                    * - Does test 2
-                   * - Attempts to do something else but will error due to invalid usage of \`performance.now()\`
+                   * - Does something else that errors due to incorrect usage of \`performance.now\`
                   */
                   describe('test block', () => {
                       it('does 1', () => {

--- a/lib/shared/src/prompt/templates.ts
+++ b/lib/shared/src/prompt/templates.ts
@@ -1,26 +1,8 @@
 import type { URI } from 'vscode-uri'
 
-import {
-    ProgrammingLanguage,
-    languageFromFilename,
-    markdownCodeBlockLanguageIDForFilename,
-} from '../common/languages'
+import { languageFromFilename, markdownCodeBlockLanguageIDForFilename } from '../common/languages'
 import type { ActiveTextEditorDiagnostic } from '../editor'
 import { displayPath } from '../editor/displayPath'
-
-const CODE_CONTEXT_TEMPLATE = `Use the following code snippet from file \`{filePath}\`:
-\`\`\`{languageID}
-{text}
-\`\`\``
-
-const CODE_CONTEXT_TEMPLATE_WITH_REPO = `Use the following code snippet from file \`{filePath}\` in repository \`{repoName}\`:
-\`\`\`{languageID}
-{text}
-\`\`\``
-
-const CODE_CONTEXT_TEMPLATE_EDIT = `Use the following code snippet from file: {filePath}:
-{text}
-`
 
 export function populateCodeContextTemplate(
     code: string,
@@ -30,93 +12,14 @@ export function populateCodeContextTemplate(
 ): string {
     const template =
         type === 'edit'
-            ? CODE_CONTEXT_TEMPLATE_EDIT
-            : repoName
-              ? CODE_CONTEXT_TEMPLATE_WITH_REPO.replace('{repoName}', repoName)
-              : CODE_CONTEXT_TEMPLATE
+            ? 'Codebase context from file {filePath}{inRepo}:\n{text}'
+            : 'Codebase context from file {filePath}{inRepo}:\n```{languageID}\n{text}```'
 
     return template
+        .replace('{inRepo}', `in repository ${repoName}`)
         .replace('{filePath}', displayPath(fileUri))
         .replace('{languageID}', markdownCodeBlockLanguageIDForFilename(fileUri))
         .replace('{text}', code)
-}
-
-const PRECISE_CONTEXT_TEMPLATE = `The symbol '{symbol}' is defined in the file {filePath} as:
-\`\`\`{languageID}
-{text}
-\`\`\``
-
-export function populatePreciseCodeContextTemplate(symbol: string, fileUri: URI, code: string): string {
-    return PRECISE_CONTEXT_TEMPLATE.replace('{symbol}', symbol)
-        .replace('{filePath}', displayPath(fileUri))
-        .replace('{languageID}', markdownCodeBlockLanguageIDForFilename(fileUri))
-        .replace('{text}', code)
-}
-
-const MARKDOWN_CONTEXT_TEMPLATE = 'Use the following text from file `{filePath}`:\n{text}'
-
-const MARKDOWN_CONTEXT_TEMPLATE_WITH_REPO =
-    'Use the following text from file `{filePath}` in repository `{repoName}`:\n{text}'
-
-export function populateMarkdownContextTemplate(
-    markdown: string,
-    fileUri: URI,
-    repoName?: string
-): string {
-    return (
-        repoName
-            ? MARKDOWN_CONTEXT_TEMPLATE_WITH_REPO.replace('{repoName}', repoName)
-            : MARKDOWN_CONTEXT_TEMPLATE
-    )
-        .replace('{filePath}', displayPath(fileUri))
-        .replace('{text}', markdown)
-}
-
-const CURRENT_EDITOR_CODE_TEMPLATE = 'I have the `{filePath}` file opened in my editor. '
-
-const CURRENT_EDITOR_CODE_TEMPLATE_WITH_REPO =
-    'I have the `{filePath}` file from the repository `{repoName}` opened in my editor. '
-
-export function populateCurrentEditorContextTemplate(
-    code: string,
-    fileUri: URI,
-    repoName?: string
-): string {
-    const context =
-        languageFromFilename(fileUri) === ProgrammingLanguage.Markdown
-            ? populateMarkdownContextTemplate(code, fileUri, repoName)
-            : populateCodeContextTemplate(code, fileUri, repoName)
-    return (
-        (repoName
-            ? CURRENT_EDITOR_CODE_TEMPLATE_WITH_REPO.replace('{repoName}', repoName)
-            : CURRENT_EDITOR_CODE_TEMPLATE
-        ).replaceAll('{filePath}', displayPath(fileUri)) + context
-    )
-}
-
-const CURRENT_EDITOR_SELECTED_CODE_TEMPLATE =
-    'Here is the selected {languageID} code from file path `{filePath}`: '
-
-const CURRENT_EDITOR_SELECTED_CODE_TEMPLATE_WITH_REPO =
-    'Here is the selected code from file `{filePath}` in the {repoName} repository, written in {languageID}: '
-
-export function populateCurrentEditorSelectedContextTemplate(
-    code: string,
-    fileUri: URI,
-    repoName?: string
-): string {
-    const context =
-        languageFromFilename(fileUri) === ProgrammingLanguage.Markdown
-            ? populateMarkdownContextTemplate(code, fileUri, repoName)
-            : populateCodeContextTemplate(code, fileUri, repoName)
-    return (
-        (repoName
-            ? CURRENT_EDITOR_SELECTED_CODE_TEMPLATE_WITH_REPO.replace('{repoName}', repoName)
-            : CURRENT_EDITOR_SELECTED_CODE_TEMPLATE
-        )
-            .replace('{languageID}', markdownCodeBlockLanguageIDForFilename(fileUri))
-            .replaceAll('{filePath}', displayPath(fileUri)) + context
-    )
 }
 
 const DIAGNOSTICS_CONTEXT_TEMPLATE = `Use the following {type} from the code snippet in the file: {filePath}:

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -1,12 +1,9 @@
 import {
     type ContextItem,
     type ContextMessage,
-    ProgrammingLanguage,
-    languageFromFilename,
     populateCodeContextTemplate,
     populateContextTemplateFromText,
     populateCurrentSelectedCodeContextTemplate,
-    populateMarkdownContextTemplate,
 } from '@sourcegraph/cody-shared'
 import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 
@@ -31,8 +28,6 @@ export function renderContextItem(contextItem: ContextItem): ContextMessage | nu
         messageText = populateContextTemplateFromText(templateText, contextItem.content, uri)
     } else if (contextItem.source === ContextItemSource.Terminal) {
         messageText = contextItem.content
-    } else if (languageFromFilename(uri) === ProgrammingLanguage.Markdown) {
-        messageText = populateMarkdownContextTemplate(contextItem.content, uri, contextItem.repoName)
     } else {
         messageText = populateCodeContextTemplate(contextItem.content, uri, contextItem.repoName)
     }


### PR DESCRIPTION
Previously, there were several very similar (but slightly different) templates for introducing code snippets as context.

- "Use the following text from FILE ..."
- Sometimes backticks around file paths and repo names, sometimes not.
- Markdown files are cited differently from non-Markdown files.

There were also several unused functions here.

This improves the response quality regarding https://github.com/sourcegraph/cody/issues/3331 (for the `how does authentication work in sourcegraph/cody?` question at least).



## Test plan

CI