### PR TITLE
explicitly enable biome in VS Code workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
   "typescript.tsc.autoDetect": "off",
   "typescript.tsdk": "node_modules/typescript/lib",
   "task.allowAutomaticTasks": "on",
+  "biome.enabled": true,
   "editor.defaultFormatter": "biomejs.biome",
   "editor.codeActionsOnSave": {
     "source.organizeImports": "never",


### PR DESCRIPTION
This makes it so you can set it to disabled by default in your VS Code user settings so it doesn't show an annoying notification in repositories that don't use Biome.



## Test plan

CI