### PR TITLE
experimental Cody CLI

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -12,9 +12,9 @@
   "main": "src/index.ts",
   "sideEffects": false,
   "scripts": {
-    "build:root": "cd .. && pnpm build && cd $(pwd)/agent",
+    "build:root": "pnpm -C .. run -s build",
     "build:agent": "node src/esbuild.mjs",
-    "build": "pnpm run build:root && pnpm run build:agent",
+    "build": "pnpm run -s build:root && pnpm run -s build:agent",
     "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node dist/index.js",
     "agent:debug": "pnpm run build && CODY_AGENT_TRACE_PATH=/tmp/agent.json CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js",

--- a/agent/src/cli/root.ts
+++ b/agent/src/cli/root.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander'
 
+import { cliCommand } from '../../../cli/src/command'
 import { evaluateAutocompleteCommand } from './evaluate-autocomplete/evaluate-autocomplete'
 import { jsonrpcCommand } from './jsonrpc'
 
@@ -12,3 +13,4 @@ export const rootCommand = new Command()
     )
     .addCommand(jsonrpcCommand)
     .addCommand(evaluateAutocompleteCommand)
+    .addCommand(cliCommand)

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -9,5 +9,5 @@
   },
   "include": ["**/*", ".*", "package.json", "src/language-file-extensions.json"],
   "exclude": ["dist", "bindings", "src/__tests__", "src/bfg/__tests__", "vitest.config.ts"],
-  "references": [{ "path": "../lib/shared" }, { "path": "../vscode" }],
+  "references": [{"path": "../cli"}, { "path": "../lib/shared" }, { "path": "../vscode" }],
 }

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,39 @@
+# Cody CLI (experimental)
+
+A command-line interface for Cody.
+
+**Status:** experimental
+
+## Usage
+
+Set the `SRC_ENDPOINT` and `SRC_ACCESS_TOKEN` environment variables:
+
+```
+# Sourcegraph URL (https://sourcegraph.com or a URL to an enterprise instance)
+export SRC_ENDPOINT=https://sourcegraph.com
+
+# Sourcegraph access token (created in Sourcegraph > User settings > Access tokens)
+export SRC_ACCESS_TOKEN=sgp_0000000000_0000000000000000000
+```
+
+Then run:
+
+```
+npm install -g @sourcegraph/cody-agent
+
+# Ask Cody a question (with no context):
+cody-agent experimental-cli chat -m 'what color is the sky?'
+
+# Ask Cody a question (with Sourcegraph Enterprise repository context):
+cody-agent experimental-cli chat --context-repo github.com/sourcegraph/{sourcegraph,cody} --show-context -m 'how is authentication handled in sourcegraph/cody?'
+```
+
+## Development & feedback
+
+Use the [Feedback on Cody CLI (experimental feature)](https://community.sourcegraph.com/t/feedback-on-cody-cli-experimental-feature/78) thread in the Sourcegraph community forum.
+
+Issues and PRs appreciated!
+
+## Releases
+
+The CLI is built and published as part of the [Cody Agent](../agent/README.md).

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,27 @@
+{
+  "private": true,
+  "name": "@sourcegraph/cody-cli",
+  "version": "0.0.1",
+  "description": "Cody CLI (bundled and published as part of @sourcegraph/cody-agent in the ../agent dir)",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/cody",
+    "directory": "cli"
+  },
+  "main": "src/main.ts",
+  "sideEffects": false,
+  "scripts": {
+    "cli": "pnpm -C ../agent run -s build && node ../agent/dist/index.js experimental-cli",
+    "build": "tsc -b",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@sourcegraph/cody-shared": "workspace:*",
+    "commander": "^12.0.0",
+    "vscode-uri": "^3.0.7"
+  },
+  "devDependencies": {
+    "esbuild": "^0.20.2"
+  }
+}

