### PR TITLE
Context: add missing whitespace in context template

### DIFF
--- a/lib/shared/src/prompt/templates.ts
+++ b/lib/shared/src/prompt/templates.ts
@@ -16,7 +16,7 @@ export function populateCodeContextTemplate(
             : 'Codebase context from file {filePath}{inRepo}:\n```{languageID}\n{text}```'
 
     return template
-        .replace('{inRepo}', `in repository ${repoName}`)
+        .replace('{inRepo}', ` in repository ${repoName}`)
         .replace('{filePath}', displayPath(fileUri))
         .replace('{languageID}', markdownCodeBlockLanguageIDForFilename(fileUri))
         .replace('{text}', code)


### PR DESCRIPTION
Update the context template to add a missing whitespace between the repository name and file path.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/4a4ff509-30dd-4735-b7fb-c29f57ec6a25)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/996bc083-75fa-4104-8ff1-7f410d0118a1)
