### PR TITLE
Autocomplete: add StarCoder2 hybrid feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -15,6 +15,8 @@ export enum FeatureFlag {
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
     // Enable Llama Code 13b as the default model via Fireworks
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-llama-code-13b',
+    // Enable StarCoder2 7b and 15b as the default model via Fireworks
+    CodyAutocompleteStarCoder2Hybrid = 'cody-autocomplete-starcoder2-hybrid',
     // Enables the bfg-mixed context retriever that will combine BFG with the default local editor
     // context.
     CodyAutocompleteContextBfgMixed = 'cody-autocomplete-context-bfg-mixed',

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Document: Added a shortcut (`Alt+D`) to immediately execute the document command. [pull/3275](https://github.com/sourcegraph/cody/pull/3275)
 - Edit: Added a ghost text hint ("Alt+K to Generate Code") that shows on empty files. [pull/3275](https://github.com/sourcegraph/cody/pull/3275)
 - Chat: Add Claude 3 Haiku for Pro users. [pull/3423](https://github.com/sourcegraph/cody/pull/3423)
+- Autocomplete: Add StarCoder2 experimental support. [pull/61207](https://github.com/sourcegraph/cody/pull/61207)
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -38,12 +38,7 @@
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
-  "categories": [
-    "Programming Languages",
-    "Machine Learning",
-    "Snippets",
-    "Education"
-  ],
+  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "ai",
     "openai",
@@ -94,11 +89,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": [
-    "onLanguage",
-    "onStartupFinished",
-    "onWebviewPanel:cody.chatPanel"
-  ],
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
   "contributes": {
     "walkthroughs": [
       {
@@ -820,20 +811,12 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": [
-            "https://github.com/sourcegraph/cody",
-            "ssh://git@github.com/sourcegraph/cody"
-          ]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "embeddings",
-            "keyword",
-            "blended",
-            "none"
-          ],
+          "enum": ["embeddings", "keyword", "blended", "none"],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -897,9 +880,7 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages. (E.g., \"Answer all my questions in Spanish.\")",
-          "examples": [
-            "Answer all my questions in Spanish."
-          ]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -964,27 +945,15 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "all",
-            "off"
-          ],
-          "enumDescriptions": [
-            "Sends usage data and errors.",
-            "Disables all extension telemetry."
-          ],
+          "enum": ["all", "off"],
+          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
         "cody.autocomplete.advanced.provider": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "anthropic",
-            "fireworks",
-            "unstable-openai",
-            "experimental-ollama"
-          ],
+          "enum": [null, "anthropic", "fireworks", "unstable-openai", "experimental-ollama"],
           "markdownDescription": "The provider used for code autocomplete. Most providers other than `anthropic` require the `cody.autocomplete.advanced.serverEndpoint` and `cody.autocomplete.advanced.accessToken` settings to also be set. Check the Cody output channel for error messages if autocomplete is not working as expected."
         },
         "cody.autocomplete.advanced.serverEndpoint": {
@@ -998,12 +967,7 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "starcoder-16b",
-            "starcoder-7b",
-            "llama-code-13b"
-          ],
+          "enum": [null, "starcoder-16b", "starcoder-7b", "starcoder2-hybrid", "llama-code-13b"],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1023,10 +987,7 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": [
-            "lsp",
-            "indentation-based"
-          ],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1052,11 +1013,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "bfg",
-            "bfg-mixed"
-          ],
+          "enum": [null, "bfg", "bfg-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.ollamaOptions": {

--- a/vscode/src/completions/get-inline-completions-tests/models.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/models.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest'
+
+import type { CompletionParameters } from '@sourcegraph/cody-shared'
+
+import { getInlineCompletionsWithInlinedChunks } from './helpers'
+
+describe('[getInlineCompletions] models', () => {
+    describe('starcoder2-hybrid', () => {
+        test('singleline', async () => {
+            const requests: CompletionParameters[] = []
+            await getInlineCompletionsWithInlinedChunks('const value = █1█', {
+                onNetworkRequest(request) {
+                    requests.push(request)
+                },
+                configuration: {
+                    autocompleteAdvancedProvider: 'fireworks',
+                    autocompleteAdvancedModel: 'starcoder2-hybrid',
+                },
+            })
+            expect(requests[0].stopSequences).toMatchInlineSnapshot(`
+              [
+                "<fim_prefix>",
+                "<fim_suffix>",
+                "<fim_middle>",
+                "<|endoftext|>",
+                "<file_sep>",
+              ]
+            `)
+            expect(requests[0].model).toBe('fireworks/starcoder2-7b')
+        })
+
+        test('multiline', async () => {
+            const requests: CompletionParameters[] = []
+            await getInlineCompletionsWithInlinedChunks('const value = {█}█', {
+                onNetworkRequest(request) {
+                    requests.push(request)
+                },
+                configuration: {
+                    autocompleteAdvancedProvider: 'fireworks',
+                    autocompleteAdvancedModel: 'starcoder2-hybrid',
+                },
+            })
+            expect(requests[0].stopSequences).toMatchInlineSnapshot(`
+              [
+                "
+
+              ",
+                "
+
+              ",
+                "<fim_prefix>",
+                "<fim_suffix>",
+                "<fim_middle>",
+                "<|endoftext|>",
+                "<file_sep>",
+              ]
+            `)
+            expect(requests[0].model).toBe('fireworks/starcoder2-15b')
+        })
+    })
+})

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -132,13 +132,18 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         return { provider: configuredProvider }
     }
 
-    const [starCoderHybrid, llamaCode13B] = await Promise.all([
+    const [starCoder2Hybrid, starCoderHybrid, llamaCode13B] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
     ])
 
     if (llamaCode13B) {
         return { provider: 'fireworks', model: 'llama-code-13b' }
+    }
+
+    if (starCoder2Hybrid) {
+        return { provider: 'fireworks', model: 'starcoder2-hybrid' }
     }
 
     if (starCoderHybrid) {

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -74,6 +74,8 @@ const MODEL_MAP = {
     starcoder: 'fireworks/starcoder',
     'starcoder-16b': 'fireworks/starcoder-16b',
     'starcoder-7b': 'fireworks/starcoder-7b',
+    'starcoder2-15b': 'fireworks/starcoder2-15b',
+    'starcoder2-7b': 'fireworks/starcoder2-7b',
 
     // Fireworks model identifiers
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
@@ -83,10 +85,15 @@ type FireworksModel =
     | keyof typeof MODEL_MAP
     // `starcoder-hybrid` uses the 16b model for multiline requests and the 7b model for single line
     | 'starcoder-hybrid'
+    // `starcoder2-hybrid` uses the 15b model for multiline requests and the 7b model for single line
+    | 'starcoder2-hybrid'
 
 function getMaxContextTokens(model: FireworksModel): number {
     switch (model) {
         case 'starcoder':
+        case 'starcoder2-hybrid':
+        case 'starcoder2-15b':
+        case 'starcoder2-7b':
         case 'starcoder-hybrid':
         case 'starcoder-16b':
         case 'starcoder-7b': {
@@ -212,9 +219,11 @@ class FireworksProvider extends Provider {
             temperature: 0.2,
             topK: 0,
             model:
-                this.model === 'starcoder-hybrid'
-                    ? MODEL_MAP[multiline ? 'starcoder-16b' : 'starcoder-7b']
-                    : MODEL_MAP[this.model],
+                this.model === 'starcoder2-hybrid'
+                    ? MODEL_MAP[multiline ? 'starcoder2-15b' : 'starcoder2-7b']
+                    : this.model === 'starcoder-hybrid'
+                      ? MODEL_MAP[multiline ? 'starcoder-16b' : 'starcoder-7b']
+                      : MODEL_MAP[this.model],
         }
 
         tracer?.params(requestParams)

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -218,7 +218,7 @@ class FireworksProvider extends Provider {
         })
 
         const { multiline } = this.options
-        const requestParams: CodeCompletionsParams = {
+        const requestParams = {
             ...partialRequestParams,
             messages: [{ speaker: 'human', text: this.createPrompt(snippets) }],
             temperature: 0.2,
@@ -229,6 +229,16 @@ class FireworksProvider extends Provider {
                     : this.model === 'starcoder-hybrid'
                       ? MODEL_MAP[multiline ? 'starcoder-16b' : 'starcoder-7b']
                       : MODEL_MAP[this.model],
+        } satisfies CodeCompletionsParams
+
+        if (requestParams.model.includes('starcoder2')) {
+            requestParams.stopSequences?.push(
+                '<fim_prefix>',
+                '<fim_suffix>',
+                '<fim_middle>',
+                '<|endoftext|>',
+                '<file_sep>'
+            )
         }
 
         tracer?.params(requestParams)

--- a/vscode/src/completions/providers/get-completion-params.ts
+++ b/vscode/src/completions/providers/get-completion-params.ts
@@ -4,9 +4,8 @@ import type { ProviderOptions } from './provider'
 
 export const MAX_RESPONSE_TOKENS = 256
 
-type LineNumberDependentCompletionParams = Pick<
-    CodeCompletionsParams,
-    'maxTokensToSample' | 'stopSequences' | 'timeoutMs'
+type LineNumberDependentCompletionParams = Required<
+    Pick<CodeCompletionsParams, 'maxTokensToSample' | 'stopSequences' | 'timeoutMs'>
 >
 
 interface LineNumberDependentCompletionParamsByType {
@@ -55,11 +54,11 @@ export function getCompletionParams(
 
     const useExtendedGeneration = isMultiline || hotStreak
 
-    const partialRequestParams: Omit<CodeCompletionsParams, 'messages'> = {
+    const partialRequestParams = {
         ...(useExtendedGeneration ? multilineParams : singlelineParams),
         temperature: 0.2,
         topK: 0,
-    }
+    } satisfies Omit<CodeCompletionsParams, 'messages'>
 
     // Apply custom multiline timeouts if they are defined.
     if (timeouts?.multiline && useExtendedGeneration) {


### PR DESCRIPTION
## Context

- Preparing for the StarCoder2 A/B test.
- Adds `starcoder2-hybrid` model to the Fireworks provider, which uses `starcoder2-7b` and `starcoder2-15b`.
- Cody-Gateway support https://github.com/sourcegraph/sourcegraph/pull/61207

## Test plan

- Tested locally by mocking the return value of the feature flag provider and asserting that the right requests were made by investigating the output console.
