### PR TITLE
Telemetry: Fix `hasV2Event` often being included as an event property

### DIFF
--- a/lib/shared/src/telemetry/index.ts
+++ b/lib/shared/src/telemetry/index.ts
@@ -54,7 +54,12 @@ export interface TelemetryEventProperties {
         | undefined
         | string[]
         | TelemetryEventProperties[]
-        | TelemetryEventProperties
+        | TelemetryEventProperties,
+    /**
+     * `hasV2Event` is a disallowed property.
+     * Did you mean to provide this as a telemetry option?
+     */
+    hasV2Event?: never
 }
 
 /** For testing. */

--- a/lib/shared/src/telemetry/index.ts
+++ b/lib/shared/src/telemetry/index.ts
@@ -54,7 +54,7 @@ export interface TelemetryEventProperties {
         | undefined
         | string[]
         | TelemetryEventProperties[]
-        | TelemetryEventProperties,
+        | TelemetryEventProperties
     /**
      * `hasV2Event` is a disallowed property.
      * Did you mean to provide this as a telemetry option?

--- a/lib/shared/src/telemetry/index.ts
+++ b/lib/shared/src/telemetry/index.ts
@@ -55,11 +55,6 @@ export interface TelemetryEventProperties {
         | string[]
         | TelemetryEventProperties[]
         | TelemetryEventProperties
-    /**
-     * `hasV2Event` is a disallowed property.
-     * Did you mean to provide this as a telemetry option?
-     */
-    hasV2Event?: never
 }
 
 /** For testing. */

--- a/vscode/src/chat/chat-view/SidebarViewController.ts
+++ b/vscode/src/chat/chat-view/SidebarViewController.ts
@@ -78,12 +78,17 @@ export class SidebarViewController implements vscode.WebviewViewProvider {
                                 async (token, endpoint) => {
                                     closeAuthProgressIndicator()
                                     const authStatus = await this.authProvider.auth(endpoint, token)
-                                    telemetryService.log('CodyVSCodeExtension:auth:fromTokenReceiver', {
-                                        type: 'callback',
-                                        from: 'web',
-                                        success: Boolean(authStatus?.isLoggedIn),
-                                        hasV2Event: true,
-                                    })
+                                    telemetryService.log(
+                                        'CodyVSCodeExtension:auth:fromTokenReceiver',
+                                        {
+                                            type: 'callback',
+                                            from: 'web',
+                                            success: Boolean(authStatus?.isLoggedIn),
+                                        },
+                                        {
+                                            hasV2Event: true,
+                                        }
+                                    )
                                     telemetryRecorder.recordEvent(
                                         'cody.auth.fromTokenReceiver.web',
                                         'succeeded',

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -171,7 +171,7 @@ export class GhostHintDecorator implements vscode.Disposable {
     }
 
     private _fireDisplayEvent(): void {
-        telemetryService.log('CodyVSCodeExtension:ghostText:visible', { hasV2Event: true })
+        telemetryService.log('CodyVSCodeExtension:ghostText:visible', {}, { hasV2Event: true })
         telemetryRecorder.recordEvent('cody.ghostText', 'visible')
     }
 

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -160,11 +160,16 @@ export class EditProvider {
         }
 
         if (!isMessageInProgress) {
-            telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', {
-                ...countCode(response),
-                source: this.config.task.source,
-                hasV2Event: true,
-            })
+            telemetryService.log(
+                'CodyVSCodeExtension:fixupResponse:hasCode',
+                {
+                    ...countCode(response),
+                    source: this.config.task.source,
+                },
+                {
+                    hasV2Event: true,
+                }
+            )
             const endpoint = this.config.authProvider?.getAuthStatus()?.endpoint
             const responseText = endpoint && isDotCom(endpoint) ? response : undefined
             telemetryRecorder.recordEvent('cody.fixup.response', 'hasCode', {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -50,58 +50,93 @@ export class FixupController
         this._disposables.push(
             vscode.workspace.registerTextDocumentContentProvider('cody-fixup', this.contentStore),
             vscode.commands.registerCommand('cody.fixup.codelens.cancel', id => {
-                telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', {
-                    op: 'cancel',
-                    hasV2Event: true,
-                })
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'cancel',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
                 telemetryRecorder.recordEvent('cody.fixup.codeLens', 'cancel')
                 return this.cancel(id)
             }),
             vscode.commands.registerCommand('cody.fixup.codelens.diff', id => {
-                telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', {
-                    op: 'diff',
-                    hasV2Event: true,
-                })
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'diff',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
                 telemetryRecorder.recordEvent('cody.fixup.codeLens', 'diff')
                 return this.diff(id)
             }),
             vscode.commands.registerCommand('cody.fixup.codelens.retry', async id => {
-                telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', {
-                    op: 'regenerate',
-                    hasV2Event: true,
-                })
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'regenerate',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
                 telemetryRecorder.recordEvent('cody.fixup.codeLens', 'retry')
                 return this.retry(id)
             }),
             vscode.commands.registerCommand('cody.fixup.codelens.undo', id => {
-                telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', {
-                    op: 'undo',
-                    hasV2Event: true,
-                })
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'undo',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
                 telemetryRecorder.recordEvent('cody.fixup.codeLens', 'undo')
                 return this.undo(id)
             }),
             vscode.commands.registerCommand('cody.fixup.codelens.accept', id => {
-                telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', {
-                    op: 'accept',
-                    hasV2Event: true,
-                })
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'accept',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
                 telemetryRecorder.recordEvent('cody.fixup.codeLens', 'accept')
                 return this.accept(id)
             }),
             vscode.commands.registerCommand('cody.fixup.codelens.error', id => {
-                telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', {
-                    op: 'show_error',
-                    hasV2Event: true,
-                })
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'show_error',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
                 telemetryRecorder.recordEvent('cody.fixup.codeLens', 'showError')
                 return this.showError(id)
             }),
             vscode.commands.registerCommand('cody.fixup.codelens.skip-formatting', id => {
-                telemetryService.log('CodyVSCodeExtension:fixup:codeLens:clicked', {
-                    op: 'skip_formatting',
-                    hasV2Event: true,
-                })
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'skip_formatting',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
                 telemetryRecorder.recordEvent('cody.fixup.codeLens', 'skipFormatting')
                 return this.skipFormatting(id)
             }),
