### PR TITLE
show "File too large" @-mention item warning on 2nd line in menu

### DIFF
--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
@@ -23,7 +23,7 @@
 }
 
 .item {
-    height: calc(var(--item-height) - 2*var(--item-padding-y));
+    min-height: calc(var(--item-height) - 2*var(--item-padding-y));
     padding: var(--item-padding-y) var(--item-padding-x);
 }
 
@@ -80,16 +80,18 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .option-item.selected {
 /* Option item content */
 .option-item {
     display: flex;
-    align-items: flex-end;
-    gap: 0.35rem;
+    flex-direction: column;
+    gap: calc(0.75*var(--item-padding-y));
 }
-.option-item-title, .option-item-description {
+.option-item-title, .option-item-description, .option-item-warning {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
 }
-.option-item-title--with-warning {
-    opacity: 0.7;
+.option-item-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.35rem;
 }
 .option-item-description {
     font-size: var(--description-font-size);
@@ -97,9 +99,7 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .option-item.selected {
     flex: 1;
 }
 .option-item-warning {
-    font-weight: bold;
-    font-size: 90%;
-    white-space: nowrap;
-    padding-left: 0.25rem;
+    font-size: var(--description-font-size);
+    opacity: 0.7;
 }
 

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -100,18 +100,20 @@ const Item: FunctionComponent<{
             onMouseEnter={onMouseEnter}
             onClick={onClick}
         >
-            {item.type === 'symbol' && icon && (
-                <i className={`codicon codicon-${icon}`} title={item.kind} />
-            )}
-            <span
-                className={classNames(
-                    styles.optionItemTitle,
-                    warning && styles.optionItemTitleWithWarning
+            <div className={styles.optionItemRow}>
+                {item.type === 'symbol' && icon && (
+                    <i className={`codicon codicon-${icon}`} title={item.kind} />
                 )}
-            >
-                {title}
-            </span>
-            {description && <span className={styles.optionItemDescription}>{description}</span>}
+                <span
+                    className={classNames(
+                        styles.optionItemTitle,
+                        warning && styles.optionItemTitleWithWarning
+                    )}
+                >
+                    {title}
+                </span>
+                {description && <span className={styles.optionItemDescription}>{description}</span>}
+            </div>
             {warning && <span className={styles.optionItemWarning}>{warning}</span>}
         </li>
     )


### PR DESCRIPTION
Previously, this warning was shown on the same line. See the screenshots below. (Note that these are on different color themes, but you get the idea.)

### After
![image](https://github.com/sourcegraph/cody/assets/1976/a459212d-fcb9-4891-b66f-8b6236e9592e)

### Before
![image](https://github.com/sourcegraph/cody/assets/1976/d1e9b842-fe3c-48e2-8621-09608e5fbff6)


## Test plan

CI