### PR TITLE
remove needless hovers and visibility checks from e2e

### DIFF
--- a/vscode/test/e2e/README.md
+++ b/vscode/test/e2e/README.md
@@ -25,14 +25,3 @@ pnpm test:e2e --debug
 # Run a specific test in debug mode
 pnpm test:e2e $TEST_FILE_NAME  --debug
 ```
-
-## Notes
-
-1. Flakiness in tests can often be attributed to timing issues, such as asynchronous actions taking longer than expected to complete. By performing a hover action before a click action, you give the application a bit more time to react and stabilize before attempting the subsequent click. This can help mitigate timing-related flakiness.
-
-   Example:
-
-   ```
-   await page.getByLabel('.vscode', { exact: true }).hover()
-   await page.getByLabel('.vscode', { exact: true }).click()
-   ```

--- a/vscode/test/e2e/auth.test.ts
+++ b/vscode/test/e2e/auth.test.ts
@@ -58,6 +58,5 @@ test.extend<ExpectedEvents>({
         .click()
     // Makes sure the sign in page is loaded in the sidebar view with Cody: Chat as the heading
     // instead of the chat panel.
-    await expect(page.getByRole('heading', { name: 'Cody: Chat' })).toBeVisible()
     await page.getByRole('heading', { name: 'Cody: Chat' }).click()
 })

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -165,7 +165,6 @@ test.extend<ExpectedEvents>({
     const noMatches = chatPanelFrame.getByRole('heading', { name: 'No files found' })
     await chatInput.pressSequentially(' @abcdefg')
     await expect(chatInput).toHaveText('Explain the @Main.java ! @abcdefgfile')
-    await noMatches.hover()
     await expect(noMatches).toBeVisible()
     await chatInput.press('ArrowLeft')
     await expect(noMatches).toBeVisible()
@@ -279,7 +278,6 @@ test('@-mention links in transcript message', async ({ page, sidebar }) => {
     await expect(mentionLink).toBeVisible()
     await mentionLink.click()
     const previewTab = page.getByRole('tab', { name: /buzz.ts, preview, Editor Group/ })
-    await previewTab.hover()
     await expect(previewTab).toBeVisible()
 })
 
@@ -293,7 +291,6 @@ test('@-mention file range', async ({ page, sidebar }) => {
 
     // Type a file with range.
     await chatInput.fill('@buzz.ts:2-4')
-    await expect(chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' }).click()
     await expect(chatInput).toHaveText('@buzz.ts:2-4 ')
 
@@ -301,13 +298,10 @@ test('@-mention file range', async ({ page, sidebar }) => {
     await chatInput.press('Enter')
 
     // @-file range with the correct line range shows up in the chat view and it opens on click
-    await chatPanelFrame.getByText('✨ Context: 3 lines from 1 file').hover()
     await chatPanelFrame.getByText('✨ Context: 3 lines from 1 file').click()
     const chatContext = chatPanelFrame.locator('details').last()
-    await chatContext.getByRole('link', { name: 'buzz.ts:2-4' }).hover()
     await chatContext.getByRole('link', { name: 'buzz.ts:2-4' }).click()
     const previewTab = page.getByRole('tab', { name: /buzz.ts, preview, Editor Group/ })
-    await previewTab.hover()
     await expect(previewTab).toBeVisible()
 })
 
@@ -328,7 +322,7 @@ test.extend<ExpectedEvents>({
     // Open the buzz.ts file so that VS Code starts to populate symbols.
     await sidebarExplorer(page).click()
     await page.getByRole('treeitem', { name: 'buzz.ts' }).locator('a').dblclick()
-    await page.getByRole('tab', { name: 'buzz.ts' }).hover()
+    await expect(page.getByRole('tab', { name: 'buzz.ts' })).toBeVisible()
 
     // Go back to the Cody chat tab
     await page.getByRole('tab', { name: 'New Chat' }).click()
@@ -339,11 +333,10 @@ test.extend<ExpectedEvents>({
 
     // Clicking on a file in the selector should autocomplete the file in chat input with added space
     await chatInput.fill('@#fizzb')
-    await expect(chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' })).toBeVisible({
+    await chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' }).click({
         // Longer timeout because sometimes tsserver takes a while to become ready.
         timeout: 15000,
     })
-    await chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' }).click()
     await expect(chatInput).toHaveText('@buzz.ts:1-15#fizzbuzz() ')
 
     // Submit the message
@@ -354,12 +347,9 @@ test.extend<ExpectedEvents>({
     await pinnedTab.getByRole('button', { name: /^Close/ }).click()
 
     // @-file with the correct line range shows up in the chat view and it opens on click
-    await chatPanelFrame.getByText('✨ Context: 15 lines from 1 file').hover()
     await chatPanelFrame.getByText('✨ Context: 15 lines from 1 file').click()
     const chatContext = chatPanelFrame.locator('details').last()
-    await chatContext.getByRole('link', { name: 'buzz.ts:1-15' }).hover()
     await chatContext.getByRole('link', { name: 'buzz.ts:1-15' }).click()
     const previewTab = page.getByRole('tab', { name: /buzz.ts, preview, Editor Group/ })
-    await previewTab.hover()
     await expect(previewTab).toBeVisible()
 })

--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -65,14 +65,12 @@ test.extend<ExpectedEvents>({
     // NOTE: Action buttons may only appear when we're hovering a chat.
     // Deleting a chat should also close its associated chat panel
     await heyTreeItem.hover()
-    await heyTreeItem.getByLabel('Delete Chat').hover()
     await heyTreeItem.getByLabel('Delete Chat').click()
     await page.waitForTimeout(100)
     expect(heyTreeItem).not.toBeVisible()
     await expect(page.getByRole('tab', { name: 'Hey' })).not.toBeVisible()
 
     await holaTreeItem.hover()
-    await holaTreeItem.getByLabel('Delete Chat').hover()
     await holaTreeItem.getByLabel('Delete Chat').click()
     await page.waitForTimeout(100)
     expect(holaTreeItem).not.toBeVisible()
@@ -80,7 +78,6 @@ test.extend<ExpectedEvents>({
 
     // Once the chat history is empty, the 'New Chat' button should show up
     await page.waitForSelector('div[class*="welcome-view-content"]')
-    await page.locator('.welcome-view-content').hover()
-    await page.getByRole('button', { name: 'New Chat', exact: true }).hover()
+    await expect(page.locator('.welcome-view-content')).toBeVisible()
     await expect(page.getByRole('button', { name: 'New Chat', exact: true })).toBeVisible()
 })

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -54,14 +54,13 @@ test('chat input focus', async ({ page, sidebar }) => {
     // and then submit a chat question from the command menu.
     await sidebarExplorer(page).click()
     await page.getByRole('treeitem', { name: 'buzz.ts' }).locator('a').dblclick()
-    await page.getByRole('tab', { name: 'buzz.ts' }).hover()
+    await expect(page.getByRole('tab', { name: 'buzz.ts' })).toBeVisible()
 
     // Open a new chat panel before opening the file to make sure
     // the chat panel is right next to the document. This helps to save loading time
     // when we submit a question later as the question will be streamed to this panel
     // directly instead of opening a new one.
     await page.click('.badge[aria-label="Cody"]')
-    await page.getByRole('button', { name: 'New Chat', exact: true }).hover()
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
     await page.click('.badge[aria-label="Cody"]')
     await page.getByRole('tab', { name: 'buzz.ts' }).dblclick()
@@ -70,7 +69,6 @@ test('chat input focus', async ({ page, sidebar }) => {
     const chatInput = chatPanel.getByRole('textbox', { name: 'Chat message' })
 
     // Submit a new chat question from the command menu.
-    await page.getByLabel(/Commands \(/).hover()
     await page.getByLabel(/Commands \(/).click()
     await page.waitForTimeout(100)
     // HACK: The 'delay' command is used to make sure the response is streamed 400ms after
@@ -86,7 +84,6 @@ test('chat input focus', async ({ page, sidebar }) => {
     await page.getByText("fizzbuzz.push('Buzz')").click()
     await expect(chatInput).not.toBeFocused()
     // once the response is 'Done', check the input focus
-    await chatInput.hover()
     await expect(chatPanel.getByText('Done')).toBeVisible()
     await expect(chatInput).not.toBeFocused()
 

--- a/vscode/test/e2e/code-actions.test.ts
+++ b/vscode/test/e2e/code-actions.test.ts
@@ -1,3 +1,4 @@
+import { expect } from 'playwright/test'
 import * as mockServer from '../fixtures/mock-server'
 
 import { sidebarExplorer, sidebarSignin } from './common'
@@ -22,7 +23,7 @@ test.extend<ExpectedEvents>({
     // Open the error.ts file from the tree view
     await page.getByRole('treeitem', { name: 'error.ts' }).locator('a').click()
     // Wait for error.ts to fully open
-    await page.getByRole('tab', { name: 'error.ts' }).hover()
+    await expect(page.getByRole('tab', { name: 'error.ts' })).toBeVisible()
 
     // Remove the comment that suppresses the type error
     await page.getByText('// @ts-nocheck').click({ clickCount: 3 })
@@ -55,7 +56,7 @@ test.extend<ExpectedEvents>({
     // Open the error.ts file from the tree view
     await page.getByRole('treeitem', { name: 'error.ts' }).locator('a').click()
     // Wait for error.ts to fully open
-    await page.getByRole('tab', { name: 'error.ts' }).hover()
+    await expect(page.getByRole('tab', { name: 'error.ts' })).toBeVisible()
 
     // Remove the comment that suppresses the type error
     await page.getByText('// @ts-nocheck').click({ clickCount: 3 })

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -33,13 +33,12 @@ test.extend<ExpectedEvents>({
     // Open the file that is on the .cody/ignore list from the tree view
     await sidebarExplorer(page).click()
     await page.getByRole('treeitem', { name: 'ignoredByCody.css' }).locator('a').dblclick()
-    await page.getByRole('tab', { name: 'ignoredByCody.css' }).hover()
+    await expect(page.getByRole('tab', { name: 'ignoredByCody.css' })).toBeVisible()
 
     // Cody icon in the status bar should shows that the file is being ignored
     const statusBarButton = page.getByRole('button', {
         name: 'cody-logo-heavy, Current file is ignored by Cody',
     })
-    await statusBarButton.hover()
     await expect(statusBarButton).toBeVisible()
 
     await page.click('.badge[aria-label="Cody"]')
@@ -72,7 +71,6 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
 
     /* TEST: Command - Ignored file do not show up with context */
-    await page.getByText('Explain Code').hover()
     await page.getByText('Explain Code').click()
     // Assistant should not response to your command, so you should still see the old message.
     await expect(chatPanel.getByText('Ignore me')).toBeVisible()

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -32,12 +32,11 @@ test.extend<ExpectedEvents>({
     // Open the index.html file from the tree view
     await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
     // Wait for index.html to fully open
-    await page.getByRole('tab', { name: 'index.html' }).hover()
+    await expect(page.getByRole('tab', { name: 'index.html' })).toBeVisible()
 
     // Bring the cody sidebar to the foreground
     await page.click('.badge[aria-label="Cody"]')
 
-    await page.getByText('Explain Code').hover()
     await page.getByText('Explain Code').click()
 
     // Find the chat iframe
@@ -105,14 +104,14 @@ test.extend<ExpectedEvents>({
     await sidebarExplorer(page).click()
     // Open the buzz.ts file from the tree view
     await page.getByRole('treeitem', { name: 'buzz.ts' }).locator('a').dblclick()
-    await page.getByRole('tab', { name: 'buzz.ts' }).hover()
+    await expect(page.getByRole('tab', { name: 'buzz.ts' })).toBeVisible()
 
     // Click on the Cody command code lenses to execute the unit test command
     await page.getByRole('button', { name: 'A Cody' }).click()
     await page.getByText('Generate Unit Tests').click()
 
     // The test file for the buzz.ts file should be opened automatically
-    await page.getByText('buzz.test.ts').hover()
+    await expect(page.getByText('buzz.test.ts')).toBeVisible()
 
     // Code lens should be visible
     await expect(page.getByRole('button', { name: 'Accept' })).toBeVisible()
@@ -142,7 +141,7 @@ test.extend<ExpectedEvents>({
 
     // Open the buzz.ts file from the tree view
     await page.getByRole('treeitem', { name: 'buzz.ts' }).locator('a').dblclick()
-    await page.getByRole('tab', { name: 'buzz.ts' }).hover()
+    await expect(page.getByRole('tab', { name: 'buzz.ts' })).toBeVisible()
 
     // Click on some code within the function
     await page.getByText("fizzbuzz.push('Buzz')").click()
@@ -151,7 +150,6 @@ test.extend<ExpectedEvents>({
     await page.click('.badge[aria-label="Cody"]')
 
     // Trigger the documentaton command
-    await page.getByText('Document Code').hover()
     await page.getByText('Document Code').click()
 
     // Code lens should be visible

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -42,7 +42,7 @@ test.extend<ExpectedEvents>({
     // Open the index.html file from the tree view
     await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
     // Wait for index.html to fully open
-    await page.getByRole('tab', { name: 'index.html' }).hover()
+    await expect(page.getByRole('tab', { name: 'index.html' })).toBeVisible()
 
     // Bring the cody sidebar to the foreground
     await page.click('.badge[aria-label="Cody"]')
@@ -87,7 +87,6 @@ test.extend<ExpectedEvents>({
     await page.keyboard.press('Enter')
     // Save it to workspace settings
     await expect(page.getByText('New Custom Cody Command: Save To…')).toBeVisible()
-    await expect(page.getByText('Workspace Settings.vscode/cody.json')).toBeVisible()
     await page.getByText('Workspace Settings.vscode/cody.json').click()
 
     // Gives time for the command to be saved to the workspace settings
@@ -95,30 +94,22 @@ test.extend<ExpectedEvents>({
 
     // Check if cody.json in the workspace has the new command added
     await sidebarExplorer(page).click()
-    await page.getByLabel('.vscode', { exact: true }).hover()
     await page.getByLabel('.vscode', { exact: true }).click()
-    await page.getByRole('treeitem', { name: 'cody.json' }).locator('a').hover()
     await page.getByRole('treeitem', { name: 'cody.json' }).locator('a').dblclick()
-    await page.getByRole('tab', { name: 'cody.json' }).hover()
+    await expect(page.getByRole('tab', { name: 'cody.json' })).toBeVisible()
     // Click on minimap to scroll to the buttom
     await page.locator('canvas').nth(2).click()
-    await page.getByText(commandName).hover()
     await expect(page.getByText(commandName)).toBeVisible()
     await page.getByText('index.html').first().click()
 
     // Show the new command in the menu and execute it
     await page.click('.badge[aria-label="Cody"]')
     await page.getByLabel('Custom Commands').locator('a').click()
-    await page.getByText('Cody: Custom Commands (Beta)').hover()
     await expect(page.getByText('Cody: Custom Commands (Beta)')).toBeVisible()
     const newCommandMenuItem = page.getByLabel('tools  ATestCommand, The test command has been created')
     const newCommandSidebarItem = page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a')
-    await newCommandMenuItem.hover()
-    await newCommandSidebarItem.hover()
     await expect(page.getByText(commandName)).toHaveCount(2) // one in sidebar, and one in menu
-    await newCommandMenuItem.hover()
     await expect(newCommandMenuItem).toBeVisible()
-    await newCommandSidebarItem.hover()
     await expect(newCommandSidebarItem).toBeVisible()
     await newCommandMenuItem.click()
 
@@ -150,7 +141,7 @@ test.extend<ExpectedEvents>({
     await sidebarExplorer(page).click()
     await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
     // Wait for index.html to fully open
-    await page.getByRole('tab', { name: 'index.html' }).hover()
+    await expect(page.getByRole('tab', { name: 'index.html' })).toBeVisible()
 
     // Bring the cody sidebar to the foreground
     await page.click('.badge[aria-label="Cody"]')
@@ -167,7 +158,6 @@ test.extend<ExpectedEvents>({
 
     /* Test: context.currentDir with currentDir command */
     await page.getByRole('treeitem', { name: 'Custom Commands' }).locator('a').click()
-    await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
     await page.getByPlaceholder('Search command to run...').fill('currentDir')
     await page.keyboard.press('Enter')
 
@@ -175,7 +165,6 @@ test.extend<ExpectedEvents>({
 
     await expect(chatPanel.getByText('Add four context files from the current directory.')).toBeVisible()
     // Show the current file numbers used as context
-    await expect(chatPanel.getByText('✨ Context: 56 lines from 5 files')).toBeVisible()
     await chatPanel.getByText('✨ Context: 56 lines from 5 files').click()
     // Display the context files to confirm no hidden files are included
     await expect(chatPanel.locator('details').filter({ hasText: '.mydotfile:1-2' })).not.toBeVisible()
@@ -188,7 +177,6 @@ test.extend<ExpectedEvents>({
     /* Test: context.filePath with filePath command */
 
     await page.getByRole('treeitem', { name: 'Custom Commands' }).locator('a').click()
-    await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
     await page.getByPlaceholder('Search command to run...').click()
     await page.getByPlaceholder('Search command to run...').fill('filePath')
     await page.keyboard.press('Enter')
@@ -199,12 +187,10 @@ test.extend<ExpectedEvents>({
     /* Test: context.directory with directory command */
 
     await page.getByRole('treeitem', { name: 'Custom Commands' }).locator('a').click()
-    await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
     await page.getByPlaceholder('Search command to run...').click()
     await page.getByPlaceholder('Search command to run...').fill('directory')
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Directory has one context file.')).toBeVisible()
-    await expect(chatPanel.getByText('✨ Context: 12 lines from 2 file')).toBeVisible()
     await chatPanel.getByText('✨ Context: 12 lines from 2 file').click()
     await expect(
         chatPanel.locator('details').filter({ hasText: withPlatformSlashes('lib/batches/env/var.go:1') })
@@ -219,13 +205,11 @@ test.extend<ExpectedEvents>({
     /* Test: context.openTabs with openTabs command */
 
     await page.getByRole('treeitem', { name: 'Custom Commands' }).locator('a').click()
-    await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
     await page.getByPlaceholder('Search command to run...').click()
     await page.getByPlaceholder('Search command to run...').fill('openTabs')
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Open tabs as context.')).toBeVisible()
     // The files from the open tabs should be added as context
-    await expect(chatPanel.getByText('✨ Context: 12 lines from 2 files')).toBeVisible()
     await chatPanel.getByText('✨ Context: 12 lines from 2 files').click()
     await expect(chatContext.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
     await expect(
@@ -253,7 +237,7 @@ test.extend<ExpectedEvents>({
     // Check if cody.json exists in the workspace
     await page.getByRole('treeitem', { name: '.vscode' }).locator('a').click()
     await page.getByRole('treeitem', { name: 'cody.json' }).locator('a').dblclick()
-    await page.getByRole('tab', { name: 'cody.json' }).hover()
+    await expect(page.getByRole('tab', { name: 'cody.json' })).toBeVisible()
 
     await page.click('.badge[aria-label="Cody"]')
 
@@ -273,9 +257,7 @@ test.extend<ExpectedEvents>({
     await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
     await page.getByLabel('Configure Custom Commands...', { exact: true }).click()
     await page.locator('a').filter({ hasText: 'Open Workspace Settings (JSON)' }).hover()
-    await expect(page.getByRole('button', { name: 'Open or Create Settings File' })).toBeVisible()
     await page.getByRole('button', { name: 'Open or Create Settings File' }).click()
-    await page.getByRole('tab', { name: 'cody.json' }).hover()
     await expect(page.getByRole('tab', { name: 'cody.json' })).toBeVisible()
 
     // Check button click to delete the cody.json file from the workspace tree view
@@ -301,7 +283,6 @@ test.extend<ExpectedEvents>({
     await page.locator('a').filter({ hasText: 'Open User Settings (JSON)' }).hover()
     await page.getByRole('button', { name: 'Open or Create Settings File' }).hover()
     await page.getByRole('button', { name: 'Open or Create Settings File' }).click()
-    await page.getByRole('tab', { name: 'cody.json, preview' }).hover()
     await expect(page.getByRole('tab', { name: 'cody.json, preview' })).toHaveCount(1)
 })
 
@@ -311,8 +292,7 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
     // Check the change is showing as a Git file in the sidebar
     const sourceControlView = page.getByLabel(/Source Control/).nth(2)
     await sourceControlView.click()
-    await page.getByRole('heading', { name: 'Source Control' }).hover()
-    await page.getByText('index.js').hover()
+    await expect(page.getByRole('heading', { name: 'Source Control' })).toBeVisible()
     await page.locator('a').filter({ hasText: 'index.js' }).click()
 
     // Run the custom command that uses terminal output as context
@@ -324,7 +304,6 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
 
     // Check the context list to confirm the terminal output is added as file
     const panel = getChatPanel(page)
-    await expect(panel.getByText('✨ Context: 1 line from 2 files')).toBeVisible()
     await panel.getByText('✨ Context: 1 line from 2 files').click()
     const chatContext = panel.locator('details').last()
     await expect(

--- a/vscode/test/e2e/command-edit.test.ts
+++ b/vscode/test/e2e/command-edit.test.ts
@@ -25,7 +25,7 @@ test.extend<ExpectedEvents>({
     // Open the index.html file from the tree view
     await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
     // Wait for index.html to fully open
-    await page.getByRole('tab', { name: 'index.html' }).hover()
+    await expect(page.getByRole('tab', { name: 'index.html' })).toBeVisible()
 
     // Find the text hello cody, and then highlight the text
     await page.getByText('<title>Hello Cody</title>').click()

--- a/vscode/test/e2e/command-menu.test.ts
+++ b/vscode/test/e2e/command-menu.test.ts
@@ -15,8 +15,7 @@ test('Start a new chat from Cody Command Menu', async ({ page, sidebar }) => {
     // Open the index.html file from the tree view
     await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
     // Wait for index.html to fully open
-    await page.getByRole('tab', { name: 'index.html' }).hover()
-    await page.getByText('<title>Hello Cody</title>').hover()
+    await expect(page.getByText('<title>Hello Cody</title>')).toBeVisible()
     await page.getByRole('tab', { name: 'index.html' }).click()
 
     // Submit a chat question via command menu using "New Chat" option in Command Menu
@@ -25,15 +24,13 @@ test('Start a new chat from Cody Command Menu', async ({ page, sidebar }) => {
     await expect(commandInputBox).toBeVisible()
     await commandInputBox.fill('new chat submitted from command menu')
     // this will fail if more than 1 New Chat item in the menu is found
-    await page.getByLabel('comment  New Chat, Start a new chat', { exact: true }).hover()
     await expect(page.getByLabel('comment  New Chat, Start a new chat', { exact: true })).toBeVisible()
-    await page.getByLabel('wand  Edit Code, Start a code edit', { exact: true }).hover()
     await expect(page.getByLabel('wand  Edit Code, Start a code edit', { exact: true })).toBeVisible()
     await page.getByLabel('Start a new chat').locator('a').click()
 
     // the question should show up in the chat panel on submit
     const chatPanel = page.frameLocator('iframe.webview').last().frameLocator('iframe')
-    await chatPanel.getByText('hello from the assistant').hover()
+    await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
 
     const expectedEvents = [
         'CodyVSCodeExtension:menu:command:default:clicked',

--- a/vscode/test/e2e/fixup-decorator.test.ts
+++ b/vscode/test/e2e/fixup-decorator.test.ts
@@ -25,7 +25,7 @@ test.skip('decorations from un-applied Cody changes appear', async ({ page, side
     // Open the index.html file from the tree view
     await page.getByRole('treeitem', { name: 'index.html' }).locator('a').dblclick()
     // Wait for index.html to fully open
-    await page.getByRole('tab', { name: 'index.html' }).hover()
+    await expect(page.getByRole('tab', { name: 'index.html' })).toBeVisible()
 
     // Count the existing decorations in the file; there should be none.
     // TODO: When communication from the background process to the test runner

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -152,11 +152,11 @@ export const test = base
                 await page.click('[aria-label="Cody"]')
             }
             // Ensure that we remove the hover from the activity icon
-            await page.getByRole('heading', { name: 'Cody: Chat' }).hover()
+            await expect(page.getByRole('heading', { name: 'Cody: Chat' })).toBeVisible()
             // Wait for Cody to become activated
             // TODO(philipp-spiess): Figure out which playwright matcher we can use that works for
             // the signed-in and signed-out cases
-            await new Promise(resolve => setTimeout(resolve, 500))
+            await page.waitForTimeout(500)
 
             // Ensure we're signed out.
             if (await page.isVisible('[aria-label="User Settings"]')) {


### PR DESCRIPTION
In our e2e tests, there were many patterns like (where `x` is some Playwright locator, ie a selector query resolved by polling):

```
await x.hover()
await x.click()
```

The intent of this pattern is (except in rare cases where hovering is actually needed) to give extra time for `x` to become visible. But this is unnecessary because Playwright's `.click()` already auto-waits for the locator to become [actionable (see Playwright's definition)](https://playwright.dev/docs/actionability). The effect of these 2 lines is just to double the timeout (from 3s to 6s), which is not usually necessary. If a longer timeout is indeed needed, you can use `.click({timeout: N})`, and if a longer timeout than 3s is ever needed by default, we can update `playwright.config.ts` (but I don't think that's needed).

Same goes for this pattern:

```
await expect(x).toBeVisible()
x.click()
```

Playwright's definition of actionability (linked above) already checks for visibility.

In some cases where the intent of `await x.hover()` was to wait for something to become visible, I changed it to `await expect(x).toBeVisible()` for clarity.

There should be no behavior change (other than 3s not 6s timeouts) with these changes.



## Test plan

CI