--- a/cli/src/agentClient.ts
+++ b/cli/src/agentClient.ts
@@ -1,0 +1,188 @@
+import { type ChildProcessWithoutNullStreams, fork } from 'node:child_process'
+import { displayLineRange } from '@sourcegraph/cody-shared'
+import { URI } from 'vscode-uri'
+import type { ExtensionMessage, ExtensionTranscriptMessage } from '../../vscode/src/chat/protocol'
+import type { ServerInfo } from '../../vscode/src/jsonrpc/agent-protocol'
+import { MessageHandler } from '../../vscode/src/jsonrpc/jsonrpc'
+
+export interface AgentClient {
+    serverInfo: ServerInfo
+    chat(message: string, options: ChatOptions): Promise<ChatResult>
+    dispose(): void
+}
+
+export interface AgentClientOptions {
+    serverEndpoint: string
+    accessToken: string
+    workspaceRootUri: string
+    debug?: boolean
+}
+
+export interface ChatOptions {
+    model?: string
+    contextRepositoryNames?: string[]
+}
+
+interface ChatResult {
+    text: string
+    contextFiles: string[]
+}
+
+export async function createAgentClient({
+    serverEndpoint,
+    accessToken,
+    workspaceRootUri,
+    debug = false,
+}: AgentClientOptions): Promise<AgentClient> {
+    const agentProcess = spawnAgent()
+    const rpc = new MessageHandler()
+    agentProcess.stdout.pipe(rpc.messageDecoder)
+    rpc.messageEncoder.pipe(agentProcess.stdin)
+
+    rpc.registerNotification('debug/message', message => {
+        if (debug) {
+            console.debug('agent: debug:', message)
+        }
+    })
+    rpc.registerNotification('webview/postMessage', message => {
+        if (debug) {
+            console.debug('agent: debug:', message)
+        }
+    })
+
+    const serverInfo = await rpc.request('initialize', {
+        name: 'cody-cli',
+        version: '0.0.1',
+        workspaceRootUri,
+        extensionConfiguration: {
+            serverEndpoint: serverEndpoint,
+            accessToken,
+            customHeaders: {},
+        },
+    })
+    rpc.notify('initialized', null)
+
+    let disposed = false
+    function spawnAgent(): ChildProcessWithoutNullStreams {
+        // This works both when running normally as `node cody-agent.js` and when using the
+        // self-contained executables built by `pnpm -C agent run build-agent-binaries`. See
+        // https://github.com/vercel/pkg#snapshot-filesystem.
+        const agentProcess = fork(process.argv[1], ['jsonrpc'], {
+            stdio: 'pipe',
+            env: {
+                ...process.env,
+                NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --enable-source-maps`,
+            },
+        })
+
+        agentProcess.on('close', () => {
+            if (!disposed) {
+                console.error('agent: close')
+                process.exit(1)
+            }
+        })
+        agentProcess.on('error', error => {
+            console.error('agent: error:', error)
+            process.exit(1)
+        })
+        agentProcess.on('exit', code => {
+            if (disposed) {
+                process.exit(code ?? 0)
+            }
+            console.error(`agent: exit with code ${code}`)
+            process.exit(1)
+        })
+        if (!agentProcess.stderr || !agentProcess.stdout || !agentProcess.stdin) {
+            console.error('agent: invalid stdio')
+            process.exit(1)
+        }
+        agentProcess.stderr!.on('data', data => {
+            console.error(`----agent stderr----\n${data}\n--------------------`)
+        })
+
+        return agentProcess as ChildProcessWithoutNullStreams
+    }
+
+    return {
+        serverInfo,
+        async chat(message: string, options: ChatOptions): Promise<ChatResult> {
+            const id = await rpc.request('chat/new', null)
+
+            if (options.model) {
+                await rpc.request('webview/receiveMessage', {
+                    id,
+                    message: {
+                        command: 'chatModel',
+                        model: options.model,
+                    },
+                })
+            }
+
+            if (options.contextRepositoryNames && options.contextRepositoryNames.length > 0) {
+                const { repos } = await rpc.request('graphql/getRepoIds', {
+                    names: options.contextRepositoryNames,
+                    first: options.contextRepositoryNames.length,
+                })
+                await rpc.request('webview/receiveMessage', {
+                    id,
+                    message: {
+                        command: 'context/choose-remote-search-repo',
+                        explicitRepos: repos,
+                    },
+                })
+            }
+
+            const transcript = asTranscriptMessage(
+                await rpc.request('chat/submitMessage', {
+                    id,
+                    message: {
+                        command: 'submit',
+                        submitType: 'user',
+                        text: message,
+                        contextFiles: [],
+                        addEnhancedContext: true,
+                    },
+                })
+            )
+
+            const sentMessage = transcript.messages.at(0)
+            if (!sentMessage) {
+                throw new Error('invalid transcript')
+            }
+
+            const reply = transcript.messages.at(-1)
+            if (!reply) {
+                throw new Error('no reply')
+            }
+            if (reply.error) {
+                throw new Error(`error reply: ${reply.error.message}`)
+            }
+
+            return {
+                text: reply.text ?? '',
+                contextFiles:
+                    sentMessage.contextFiles?.map(c =>
+                        c.repoName
+                            ? // TODO(sqs): Fix URL-encoding for Sourcegraph URLs.
+                              URI.revive(c.uri)
+                                  .toString()
+                                  .replace('.com//', '.com/')
+                                  .replace('%40', '@')
+                            : `${c.uri.path}${c.range ? `?L${displayLineRange(c.range)}` : ''}`
+                    ) ?? [],
+            }
+        },
+        dispose(): void {
+            disposed = true
+            rpc.exit()
+            agentProcess.kill()
+        },
+    }
+}
+
+function asTranscriptMessage(reply: ExtensionMessage): ExtensionTranscriptMessage {
+    if (reply.type === 'transcript') {
+        return reply
+    }
+    throw new Error(`expected transcript, got: ${JSON.stringify(reply)}`)
+}

--- a/cli/src/chat.ts
+++ b/cli/src/chat.ts
@@ -1,0 +1,56 @@
+import { resolve } from 'node:path'
+import { Command } from 'commander'
+import { createAgentClient } from './agentClient'
+
+declare const process: { pkg: { entrypoint: string } } & NodeJS.Process
+
+export const chatCommand = new Command('chat')
+    .description('Chat with codebase context')
+    .requiredOption('-m, --message <message>', 'Message to send')
+    .option(
+        '--endpoint',
+        'Sourcegraph URL (SRC_ENDPOINT env var)',
+        process.env.SRC_ENDPOINT ?? 'https://sourcegraph.com'
+    )
+    .option(
+        '--access-token',
+        'Sourcegraph access token (SRC_ACCESS_TOKEN env var)',
+        process.env.SRC_ACCESS_TOKEN ?? ''
+    )
+    .option('-C, --dir <dir>', 'Run in directory <dir>', process.cwd())
+    .option('--model <model>', 'Chat model to use')
+    .option('--context-repo <repos...>', 'Names of repositories to use as context')
+    .option('--show-context', 'Show context items in reply', false)
+    .option('--debug', 'Enable debug logging', false)
+    .action(
+        async (options: {
+            endpoint: string
+            accessToken: string
+            message: string
+            dir: string
+            model?: string
+            contextRepo?: string[]
+            showContext: boolean
+            debug: boolean
+        }) => {
+            const client = await createAgentClient({
+                serverEndpoint: options.endpoint,
+                accessToken: options.accessToken,
+                workspaceRootUri: `file://${resolve(options.dir)}`,
+                debug: options.debug,
+            })
+            const { text, contextFiles } = await client.chat(options.message, {
+                model: options.model,
+                contextRepositoryNames: options.contextRepo,
+            })
+            if (options.showContext) {
+                console.log('> Context items:')
+                for (const [i, item] of contextFiles.entries()) {
+                    console.log(`> ${i + 1}. ${item}`)
+                }
+                console.log()
+            }
+            console.log(text)
+            client.dispose()
+        }
+    )

--- a/cli/src/command.ts
+++ b/cli/src/command.ts
@@ -1,0 +1,6 @@
+import { Command } from 'commander'
+import { chatCommand } from './chat'
+
+export const cliCommand = new Command('experimental-cli')
+    .description('Experimental Cody command-line interface')
+    .addCommand(chatCommand)

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2022",
+    "rootDir": "src",
+    "outDir": "dist",
+  },
+  "include": ["src"],
+  "references": [{ "path": "../lib/shared" }, { "path": "../vscode" }],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,22 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
 
