### PR TITLE
Autocomplete: starcoder2 ollama stop sequences

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -28,6 +28,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Enabled dynamic multiline completions by default. [pull/3392](https://github.com/sourcegraph/cody/pull/3392)
 - Document: Upgraded to use a faster model. [pull/3275](https://github.com/sourcegraph/cody/pull/3275)
 - Autocomplete: Wrap tree-sitter parse calls in OpenTelemetry spans. [pull/3419](https://github.com/sourcegraph/cody/pull/3419)
+- Autocomplete: Improve StarCoder2 Ollama support. [pull/3452](https://github.com/sourcegraph/cody/pull/3452)
 
 ## [1.8.3]
 

--- a/vscode/src/completions/providers/ollama-models.ts
+++ b/vscode/src/completions/providers/ollama-models.ts
@@ -99,7 +99,7 @@ class CodeLlama extends DefaultOllamaModel {
     }
 }
 
-class StarCoder extends DefaultOllamaModel {
+class StarCoder2 extends DefaultOllamaModel {
     getPrompt(ollamaPrompt: OllamaPromptContext): string {
         const { context, prefix, suffix } = ollamaPrompt
 
@@ -111,7 +111,7 @@ class StarCoder extends DefaultOllamaModel {
     }
 
     getRequestOptions(isMultiline: boolean): OllamaGenerateParameters {
-        const stop = ['<fim_prefix>', '<fim_suffix>', '<fim_middle>', '<|endoftext|>']
+        const stop = ['<fim_prefix>', '<fim_suffix>', '<fim_middle>', '<|endoftext|>', '<file_sep>']
 
         const params = {
             stop: ['\n', ...stop],
@@ -138,8 +138,8 @@ export function getModelHelpers(model: string) {
         return new DeepseekCoder()
     }
 
-    if (model.includes('starcoder')) {
-        return new StarCoder()
+    if (model.includes('starcoder2')) {
+        return new StarCoder2()
     }
 
     return new DefaultOllamaModel()


### PR DESCRIPTION
## Context

- Add a missing stop sequence for StarCoder2 served via Ollama. Reference: https://arxiv.org/html/2402.19173v1

## Test plan

Tested locally