### PR TITLE
speed up & respect ignores in finding workspace files for file @-mentions

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Document: Fixed an issue where the generated documentation would be incorrectly inserted for Python. Cody will now follow PEP 257 – Docstring Conventions. [pull/3275](https://github.com/sourcegraph/cody/pull/3275)
 - Edit: Fixed incorrect decorations being shown for edits that only insert new code. [pull/3424](https://github.com/sourcegraph/cody/pull/3424)
+- When `@`-mentioning files in chat and edits, the list of fuzzy-matching files is shown much faster (which is especially noticeable in large workspaces).
 
 ### Changed
 

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -1,0 +1,37 @@
+import type { ContextItem } from '@sourcegraph/cody-shared'
+import type * as vscode from 'vscode'
+import {
+    getFileContextFiles,
+    getOpenTabsContextFile,
+    getSymbolContextFiles,
+} from '../../editor/utils/editor-context'
+
+export async function getChatContextItemsForMention(
+    query: string,
+    cancellationToken: vscode.CancellationToken,
+    telemetryRecorder?: {
+        empty: () => void
+        withType: (type: 'symbol' | 'file') => void
+    }
+): Promise<ContextItem[]> {
+    // Logging: log when the at-mention starts, and then log when we know the type (after the 1st
+    // character is typed). Don't log otherwise because we would be logging prefixes of the same
+    // query repeatedly, which is not needed.
+    const queryType = query.startsWith('#') ? 'symbol' : 'file'
+    if (query === '') {
+        telemetryRecorder?.empty()
+    } else if (query.length === 1) {
+        telemetryRecorder?.withType(queryType)
+    }
+
+    if (query.length === 0) {
+        return getOpenTabsContextFile()
+    }
+
+    const MAX_RESULTS = 20
+    if (query.startsWith('#')) {
+        // It would be nice if the VS Code symbols API supports cancellation, but it doesn't
+        return getSymbolContextFiles(query.slice(1), MAX_RESULTS)
+    }
+    return getFileContextFiles(query, MAX_RESULTS, cancellationToken)
+}

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -125,15 +125,6 @@ describe('getFileContextFiles', () => {
 
         expect(vscode.workspace.findFiles).toBeCalledTimes(1)
     })
-
-    it('cancels previous requests', async () => {
-        vscode.workspace.findFiles = vi.fn().mockResolvedValueOnce([])
-        const cancellation = new vscode.CancellationTokenSource()
-        await getFileContextFiles('search', 5, cancellation.token)
-        await getFileContextFiles('search', 5, new vscode.CancellationTokenSource().token)
-        expect(cancellation.token.isCancellationRequested)
-        expect(vscode.workspace.findFiles).toBeCalledTimes(2)
-    })
 })
 
 describe('filterLargeFiles', () => {

--- a/vscode/src/editor/utils/findWorkspaceFiles.ts
+++ b/vscode/src/editor/utils/findWorkspaceFiles.ts
@@ -1,0 +1,78 @@
+import * as vscode from 'vscode'
+
+/**
+ * Find all files in all workspace folders, respecting the user's `files.exclude`, `search.exclude`,
+ * and other exclude settings. The intent is to match the files shown by VS Code's built-in `Go to
+ * File...` command.
+ */
+export async function findWorkspaceFiles(
+    cancellationToken: vscode.CancellationToken
+): Promise<vscode.Uri[]> {
+    return (
+        await Promise.all(
+            (vscode.workspace.workspaceFolders ?? [null]).map(async workspaceFolder =>
+                vscode.workspace.findFiles(
+                    workspaceFolder ? new vscode.RelativePattern(workspaceFolder, '**') : '',
+                    await getExcludePattern(workspaceFolder),
+                    undefined,
+                    cancellationToken
+                )
+            )
+        )
+    ).flat()
+}
+
+type IgnoreRecord = Record<string, boolean>
+
+async function getExcludePattern(workspaceFolder: vscode.WorkspaceFolder | null): Promise<string> {
+    const config = vscode.workspace.getConfiguration('', workspaceFolder)
+    const filesExclude = config.get<IgnoreRecord>('files.exclude', {})
+    const searchExclude = config.get<IgnoreRecord>('search.exclude', {})
+
+    const useIgnoreFiles = config.get<boolean>('search.useIgnoreFiles')
+    const gitignoreExclude =
+        useIgnoreFiles && workspaceFolder
+            ? await readIgnoreFile(vscode.Uri.joinPath(workspaceFolder.uri, '.gitignore'))
+            : {}
+    const ignoreExclude =
+        useIgnoreFiles && workspaceFolder
+            ? await readIgnoreFile(vscode.Uri.joinPath(workspaceFolder.uri, '.ignore'))
+            : {}
+
+    const mergedExclude: IgnoreRecord = {
+        ...filesExclude,
+        ...searchExclude,
+        ...gitignoreExclude,
+        ...ignoreExclude,
+    }
+    const excludePatterns = Object.keys(mergedExclude).filter(key => mergedExclude[key] === true)
+    return `{${excludePatterns.join(',')}}`
+}
+
+async function readIgnoreFile(uri: vscode.Uri): Promise<IgnoreRecord> {
+    const ignore: IgnoreRecord = {}
+    try {
+        const data = await vscode.workspace.fs.readFile(uri)
+        for (let line of Buffer.from(data).toString('utf-8').split('\n')) {
+            if (line.startsWith('!')) {
+                continue
+            }
+
+            // Strip comment and trailing whitespace.
+            line = line.replace(/\s*(#.*)?$/, '')
+
+            if (line === '') {
+                continue
+            }
+
+            if (line.endsWith('/')) {
+                line = line.slice(0, -1)
+            }
+            if (!line.startsWith('/') && !line.startsWith('**/')) {
+                line = `**/${line}`
+            }
+            ignore[line] = true
+        }
+    } catch {}
+    return ignore
+}

--- a/vscode/src/editor/utils/index.ts
+++ b/vscode/src/editor/utils/index.ts
@@ -33,15 +33,6 @@ export async function getSmartSelection(
 }
 
 /**
- * Searches for workspace symbols matching the given query string.
- * @param query - The search query string.
- * @returns A promise resolving to the array of SymbolInformation objects representing the matched workspace symbols.
- */
-export async function getWorkspaceSymbols(query = ''): Promise<vscode.SymbolInformation[]> {
-    return vscode.commands.executeCommand('vscode.executeWorkspaceSymbolProvider', query)
-}
-
-/**
  * Returns an array of URI's for all unique open editor tabs.
  *
  * Loops through all open tab groups and tabs, collecting the URI

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -102,8 +102,7 @@ test.extend<ExpectedEvents>({
         chatPanelFrame.getByRole('option', { name: withPlatformSlashes('visualize.go') })
     ).toBeVisible()
     await chatInput.press('ArrowDown') // second item (visualize.go)
-    await chatInput.press('ArrowDown') // third item (.vscode/settings.json)
-    await chatInput.press('ArrowDown') // wraps back to first item
+    await chatInput.press('ArrowDown') // wraps back to first item (var.go)
     await chatInput.press('ArrowDown') // second item again
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText(


### PR DESCRIPTION
1. Finding the list of files now respects the `files.exclude`,
   `search.exclude`, and gitignore/ignore files. This makes it much faster
   (~1200ms -> 100ms on sourcegraph/sourcegraph on my machine) and eliminates
   irrelevant files (such as tons of `bazel-bin/` and `*.js` files).
2. Removes the cancellation on `throttledFindFiles`. This actually made it
   slower because each time `throttledFindFiles.cancel()` was called, it would
   invalidate the cached result, which means the next call would invoke the
   expensive find-files operation even if it had been less than 10000ms since
   the previous successful call. We do not need cancellation for this
   operation because each call uses the same arguments, so earlier calls are
   not wasted and just mean the result will be returned slightly sooner.

Note: the e2e tests have 1 change because the `.gitignore` in the vscode/test/fixtures/workspace dir is now respected, so there is one less item in the dropdown. This is an enhancement.


### Before

![files-before](https://github.com/sourcegraph/cody/assets/1976/a1fc3832-06ce-4f7f-9834-a7d32ad70bdf)


### After

![after-file](https://github.com/sourcegraph/cody/assets/1976/a2c4debf-23ba-4df4-be4e-17998f4ec129)


## Test plan

CI