### PR TITLE
fix log spam in e2e flakiness detector

### DIFF
--- a/.github/workflows/e2e-flakiness-detector.yml
+++ b/.github/workflows/e2e-flakiness-detector.yml
@@ -36,8 +36,12 @@ jobs:
       - run: pnpm install
       - run: xvfb-run -a pnpm -C vscode run test:e2e --repeat-each 10 --retries 0
         if: matrix.runner == 'ubuntu'
+        env:
+          NO_LOG_TESTING_TELEMETRY_CALLS: "1"
       - run: pnpm -C vscode run test:e2e --repeat-each 10 --retries 0
         if: matrix.runner != 'ubuntu'
+        env:
+          NO_LOG_TESTING_TELEMETRY_CALLS: "1"
       - uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -57,16 +57,11 @@ const pubSubClient = new PubSub({
     projectId: 'sourcegraph-telligent-testing',
 })
 
-const publishOptions = {
+const topicPublisher = pubSubClient.topic('projects/sourcegraph-telligent-testing/topics/e2e-testing', {
     gaxOpts: {
         timeout: 120000,
     },
-}
-
-const topicPublisher = pubSubClient.topic(
-    'projects/sourcegraph-telligent-testing/topics/e2e-testing',
-    publishOptions
-)
+})
 
 //#region GraphQL Mocks
 
@@ -480,7 +475,7 @@ export class MockServer {
 const loggedTestRun: Record<string, boolean> = {}
 
 async function logTestingData(type: 'legacy' | 'new', data: string): Promise<void> {
-    if (process.env.CI === undefined) {
+    if (process.env.CI === undefined || process.env.NO_LOG_TESTING_TELEMETRY_CALLS) {
         return
     }
 


### PR DESCRIPTION
The GitHub action appears to fail because of tons of log lines from the thing that logs our telemetry from e2e runs. Example: https://github.com/sourcegraph/cody/actions/runs/8321504214/job/22767854935



## Test plan

CI