### PR TITLE
Fix chat abort before first streaming chunk is coming in

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -20,6 +20,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Document: Fixed an issue where the generated documentation would be incorrectly inserted for Python. Cody will now follow PEP 257 – Docstring Conventions. [pull/3275](https://github.com/sourcegraph/cody/pull/3275)
 - Edit: Fixed incorrect decorations being shown for edits that only insert new code. [pull/3424](https://github.com/sourcegraph/cody/pull/3424)
 - When `@`-mentioning files in chat and edits, the list of fuzzy-matching files is shown much faster (which is especially noticeable in large workspaces).
+- Chat: Fix abort related error messages with Claude 3. [pull/3466](https://github.com/sourcegraph/cody/pull/3466)
+
 
 ### Changed
 


### PR DESCRIPTION
Review this with whitespace changes removed. I need to validate this still works for rate limiting issues.

## Test plan

- Send a message and abort before the message starts streaming the first chars