+  cli:
+    dependencies:
+      '@sourcegraph/cody-shared':
+        specifier: workspace:*
+        version: link:../lib/shared
+      commander:
+        specifier: ^12.0.0
+        version: 12.0.0
+      vscode-uri:
+        specifier: ^3.0.7
+        version: 3.0.7
+    devDependencies:
+      esbuild:
+        specifier: ^0.20.2
+        version: 0.20.2
+
   lib/icons:
     dependencies:
       svgtofont:
@@ -2071,6 +2087,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.20.2:
+    resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64@0.18.19:
     resolution: {integrity: sha512-4+jkUFQxZkQfQOOxfGVZB38YUWHMJX2ihZwF+2nh8m7bHdWXpixiurgGRN3c/KMSwlltbYI0/i929jwBRMFzbA==}
     engines: {node: '>=12'}
@@ -2091,6 +2116,15 @@ packages:
 
   /@esbuild/android-arm64@0.19.12:
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.20.2:
+    resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -2125,6 +2159,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm@0.20.2:
+    resolution: {integrity: sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-x64@0.18.19:
     resolution: {integrity: sha512-ae5sHYiP/Ogj2YNrLZbWkBmyHIDOhPgpkGvFnke7XFGQldBDWvc/AyYwSLpNuKw9UNkgnLlB/jPpnBmlF3G9Bg==}
     engines: {node: '>=12'}
@@ -2145,6 +2188,15 @@ packages:
 
   /@esbuild/android-x64@0.19.12:
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.20.2:
+    resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -2179,6 +2231,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-arm64@0.20.2:
+    resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-x64@0.18.19:
     resolution: {integrity: sha512-m6JdvXJQt0thNLIcWOeG079h2ivhYH4B5sVCgqb/B29zTcFd7EE8/J1nIUHhdtwGeItdUeqKaqqb4towwxvglQ==}
     engines: {node: '>=12'}
@@ -2199,6 +2260,15 @@ packages:
 
   /@esbuild/darwin-x64@0.19.12:
     resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.20.2:
+    resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -2233,6 +2303,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-arm64@0.20.2:
+    resolution: {integrity: sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-x64@0.18.19:
     resolution: {integrity: sha512-hBxgRlG42+W+j/1/cvlnSa+3+OBKeDCyO7OG2ICya1YJaSCYfSpuG30KfOnQHI7Ytgu4bRqCgrYXxQEzy0zM5Q==}
     engines: {node: '>=12'}
@@ -2253,6 +2332,15 @@ packages:
 
   /@esbuild/freebsd-x64@0.19.12:
     resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.20.2:
+    resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -2287,6 +2375,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64@0.20.2:
+    resolution: {integrity: sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm@0.18.19:
     resolution: {integrity: sha512-qtWyoQskfJlb9MD45mvzCEKeO4uCnDZ7lPFeNqbfaaJHqBiH9qA5Vu2EuckqYZuFMJWy1l4dxTf9NOulCVfUjg==}
     engines: {node: '>=12'}
@@ -2307,6 +2404,15 @@ packages:
 
   /@esbuild/linux-arm@0.19.12:
     resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.20.2:
+    resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -2341,6 +2447,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ia32@0.20.2:
+    resolution: {integrity: sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-loong64@0.18.19:
     resolution: {integrity: sha512-YLAslaO8NsB9UOxBchos82AOMRDbIAWChwDKfjlGrHSzS3v1kxce7dGlSTsrb0PJwo1KYccypN3VNjQVLtz7LA==}
     engines: {node: '>=12'}
@@ -2361,6 +2476,15 @@ packages:
 
   /@esbuild/linux-loong64@0.19.12:
     resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.20.2:
+    resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -2395,6 +2519,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-mips64el@0.20.2:
+    resolution: {integrity: sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ppc64@0.18.19:
     resolution: {integrity: sha512-tgG41lRVwlzqO9tv9l7aXYVw35BxKXLtPam1qALScwSqPivI8hjkZLNH0deaaSCYCFT9cBIdB+hUjWFlFFLL9A==}
     engines: {node: '>=12'}
@@ -2415,6 +2548,15 @@ packages:
 
   /@esbuild/linux-ppc64@0.19.12:
     resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.20.2:
+    resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -2449,6 +2591,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-riscv64@0.20.2:
+    resolution: {integrity: sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-s390x@0.18.19:
     resolution: {integrity: sha512-q1V1rtHRojAzjSigZEqrcLkpfh5K09ShCoIsdTakozVBnM5rgV58PLFticqDp5UJ9uE0HScov9QNbbl8HBo6QQ==}
     engines: {node: '>=12'}
@@ -2469,6 +2620,15 @@ packages:
 
   /@esbuild/linux-s390x@0.19.12:
     resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.20.2:
+    resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -2503,6 +2663,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-x64@0.20.2:
+    resolution: {integrity: sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/netbsd-x64@0.18.19:
     resolution: {integrity: sha512-3tt3SOS8L3D54R8oER41UdDshlBIAjYhdWRPiZCTZ1E41+shIZBpTjaW5UaN/jD1ENE/Ok5lkeqhoNMbxstyxw==}
     engines: {node: '>=12'}
@@ -2523,6 +2692,15 @@ packages:
 
   /@esbuild/netbsd-x64@0.19.12:
     resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.20.2:
+    resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -2557,6 +2735,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/openbsd-x64@0.20.2:
+    resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.18.19:
     resolution: {integrity: sha512-m0/UOq1wj25JpWqOJxoWBRM9VWc3c32xiNzd+ERlYstUZ6uwx5SZsQUtkiFHaYmcaoj+f6+Tfcl7atuAz3idwQ==}
     engines: {node: '>=12'}
@@ -2577,6 +2764,15 @@ packages:
 
   /@esbuild/sunos-x64@0.19.12:
     resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.20.2:
+    resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -2611,6 +2807,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-arm64@0.20.2:
+    resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-ia32@0.18.19:
     resolution: {integrity: sha512-rQng7LXSKdrDlNDb7/v0fujob6X0GAazoK/IPd9C3oShr642ri8uIBkgM37/l8B3Rd5sBQcqUXoDdEy75XC/jg==}
     engines: {node: '>=12'}
@@ -2638,6 +2843,15 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32@0.20.2:
+    resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64@0.18.19:
     resolution: {integrity: sha512-z69jhyG20Gq4QL5JKPLqUT+eREuqnDAFItLbza4JCmpvUnIlY73YNjd5djlO7kBiiZnvTnJuAbOjIoZIOa1GjA==}
     engines: {node: '>=12'}
@@ -2658,6 +2872,15 @@ packages:
 
   /@esbuild/win32-x64@0.19.12:
     resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.20.2:
+    resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -6414,6 +6637,11 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
+  /commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
+    dev: false
+
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -7246,6 +7474,37 @@ packages:
       '@esbuild/win32-arm64': 0.19.12
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
+    dev: true
+
+  /esbuild@0.20.2:
+    resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.20.2
+      '@esbuild/android-arm': 0.20.2
+      '@esbuild/android-arm64': 0.20.2
+      '@esbuild/android-x64': 0.20.2
+      '@esbuild/darwin-arm64': 0.20.2
+      '@esbuild/darwin-x64': 0.20.2
+      '@esbuild/freebsd-arm64': 0.20.2
+      '@esbuild/freebsd-x64': 0.20.2
+      '@esbuild/linux-arm': 0.20.2
+      '@esbuild/linux-arm64': 0.20.2
+      '@esbuild/linux-ia32': 0.20.2
+      '@esbuild/linux-loong64': 0.20.2
+      '@esbuild/linux-mips64el': 0.20.2
+      '@esbuild/linux-ppc64': 0.20.2
+      '@esbuild/linux-riscv64': 0.20.2
+      '@esbuild/linux-s390x': 0.20.2
+      '@esbuild/linux-x64': 0.20.2
+      '@esbuild/netbsd-x64': 0.20.2
+      '@esbuild/openbsd-x64': 0.20.2
+      '@esbuild/sunos-x64': 0.20.2
+      '@esbuild/win32-arm64': 0.20.2
+      '@esbuild/win32-ia32': 0.20.2
+      '@esbuild/win32-x64': 0.20.2
     dev: true
 
   /escalade@3.1.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - agent
+  - cli
   - lib/*
   - vscode

--- a/vitest.workspace.js
+++ b/vitest.workspace.js
@@ -1,3 +1,3 @@
 // @ts-check
 
-export default ['agent', 'lib/shared', 'vscode']
+export default ['agent', 'cli', 'lib/shared', 'vscode']


### PR DESCRIPTION
The experimental Cody CLI spawns the agent and uses it to support CLI invocations like:

```
cody-agent experimental-cli chat -m 'what color is the sky?'

cody-agent experimental-cli chat --context-repo github.com/sourcegraph/{sourcegraph,cody} -m 'how is authentication handled in sourcegraph/cody?'
```

Unlike the previous CLI (which was removed), this CLI requires almost *no changes* to code outside the new `cli/` directory, which is a nice win for the agent architecture and means that this experimental CLI does not necessitate bad code abstractions.

Depends on https://github.com/sourcegraph/cody/pull/3671 to publish `cody-agent` binaries and packages, so that it's easy to run the CLI without building it locally from source.

## Test plan

n/a