### PR TITLE
Edit: Only compute diffs for actual edits

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -984,7 +984,7 @@ export class FixupController
         if (this.needsDiffUpdate_.size === 0) {
             void this.scheduler.scheduleIdle(() => this.updateDiffs())
         }
-        if (!this.needsDiffUpdate_.has(task)) {
+        if (task.mode === 'edit' && !this.needsDiffUpdate_.has(task)) {
             this.needsDiffUpdate_.add(task)
         }
     }


### PR DESCRIPTION
## Description

We currently try to compute the diff for all Edits, regardless if they are editing existing code or inserting new code.

Trying to produce a diff for `inserting` code is weird, because we actually don't care about the users' selection, but we still use it to compute the diff.

This can lead to a very misleading animation as the Edit computes, and it's also inefficient as we just throw the diff away anyway

## Test plan

1. Make an edit, check functions as normal
2. Make an edit that only inserts new code (e.g. document, or add), check functions as normal

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
