### PR TITLE
make cody ignore e2e test less flaky on Windows

### DIFF
--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -65,6 +65,7 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
     await chatInput.clear()
     await chatInput.fill('@ignore')
+    await page.waitForTimeout(1000) // seems to make it less flaky on Windows
     await expect(
         chatPanel.getByRole('option', { name: withPlatformSlashes('ignore .cody') })
     ).toBeVisible()


### PR DESCRIPTION
Not sure why this helps, but it certainly seems to.



## Test plan

CI