### PR TITLE
wip: speed up builds w/ parallelism

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -810,7 +810,9 @@ export class SourcegraphGraphQLAPIClient {
 
     // make an anonymous request to the Testing API
     private fetchSourcegraphTestingAPI<T>(body: Record<string, any>): Promise<T | Error> {
-        const url = 'http://localhost:49300/.api/testLogging'
+        const url = `http://localhost:4930${
+            process.env.VITEST_POOL_ID ?? process.env.TEST_PARALLEL_INDEX ?? 0
+        }/.api/testLogging`
         const headers = new Headers({
             'Content-Type': 'application/json',
         })

--- a/lib/shared/src/sourcegraph-api/telemetry/MockServerTelemetryExporter.ts
+++ b/lib/shared/src/sourcegraph-api/telemetry/MockServerTelemetryExporter.ts
@@ -3,7 +3,9 @@ import type { TelemetryEventInput, TelemetryExporter } from '@sourcegraph/teleme
 import { logError } from '../../logger'
 import { isError } from '../../utils'
 
-const MOCK_URL = 'http://localhost:49300'
+const MOCK_URL = `http://localhost:4930${
+    process.env.VITEST_POOL_ID ?? process.env.TEST_PARALLEL_INDEX ?? 0
+}/`
 const ENDPOINT = '/.api/mockEventRecording'
 
 /**

--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
     testDir: 'test/e2e',
     timeout: isWin ? 30000 : 20000,
     expect: {
-        timeout: isWin ? 5000 : 3000,
+        timeout: isWin ? 5000 : 6000,
     },
 })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -191,7 +191,8 @@ export const getFullConfig = async (): Promise<ConfigurationWithAccessToken> => 
     const config = getConfiguration()
     const isTesting = process.env.CODY_TESTING === 'true'
     const serverEndpoint =
-        localStorage?.getEndpoint() || (isTesting ? `http://localhost:4930${process.env.VITEST_POOL_ID || 0}/` : DOTCOM_URL.href)
+        localStorage?.getEndpoint() ||
+        (isTesting ? `http://localhost:4930${process.env.VITEST_POOL_ID || 0}/` : DOTCOM_URL.href)
     const accessToken = (await getAccessToken()) || null
     return { ...config, accessToken, serverEndpoint }
 }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -192,7 +192,11 @@ export const getFullConfig = async (): Promise<ConfigurationWithAccessToken> => 
     const isTesting = process.env.CODY_TESTING === 'true'
     const serverEndpoint =
         localStorage?.getEndpoint() ||
-        (isTesting ? `http://localhost:4930${process.env.VITEST_POOL_ID || 0}/` : DOTCOM_URL.href)
+        (isTesting
+            ? `http://localhost:4930${
+                  process.env.VITEST_POOL_ID ?? process.env.TEST_PARALLEL_INDEX ?? 0
+              }/`
+            : DOTCOM_URL.href)
     const accessToken = (await getAccessToken()) || null
     return { ...config, accessToken, serverEndpoint }
 }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -191,7 +191,7 @@ export const getFullConfig = async (): Promise<ConfigurationWithAccessToken> => 
     const config = getConfiguration()
     const isTesting = process.env.CODY_TESTING === 'true'
     const serverEndpoint =
-        localStorage?.getEndpoint() || (isTesting ? 'http://localhost:49300/' : DOTCOM_URL.href)
+        localStorage?.getEndpoint() || (isTesting ? `http://localhost:4930${process.env.VITEST_POOL_ID || 0}/` : DOTCOM_URL.href)
     const accessToken = (await getAccessToken()) || null
     return { ...config, accessToken, serverEndpoint }
 }

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -16,10 +16,6 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:at-mention:file:executed',
     ],
 })('@-mention file in chat', async ({ page, sidebar }) => {
-    // This test requires that the window be focused in the OS window manager because it deals with
-    // focus.
-    await page.bringToFront()
-
     await sidebarSignin(page, sidebar)
 
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -45,10 +45,6 @@ test.extend<ExpectedEvents>({
 })
 
 test('chat input focus', async ({ page, sidebar }) => {
-    // This test requires that the window be focused in the OS window manager because it deals with
-    // focus.
-    await page.bringToFront()
-
     await sidebarSignin(page, sidebar)
     // Open the buzz.ts file from the tree view,
     // and then submit a chat question from the command menu.

--- a/vscode/test/e2e/context-settings.test.ts
+++ b/vscode/test/e2e/context-settings.test.ts
@@ -15,17 +15,23 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:Auth:connected',
         'CodyVSCodeExtension:useEnhancedContextToggler:clicked',
     ],
-})('enhanced context selector is keyboard accessible', async ({ page, sidebar }) => {
-    // This test requires that the window be focused in the OS window manager because it deals with
-    // focus.
-    await page.bringToFront()
+})('enhanced context selector is keyboard accessible', async ({ page, sidebar }, testInfo) => {
+    // This test requires that the window be focused in the OS's window manager. This
+    // does not work when other tests are running in parallel. TODO(sqs): make this testable in parallel.
+    const isParallelTest = process.env.TEST_PARALLEL_INDEX !== undefined
+    if (isParallelTest) {
+        testInfo.skip()
+        return
+    }
 
+    await page.bringToFront()
     await sidebarSignin(page, sidebar)
     const chatFrame = await newChat(page)
     const contextSettingsButton = chatFrame.getByTitle('Configure Enhanced Context')
     await contextSettingsButton.focus()
 
     await page.keyboard.press('Space')
+
     // Opening the enhanced context settings should focus the checkbox for toggling it.
     const enhancedContextCheckbox = chatFrame.locator('#enhanced-context-checkbox')
     await expect(enhancedContextCheckbox).toBeFocused()

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -258,7 +258,7 @@ async function buildWorkSpaceSettings(
     extraSettings: WorkspaceSettings
 ): Promise<void> {
     const settings = {
-        'cody.serverEndpoint': 'http://localhost:49300',
+        'cody.serverEndpoint': `http://localhost:4930${process.env.VITEST_POOL_ID || 0}`,
         'cody.commandCodeLenses': true,
         'cody.editorTitleCommandIcon': true,
         ...extraSettings,

--- a/vscode/test/fixtures/.vscode/settings.json
+++ b/vscode/test/fixtures/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "cody.codebase": "http://localhost:49300",
   "cody.debug.enable": true,
   "cody.debug.verbose": true,
 }

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -18,9 +18,8 @@ interface MockRequest {
     }
 }
 
-const SERVER_PORT = 49300
-
-export const SERVER_URL = 'http://localhost:49300'
+const SERVER_PORT = Number(`4930${process.env.VITEST_POOL_ID || 0}`)
+export const SERVER_URL = `http://localhost:${SERVER_PORT}`
 export const VALID_TOKEN = 'sgp_1234567890123456789012345678901234567890'
 
 const responses = {

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -18,7 +18,7 @@ interface MockRequest {
     }
 }
 
-const SERVER_PORT = Number(`4930${process.env.VITEST_POOL_ID || 0}`)
+const SERVER_PORT = Number(`4930${process.env.VITEST_POOL_ID ?? process.env.TEST_PARALLEL_INDEX ?? 0}`)
 export const SERVER_URL = `http://localhost:${SERVER_PORT}`
 export const VALID_TOKEN = 'sgp_1234567890123456789012345678901234567890'
 

--- a/vscode/test/fixtures/multi-root.code-workspace
+++ b/vscode/test/fixtures/multi-root.code-workspace
@@ -10,7 +10,6 @@
     "settings": {
         // Settings that should also apply to the single-root workspace tests should also be
         // included in fixtures\workspace\.vscode\settings.json!
-        "cody.serverEndpoint": "http://localhost:49300",
         "cody.commandCodeLenses": true,
         "cody.editorTitleCommandIcon": true,
         "cody.experimental.symfContext": false,


### PR DESCRIPTION
Build time is now 13 min. Last time (pre-windows builds) we got it back down to 4-5 min by bumping macOS instance size. We've hit the limits for bumping instance on macOS, so we'll need to split tasks (and probably bump instances for Windows & Ubuntu, which require GitHub org admin access).

But first let's see if we can parallelize on-machine, though I'm not hopeful: in general I've found this to be a fool's errand — parallelising e2e tests is a notorious change for introducing flakiness.

## Test plan

n/a