@@ -301,10 +336,15 @@ export class FixupController
     private scheduleRespin(task: FixupTask): void {
         const MAX_SPIN_COUNT_PER_TASK = 5
         if (task.spinCount >= MAX_SPIN_COUNT_PER_TASK) {
-            telemetryService.log('CodyVSCodeExtension:fixup:respin', {
-                count: task.spinCount,
-                hasV2Event: true,
-            })
+            telemetryService.log(
+                'CodyVSCodeExtension:fixup:respin',
+                {
+                    count: task.spinCount,
+                },
+                {
+                    hasV2Event: true,
+                }
+            )
             telemetryRecorder.recordEvent('cody.fixup.respin', 'scheduled', {
                 metadata: { spinCount: task.spinCount },
             })
@@ -737,9 +777,13 @@ export class FixupController
         })
 
         if (!editOk) {
-            telemetryService.log('CodyVSCodeExtension:fixup:revert:failed', {
-                hasV2Event: true,
-            })
+            telemetryService.log(
+                'CodyVSCodeExtension:fixup:revert:failed',
+                {},
+                {
+                    hasV2Event: true,
+                }
+            )
             telemetryRecorder.recordEvent('cody.fixup.revert', 'failed')
             return
         }

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -76,14 +76,18 @@ export class AuthProvider {
     public async signinMenu(type?: 'enterprise' | 'dotcom' | 'token', uri?: string): Promise<void> {
         const mode = this.authStatus.isLoggedIn ? 'switch' : 'signin'
         logDebug('AuthProvider:signinMenu', mode)
-        telemetryService.log('CodyVSCodeExtension:login:clicked', { hasV2Event: true })
+        telemetryService.log('CodyVSCodeExtension:login:clicked', {}, { hasV2Event: true })
         telemetryRecorder.recordEvent('cody.auth.login', 'clicked')
         const item = await AuthMenu(mode, this.endpointHistory)
         if (!item) {
             return
         }
         const menuID = type || item?.id
-        telemetryService.log('CodyVSCodeExtension:auth:selectSigninMenu', { menuID, hasV2Event: true })
+        telemetryService.log(
+            'CodyVSCodeExtension:auth:selectSigninMenu',
+            { menuID },
+            { hasV2Event: true }
+        )
         telemetryRecorder.recordEvent('cody.auth.signin.menu', 'clicked', {
             privateMetadata: { menuID },
         })
@@ -132,10 +136,13 @@ export class AuthProvider {
             return
         }
         const authState = await this.auth(instanceUrl, accessToken)
-        telemetryService.log('CodyVSCodeExtension:auth:fromToken', {
-            success: Boolean(authState?.isLoggedIn),
-            hasV2Event: true,
-        })
+        telemetryService.log(
+            'CodyVSCodeExtension:auth:fromToken',
+            {
+                success: Boolean(authState?.isLoggedIn),
+            },
+            { hasV2Event: true }
+        )
         telemetryRecorder.recordEvent('cody.auth.signin.token', 'clicked', {
             metadata: {
                 success: authState?.isLoggedIn ? 1 : 0,
@@ -145,7 +152,7 @@ export class AuthProvider {
     }
 
     public async signoutMenu(): Promise<void> {
-        telemetryService.log('CodyVSCodeExtension:logout:clicked', { hasV2Event: true })
+        telemetryService.log('CodyVSCodeExtension:logout:clicked', {}, { hasV2Event: true })
         telemetryRecorder.recordEvent('cody.auth.logout', 'clicked')
         const { endpoint } = this.getAuthStatus()
 
@@ -363,12 +370,15 @@ export class AuthProvider {
             return
         }
         const authState = await this.auth(endpoint, token, customHeaders)
-        telemetryService.log('CodyVSCodeExtension:auth:fromCallback', {
-            type: 'callback',
-            from: 'web',
-            success: Boolean(authState?.isLoggedIn),
-            hasV2Event: true,
-        })
+        telemetryService.log(
+            'CodyVSCodeExtension:auth:fromCallback',
+            {
+                type: 'callback',
+                from: 'web',
+                success: Boolean(authState?.isLoggedIn),
+            },
+            { hasV2Event: true }
+        )
         telemetryRecorder.recordEvent('cody.auth.fromCallback.web', 'succeeded', {
             metadata: {
                 success: authState?.isLoggedIn ? 1 : 0,

--- a/vscode/src/services/utils/codeblock-action-tracker.ts
+++ b/vscode/src/services/utils/codeblock-action-tracker.ts
@@ -50,7 +50,7 @@ function setLastStoredCode(
     const op = eventName.includes('copy') ? 'copy' : eventName.startsWith('insert') ? 'insert' : 'save'
     const args = { op, charCount, lineCount, source, requestID }
 
-    telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, { args, hasV2Event: true })
+    telemetryService.log(`CodyVSCodeExtension:${eventName}:clicked`, { args }, { hasV2Event: true })
     telemetryRecorder.recordEvent(`cody.${eventName}`, 'clicked', {
         metadata: {
             lineCount,
@@ -135,14 +135,19 @@ export async function onTextDocumentChange(newCode: string): Promise<void> {
         const op = 'paste'
         const eventType = 'keyDown'
         // e.g.'CodyVSCodeExtension:keyDown:Paste:clicked'
-        telemetryService.log(`CodyVSCodeExtension:${eventType}:Paste:clicked`, {
-            op,
-            lineCount,
-            charCount,
-            source,
-            requestID,
-            hasV2Event: true,
-        })
+        telemetryService.log(
+            `CodyVSCodeExtension:${eventType}:Paste:clicked`,
+            {
+                op,
+                lineCount,
+                charCount,
+                source,
+                requestID,
+            },
+            {
+                hasV2Event: true,
+            }
+        )
 
         telemetryRecorder.recordEvent(`cody.${eventType}`, 'paste', {
             metadata: {


### PR DESCRIPTION
## Description

- Bans `hasV2Event` from telemetry properties
- Fixes type errors created from this

## Test plan

Build passes, type only change as this is an unused telemetry property

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
