### PR TITLE
V1 new client extension API, for inline edits + document code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,6 +63,13 @@
       "args": ["--extensionDevelopmentPath=${workspaceRoot}/vscode", "--extensionDevelopmentKind=web"]
     },
     {
+      "name": "Attach to Agent",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Debug Current File with vitest",

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentClient.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentClient.kt
@@ -28,8 +28,10 @@ interface CodyAgentClient {
   // =============
   @JsonNotification("debug/message")
   fun debug_message(params: DebugMessage)
-  @JsonNotification("editTaskState/didChange")
-  fun editTaskState_didChange(params: EditTask)
+  @JsonNotification("editTask/didUpdate")
+  fun editTask_didUpdate(params: EditTask)
+  @JsonNotification("editTask/didDelete")
+  fun editTask_didDelete(params: EditTask)
   @JsonNotification("codeLenses/display")
   fun codeLenses_display(params: DisplayCodeLensParams)
   @JsonNotification("webview/postMessage")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -34,10 +34,20 @@ interface CodyAgentServer {
   fun commands_smell(params: Null): CompletableFuture<String>
   @JsonRequest("commands/custom")
   fun commands_custom(params: Commands_CustomParams): CompletableFuture<CustomCommandResult>
+  @JsonRequest("editCommands/code")
+  fun editCommands_code(params: EditCommands_CodeParams): CompletableFuture<EditTask>
   @JsonRequest("editCommands/test")
   fun editCommands_test(params: Null): CompletableFuture<EditTask>
   @JsonRequest("commands/document")
   fun commands_document(params: Null): CompletableFuture<EditTask>
+  @JsonRequest("editTask/accept")
+  fun editTask_accept(params: FixupTaskID): CompletableFuture<Null>
+  @JsonRequest("editTask/undo")
+  fun editTask_undo(params: FixupTaskID): CompletableFuture<Null>
+  @JsonRequest("editTask/cancel")
+  fun editTask_cancel(params: FixupTaskID): CompletableFuture<Null>
+  @JsonRequest("editTask/getFoldingRanges")
+  fun editTask_getFoldingRanges(params: GetFoldingRangeParams): CompletableFuture<GetFoldingRangeResult>
   @JsonRequest("command/execute")
   fun command_execute(params: ExecuteCommandParams): CompletableFuture<Any>
   @JsonRequest("autocomplete/execute")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditCommands_CodeParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditCommands_CodeParams.kt
@@ -1,0 +1,6 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class EditCommands_CodeParams(
+  val instruction: String? = null,
+)

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask.kt
@@ -5,5 +5,6 @@ data class EditTask(
   val id: String? = null,
   val state: CodyTaskState? = null,
   val error: CodyError? = null,
+  val selectionRange: Range? = null,
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/FixupTaskID.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/FixupTaskID.kt
@@ -1,7 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-data class EditCommands_CodeParams(
-  val params: ParamsParams? = null,
-)
+typealias FixupTaskID = String // One of: 
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetFoldingRangeParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetFoldingRangeParams.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-data class EditCommands_CodeParams(
-  val params: ParamsParams? = null,
+data class GetFoldingRangeParams(
+  val uri: String? = null,
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetFoldingRangeResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/GetFoldingRangeResult.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-data class EditCommands_CodeParams(
-  val params: ParamsParams? = null,
+data class GetFoldingRangeResult(
+  val ranges: List<Range>? = null,
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ParamsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ParamsParams.kt
@@ -1,7 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-data class EditCommands_CodeParams(
-  val params: ParamsParams? = null,
+data class ParamsParams(
+  val instruction: String? = null,
 )
 

--- a/agent/package.json
+++ b/agent/package.json
@@ -17,7 +17,7 @@
     "build": "pnpm run build:root && pnpm run build:agent",
     "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node dist/index.js",
-    "agent:debug": "pnpm run build && node --inspect --enable-source-maps ./dist/index.js",
+    "agent:debug": "pnpm run build && CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js",
     "build-ts": "tsc --build",
     "build-agent-binaries": "pnpm run build && pkg  --compress GZip --no-bytecode --public-packages \"*\" --public . --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
     "test-agent-binary": "esbuild ./scripts/test-agent-binary.ts --bundle --platform=node --alias:vscode=./src/vscode-shim.ts --outdir=dist && node ./dist/test-agent-binary.js",

--- a/agent/package.json
+++ b/agent/package.json
@@ -17,7 +17,7 @@
     "build": "pnpm run build:root && pnpm run build:agent",
     "build-minify": "pnpm run build --minify",
     "agent": "pnpm run build && node dist/index.js",
-    "agent:debug": "pnpm run build && CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js",
+    "agent:debug": "pnpm run build && CODY_AGENT_TRACE_PATH=/tmp/agent.json CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js",
     "build-ts": "tsc --build",
     "build-agent-binaries": "pnpm run build && pkg  --compress GZip --no-bytecode --public-packages \"*\" --public . --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
     "test-agent-binary": "esbuild ./scripts/test-agent-binary.ts --bundle --platform=node --alias:vscode=./src/vscode-shim.ts --outdir=dist && node ./dist/test-agent-binary.js",

--- a/agent/src/AgentFixupControls.ts
+++ b/agent/src/AgentFixupControls.ts
@@ -50,6 +50,7 @@ export class AgentFixupControls implements FixupControlApplicator {
             id: task.id,
             state: task.state,
             error: errorToCodyError(task.error),
+            selectionRange: task.selectionRange,
         }
     }
 }

--- a/agent/src/AgentFixupControls.ts
+++ b/agent/src/AgentFixupControls.ts
@@ -1,0 +1,55 @@
+import type { FixupFile } from '../../vscode/src/non-stop/FixupFile'
+import type { FixupTask, FixupTaskID } from '../../vscode/src/non-stop/FixupTask'
+import type { FixupActor, FixupFileCollection } from '../../vscode/src/non-stop/roles'
+import type { FixupControlApplicator } from '../../vscode/src/non-stop/strategies'
+import { type Agent, errorToCodyError } from './agent'
+import type { EditTask } from './protocol-alias'
+
+export class AgentFixupControls implements FixupControlApplicator {
+    constructor(
+        private readonly fixups: FixupActor & FixupFileCollection,
+        private readonly notify: typeof Agent.prototype.notify
+    ) {}
+
+    public accept(id: FixupTaskID): void {
+        const task = this.fixups.taskForId(id)
+        if (task) {
+            this.fixups.accept(task)
+        }
+    }
+
+    public undo(id: FixupTaskID): void {
+        const task = this.fixups.taskForId(id)
+        if (task) {
+            this.fixups.undo(task)
+        }
+    }
+
+    public cancel(id: FixupTaskID): void {
+        const task = this.fixups.taskForId(id)
+        if (task) {
+            this.fixups.cancel(task)
+        }
+    }
+
+    // FixupControlApplicator
+
+    didUpdateTask(task: FixupTask): void {
+        this.notify('editTask/didUpdate', AgentFixupControls.serialize(task))
+    }
+    didDeleteTask(task: FixupTask): void {
+        this.notify('editTask/didDelete', AgentFixupControls.serialize(task))
+    }
+
+    visibleFilesWithTasksMaybeChanged(files: readonly FixupFile[]): void {}
+
+    dispose() {}
+
+    public static serialize(task: FixupTask): EditTask {
+        return {
+            id: task.id,
+            state: task.state,
+            error: errorToCodyError(task.error),
+        }
+    }
+}

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -343,33 +343,52 @@ export class TestClient extends MessageHandler {
                 )
         }
 
-        let disposable: vscode.Disposable
+        let disposables: vscode.Disposable[]
         return new Promise<void>((resolve, reject) => {
-            disposable = this.onDidChangeTaskState(({ id, state, error }) => {
-                if (id === params.id) {
-                    switch (state) {
-                        case CodyTaskState.applied:
-                            return resolve()
-                        case CodyTaskState.error:
-                        case CodyTaskState.finished:
-                            return reject(
-                                new Error(
-                                    `Task reached terminal state before being applied ${JSON.stringify({
-                                        id,
-                                        state: CodyTaskState[state],
-                                        error,
-                                    })}`
+            disposables = [
+                this.onDidUpdateTask(({ id, state, error }) => {
+                    if (id === params.id) {
+                        switch (state) {
+                            case CodyTaskState.applied:
+                                return resolve()
+                            case CodyTaskState.error:
+                            case CodyTaskState.finished:
+                                return reject(
+                                    new Error(
+                                        `Task reached terminal state before being applied ${JSON.stringify(
+                                            {
+                                                id,
+                                                state: CodyTaskState[state],
+                                                error,
+                                            }
+                                        )}`
+                                    )
                                 )
-                            )
+                        }
                     }
-                }
-            })
-        }).finally(() => disposable.dispose())
+                }),
+                this.onDidDeleteTask(task => {
+                    if (task.id === params.id) {
+                        // Applied tasks can also be deleted, but in that case
+                        // the Promise is already resolved and this is a no-op.
+                        reject(
+                            new Error(`Task was deleted before being applied ${JSON.stringify(task)}`)
+                        )
+                    }
+                }),
+            ]
+        }).finally(() => {
+            for (const disposable of disposables) {
+                disposable.dispose()
+            }
+        })
     }
 
     public codeLenses = new Map<string, ProtocolCodeLens[]>()
-    public newTaskState = new vscode.EventEmitter<EditTask>()
-    public onDidChangeTaskState = this.newTaskState.event
+    public taskUpdate = new vscode.EventEmitter<EditTask>()
+    public onDidUpdateTask = this.taskUpdate.event
+    public taskDelete = new vscode.EventEmitter<EditTask>()
+    public onDidDeleteTask = this.taskDelete.event
     public webviewMessages: WebviewPostMessageParams[] = []
     public webviewMessagesEmitter = new vscode.EventEmitter<WebviewPostMessageParams>()
 
@@ -416,8 +435,11 @@ export class TestClient extends MessageHandler {
         this.connectProcess(this.agentProcess, error => {
             console.error(error)
         })
-        this.registerNotification('editTaskState/didChange', params => {
-            this.newTaskState.fire(params)
+        this.registerNotification('editTask/didUpdate', params => {
+            this.taskUpdate.fire(params)
+        })
+        this.registerNotification('editTask/didDelete', params => {
+            this.taskDelete.fire(params)
         })
 
         this.registerNotification('webview/postMessage', params => {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1076,11 +1076,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 `Expected a non-empty edit command result. Got ${JSON.stringify(result)}`
             )
         }
-        return {
-            id: result.task.id,
-            state: result.task.state,
-            error: errorToCodyError(result.task.error),
-        }
+        return AgentFixupControls.serialize(result.task)
     }
 
     private async createChatPanel(commandResult: Thenable<CommandResult | undefined>): Promise<string> {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -39,12 +39,12 @@ import type { ExtensionClient } from '../../vscode/src/extension-client'
 import { IndentationBasedFoldingRangeProvider } from '../../vscode/src/lsp/foldingRanges'
 import type { CommandResult } from '../../vscode/src/main'
 import type { FixupTask } from '../../vscode/src/non-stop/FixupTask'
+import { FixupCodeLenses } from '../../vscode/src/non-stop/codelenses/provider'
+import type { FixupActor, FixupFileCollection } from '../../vscode/src/non-stop/roles'
 import {
-    FixupCodeLenses,
     type FixupControlApplicator,
-    NullFixupControlsApplicator,
-} from '../../vscode/src/non-stop/codelenses/provider'
-import type { FixupFileCollection } from '../../vscode/src/non-stop/roles'
+    NullFixupControlApplicator,
+} from '../../vscode/src/non-stop/strategies'
 import { CodyTaskState } from '../../vscode/src/non-stop/utils'
 import { AgentWorkspaceEdit } from '../../vscode/src/testutils/AgentWorkspaceEdit'
 import { emptyEvent } from '../../vscode/src/testutils/emptyEvent'
@@ -870,11 +870,13 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
     // ExtensionClient callbacks.
 
-    public createFixupControlApplicator(files: FixupFileCollection): FixupControlApplicator {
-        return this.clientInfo?.capabilities?.codeLenses &&
-            this.clientInfo?.capabilities?.fixupCodeLenses
+    public createFixupControlApplicator(
+        files: FixupActor & FixupFileCollection
+    ): FixupControlApplicator {
+        return this.clientInfo?.capabilities?.codeLenses === 'enabled' &&
+            this.clientInfo?.capabilities?.fixupControls === 'lenses'
             ? new FixupCodeLenses(files)
-            : new NullFixupControlsApplicator()
+            : new NullFixupControlApplicator()
     }
 
     private codeLensToken = new vscode.CancellationTokenSource()

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -39,7 +39,7 @@ import { getDocumentSections } from '../../vscode/src/editor/utils/document-sect
 import type { ExtensionClient } from '../../vscode/src/extension-client'
 import { IndentationBasedFoldingRangeProvider } from '../../vscode/src/lsp/foldingRanges'
 import type { CommandResult, EditCommandResult } from '../../vscode/src/main'
-import { FixupTask } from '../../vscode/src/non-stop/FixupTask'
+import type { FixupTask } from '../../vscode/src/non-stop/FixupTask'
 import type { FixupActor, FixupFileCollection } from '../../vscode/src/non-stop/roles'
 import type { FixupControlApplicator } from '../../vscode/src/non-stop/strategies'
 import { AgentWorkspaceEdit } from '../../vscode/src/testutils/AgentWorkspaceEdit'

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -734,6 +734,13 @@ export class Agent extends MessageHandler implements ExtensionClient {
             return Promise.resolve(null)
         })
 
+        this.registerAuthenticatedRequest('editCommands/code', params => {
+            const args = { configuration: { ...params } }
+            return this.createEditTask(
+                vscode.commands.executeCommand<CommandResult | undefined>('cody.command.edit-code', args)
+            )
+        })
+
         this.registerAuthenticatedRequest('commands/smell', () => {
             return this.createChatPanel(
                 vscode.commands.executeCommand('cody.command.smell-code', commandArgs)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -770,7 +770,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                     return Promise.resolve({ ranges: [] })
                 }
                 const ranges = await getDocumentSections(document)
-                return { ranges: ranges }
+                return { ranges }
             }
         )
 

--- a/agent/src/bfg/BfgRetriever.test.ts
+++ b/agent/src/bfg/BfgRetriever.test.ts
@@ -12,6 +12,7 @@ import * as vscode from 'vscode'
 import { BfgRetriever } from '../../../vscode/src/completions/context/retrievers/bfg/bfg-retriever'
 import { getCurrentDocContext } from '../../../vscode/src/completions/get-current-doc-context'
 import { initTreeSitterParser } from '../../../vscode/src/completions/test-helpers'
+import { defaultVSCodeExtensionClient } from '../../../vscode/src/extension-client'
 import { initializeVscodeExtension, newEmbeddedAgentClient } from '../agent'
 import * as vscode_shim from '../vscode-shim'
 
@@ -34,7 +35,7 @@ describe('BfgRetriever', async () => {
     beforeAll(async () => {
         process.env.CODY_TESTING = 'true'
         await initTreeSitterParser()
-        await initializeVscodeExtension(vscode.Uri.file(process.cwd()))
+        await initializeVscodeExtension(vscode.Uri.file(process.cwd()), defaultVSCodeExtensionClient())
 
         if (shouldCreateGitDir) {
             await exec('git init', { cwd: dir })

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -664,24 +664,9 @@ describe('Agent', () => {
                 const task = await documentClient.request('commands/document', null)
                 await documentClient.taskHasReachedAppliedPhase(task)
                 const lenses = documentClient.codeLenses.get(uri.toString()) ?? []
-                expect(lenses).toHaveLength(4) // Show diff, accept, retry , undo
-                const acceptCommand = lenses.find(
-                    ({ command }) => command?.command === 'cody.fixup.codelens.accept'
-                )
-                if (acceptCommand === undefined || acceptCommand.command === undefined) {
-                    throw new Error(
-                        `Expected accept command, found none. Lenses ${JSON.stringify(lenses, null, 2)}`
-                    )
-                }
+                expect(lenses).toHaveLength(0) // Code lenses are now handled client side
 
-                // Check the command is corrected parsed by the agent
-                expect(acceptCommand.command.title.text).toBe(' Accept')
-                expect(acceptCommand.command.title.icons).toStrictEqual([
-                    { position: 0, value: '$(cody-logo)' },
-                ])
-
-                await documentClient.request('command/execute', acceptCommand.command)
-                expect(documentClient.codeLenses.get(uri.toString()) ?? []).toHaveLength(0)
+                await documentClient.request('editTask/accept', task.id)
                 const newContent = documentClient.workspace.getDocument(uri)?.content
                 assertion(trimEndOfLine(newContent))
             },

--- a/vscode/src/commands/execute/edit.ts
+++ b/vscode/src/commands/execute/edit.ts
@@ -31,5 +31,4 @@ export async function executeEditCommand(
             } satisfies ExecuteEditArguments),
         }
     })
-
 }

--- a/vscode/src/commands/execute/edit.ts
+++ b/vscode/src/commands/execute/edit.ts
@@ -1,0 +1,35 @@
+import { DefaultEditCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import { type ExecuteEditArguments, executeEdit } from '../../edit/execute'
+import { getEditor } from '../../editor/active-editor'
+import type { EditCommandResult } from '../../main'
+
+import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
+
+export async function executeEditCommand(
+    args: ExecuteEditArguments
+): Promise<EditCommandResult | undefined> {
+    return wrapInActiveSpan('command.test', async span => {
+        span.setAttribute('sampled', true)
+        const instruction = args.configuration?.instruction // get the instruction
+        const editor = getEditor()?.active // get the active editor
+        const document = editor?.document // get the document from the editor
+        if (!document || !instruction) {
+            return
+        }
+
+        // execute the edit with the provided configuration
+        return {
+            type: 'edit',
+            task: await executeEdit({
+                configuration: {
+                    ...args.configuration,
+                    instruction,
+                    document,
+                    mode: 'edit',
+                },
+                source: DefaultEditCommands.Test,
+            } satisfies ExecuteEditArguments),
+        }
+    })
+
+}

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -38,7 +38,7 @@ export interface EditManagerOptions {
 // generic FixupTasks, and pairs a FixupTask with an EditProvider to generate
 // a completion.
 export class EditManager implements vscode.Disposable {
-    private controller: FixupController
+    private readonly controller: FixupController
     private disposables: vscode.Disposable[] = []
     private editProviders = new WeakMap<FixupTask, EditProvider>()
     private models: ModelProvider[] = []

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -13,6 +13,7 @@ import type { VSCodeEditor } from '../editor/vscode-editor'
 import { FixupController } from '../non-stop/FixupController'
 import type { FixupTask } from '../non-stop/FixupTask'
 
+import type { ExtensionClient } from '../extension-client'
 import { editModel } from '../models'
 import { ACTIVE_TASK_STATES } from '../non-stop/codelenses/constants'
 import type { AuthProvider } from '../services/AuthProvider'
@@ -30,17 +31,21 @@ export interface EditManagerOptions {
     chat: ChatClient
     ghostHintDecorator: GhostHintDecorator
     authProvider: AuthProvider
+    extensionClient: ExtensionClient
 }
 
+// EditManager handles translating specific edit intents (document, edit) into
+// generic FixupTasks, and pairs a FixupTask with an EditProvider to generate
+// a completion.
 export class EditManager implements vscode.Disposable {
     private controller: FixupController
     private disposables: vscode.Disposable[] = []
-    private editProviders = new Map<FixupTask, EditProvider>()
+    private editProviders = new WeakMap<FixupTask, EditProvider>()
     private models: ModelProvider[] = []
 
     constructor(public options: EditManagerOptions) {
         this.models = getEditModelsForUser(options.authProvider.getAuthStatus())
-        this.controller = new FixupController(options.authProvider)
+        this.controller = new FixupController(options.authProvider, options.extensionClient)
         this.disposables.push(
             this.controller,
             vscode.commands.registerCommand('cody.command.edit-code', (args: ExecuteEditArguments) =>
@@ -170,7 +175,7 @@ export class EditManager implements vscode.Disposable {
         return task
     }
 
-    public getProviderForTask(task: FixupTask): EditProvider {
+    private getProviderForTask(task: FixupTask): EditProvider {
         let provider = this.editProviders.get(task)
 
         if (!provider) {

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -153,7 +153,7 @@ export class EditManager implements vscode.Disposable {
         })
 
         if (activeTask) {
-            this.controller.cancelTask(task)
+            this.controller.cancel(task)
             return
         }
 

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -7,7 +7,6 @@ import {
     type ModelProvider,
 } from '@sourcegraph/cody-shared'
 
-import type { ContextProvider } from '../chat/ContextProvider'
 import type { GhostHintDecorator } from '../commands/GhostHintDecorator'
 import { getEditor } from '../editor/active-editor'
 import type { VSCodeEditor } from '../editor/vscode-editor'
@@ -29,7 +28,6 @@ import { getEditLineSelection, getEditSmartSelection } from './utils/edit-select
 export interface EditManagerOptions {
     editor: VSCodeEditor
     chat: ChatClient
-    contextProvider: ContextProvider
     ghostHintDecorator: GhostHintDecorator
     authProvider: AuthProvider
 }

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -32,6 +32,9 @@ interface EditProviderOptions extends EditManagerOptions {
     controller: FixupController
 }
 
+// Initiates a completion and responds to the result from the LLM. Implements
+// "tools" like directing the response into a specific file. Code is forwarded
+// to the FixupTask.
 export class EditProvider {
     private insertionResponse: string | null = null
     private insertionInProgress = false

--- a/vscode/src/editor/utils/document-sections.ts
+++ b/vscode/src/editor/utils/document-sections.ts
@@ -14,7 +14,7 @@ export async function getDocumentSections(
     // Remove imports, comments, and regions from the folding ranges
     const foldingRanges = await getFoldingRanges(doc.uri).then(r => r?.filter(r => !r.kind))
     if (!foldingRanges?.length) {
-        console.warn("No indentation-based folding ranges found", doc.uri)
+        console.warn('No indentation-based folding ranges found', doc.uri)
         return []
     }
 

--- a/vscode/src/editor/utils/document-sections.ts
+++ b/vscode/src/editor/utils/document-sections.ts
@@ -14,6 +14,7 @@ export async function getDocumentSections(
     // Remove imports, comments, and regions from the folding ranges
     const foldingRanges = await getFoldingRanges(doc.uri).then(r => r?.filter(r => !r.kind))
     if (!foldingRanges?.length) {
+        console.warn("No indentation-based folding ranges found", doc.uri)
         return []
     }
 

--- a/vscode/src/extension-api.ts
+++ b/vscode/src/extension-api.ts
@@ -7,6 +7,7 @@ export class ExtensionApi {
     // environment contains CODY_TESTING=true . This is only for
     // testing and the API will change.
     public testing: TestSupport | undefined = undefined
+
     constructor(public extensionMode: ExtensionMode) {
         if (process.env.CODY_TESTING === 'true') {
             console.warn('Setting up testing hooks')

--- a/vscode/src/extension-client.ts
+++ b/vscode/src/extension-client.ts
@@ -1,11 +1,12 @@
-import { FixupCodeLenses, type FixupControlApplicator } from './non-stop/codelenses/provider'
-import type { FixupFileCollection } from './non-stop/roles'
+import { FixupCodeLenses } from './non-stop/codelenses/provider'
+import type { FixupActor, FixupFileCollection } from './non-stop/roles'
+import type { FixupControlApplicator } from './non-stop/strategies'
 
 // Lets the extension delegate to the client (VSCode, Agent, etc.) to control
 // which components are used depending on the client's capabilities.
 export interface ExtensionClient {
     // Create the component which decorates FixupTasks with controls.
-    createFixupControlApplicator(files: FixupFileCollection): FixupControlApplicator
+    createFixupControlApplicator(files: FixupActor & FixupFileCollection): FixupControlApplicator
 }
 
 export function defaultVSCodeExtensionClient(): ExtensionClient {

--- a/vscode/src/extension-client.ts
+++ b/vscode/src/extension-client.ts
@@ -6,7 +6,7 @@ import type { FixupControlApplicator } from './non-stop/strategies'
 // which components are used depending on the client's capabilities.
 export interface ExtensionClient {
     // Create the component which decorates FixupTasks with controls.
-    createFixupControlApplicator(files: FixupActor & FixupFileCollection): FixupControlApplicator
+    createFixupControlApplicator(fixups: FixupActor & FixupFileCollection): FixupControlApplicator
 }
 
 export function defaultVSCodeExtensionClient(): ExtensionClient {

--- a/vscode/src/extension-client.ts
+++ b/vscode/src/extension-client.ts
@@ -1,0 +1,15 @@
+import { FixupCodeLenses, type FixupControlApplicator } from './non-stop/codelenses/provider'
+import type { FixupFileCollection } from './non-stop/roles'
+
+// Lets the extension delegate to the client (VSCode, Agent, etc.) to control
+// which components are used depending on the client's capabilities.
+export interface ExtensionClient {
+    // Create the component which decorates FixupTasks with controls.
+    createFixupControlApplicator(files: FixupFileCollection): FixupControlApplicator
+}
+
+export function defaultVSCodeExtensionClient(): ExtensionClient {
+    return {
+        createFixupControlApplicator: files => new FixupCodeLenses(files),
+    }
+}

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -52,8 +52,6 @@ export async function activate(
     context: vscode.ExtensionContext,
     platformContext: PlatformContext
 ): Promise<ExtensionApi> {
-    const api = new ExtensionApi(context.extensionMode)
-
     try {
         const disposable = await start(context, platformContext)
         if (!context.globalState.get('extension.hasActivatedPreviously')) {
@@ -69,5 +67,5 @@ export async function activate(
         console.error(error)
     }
 
-    return api
+    return new ExtensionApi(context.extensionMode)
 }

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -52,6 +52,7 @@ export async function activate(
     context: vscode.ExtensionContext,
     platformContext: PlatformContext
 ): Promise<ExtensionApi> {
+    const api = new ExtensionApi(context.extensionMode)
     try {
         const disposable = await start(context, platformContext)
         if (!context.globalState.get('extension.hasActivatedPreviously')) {
@@ -66,6 +67,5 @@ export async function activate(
         captureException(error)
         console.error(error)
     }
-
-    return new ExtensionApi(context.extensionMode)
+    return api
 }

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -15,6 +15,7 @@ import './editor/displayPathEnvInfo' // import for side effects
 
 import type { CommandsProvider } from './commands/services/provider'
 import { ExtensionApi } from './extension-api'
+import type { ExtensionClient } from './extension-client'
 import type { ContextRankerConfig, ContextRankingController } from './local-context/context-ranking'
 import type { LocalEmbeddingsConfig, LocalEmbeddingsController } from './local-context/local-embeddings'
 import type { SymfRunner } from './local-context/symf'
@@ -44,6 +45,7 @@ export interface PlatformContext {
     createOpenTelemetryService?: (config: OpenTelemetryServiceConfig) => OpenTelemetryService
     startTokenReceiver?: typeof startTokenReceiver
     onConfigurationChange?: (configuration: Configuration) => void
+    extensionClient: ExtensionClient
 }
 
 export async function activate(

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -5,6 +5,7 @@ import { startTokenReceiver } from './auth/token-receiver'
 import { CommandsProvider } from './commands/services/provider'
 import { BfgRetriever } from './completions/context/retrievers/bfg/bfg-retriever'
 import type { ExtensionApi } from './extension-api'
+import { type ExtensionClient, defaultVSCodeExtensionClient } from './extension-client'
 import { activate as activateCommon } from './extension.common'
 import { initializeNetworkAgent, setCustomAgent } from './fetch.node'
 import {
@@ -19,12 +20,20 @@ import {
 import { SymfRunner } from './local-context/symf'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
 import { NodeSentryService } from './services/sentry/sentry.node'
+
 /**
  * Activation entrypoint for the VS Code extension when running VS Code as a desktop app
  * (Node.js/Electron).
  */
-export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi> {
+export function activate(
+    context: vscode.ExtensionContext,
+    extensionClient?: ExtensionClient
+): Promise<ExtensionApi> {
     initializeNetworkAgent()
+
+    // When activated by VSCode, we are only passed the extension context.
+    // Create the default client for VSCode.
+    extensionClient ||= defaultVSCodeExtensionClient()
 
     // NOTE: local embeddings are only going to be supported in VSC for now.
     // Until we revisit this decision, we disable local embeddings for all agent
@@ -49,5 +58,6 @@ export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi
         startTokenReceiver: (...args) => startTokenReceiver(...args),
 
         onConfigurationChange: setCustomAgent,
+        extensionClient,
     })
 }

--- a/vscode/src/extension.web.ts
+++ b/vscode/src/extension.web.ts
@@ -3,6 +3,7 @@ import type * as vscode from 'vscode'
 import { SourcegraphBrowserCompletionsClient } from '@sourcegraph/cody-shared'
 
 import type { ExtensionApi } from './extension-api'
+import { defaultVSCodeExtensionClient } from './extension-client'
 import { activate as activateCommon } from './extension.common'
 import { WebSentryService } from './services/sentry/sentry.web'
 
@@ -14,5 +15,6 @@ export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi
     return activateCommon(context, {
         createCompletionsClient: (...args) => new SourcegraphBrowserCompletionsClient(...args),
         createSentryService: (...args) => new WebSentryService(...args),
+        extensionClient: defaultVSCodeExtensionClient(),
     })
 }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -329,9 +329,9 @@ interface ClientCapabilities {
     showDocument?: 'none' | 'enabled'
     codeLenses?: 'none' | 'enabled'
     showWindowMessage?: 'notification' | 'request'
-    // The strategy for decorating fixups with controls in code lenses.
-    // To enable, must also have codeLenses == 'enabled'.
-    fixupCodeLenses?: 'none' | 'enabled'
+    // How to render fixup controls.
+    // To use 'lenses', must also have codeLenses === 'enabled'.
+    fixupControls?: 'none' | 'lenses'
 }
 
 export interface ServerInfo {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -604,6 +604,7 @@ export interface EditTask {
     id: string
     state: CodyTaskState
     error?: CodyError
+    selectionRange: Range
 }
 
 export interface CodyError {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -78,6 +78,7 @@ export type ClientRequests = {
     'editCommands/code': [{ params: { instruction: string } }, EditTask]
     'editCommands/test': [null, EditTask]
     'commands/document': [null, EditTask] // TODO: rename to editCommands/document
+
     // If the task is "applied", discards the task.
     'editTask/accept': [FixupTaskID, null]
     // If the task is "applied", attempts to revert the task's edit, then
@@ -85,6 +86,10 @@ export type ClientRequests = {
     'editTask/undo': [FixupTaskID, null]
     // Discards the task. Applicable to tasks in any state.
     'editTask/cancel': [FixupTaskID, null]
+
+    // Utility for clients that don't have language-neutral folding-range support.
+    // Provides a list of all the computed folding ranges in the specified document.
+    'editTask/getFoldingRanges': [GetFoldingRangeParams, GetFoldingRangeResult]
 
     // Low-level API to trigger a VS Code command with any argument list. Avoid
     // using this API in favor of high-level wrappers like 'chat/new'.
@@ -677,4 +682,12 @@ export interface CustomChatCommandResult {
 export interface CustomEditCommandResult {
     type: 'edit'
     editResult: EditTask
+}
+
+export interface GetFoldingRangeParams {
+    uri: string
+}
+
+export interface GetFoldingRangeResult {
+    ranges: Range[]
 }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -18,6 +18,7 @@ import type * as vscode from 'vscode'
 import type { ExtensionMessage, WebviewMessage } from '../chat/protocol'
 import type { CompletionBookkeepingEvent } from '../completions/logger'
 import type { Repo } from '../context/repo-fetcher'
+import { FixupTaskID } from '../non-stop/FixupTask'
 import type { CodyTaskState } from '../non-stop/utils'
 
 // This file documents the Cody Agent JSON-RPC protocol. Consult the JSON-RPC
@@ -76,6 +77,13 @@ export type ClientRequests = {
     // Trigger commands that edit the code.
     'editCommands/test': [null, EditTask]
     'commands/document': [null, EditTask] // TODO: rename to editCommands/test
+    // If the task is "applied", discards the task.
+    'editTask/accept': [FixupTaskID, null]
+    // If the task is "applied", attempts to revert the task's edit, then
+    // discards the task.
+    'editTask/undo': [FixupTaskID, null]
+    // Discards the task. Applicable to tasks in any state.
+    'editTask/cancel': [FixupTaskID, null]
 
     // Low-level API to trigger a VS Code command with any argument list. Avoid
     // using this API in favor of high-level wrappers like 'chat/new'.
@@ -244,7 +252,15 @@ export type ClientNotifications = {
 export type ServerNotifications = {
     'debug/message': [DebugMessage]
 
-    'editTaskState/didChange': [EditTask]
+    // Certain properties of the task are updated:
+    // - State
+    // - The associated range has changed because the document was edited
+    // Only sent if client capabilities fixupControls === 'events'
+    'editTask/didUpdate': [EditTask]
+    // The task is deleted because it has been accepted or cancelled.
+    // Only sent if client capabilities fixupControls === 'events'.
+    'editTask/didDelete': [EditTask]
+
     'codeLenses/display': [DisplayCodeLensParams]
 
     // Low-level webview notification for the given chat session ID (created via
@@ -329,9 +345,6 @@ interface ClientCapabilities {
     showDocument?: 'none' | 'enabled'
     codeLenses?: 'none' | 'enabled'
     showWindowMessage?: 'notification' | 'request'
-    // How to render fixup controls.
-    // To use 'lenses', must also have codeLenses === 'enabled'.
-    fixupControls?: 'none' | 'lenses'
 }
 
 export interface ServerInfo {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -329,6 +329,9 @@ interface ClientCapabilities {
     showDocument?: 'none' | 'enabled'
     codeLenses?: 'none' | 'enabled'
     showWindowMessage?: 'notification' | 'request'
+    // The strategy for decorating fixups with controls in code lenses.
+    // To enable, must also have codeLenses == 'enabled'.
+    fixupCodeLenses?: 'none' | 'enabled'
 }
 
 export interface ServerInfo {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -75,8 +75,9 @@ export type ClientRequests = {
     'commands/custom': [{ key: string }, CustomCommandResult]
 
     // Trigger commands that edit the code.
+    'editCommands/code': [{ params: { instruction: string } }, EditTask]
     'editCommands/test': [null, EditTask]
-    'commands/document': [null, EditTask] // TODO: rename to editCommands/test
+    'commands/document': [null, EditTask] // TODO: rename to editCommands/document
     // If the task is "applied", discards the task.
     'editTask/accept': [FixupTaskID, null]
     // If the task is "applied", attempts to revert the task's edit, then

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -18,7 +18,7 @@ import type * as vscode from 'vscode'
 import type { ExtensionMessage, WebviewMessage } from '../chat/protocol'
 import type { CompletionBookkeepingEvent } from '../completions/logger'
 import type { Repo } from '../context/repo-fetcher'
-import { FixupTaskID } from '../non-stop/FixupTask'
+import type { FixupTaskID } from '../non-stop/FixupTask'
 import type { CodyTaskState } from '../non-stop/utils'
 
 // This file documents the Cody Agent JSON-RPC protocol. Consult the JSON-RPC

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -217,6 +217,7 @@ const register = async (
         editor,
         ghostHintDecorator,
         authProvider,
+        extensionClient: platform.extensionClient,
     })
     disposables.push(ghostHintDecorator, editorManager, new CodeActionProvider({ contextProvider }))
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -215,7 +215,6 @@ const register = async (
     const editorManager = new EditManager({
         chat: chatClient,
         editor,
-        contextProvider,
         ghostHintDecorator,
         authProvider,
     })

--- a/vscode/src/non-stop/FixupContentStore.ts
+++ b/vscode/src/non-stop/FixupContentStore.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode'
 
-import type { taskID } from './FixupTask'
+import type { FixupTaskID } from './FixupTask'
 
 type fileName = string
 type fileContent = string
@@ -11,9 +11,9 @@ export class ContentProvider implements vscode.TextDocumentContentProvider, vsco
     // This stores the content of the document for each task ID
     // The content is initialized by the fixup task with the original content
     // and then updated by the fixup task with the replacement content
-    private contentStore = new Map<taskID, fileContent>()
+    private contentStore = new Map<FixupTaskID, fileContent>()
     // This tracks the task IDs belong toe each file path
-    private tasksByFilePath = new Map<fileName, taskID[]>()
+    private tasksByFilePath = new Map<fileName, FixupTaskID[]>()
     private _onDidChange = new vscode.EventEmitter<vscode.Uri>()
     private _disposables: vscode.Disposable
 
@@ -70,7 +70,7 @@ export class ContentProvider implements vscode.TextDocumentContentProvider, vsco
     public dispose(): void {
         this._disposables.dispose()
         this._onDidChange.dispose()
-        this.contentStore = new Map<taskID, fileContent>()
-        this.tasksByFilePath = new Map<fileName, taskID[]>()
+        this.contentStore = new Map<FixupTaskID, fileContent>()
+        this.tasksByFilePath = new Map<fileName, FixupTaskID[]>()
     }
 }

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -18,30 +18,27 @@ import { getEditorInsertSpaces, getEditorTabSize } from '../utils'
 import { getInput } from '../edit/input/get-input'
 import type { ExtensionClient } from '../extension-client'
 import type { AuthProvider } from '../services/AuthProvider'
-import { ContentProvider } from './FixupContentStore'
 import { FixupDecorator } from './FixupDecorator'
 import { FixupDocumentEditObserver } from './FixupDocumentEditObserver'
 import type { FixupFile } from './FixupFile'
 import { FixupFileObserver } from './FixupFileObserver'
 import { FixupScheduler } from './FixupScheduler'
-import { FixupTask, type taskID } from './FixupTask'
-import { ACTIONABLE_TASK_STATES, ACTIVE_TASK_STATES } from './codelenses/constants'
+import { FixupTask, type FixupTaskID } from './FixupTask'
 import { type Diff, computeDiff } from './diff'
-import type { FixupFileCollection, FixupIdleTaskRunner, FixupTextChanged } from './roles'
+import type { FixupActor, FixupFileCollection, FixupIdleTaskRunner, FixupTextChanged } from './roles'
 import { CodyTaskState, getMinimumDistanceToRangeBoundary } from './utils'
 
 // This class acts as the factory for Fixup Tasks and handles communication between the Tree View and editor
 export class FixupController
-    implements FixupFileCollection, FixupIdleTaskRunner, FixupTextChanged, vscode.Disposable
+    implements FixupActor, FixupFileCollection, FixupIdleTaskRunner, FixupTextChanged, vscode.Disposable
 {
-    private tasks = new Map<taskID, FixupTask>()
+    private tasks = new Map<FixupTaskID, FixupTask>()
     private readonly files: FixupFileObserver
     private readonly editObserver: FixupDocumentEditObserver
     // TODO: Make the fixup scheduler use a cooldown timer with a longer delay
     private readonly scheduler = new FixupScheduler(10)
     private readonly decorator = new FixupDecorator()
     private readonly controlApplicator
-    private readonly contentStore = new ContentProvider()
 
     private _disposables: vscode.Disposable[] = []
 
@@ -50,129 +47,6 @@ export class FixupController
         client: ExtensionClient
     ) {
         this.controlApplicator = client.createFixupControlApplicator(this)
-        // Register commands
-        this._disposables.push(
-            vscode.workspace.registerTextDocumentContentProvider('cody-fixup', this.contentStore),
-            vscode.commands.registerCommand('cody.fixup.codelens.cancel', id => {
-                telemetryService.log(
-                    'CodyVSCodeExtension:fixup:codeLens:clicked',
-                    {
-                        op: 'cancel',
-                    },
-                    {
-                        hasV2Event: true,
-                    }
-                )
-                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'cancel')
-                return this.cancel(id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.codelens.diff', id => {
-                telemetryService.log(
-                    'CodyVSCodeExtension:fixup:codeLens:clicked',
-                    {
-                        op: 'diff',
-                    },
-                    {
-                        hasV2Event: true,
-                    }
-                )
-                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'diff')
-                return this.diff(id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.codelens.retry', async id => {
-                telemetryService.log(
-                    'CodyVSCodeExtension:fixup:codeLens:clicked',
-                    {
-                        op: 'regenerate',
-                    },
-                    {
-                        hasV2Event: true,
-                    }
-                )
-                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'retry')
-                return this.retry(id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.codelens.undo', id => {
-                telemetryService.log(
-                    'CodyVSCodeExtension:fixup:codeLens:clicked',
-                    {
-                        op: 'undo',
-                    },
-                    {
-                        hasV2Event: true,
-                    }
-                )
-                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'undo')
-                return this.undo(id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.codelens.accept', id => {
-                telemetryService.log(
-                    'CodyVSCodeExtension:fixup:codeLens:clicked',
-                    {
-                        op: 'accept',
-                    },
-                    {
-                        hasV2Event: true,
-                    }
-                )
-                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'accept')
-                return this.accept(id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.codelens.error', id => {
-                telemetryService.log(
-                    'CodyVSCodeExtension:fixup:codeLens:clicked',
-                    {
-                        op: 'show_error',
-                    },
-                    {
-                        hasV2Event: true,
-                    }
-                )
-                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'showError')
-                return this.showError(id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.codelens.skip-formatting', id => {
-                telemetryService.log(
-                    'CodyVSCodeExtension:fixup:codeLens:clicked',
-                    {
-                        op: 'skip_formatting',
-                    },
-                    {
-                        hasV2Event: true,
-                    }
-                )
-                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'skipFormatting')
-                return this.skipFormatting(id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.cancelNearest', () => {
-                const nearestTask = this.getNearestTask({ filter: { states: ACTIVE_TASK_STATES } })
-                if (!nearestTask) {
-                    return
-                }
-                return vscode.commands.executeCommand('cody.fixup.codelens.cancel', nearestTask.id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.acceptNearest', () => {
-                const nearestTask = this.getNearestTask({ filter: { states: ACTIONABLE_TASK_STATES } })
-                if (!nearestTask) {
-                    return
-                }
-                return vscode.commands.executeCommand('cody.fixup.codelens.accept', nearestTask.id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.retryNearest', () => {
-                const nearestTask = this.getNearestTask({ filter: { states: ACTIONABLE_TASK_STATES } })
-                if (!nearestTask) {
-                    return
-                }
-                return vscode.commands.executeCommand('cody.fixup.codelens.retry', nearestTask.id)
-            }),
-            vscode.commands.registerCommand('cody.fixup.undoNearest', () => {
-                const nearestTask = this.getNearestTask({ filter: { states: ACTIONABLE_TASK_STATES } })
-                if (!nearestTask) {
-                    return
-                }
-                return vscode.commands.executeCommand('cody.fixup.codelens.undo', nearestTask.id)
-            })
-        )
         // Observe file renaming and deletion
         this.files = new FixupFileObserver()
         this._disposables.push(
@@ -203,7 +77,7 @@ export class FixupController
                     // This helps ensure that the codelens doesn't stay around unnecessarily and become an annoyance.
                     for (const task of this.tasks.values()) {
                         if (task.fixupFile.uri.fsPath.endsWith(uri.fsPath)) {
-                            this.accept(task.id)
+                            this.accept(task)
                         }
                     }
                 })
@@ -211,13 +85,142 @@ export class FixupController
         }
     }
 
+    // FixupActor
+
+    public accept(task: FixupTask): void {
+        if (!task || task.state !== CodyTaskState.applied) {
+            return
+        }
+        this.setTaskState(task, CodyTaskState.finished)
+        this.discard(task)
+    }
+
+    public cancel(task: FixupTask): void {
+        this.setTaskState(
+            task,
+            task.state === CodyTaskState.error ? CodyTaskState.error : CodyTaskState.finished
+        )
+        this.discard(task)
+    }
+
+    /**
+     * Reverts an applied fixup task by replacing the edited code range with the original code.
+     *
+     * TODO: It is possible the original code is out of date if the user edited it whilst the fixup was running.
+     * Handle this case better. Possibly take a copy of the previous code just before the fixup is applied.
+     */
+    public async undo(task: FixupTask): Promise<void> {
+        if (task.state !== CodyTaskState.applied) {
+            return
+        }
+
+        let editor = vscode.window.visibleTextEditors.find(
+            editor => editor.document.uri === task.fixupFile.uri
+        )
+        if (!editor) {
+            editor = await vscode.window.showTextDocument(task.fixupFile.uri)
+        }
+
+        const replacementText = task.replacement
+        if (!replacementText) {
+            return
+        }
+
+        editor.revealRange(task.selectionRange)
+        const editOk = await editor.edit(editBuilder => {
+            editBuilder.replace(task.selectionRange, task.original)
+        })
+
+        if (!editOk) {
+            telemetryService.log('CodyVSCodeExtension:fixup:revert:failed', {
+                hasV2Event: true,
+            })
+            telemetryRecorder.recordEvent('cody.fixup.revert', 'failed')
+            return
+        }
+
+        const tokenCount = countCode(replacementText)
+        telemetryService.log('CodyVSCodeExtension:fixup:reverted', tokenCount, {
+            hasV2Event: true,
+        })
+        telemetryRecorder.recordEvent('cody.fixup.reverted', 'clicked', {
+            metadata: tokenCount,
+        })
+
+        this.setTaskState(task, CodyTaskState.finished)
+    }
+
+    // Undo the specified task, then prompt for a new set of instructions near
+    // the same region and start a new task.
+    public async retry(task: FixupTask, source: ChatEventSource): Promise<FixupTask | undefined> {
+        const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
+        // Prompt the user for a new instruction, and create a new fixup
+        const input = await getInput(
+            document,
+            this.authProvider,
+            {
+                initialInputValue: task.instruction,
+                initialRange: task.selectionRange,
+                initialSelectedContextItems: task.userContextItems,
+                initialModel: task.model,
+                initialIntent: task.intent,
+            },
+            source
+        )
+        if (!input) {
+            return
+        }
+
+        // If the selected range is the same as what we provided, we actually want the original
+        // range, which is the range which will be left in the document after the task is undone.
+        // Otherwise, use the new selected range.
+        const updatedRange = input.range.isEqual(task.selectionRange) ? task.originalRange : input.range
+
+        // Revert and remove the previous task
+        await this.undo(task)
+
+        return executeEdit({
+            configuration: {
+                range: updatedRange,
+                instruction: input.instruction,
+                userContextFiles: input.userContextFiles,
+                document,
+                intent: input.intent,
+                mode: task.mode,
+                model: input.model,
+            },
+            source,
+        })
+    }
+
     // FixupFileCollection
+
+    public taskForId(id: FixupTaskID): FixupTask | undefined {
+        return this.tasks.get(id)
+    }
+
     public tasksForFile(file: FixupFile): FixupTask[] {
         return [...this.tasks.values()].filter(task => task.fixupFile === file)
     }
 
     public maybeFileForUri(uri: vscode.Uri): FixupFile | undefined {
         return this.files.maybeForUri(uri)
+    }
+
+    public taskNearPosition(
+        file: FixupFile,
+        position: vscode.Position,
+        filter: { states: CodyTaskState[] }
+    ): FixupTask | undefined {
+        const closestTask = this.tasksForFile(file)
+            .filter(({ state }) => filter.states.includes(state))
+            .sort(
+                (a, b) =>
+                    getMinimumDistanceToRangeBoundary(position, a.selectionRange) -
+                    getMinimumDistanceToRangeBoundary(position, b.selectionRange)
+            )[0]
+
+        return closestTask
     }
 
     // FixupIdleTaskScheduler
@@ -306,7 +309,7 @@ export class FixupController
     }
 
     // Apply single fixup from task ID. Public for testing.
-    public async apply(id: taskID): Promise<void> {
+    public async apply(id: FixupTaskID): Promise<void> {
         logDebug('FixupController:apply', 'applying', { verbose: { id } })
         const task = this.tasks.get(id)
         if (!task) {
@@ -737,91 +740,7 @@ export class FixupController
         }
     }
 
-    private cancel(id: taskID): void {
-        const task = this.tasks.get(id)
-        if (!task) {
-            return
-        }
-        this.cancelTask(task)
-    }
-
-    public cancelTask(task: FixupTask): void {
-        this.setTaskState(
-            task,
-            task.state === CodyTaskState.error ? CodyTaskState.error : CodyTaskState.finished
-        )
-        this.discard(task)
-    }
-
-    private accept(id: taskID): void {
-        const task = this.tasks.get(id)
-        if (!task || task.state !== CodyTaskState.applied) {
-            return
-        }
-        this.setTaskState(task, CodyTaskState.finished)
-        this.discard(task)
-    }
-
-    private async undo(id: taskID): Promise<void> {
-        const task = this.tasks.get(id)
-        if (!task) {
-            return
-        }
-        return this.undoTask(task)
-    }
-
-    /**
-     * Reverts an applied fixup task by replacing the edited code range with the original code.
-     *
-     * TODO: It is possible the original code is out of date if the user edited it whilst the fixup was running.
-     * Handle this case better. Possibly take a copy of the previous code just before the fixup is applied.
-     */
-    private async undoTask(task: FixupTask): Promise<void> {
-        if (task.state !== CodyTaskState.applied) {
-            return
-        }
-
-        let editor = vscode.window.visibleTextEditors.find(
-            editor => editor.document.uri === task.fixupFile.uri
-        )
-        if (!editor) {
-            editor = await vscode.window.showTextDocument(task.fixupFile.uri)
-        }
-
-        const replacementText = task.replacement
-        if (!replacementText) {
-            return
-        }
-
-        editor.revealRange(task.selectionRange)
-        const editOk = await editor.edit(editBuilder => {
-            editBuilder.replace(task.selectionRange, task.original)
-        })
-
-        if (!editOk) {
-            telemetryService.log(
-                'CodyVSCodeExtension:fixup:revert:failed',
-                {},
-                {
-                    hasV2Event: true,
-                }
-            )
-            telemetryRecorder.recordEvent('cody.fixup.revert', 'failed')
-            return
-        }
-
-        const tokenCount = countCode(replacementText)
-        telemetryService.log('CodyVSCodeExtension:fixup:reverted', tokenCount, {
-            hasV2Event: true,
-        })
-        telemetryRecorder.recordEvent('cody.fixup.reverted', 'clicked', {
-            metadata: tokenCount,
-        })
-
-        this.setTaskState(task, CodyTaskState.finished)
-    }
-
-    public error(id: taskID, error: Error): void {
+    public error(id: FixupTaskID, error: Error): void {
         const task = this.tasks.get(id)
         if (!task) {
             return
@@ -831,35 +750,9 @@ export class FixupController
         this.setTaskState(task, CodyTaskState.error)
     }
 
-    private showError(id: taskID): void {
-        const task = this.tasks.get(id)
-        if (!task?.error) {
-            return
-        }
-
-        void vscode.window.showErrorMessage('Applying Edits Failed', {
-            modal: true,
-            detail: task.error.message,
-        })
-    }
-
-    private skipFormatting(id: taskID): void {
-        const task = this.tasks.get(id)
-        if (!task) {
-            return
-        }
-
-        if (!task.formattingResolver) {
-            return
-        }
-
-        task.formattingResolver(false)
-    }
-
     private discard(task: FixupTask): void {
         this.needsDiffUpdate_.delete(task)
         this.controlApplicator.didDeleteTask(task)
-        this.contentStore.delete(task.id)
         this.decorator.didCompleteTask(task)
         this.tasks.delete(task.id)
     }
@@ -979,7 +872,7 @@ export class FixupController
         // This helps ensure that the codelens doesn't stay around unnecessarily and become an annoyance.
         // Note: This will also apply if the user attempts to undo the applied change.
         if (task.state === CodyTaskState.applied) {
-            this.accept(task.id)
+            this.accept(task)
             return
         }
         if (task.state === CodyTaskState.finished) {
@@ -1090,101 +983,6 @@ export class FixupController
         }
     }
 
-    // Show diff between before and after edits
-    private async diff(id: taskID): Promise<void> {
-        const task = this.tasks.get(id)
-        if (!task) {
-            return
-        }
-        // Get an up-to-date diff
-        const editor = vscode.window.visibleTextEditors.find(
-            editor => editor.document.uri === task.fixupFile.uri
-        )
-        if (!editor) {
-            return
-        }
-        const diff = task.diff
-        if (!diff) {
-            return
-        }
-        // show diff view between the current document and replacement
-        // Add replacement content to the temp document
-
-        // Ensure each diff is fresh so there is no chance of diffing an already diffed file.
-        const diffId = `${task.id}-${Date.now()}`
-        await this.contentStore.set(diffId, task.fixupFile.uri)
-        const tempDocUri = vscode.Uri.parse(`cody-fixup:${task.fixupFile.uri.fsPath}#${diffId}`)
-        const doc = await vscode.workspace.openTextDocument(tempDocUri)
-        const edit = new vscode.WorkspaceEdit()
-        edit.replace(tempDocUri, task.selectionRange, diff.originalText)
-        await vscode.workspace.applyEdit(edit)
-        await doc.save()
-
-        // Show diff between current document and replacement content
-        await vscode.commands.executeCommand(
-            'vscode.diff',
-            tempDocUri,
-            task.fixupFile.uri,
-            `Cody Edit Diff View - ${task.id}`,
-            {
-                preview: true,
-                preserveFocus: false,
-                label: 'Cody Edit Diff View',
-                description: `Cody Edit Diff View: ${task.fixupFile.uri.fsPath}`,
-            }
-        )
-    }
-
-    // Regenerate code with the same set of instruction
-    public async retry(id: taskID): Promise<void> {
-        const task = this.tasks.get(id)
-        if (!task) {
-            return
-        }
-
-        const document = await vscode.workspace.openTextDocument(task.fixupFile.uri)
-        // Prompt the user for a new instruction, and create a new fixup
-        const input = await getInput(
-            document,
-            this.authProvider,
-            {
-                initialInputValue: task.instruction,
-                initialRange: task.selectionRange,
-                initialSelectedContextItems: task.userContextItems,
-                initialModel: task.model,
-                initialIntent: task.intent,
-            },
-            'code-lens'
-        )
-        if (!input) {
-            return
-        }
-
-        /**
-         * If the selected range is the same as what we provided, we actually want the original
-         * range, which is the range which will be left in the document after the task is undone.
-         *
-         * Otherwise, use the new selected range.
-         */
-        const updatedRange = input.range.isEqual(task.selectionRange) ? task.originalRange : input.range
-
-        // Revert and remove the previous task
-        await this.undoTask(task)
-
-        void executeEdit({
-            configuration: {
-                range: updatedRange,
-                instruction: input.instruction,
-                userContextFiles: input.userContextFiles,
-                document,
-                intent: input.intent,
-                mode: task.mode,
-                model: input.model,
-            },
-            source: 'code-lens',
-        })
-    }
-
     private setTaskState(task: FixupTask, state: CodyTaskState): void {
         const oldState = task.state
         if (oldState === state) {
@@ -1224,35 +1022,8 @@ export class FixupController
         }
     }
 
-    private getNearestTask({ filter }: { filter: { states: CodyTaskState[] } }): FixupTask | undefined {
-        const editor = vscode.window.activeTextEditor
-        if (!editor) {
-            return
-        }
-
-        const fixupFile = this.maybeFileForUri(editor.document.uri)
-        if (!fixupFile) {
-            return
-        }
-
-        const position = editor.selection.active
-
-        /**
-         * Get the task closest to the current cursor position from the tasks associated with the current file.
-         */
-        const closestTask = this.tasksForFile(fixupFile)
-            .filter(({ state }) => filter.states.includes(state))
-            .sort(
-                (a, b) =>
-                    getMinimumDistanceToRangeBoundary(position, a.selectionRange) -
-                    getMinimumDistanceToRangeBoundary(position, b.selectionRange)
-            )[0]
-
-        return closestTask
-    }
-
     private reset(): void {
-        this.tasks = new Map<taskID, FixupTask>()
+        this.tasks = new Map<FixupTaskID, FixupTask>()
     }
 
     public dispose(): void {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -16,6 +16,7 @@ import { countCode } from '../services/utils/code-count'
 import { getEditorInsertSpaces, getEditorTabSize } from '../utils'
 
 import { getInput } from '../edit/input/get-input'
+import type { ExtensionClient } from '../extension-client'
 import type { AuthProvider } from '../services/AuthProvider'
 import { ContentProvider } from './FixupContentStore'
 import { FixupDecorator } from './FixupDecorator'
@@ -25,7 +26,6 @@ import { FixupFileObserver } from './FixupFileObserver'
 import { FixupScheduler } from './FixupScheduler'
 import { FixupTask, type taskID } from './FixupTask'
 import { ACTIONABLE_TASK_STATES, ACTIVE_TASK_STATES } from './codelenses/constants'
-import { FixupCodeLenses } from './codelenses/provider'
 import { type Diff, computeDiff } from './diff'
 import type { FixupFileCollection, FixupIdleTaskRunner, FixupTextChanged } from './roles'
 import { CodyTaskState, getMinimumDistanceToRangeBoundary } from './utils'
@@ -40,12 +40,16 @@ export class FixupController
     // TODO: Make the fixup scheduler use a cooldown timer with a longer delay
     private readonly scheduler = new FixupScheduler(10)
     private readonly decorator = new FixupDecorator()
-    private readonly codelenses = new FixupCodeLenses(this)
+    private readonly controlApplicator
     private readonly contentStore = new ContentProvider()
 
     private _disposables: vscode.Disposable[] = []
 
-    constructor(private readonly authProvider: AuthProvider) {
+    constructor(
+        private readonly authProvider: AuthProvider,
+        client: ExtensionClient
+    ) {
+        this.controlApplicator = client.createFixupControlApplicator(this)
         // Register commands
         this._disposables.push(
             vscode.workspace.registerTextDocumentContentProvider('cody-fixup', this.contentStore),
@@ -854,7 +858,7 @@ export class FixupController
 
     private discard(task: FixupTask): void {
         this.needsDiffUpdate_.delete(task)
-        this.codelenses.didDeleteTask(task)
+        this.controlApplicator.didDeleteTask(task)
         this.contentStore.delete(task.id)
         this.decorator.didCompleteTask(task)
         this.tasks.delete(task.id)
@@ -991,7 +995,7 @@ export class FixupController
 
     // Handles when the range associated with a fixup task changes.
     public rangeDidChange(task: FixupTask): void {
-        this.codelenses.didUpdateTask(task)
+        this.controlApplicator.didUpdateTask(task)
         // We don't notify the decorator about this range change; vscode
         // updates any text decorations and we can recompute them, lazily,
         // if the diff is dirtied.
@@ -1035,8 +1039,7 @@ export class FixupController
             this.decorator.didChangeVisibleTextEditors(file, editors)
         }
 
-        // Update shortcut enablement for visible files
-        this.codelenses.updateKeyboardShortcutEnablement([...editorsByFile.keys()])
+        this.controlApplicator.visibleFilesWithTasksMaybeChanged([...editorsByFile.keys()])
     }
 
     private updateDiffs(): void {
@@ -1206,7 +1209,7 @@ export class FixupController
             return
         }
         // Save states of the task
-        this.codelenses.didUpdateTask(task)
+        this.controlApplicator.didUpdateTask(task)
 
         if (task.state === CodyTaskState.applying) {
             void this.apply(task.id)
@@ -1254,7 +1257,7 @@ export class FixupController
 
     public dispose(): void {
         this.reset()
-        this.codelenses.dispose()
+        this.controlApplicator.dispose()
         this.decorator.dispose()
         for (const disposable of this._disposables) {
             disposable.dispose()

--- a/vscode/src/non-stop/FixupDocumentEditObserver.ts
+++ b/vscode/src/non-stop/FixupDocumentEditObserver.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 
 import { type RangeData, toRangeData } from '@sourcegraph/cody-shared'
 import type { Edit, Position } from './diff'
-import type { FixupFileCollection, FixupTextChanged } from './roles'
+import type { FixupActor, FixupFileCollection, FixupTextChanged } from './roles'
 import { type TextChange, updateFixedRange, updateRangeMultipleChanges } from './tracked-range'
 import { CodyTaskState } from './utils'
 
@@ -44,7 +44,7 @@ function updateEdits(edits: Edit[], changes: TextChange[]): void {
  * and the decorations indicating where edits will appear.
  */
 export class FixupDocumentEditObserver {
-    constructor(private readonly provider_: FixupFileCollection & FixupTextChanged) {}
+    constructor(private readonly provider_: FixupFileCollection & FixupTextChanged & FixupActor) {}
 
     public textDocumentChanged(event: vscode.TextDocumentChangeEvent): void {
         const file = this.provider_.maybeFileForUri(event.document.uri)
@@ -60,7 +60,7 @@ export class FixupDocumentEditObserver {
                 task.state === CodyTaskState.inserting &&
                 event.reason === vscode.TextDocumentChangeReason.Undo
             ) {
-                this.provider_.cancelTask(task)
+                this.provider_.cancel(task)
                 continue
             }
 

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -56,6 +56,7 @@ export class FixupTask {
         public readonly userContextItems: ContextItem[],
         /* The intent of the edit, derived from the source of the command. */
         public readonly intent: EditIntent,
+        /* The range being edited. This range is tracked and updates as the user (or Cody) edits code. */
         public selectionRange: vscode.Range,
         /* The mode indicates how code should be inserted */
         public readonly mode: EditMode,

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -9,10 +9,10 @@ import type { FixupFile } from './FixupFile'
 import type { Diff } from './diff'
 import { CodyTaskState } from './utils'
 
-export type taskID = string
+export type FixupTaskID = string
 
 export class FixupTask {
-    public id: taskID
+    public id: FixupTaskID
     public state_: CodyTaskState = CodyTaskState.idle
     private stateChanges = new vscode.EventEmitter<CodyTaskState>()
     public onDidStateChange = this.stateChanges.event

--- a/vscode/src/non-stop/codelenses/provider.ts
+++ b/vscode/src/non-stop/codelenses/provider.ts
@@ -1,36 +1,21 @@
 import * as vscode from 'vscode'
 
+import { telemetryService } from '../../services/telemetry'
+import { telemetryRecorder } from '../../services/telemetry-v2'
+import { ContentProvider } from '../FixupContentStore'
 import type { FixupFile } from '../FixupFile'
-import type { FixupTask } from '../FixupTask'
-import type { FixupFileCollection } from '../roles'
+import type { FixupTask, FixupTaskID } from '../FixupTask'
+import type { FixupActor, FixupFileCollection } from '../roles'
+import type { FixupControlApplicator } from '../strategies'
 import { CodyTaskState } from '../utils'
-import { ALL_ACTIONABLE_TASK_STATES } from './constants'
+import { ACTIONABLE_TASK_STATES, ACTIVE_TASK_STATES, ALL_ACTIONABLE_TASK_STATES } from './constants'
 import { getLensesForTask } from './items'
 
-// An interface for decorating fixup tasks with controls.
-export interface FixupControlApplicator extends vscode.Disposable {
-    didUpdateTask(task: FixupTask): void
-    didDeleteTask(task: FixupTask): void
-    // Called when visible files changed. This is *not* called when a new task
-    // is created in a file that is already visible. It *is* called every time
-    // visible files change, so be prepared to handle repeated calls with
-    // an empty or unchanged set of files efficiently.
-    visibleFilesWithTasksMaybeChanged(files: readonly FixupFile[]): void
-}
-
-// A FixupControlsApplicator which does not present any controls for fixup
-// tasks.
-export class NullFixupControlsApplicator implements FixupControlApplicator {
-    public didUpdateTask(task: FixupTask): void {}
-    public didDeleteTask(task: FixupTask): void {}
-    public visibleFilesWithTasksMaybeChanged(files: readonly FixupFile[]): void {}
-    public dispose(): void {}
-}
-
-// A FixupControlsApplicator which produces code lenses.
+// A FixupControlApplicator which produces code lenses.
 export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApplicator {
     private taskLenses = new Map<FixupTask, vscode.CodeLens[]>()
 
+    private readonly contentStore = new ContentProvider()
     private _disposables: vscode.Disposable[] = []
     private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
     public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event
@@ -38,9 +23,180 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
     /**
      * Create a code lens provider
      */
-    constructor(private readonly files: FixupFileCollection) {
+    constructor(private readonly controller: FixupActor & FixupFileCollection) {
         this.provideCodeLenses = this.provideCodeLenses.bind(this)
-        this._disposables.push(vscode.languages.registerCodeLensProvider('*', this))
+        this._disposables.push(
+            this.contentStore,
+            vscode.languages.registerCodeLensProvider('*', this),
+            vscode.workspace.registerTextDocumentContentProvider('cody-fixup', this.contentStore),
+            vscode.commands.registerCommand('cody.fixup.codelens.cancel', id => {
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'cancel',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
+                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'cancel')
+                const task = this.controller.taskForId(id)
+                if (task) {
+                    this.controller.cancel(task)
+                }
+            }),
+            vscode.commands.registerCommand('cody.fixup.codelens.diff', id => {
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'diff',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
+                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'diff')
+                return this.diff(id)
+            }),
+            vscode.commands.registerCommand('cody.fixup.codelens.retry', async id => {
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'regenerate',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
+                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'retry')
+                const task = this.controller.taskForId(id)
+                return task ? this.controller.retry(task, 'code-lens') : Promise.resolve()
+            }),
+            vscode.commands.registerCommand('cody.fixup.codelens.undo', id => {
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'undo',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
+                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'undo')
+                const task = this.controller.taskForId(id)
+                return task ? this.controller.undo(task) : Promise.resolve()
+            }),
+            vscode.commands.registerCommand('cody.fixup.codelens.accept', id => {
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'accept',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
+                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'accept')
+                const task = this.controller.taskForId(id)
+                if (task) {
+                    this.controller.accept(task)
+                }
+            }),
+            vscode.commands.registerCommand('cody.fixup.codelens.error', id => {
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'show_error',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
+                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'showError')
+                return this.showError(id)
+            }),
+            vscode.commands.registerCommand('cody.fixup.codelens.skip-formatting', id => {
+                telemetryService.log(
+                    'CodyVSCodeExtension:fixup:codeLens:clicked',
+                    {
+                        op: 'skip_formatting',
+                    },
+                    {
+                        hasV2Event: true,
+                    }
+                )
+                telemetryRecorder.recordEvent('cody.fixup.codeLens', 'skipFormatting')
+                return this.skipFormatting(id)
+            }),
+            vscode.commands.registerCommand('cody.fixup.cancelNearest', () => {
+                const nearestTask = this.getNearestTask({ filter: { states: ACTIVE_TASK_STATES } })
+                if (!nearestTask) {
+                    return
+                }
+                return vscode.commands.executeCommand('cody.fixup.codelens.cancel', nearestTask.id)
+            }),
+            vscode.commands.registerCommand('cody.fixup.acceptNearest', () => {
+                const nearestTask = this.getNearestTask({ filter: { states: ACTIONABLE_TASK_STATES } })
+                if (!nearestTask) {
+                    return
+                }
+                return vscode.commands.executeCommand('cody.fixup.codelens.accept', nearestTask.id)
+            }),
+            vscode.commands.registerCommand('cody.fixup.retryNearest', () => {
+                const nearestTask = this.getNearestTask({ filter: { states: ACTIONABLE_TASK_STATES } })
+                if (!nearestTask) {
+                    return
+                }
+                return vscode.commands.executeCommand('cody.fixup.codelens.retry', nearestTask.id)
+            }),
+            vscode.commands.registerCommand('cody.fixup.undoNearest', () => {
+                const nearestTask = this.getNearestTask({ filter: { states: ACTIONABLE_TASK_STATES } })
+                if (!nearestTask) {
+                    return
+                }
+                return vscode.commands.executeCommand('cody.fixup.codelens.undo', nearestTask.id)
+            })
+        )
+    }
+
+    private showError(id: FixupTaskID): void {
+        const task = this.controller.taskForId(id)
+        if (!task?.error) {
+            return
+        }
+
+        void vscode.window.showErrorMessage('Applying Edits Failed', {
+            modal: true,
+            detail: task.error.message,
+        })
+    }
+
+    private getNearestTask({ filter }: { filter: { states: CodyTaskState[] } }): FixupTask | undefined {
+        const editor = vscode.window.activeTextEditor
+        if (!editor) {
+            return
+        }
+
+        const fixupFile = this.controller.maybeFileForUri(editor.document.uri)
+        if (!fixupFile) {
+            return
+        }
+
+        const position = editor.selection.active
+        return this.controller.taskNearPosition(fixupFile, position, filter)
+    }
+
+    private skipFormatting(id: FixupTaskID): void {
+        const task = this.controller.taskForId(id)
+        if (!task) {
+            return
+        }
+
+        if (!task.formattingResolver) {
+            return
+        }
+
+        task.formattingResolver(false)
     }
 
     /**
@@ -50,12 +206,12 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
         document: vscode.TextDocument,
         token: vscode.CancellationToken
     ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-        const file = this.files.maybeFileForUri(document.uri)
+        const file = this.controller.maybeFileForUri(document.uri)
         if (!file) {
             return []
         }
         const lenses = []
-        for (const task of this.files.tasksForFile(file)) {
+        for (const task of this.controller.tasksForFile(file)) {
             lenses.push(...(this.taskLenses.get(task) || []))
         }
         return lenses
@@ -74,6 +230,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
     public didDeleteTask(task: FixupTask): void {
         this.updateKeyboardShortcutEnablement([task.fixupFile])
         this.removeLensesFor(task)
+        this.contentStore.delete(task.id)
     }
 
     private removeLensesFor(task: FixupTask): void {
@@ -97,7 +254,7 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
             .filter(file =>
                 vscode.window.visibleTextEditors.some(editor => editor.document.uri === file.uri)
             )
-            .flatMap(file => this.files.tasksForFile(file))
+            .flatMap(file => this.controller.tasksForFile(file))
 
         const hasActionableEdit = allTasks.some(task => ALL_ACTIONABLE_TASK_STATES.includes(task.state))
         void vscode.commands.executeCommand('setContext', 'cody.hasActionableEdit', hasActionableEdit)
@@ -105,6 +262,51 @@ export class FixupCodeLenses implements vscode.CodeLensProvider, FixupControlApp
 
     private notifyCodeLensesChanged(): void {
         this._onDidChangeCodeLenses.fire()
+    }
+
+    // Show diff between before and after edits
+    private async diff(id: FixupTaskID): Promise<void> {
+        const task = this.controller.taskForId(id)
+        if (!task) {
+            return
+        }
+        // Get an up-to-date diff
+        const editor = vscode.window.visibleTextEditors.find(
+            editor => editor.document.uri === task.fixupFile.uri
+        )
+        if (!editor) {
+            return
+        }
+        const diff = task.diff
+        if (!diff) {
+            return
+        }
+        // show diff view between the current document and replacement
+        // Add replacement content to the temp document
+
+        // Ensure each diff is fresh so there is no chance of diffing an already diffed file.
+        const diffId = `${task.id}-${Date.now()}`
+        await this.contentStore.set(diffId, task.fixupFile.uri)
+        const tempDocUri = vscode.Uri.parse(`cody-fixup:${task.fixupFile.uri.fsPath}#${diffId}`)
+        const doc = await vscode.workspace.openTextDocument(tempDocUri)
+        const edit = new vscode.WorkspaceEdit()
+        edit.replace(tempDocUri, task.selectionRange, diff.originalText)
+        await vscode.workspace.applyEdit(edit)
+        await doc.save()
+
+        // Show diff between current document and replacement content
+        await vscode.commands.executeCommand(
+            'vscode.diff',
+            tempDocUri,
+            task.fixupFile.uri,
+            `Cody Edit Diff View - ${task.id}`,
+            {
+                preview: true,
+                preserveFocus: false,
+                label: 'Cody Edit Diff View',
+                description: `Cody Edit Diff View: ${task.fixupFile.uri.fsPath}`,
+            }
+        )
     }
 
     /**

--- a/vscode/src/non-stop/roles.ts
+++ b/vscode/src/non-stop/roles.ts
@@ -1,16 +1,64 @@
 import type * as vscode from 'vscode'
 
+import type { ChatEventSource } from '@sourcegraph/cody-shared'
 import type { FixupFile } from './FixupFile'
-import type { FixupTask } from './FixupTask'
+import type { FixupTask, FixupTaskID } from './FixupTask'
+import type { CodyTaskState } from './utils'
 
 // Role interfaces so that sub-objects of the FixupController can consume a
 // narrow part of the controller.
 
 /**
+ * Operations on FixupTasks.
+ */
+export interface FixupActor {
+    /**
+     * Mark a task as accepted and stop tracking the task. Only applicable to
+     * tasks in the "applied" state. Sets the task state to "finished" and
+     * discards the task.
+     */
+    accept(task: FixupTask): void
+
+    /**
+     * Undo a task's edits and stop tracking the task. Only applicable to
+     * tasks in the "applied" state. If the undo succeeds, the task state is
+     * set to "finished" and the task is discarded.
+     */
+    undo(task: FixupTask): Promise<void>
+
+    /**
+     * Cancel a task. Sets the task state to "error" or "finished" and stops
+     * tracking the task. Tasks in any state can be cancelled.
+     */
+    cancel(task: FixupTask): void
+
+    /**
+     * Undo the task (see `undo`), prompt for updated instructions, and start
+     * a new task to try again. Only applicable to tasks in the "applied" state.
+     * @param task the task to retry.
+     * @param source the source of the retry, for event logging.
+     */
+    retry(task: FixupTask, source: ChatEventSource): Promise<FixupTask | undefined>
+}
+
+/**
  * Provides access to a list of fixup tasks.
  */
 export interface FixupFileCollection {
+    taskForId(id: FixupTaskID): FixupTask | undefined
     tasksForFile(file: FixupFile): FixupTask[]
+
+    /**
+     * Gets the closest fixup task in the given file.
+     * @param file the FixupFile to search for tasks.
+     * @param position the position in the file to search from.
+     * @param filter only return tasks in one of the given states.
+     */
+    taskNearPosition(
+        file: FixupFile,
+        position: vscode.Position,
+        filter: { states: readonly CodyTaskState[] }
+    ): FixupTask | undefined
 
     /**
      * If there is a FixupFile for the specified URI, return it, otherwise
@@ -35,5 +83,4 @@ export interface FixupIdleTaskRunner {
 export interface FixupTextChanged {
     textDidChange(task: FixupTask): void
     rangeDidChange(task: FixupTask): void
-    cancelTask(task: FixupTask): void
 }

--- a/vscode/src/non-stop/strategies.ts
+++ b/vscode/src/non-stop/strategies.ts
@@ -1,0 +1,28 @@
+// FixupController has pluggable strategies for controls and presentation. This
+// file defines the interfaces for those strategies.
+
+import type * as vscode from 'vscode'
+import type { FixupFile } from './FixupFile'
+import type { FixupTask } from './FixupTask'
+
+// An interface for decorating fixup tasks with controls.
+export interface FixupControlApplicator extends vscode.Disposable {
+    didUpdateTask(task: FixupTask): void
+    didDeleteTask(task: FixupTask): void
+    // Called when visible files changed.
+    // TODO: This API design is gross: this is *not* called when a new task
+    // is created in a file that is already visible. It *is* called every time
+    // visible files change, so be prepared to handle repeated calls with
+    // an empty or unchanged set of files efficiently. Unearth a consistent
+    // API here.
+    visibleFilesWithTasksMaybeChanged(files: readonly FixupFile[]): void
+}
+
+// A FixupControlApplicator which does not present any controls for fixup
+// tasks.
+export class NullFixupControlApplicator implements FixupControlApplicator {
+    public didUpdateTask(task: FixupTask): void {}
+    public didDeleteTask(task: FixupTask): void {}
+    public visibleFilesWithTasksMaybeChanged(files: readonly FixupFile[]): void {}
+    public dispose(): void {}
+}

--- a/vscode/src/non-stop/utils.ts
+++ b/vscode/src/non-stop/utils.ts
@@ -1,5 +1,6 @@
 import type * as vscode from 'vscode'
 
+/*
 export enum CodyTaskState {
     /**
      * The task has been created, but not yet started.
@@ -53,6 +54,19 @@ export enum CodyTaskState {
      * some additional information before it is started (e.g. a file name from the LLM)
      */
     pending = 9,
+}
+*/
+
+export enum CodyTaskState {
+    idle = 0,
+    working = 1,
+    inserting = 2,
+    applying = 3,
+    formatting = 4,
+    applied = 5,
+    finished = 6,
+    error = 7,
+    pending = 8,
 }
 
 /**

--- a/vscode/src/non-stop/utils.ts
+++ b/vscode/src/non-stop/utils.ts
@@ -1,6 +1,5 @@
 import type * as vscode from 'vscode'
 
-/*
 export enum CodyTaskState {
     /**
      * The task has been created, but not yet started.
@@ -54,19 +53,6 @@ export enum CodyTaskState {
      * some additional information before it is started (e.g. a file name from the LLM)
      */
     pending = 9,
-}
-*/
-
-export enum CodyTaskState {
-    idle = 0,
-    working = 1,
-    inserting = 2,
-    applying = 3,
-    formatting = 4,
-    applied = 5,
-    finished = 6,
-    error = 7,
-    pending = 8,
 }
 
 /**


### PR DESCRIPTION
This commit is part 1 of a joint effort between @dominiccooney and @steveyegge to make our client API simpler, more robust, and easier to test. The main change from the client's perspective is that the client no longer has to receive lenses as part of the protocol, focusing only on state transitions. This enabled a significant cleanup of the JetBrains-side logic.

The FixupController has been rewritten to use Strategy objects to abstract the operations and decouple the UI. There are several bug fixes in the Agent, as well as a new getFoldingRanges API for clients that need it. It's useful for figuring out the very first place to put a spinner, before the FixupController's task has finished initializing.

The commit goes hand in hand with [stevey/inline-edits](https://github.com/sourcegraph/jetbrains/tree/stevey/inline-edits) on the jetbrains repo, which implements v1 of Document Code and Edit Code.

## Test plan

We will start immediately on the integration test framework for JetBrains. This commit is just a checkpoint so that we can start parallelizing some of this work.
