### PR TITLE
Rename span to indicate it doesn't use embeddings

### DIFF
--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -243,7 +243,7 @@ async function searchRemote(
     remoteSearch: RemoteSearch | null,
     userText: string
 ): Promise<ContextItem[]> {
-    return wrapInActiveSpan('chat.context.embeddings.remote', async () => {
+    return wrapInActiveSpan('chat.context.search.remote', async () => {
         if (!remoteSearch) {
             return []
         }


### PR DESCRIPTION
Rename span not to use embeddings in the name (it uses remote keyword search). 

## Test plan

- this should only change Trace span names
- `pnpm test` passes
- old name is [not used anywhere else](https://sourcegraph.sourcegraph.com/search?q=context:global+chat.context.embeddings.remote&patternType=keyword&sm=0)
