### PR TITLE
remove `typing @-mention text does not automatically accept it` e2e test

### DIFF
--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -226,24 +226,6 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await expect(chatPanelFrame.getByText(/^✨ Context: 2 files/)).toHaveCount(1)
 })
 
-test('typing @-mention text does not automatically accept it', async ({ page, sidebar }) => {
-    await sidebarSignin(page, sidebar)
-    await page.getByRole('button', { name: 'New Chat', exact: true }).click()
-    const chatPanelFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
-    const chatInput = chatPanelFrame.getByRole('textbox', { name: 'Chat message' })
-
-    // Typing out the whole file path without pressing tab/enter should NOT include the file as
-    // context.
-    await chatInput.fill('Explain @index.htm')
-    await page.waitForTimeout(100)
-    await chatInput.press('l')
-    await expect(chatPanelFrame.getByRole('option', { name: 'index.html' })).toBeVisible()
-    await chatInput.press('Space')
-    await expect(chatPanelFrame.getByRole('option', { name: 'index.html' })).not.toBeVisible()
-    await chatInput.press('Enter')
-    await expect(chatPanelFrame.getByText(/^✨ Context:/)).toHaveCount(0)
-})
-
 test('pressing Enter with @-mention menu open selects item, does not submit message', async ({
     page,
     sidebar,


### PR DESCRIPTION
This e2e test no longer makes sense now that we changed the behavior so that pressing <kbd>Space</kbd> actually does accept the first suggestion. We could add a test for pressing something else like <kbd>,</kbd>, but that seems of marginal importance and we might even want <kbd>,</kbd> and other punctuation to select the suggestion in the future. The reason this test was passing is due to flakiness, a race condition where zero context items were shown because the response had not loaded yet, not because the behavior was as expected.



## Test plan

CI