### PR TITLE
only allow 1 retry for flaky e2e tests

### DIFF
--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -4,8 +4,7 @@ const isWin = process.platform.startsWith('win')
 
 export default defineConfig({
     workers: 1,
-    // Give failing tests more chances
-    retries: isWin ? 4 : 2,
+    retries: 1, // give flaky tests 1 more chance, but we should fix flakiness when we see it
     testDir: 'test/e2e',
     timeout: isWin ? 30000 : 20000,
     expect: {


### PR DESCRIPTION
This will mean more annoying e2e failures due to flakiness in our PRs, which is bad. But it, along with https://github.com/sourcegraph/cody/pull/3446, will mean that we (if we are good people :) will notice the flakiness better and will fix it, thereby making it so we don't need to wait for multiple retries of some flaky tests on each build, thereby saving us time overall.

We should make this `retries: 0` soon once we reduce the flakes (which #3446 will help us identify).

## Test plan

CI