### PR TITLE
misc e2e test improvements

### DIFF
--- a/.github/workflows/e2e-flakiness-detector.yml
+++ b/.github/workflows/e2e-flakiness-detector.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         runner: [ubuntu, windows]
     runs-on: ${{ matrix.runner }}-latest
-    timeout-minutes: 15
+    timeout-minutes: 120
     permissions:
       id-token: write
       contents: read
@@ -38,7 +38,7 @@ jobs:
         if: matrix.runner == 'ubuntu'
         env:
           NO_LOG_TESTING_TELEMETRY_CALLS: "1"
-      - run: pnpm -C vscode run test:e2e --repeat-each 10 --retries 0
+      - run: pnpm -C vscode run test:e2e --repeat-each 4 --retries 0
         if: matrix.runner != 'ubuntu'
         env:
           NO_LOG_TESTING_TELEMETRY_CALLS: "1"

--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -5,6 +5,7 @@ const isWin = process.platform.startsWith('win')
 export default defineConfig({
     workers: 1,
     retries: 1, // give flaky tests 1 more chance, but we should fix flakiness when we see it
+    forbidOnly: !!process.env.CI,
     testDir: 'test/e2e',
     timeout: isWin ? 30000 : 20000,
     expect: {

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -97,13 +97,16 @@ test.extend<ExpectedEvents>({
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText(withPlatformSlashes('Explain @lib/batches/env/var.go '))
     await chatInput.focus()
-    await chatInput.pressSequentially('and @vgo')
-    await expect(
-        chatPanelFrame.getByRole('option', { name: withPlatformSlashes('visualize.go') })
-    ).toBeVisible()
+    await chatInput.pressSequentially('and ')
+    await chatInput.pressSequentially('@vgo', { delay: 10 })
+    await expect(chatPanelFrame.getByRole('option', { name: 'visualize.go' })).toBeVisible()
+    await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/var\.go/)
     await chatInput.press('ArrowDown') // second item (visualize.go)
+    await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/visualize\.go/)
     await chatInput.press('ArrowDown') // wraps back to first item (var.go)
+    await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/var\.go/)
     await chatInput.press('ArrowDown') // second item again
+    await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/visualize\.go/)
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText(
         withPlatformSlashes(
@@ -129,7 +132,7 @@ test.extend<ExpectedEvents>({
     // https://github.com/sourcegraph/cody/issues/2200
     await chatInput.focus()
     await chatInput.clear()
-    await chatInput.pressSequentially('@Main.java')
+    await chatInput.pressSequentially('@Main.java', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText('@Main.java ')
@@ -137,7 +140,7 @@ test.extend<ExpectedEvents>({
     // Check pressing tab after typing a partial filename but where that complete
     // filename already exists earlier in the input.
     // https://github.com/sourcegraph/cody/issues/2243
-    await chatInput.pressSequentially('and @Main.ja', { delay: 50 })
+    await chatInput.pressSequentially('and @Main.ja', { delay: 10 })
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText('@Main.java and @Main.java ')
 
@@ -151,7 +154,7 @@ test.extend<ExpectedEvents>({
     await chatInput.press('ArrowLeft') // 'Explain the |file'
     await chatInput.press('ArrowLeft') // 'Explain the| file'
     await chatInput.press('Space') // 'Explain the | file'
-    await chatInput.pressSequentially('@Main')
+    await chatInput.pressSequentially('@Main', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText('Explain the @Main.java file')

--- a/vscode/test/e2e/chat-history.test.ts
+++ b/vscode/test/e2e/chat-history.test.ts
@@ -36,6 +36,13 @@ test.extend<ExpectedEvents>({
     // Check if chat shows up in sidebar chat history tree view
     await expect(heyTreeItem).toBeVisible()
 
+    // Wait at least 1 second to ensure that the 2 chats have different IDs (which are currently
+    // created using `new Date(Date.now()).toUTCString()`, so they are the same if they are
+    // generated in the same second).
+    //
+    // TODO(sqs): investigate and fix the underlying bug here
+    await page.waitForTimeout(1000)
+
     // Clear and restart chat session
     // All current messages should be removed, and the panel name should be updated to 'New Chat'
     await chatInput.fill('/reset')

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -65,7 +65,6 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
     await chatInput.clear()
     await chatInput.fill('@ignore')
-    await page.waitForTimeout(1000) // seems to make it less flaky on Windows
     await expect(
         chatPanel.getByRole('option', { name: withPlatformSlashes('ignore .cody') })
     ).toBeVisible()

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -154,8 +154,11 @@ test.extend<ExpectedEvents>({
     await page.getByText('Document Code').hover()
     await page.getByText('Document Code').click()
 
-    // Code lens should be visible
-    await expect(page.getByRole('button', { name: 'Accept' })).toBeVisible()
+    // Code lens should be visible.
+    await expect(page.getByRole('button', { name: 'Accept' })).toBeVisible({
+        // Wait a bit longer because formatting can sometimes be slow.
+        timeout: 10000,
+    })
     await expect(page.getByRole('button', { name: 'Undo' })).toBeVisible()
 
     // Code lens should be at the start of the function (range expanded from click position)

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -90,9 +90,6 @@ test.extend<ExpectedEvents>({
     await expect(page.getByText('Workspace Settings.vscode/cody.json')).toBeVisible()
     await page.getByText('Workspace Settings.vscode/cody.json').click()
 
-    // Gives time for the command to be saved to the workspace settings
-    await page.waitForTimeout(500)
-
     // Check if cody.json in the workspace has the new command added
     await sidebarExplorer(page).click()
     await page.getByLabel('.vscode', { exact: true }).hover()

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -342,7 +342,7 @@ export async function openFile(page: Page, filename: string): Promise<void> {
 
 // Starts a new panel chat and returns a FrameLocator for the chat.
 export async function newChat(page: Page): Promise<FrameLocator> {
-    await page.getByRole('button', { name: 'New Chat' }).click()
+    await page.getByRole('button', { name: 'New Chat', exact: true }).click()
     return page.frameLocator('iframe.webview').last().frameLocator('iframe')
 }
 


### PR DESCRIPTION
- Remove `page.waitForTimeout` calls when they are unnecessary (before another `expect` call that waits for 3000ms). Keep `page.waitForTimeout` calls that perform an action immediately after because those delays are needed.
- Improve the @-mention test to check that the correct results are in the mention list for easier debuggability, and slow down keypresses to avoid flakiness that seems only to occur if multiple keyboard events are sent without intervening delay.
- Increase timeout in the Document Command e2e test because formatting sometimes is slow.
- Increase timeout for the e2e flakiness detector because it was timing out (exceeding 15 min).


## Test plan

CI