### PR TITLE
only show at-mention menu header in empty states

### DIFF
--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
@@ -1,18 +1,29 @@
-.container {
+.outer-container {
     min-width: 180px;
+    max-width: 85vw;
+    overflow: hidden;
+    height: calc(9*var(--item-height));
+}
+
+.visible-container {
+    background: var(--vscode-sideBar-background);
+    color: var(--vscode-sideBar-foreground);
+    border: 1px solid var(--vscode-widget-border);
+    box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
     font-size: var(--vscode-font-size);
-    padding: 0 5px 5px 5px; /* match VS Code quickpick padding */
+    padding: 5px; /* match VS Code quickpick padding */
+    border-radius: 6px; /* match VS Code */
 }
 
 :root {
     --item-height: 22px; /* match VS Code quickpick item height */
     --item-padding-y: 0.2rem;
-    --item-padding-x: 11px; /* match VS Code quickpick padding */
+    --item-padding-x: 6px; /* match VS Code quickpick padding */
     --description-font-size: 0.9em; /* match VS Code quickpick description */
 }
 
 .list {
-    max-height: calc(8*var(--item-height));
+    height: calc(8*var(--item-height));
     overflow-y: scroll;
     list-style: none;
     padding: var(--list-padding-y) 0;
@@ -20,6 +31,9 @@
 
     border-top: 1px solid var(--vscode-pickerGroup-border);
     margin-top: -1px;
+}
+.help-item:empty + .list {
+    border-top: none;
 }
 
 .item {
@@ -29,7 +43,6 @@
 
 .help-item {
     opacity: 0.75;
-    padding: 5px var(--item-padding-x);
     user-select: none;
     font-size: inherit;
     font-weight: normal;
@@ -37,6 +50,9 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+}
+.help-item:empty {
+    display: none;
 }
 
 /* Hide scrollbar */

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -25,42 +25,43 @@ export const OptionsList: FunctionComponent<
     }, [options])
 
     return (
-        <div className={styles.container}>
-            <h3 className={classNames(styles.item, styles.helpItem)}>
-                {query === ''
-                    ? 'Search for a file to include, or type # for symbols...'
-                    : query.startsWith('#')
-                      ? options.length > 0
-                            ? 'Search for a symbol to include...'
-                            : `No symbols found${
-                                  query.length <= 2
-                                      ? ' (try installing language extensions and opening a file)'
-                                      : ''
-                              }`
-                      : options.length > 0
-                          ? 'Search for a file to include...'
-                          : 'No files found'}
-                <br />
-            </h3>
-            {options.length > 0 && (
-                <ul ref={ref} className={styles.list}>
-                    {options.map((option, i) => (
-                        <Item
-                            isSelected={selectedIndex === i}
-                            onClick={() => {
-                                setHighlightedIndex(i)
-                                selectOptionAndCleanUp(option)
-                            }}
-                            onMouseEnter={() => {
-                                setHighlightedIndex(i)
-                            }}
-                            key={option.key}
-                            option={option}
-                            className={styles.item}
-                        />
-                    ))}
-                </ul>
-            )}
+        <div className={styles.outerContainer}>
+            <div className={styles.visibleContainer}>
+                <h3 className={classNames(styles.item, styles.helpItem)}>
+                    {query === ''
+                        ? 'Search for a file to include, or type # for symbols...'
+                        : query === '#'
+                          ? 'Search for a symbol to include...'
+                          : options.length === 0
+                              ? query.startsWith('#')
+                                    ? `No symbols found${
+                                          query.length <= 2
+                                              ? ' (try installing language extensions and opening a file)'
+                                              : ''
+                                      }`
+                                    : 'No files found'
+                              : null}
+                </h3>
+                {options.length > 0 && (
+                    <ul ref={ref} className={styles.list}>
+                        {options.map((option, i) => (
+                            <Item
+                                isSelected={selectedIndex === i}
+                                onClick={() => {
+                                    setHighlightedIndex(i)
+                                    selectOptionAndCleanUp(option)
+                                }}
+                                onMouseEnter={() => {
+                                    setHighlightedIndex(i)
+                                }}
+                                key={option.key}
+                                option={option}
+                                className={styles.item}
+                            />
+                        ))}
+                    </ul>
+                )}
+            </div>
         </div>
     )
 }

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.module.css
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.module.css
@@ -1,13 +1,3 @@
-.popover {
-    overflow: hidden;
-    background: var(--vscode-sideBar-background);
-    color: var(--vscode-sideBar-foreground);
-    border: 1px solid var(--vscode-widget-border);
-    box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
-    border-radius: 6px;
-    max-width: 85vw;
-}
-
 .reset-anchor {
     top: 0 !important;
     left: 0 !important;

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -16,7 +16,6 @@ import { type FunctionComponent, useCallback, useEffect, useMemo, useState } fro
 import styles from './atMentions.module.css'
 
 import { type ContextItem, type RangeData, displayPath } from '@sourcegraph/cody-shared'
-import classNames from 'classnames'
 import { $createContextItemMentionNode } from '../../nodes/ContextItemMentionNode'
 import { OptionsList } from './OptionsList'
 import { useChatContextItems } from './chatContextClient'
@@ -201,7 +200,6 @@ export default function MentionsPlugin(): JSX.Element | null {
                                     left: x ?? 0,
                                     width: 'max-content',
                                 }}
-                                className={classNames(styles.popover)}
                             >
                                 <OptionsList
                                     query={query}

--- a/vscode/webviews/promptEditor/plugins/atMentions/fixtures.ts
+++ b/vscode/webviews/promptEditor/plugins/atMentions/fixtures.ts
@@ -8,7 +8,7 @@ import type { ChatContextClient } from './chatContextClient'
  */
 export const dummyChatContextClient: ChatContextClient = {
     async getChatContextItems(query) {
-        await new Promise<void>(resolve => setTimeout(resolve, 250))
+        await new Promise<void>(resolve => setTimeout(resolve, 100))
 
         query = query.toLowerCase()
         return query.startsWith('#')


### PR DESCRIPTION
Previously, the at-mention menu header ("Search for files to include...") was always shown. It is not necessary to show it and it adds noise, so now it's only shown when (a) the query is empty (`@` or `@#`) or (b) there are no results.



## Test plan

CI