### PR TITLE
remove needless command:_cody.vscode.open wrapping for https? URLs

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -22,7 +22,7 @@ export type {
 } from './chat/transcript/messages'
 export {
     CODY_PASSTHROUGH_VSCODE_OPEN_COMMAND_ID,
-    commandURIForVSCodeOpen,
+    webviewOpenURIForContextItem,
 } from './chat/transcript/display-text'
 export { Typewriter } from './chat/typewriter'
 export { reformatBotMessageForChat } from './chat/viewHelpers'

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -303,8 +303,9 @@ test('@-mention file range', async ({ page, sidebar }) => {
     // @-file range with the correct line range shows up in the chat view and it opens on click
     await chatPanelFrame.getByText('✨ Context: 3 lines from 1 file').hover()
     await chatPanelFrame.getByText('✨ Context: 3 lines from 1 file').click()
-    await chatPanelFrame.getByRole('button', { name: '@buzz.ts:2-4' }).hover()
-    await chatPanelFrame.getByRole('button', { name: '@buzz.ts:2-4' }).click()
+    const chatContext = chatPanelFrame.locator('details').last()
+    await chatContext.getByRole('link', { name: '@buzz.ts:2-4' }).hover()
+    await chatContext.getByRole('link', { name: '@buzz.ts:2-4' }).click()
     const previewTab = page.getByRole('tab', { name: /buzz.ts, preview, Editor Group/ })
     await previewTab.hover()
     await expect(previewTab).toBeVisible()
@@ -355,8 +356,9 @@ test.extend<ExpectedEvents>({
     // @-file with the correct line range shows up in the chat view and it opens on click
     await chatPanelFrame.getByText('✨ Context: 15 lines from 1 file').hover()
     await chatPanelFrame.getByText('✨ Context: 15 lines from 1 file').click()
-    await chatPanelFrame.getByRole('button', { name: '@buzz.ts:1-15' }).hover()
-    await chatPanelFrame.getByRole('button', { name: '@buzz.ts:1-15' }).click()
+    const chatContext = chatPanelFrame.locator('details').last()
+    await chatContext.getByRole('link', { name: '@buzz.ts:1-15' }).hover()
+    await chatContext.getByRole('link', { name: '@buzz.ts:1-15' }).click()
     const previewTab = page.getByRole('tab', { name: /buzz.ts, preview, Editor Group/ })
     await previewTab.hover()
     await expect(previewTab).toBeVisible()

--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -129,9 +129,10 @@ test.extend<ExpectedEvents>({
     // both main.java and var.go should be used
     await expect(chatFrame.getByText(/Context: 2 files/)).toBeVisible()
     await chatFrame.getByText(/Context: 2 files/).click()
-    await expect(chatFrame.getByRole('button', { name: 'Main.java' })).toBeVisible()
+    const chatContext = chatFrame.locator('details').last()
+    await expect(chatContext.getByRole('link', { name: 'Main.java' })).toBeVisible()
     await expect(
-        chatFrame.getByRole('button', { name: withPlatformSlashes('lib/batches/env/var.go') })
+        chatContext.getByRole('link', { name: withPlatformSlashes('lib/batches/env/var.go') })
     ).toBeVisible()
 
     // Meta+/ also creates a new chat session

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -53,7 +53,8 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
 
     // Click on the file link in chat
-    await chatPanel.getByRole('button', { name: '@index.html' }).click()
+    const chatContext = chatPanel.locator('details').last()
+    await chatContext.getByRole('link', { name: '@index.html' }).click()
 
     // Check if the file is opened
     await expect(page.getByRole('list').getByText('index.html')).toBeVisible()

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -210,8 +210,9 @@ test.extend<ExpectedEvents>({
         chatPanel.locator('span').filter({ hasText: withPlatformSlashes('@lib/batches/env/var.go:1') })
     ).toBeVisible()
     // Click on the file link should open the 'var.go file in the editor
-    await chatPanel
-        .getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
+    const chatContext = chatPanel.locator('details').last()
+    await chatContext
+        .getByRole('link', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
         .click()
     await expect(page.getByRole('tab', { name: 'var.go' })).toBeVisible()
 
@@ -226,9 +227,9 @@ test.extend<ExpectedEvents>({
     // The files from the open tabs should be added as context
     await expect(chatPanel.getByText('✨ Context: 12 lines from 2 files')).toBeVisible()
     await chatPanel.getByText('✨ Context: 12 lines from 2 files').click()
-    await expect(chatPanel.getByRole('button', { name: '@index.html:1-11' })).toBeVisible()
+    await expect(chatContext.getByRole('link', { name: '@index.html:1-11' })).toBeVisible()
     await expect(
-        chatPanel.getByRole('button', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
+        chatContext.getByRole('link', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
     ).toBeVisible()
 })
 
@@ -325,7 +326,8 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
     const panel = getChatPanel(page)
     await expect(panel.getByText('✨ Context: 1 line from 2 files')).toBeVisible()
     await panel.getByText('✨ Context: 1 line from 2 files').click()
+    const chatContext = panel.locator('details').last()
     await expect(
-        panel.getByRole('button', { name: withPlatformSlashes('@/terminal-output') })
+        chatContext.getByRole('link', { name: withPlatformSlashes('@/terminal-output') })
     ).toBeVisible()
 })

--- a/vscode/webviews/Components/FileLink.module.css
+++ b/vscode/webviews/Components/FileLink.module.css
@@ -5,7 +5,6 @@
     cursor: pointer;
     font-size: inherit;
     text-decoration: underline;
-    display: contents; /* so our parent can tell us to truncate with ellipsis */
     padding: 0;
     margin: 0;
     text-align: left;

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -1,9 +1,7 @@
 import type React from 'react'
 
-import { displayLineRange, displayPath } from '@sourcegraph/cody-shared'
+import { displayLineRange, displayPath, webviewOpenURIForContextItem } from '@sourcegraph/cody-shared'
 import type { FileLinkProps } from '../chat/components/EnhancedContext'
-
-import { getVSCodeAPI } from '../utils/VSCodeApi'
 
 import styles from './FileLink.module.css'
 
@@ -37,16 +35,10 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
     const pathToDisplay = `@${displayPath(uri)}`
     const pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
     const tooltip = source ? `${pathWithRange} included via ${source}` : pathWithRange
+    const { href, target } = webviewOpenURIForContextItem({ uri, range })
     return (
-        <button
-            className={styles.linkButton}
-            type="button"
-            title={tooltip}
-            onClick={() => {
-                getVSCodeAPI().postMessage({ command: 'openFile', uri, range })
-            }}
-        >
+        <a className={styles.linkButton} title={tooltip} href={href} target={target}>
             {pathWithRange}
-        </button>
+        </a>
     )
 }

--- a/vscode/webviews/chat/CodeBlocks.tsx
+++ b/vscode/webviews/chat/CodeBlocks.tsx
@@ -21,6 +21,7 @@ export interface CodeBlockActionsProps {
 
 interface CodeBlocksProps {
     displayMarkdown: string
+    wrapLinksWithCodyCommand: boolean
 
     copyButtonClassName?: string
     insertButtonClassName?: string
@@ -240,6 +241,7 @@ class GuardrailsStatusController {
 export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
     function CodeBlocksContent({
         displayMarkdown,
+        wrapLinksWithCodyCommand,
         copyButtonClassName,
         copyButtonOnSubmit,
         insertButtonClassName,
@@ -317,12 +319,14 @@ export const CodeBlocks: React.FunctionComponent<CodeBlocksProps> = React.memo(
                     ref={rootRef}
                     // biome-ignore lint/security/noDangerouslySetInnerHtml: the result is run through dompurify
                     dangerouslySetInnerHTML={{
-                        // wrapLinksWithCodyCommand opens all links using the _cody.vscode.open command
-                        __html: renderCodyMarkdown(displayMarkdown, { wrapLinksWithCodyCommand: true }),
+                        // wrapLinksWithCodyCommand opens all links in assistant responses using the
+                        // _cody.vscode.open command (but not human messages because those already
+                        // have the right URIs and are trusted).
+                        __html: renderCodyMarkdown(displayMarkdown, { wrapLinksWithCodyCommand }),
                     }}
                 />
             ),
-            [displayMarkdown]
+            [displayMarkdown, wrapLinksWithCodyCommand]
         )
     }
 )

--- a/vscode/webviews/chat/TranscriptItem.tsx
+++ b/vscode/webviews/chat/TranscriptItem.tsx
@@ -145,6 +145,7 @@ export const TranscriptItem: React.FunctionComponent<
                 {displayMarkdown ? (
                     <CodeBlocks
                         displayMarkdown={displayMarkdown}
+                        wrapLinksWithCodyCommand={message.speaker !== 'human'}
                         copyButtonClassName={codeBlocksCopyButtonClassName}
                         copyButtonOnSubmit={copyButtonOnSubmit}
                         insertButtonClassName={codeBlocksInsertButtonClassName}

--- a/vscode/webviews/chat/actions/TranscriptAction.module.css
+++ b/vscode/webviews/chat/actions/TranscriptAction.module.css
@@ -9,8 +9,7 @@
     gap: 4px;
 }
 
-.step button {
-    display: block;
+.step a {
     max-width: 100%;
     padding: 1px 2px;
     box-sizing: border-box;

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -5,9 +5,9 @@ import {
     type ContextItem,
     type ContextItemFile,
     type ContextItemSymbol,
-    commandURIForVSCodeOpen,
     displayLineRange,
     displayPath,
+    webviewOpenURIForContextItem,
 } from '@sourcegraph/cody-shared'
 import {
     $applyNodeReplacement,
@@ -130,7 +130,14 @@ export class ContextItemMentionNode extends TextNode {
         element.className = ContextItemMentionNode.CLASS_NAMES
 
         const link = document.createElement('a')
-        link.href = commandURIForVSCodeOpen(URI.parse(this.contextItem.uri), this.contextItem.range)
+        const { href, target } = webviewOpenURIForContextItem({
+            uri: URI.parse(this.contextItem.uri),
+            range: this.contextItem.range,
+        })
+        link.href = href
+        if (target) {
+            link.target = target
+        }
         link.textContent = this.__text
         element.appendChild(link)
 


### PR DESCRIPTION
Now, links in human messages open in the web browser when clicked, instead of showing a VS Code "do you trust this domain?" dialog.



## Test plan

CI; e2e tests handle these cases