### PR TITLE
Test: Fix cody-ignore e2e test on Windows

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -598,6 +598,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         }
 
         const cancellation = new vscode.CancellationTokenSource()
+        this.contextFilesQueryCancellation = cancellation
         getChatContextItemsForMention(query, cancellation.token, scopedTelemetryRecorder)
             .then(items => {
                 if (!cancellation.token.isCancellationRequested) {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -144,6 +144,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private readonly repoPicker: RemoteRepoPicker | null
 
     private history = new ChatHistoryManager()
+    private contextFilesQueryCancellation?: vscode.CancellationTokenSource
 
     private disposables: vscode.Disposable[] = []
     public dispose(): void {
@@ -592,8 +593,12 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             },
         }
 
+        // Cancel & dispose previously in-flight query.
+        this.contextFilesQueryCancellation?.cancel()
+        this.contextFilesQueryCancellation?.dispose()
+
         const cancellation = new vscode.CancellationTokenSource()
-        cancellation.token.onCancellationRequested(() => cancellation.cancel())
+        this.contextFilesQueryCancellation = cancellation
         getChatContextItemsForMention(query, cancellation.token, scopedTelemetryRecorder)
             .then(items => {
                 this.postMessage({

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -578,8 +578,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
     private async handleGetUserContextFilesCandidates(query: string): Promise<void> {
         // Cancel and dispose in-flight query
+        const cancellation = new vscode.CancellationTokenSource()
         this.contextFilesQueryCancellation?.cancel()
         this.contextFilesQueryCancellation?.dispose()
+        this.contextFilesQueryCancellation = cancellation
 
         const source = 'chat'
         const scopedTelemetryRecorder: Parameters<typeof getChatContextItemsForMention>[2] = {
@@ -597,9 +599,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             },
         }
 
-        const cancellation = new vscode.CancellationTokenSource()
-        this.contextFilesQueryCancellation = cancellation
-        getChatContextItemsForMention(query, cancellation.token, scopedTelemetryRecorder)
+        await getChatContextItemsForMention(query, cancellation.token, scopedTelemetryRecorder)
             .then(items => {
                 if (!cancellation.token.isCancellationRequested) {
                     this.postMessage({

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -144,7 +144,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private readonly repoPicker: RemoteRepoPicker | null
 
     private history = new ChatHistoryManager()
-    private contextFilesQueryCancellation?: vscode.CancellationTokenSource
 
     private disposables: vscode.Disposable[] = []
     public dispose(): void {
@@ -593,12 +592,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             },
         }
 
-        // Cancel & dispose previously in-flight query.
-        this.contextFilesQueryCancellation?.cancel()
-        this.contextFilesQueryCancellation?.dispose()
-
         const cancellation = new vscode.CancellationTokenSource()
-        this.contextFilesQueryCancellation = cancellation
         getChatContextItemsForMention(query, cancellation.token, scopedTelemetryRecorder)
             .then(items => {
                 this.postMessage({

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -577,9 +577,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     private async handleGetUserContextFilesCandidates(query: string): Promise<void> {
-        // Cancel & dispose previously in-flight query.
-        this.contextFilesQueryCancellation?.dispose()
-
         const source = 'chat'
         const scopedTelemetryRecorder: Parameters<typeof getChatContextItemsForMention>[2] = {
             empty: () => {
@@ -595,6 +592,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 })
             },
         }
+
+        // Cancel & dispose previously in-flight query.
+        this.contextFilesQueryCancellation?.cancel()
+        this.contextFilesQueryCancellation?.dispose()
 
         const cancellation = new vscode.CancellationTokenSource()
         this.contextFilesQueryCancellation = cancellation

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -144,7 +144,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     private readonly repoPicker: RemoteRepoPicker | null
 
     private history = new ChatHistoryManager()
-    private contextFilesQueryCancellation?: vscode.CancellationTokenSource
 
     private disposables: vscode.Disposable[] = []
     public dispose(): void {
@@ -593,12 +592,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             },
         }
 
-        // Cancel & dispose previously in-flight query.
-        this.contextFilesQueryCancellation?.cancel()
-        this.contextFilesQueryCancellation?.dispose()
-
         const cancellation = new vscode.CancellationTokenSource()
-        this.contextFilesQueryCancellation = cancellation
+        cancellation.token.onCancellationRequested(() => cancellation.cancel())
         getChatContextItemsForMention(query, cancellation.token, scopedTelemetryRecorder)
             .then(items => {
                 this.postMessage({

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -578,7 +578,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
     private async handleGetUserContextFilesCandidates(query: string): Promise<void> {
         // Cancel & dispose previously in-flight query.
-        this.contextFilesQueryCancellation?.cancel()
         this.contextFilesQueryCancellation?.dispose()
 
         const source = 'chat'

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -55,6 +55,7 @@ test.extend<ExpectedEvents>({
     await expect(chatPanelFrame.getByRole('heading', { name: 'No files found' })).toBeVisible()
 
     // Includes dotfiles after just "."
+    await chatInput.clear()
     await chatInput.fill('@.')
     await expect(chatPanelFrame.getByRole('option', { name: '.mydotfile' })).toBeVisible()
 

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -55,8 +55,7 @@ test.extend<ExpectedEvents>({
     await expect(chatPanelFrame.getByRole('heading', { name: 'No files found' })).toBeVisible()
 
     // Includes dotfiles after just "."
-    await chatInput.click()
-    await chatInput.fill('@.')
+    await chatInput.pressSequentially('@.', { delay: 50 })
     await expect(chatPanelFrame.getByRole('option', { name: '.mydotfile' })).toBeVisible()
 
     // Forward slashes

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -55,7 +55,6 @@ test.extend<ExpectedEvents>({
     await expect(chatPanelFrame.getByRole('heading', { name: 'No files found' })).toBeVisible()
 
     // Includes dotfiles after just "."
-    await chatInput.clear()
     await chatInput.fill('@.')
     await expect(chatPanelFrame.getByRole('option', { name: '.mydotfile' })).toBeVisible()
 

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -55,7 +55,7 @@ test.extend<ExpectedEvents>({
     await expect(chatPanelFrame.getByRole('heading', { name: 'No files found' })).toBeVisible()
 
     // Includes dotfiles after just "."
-    await chatInput.clear()
+    await chatInput.click()
     await chatInput.fill('@.')
     await expect(chatPanelFrame.getByRole('option', { name: '.mydotfile' })).toBeVisible()
 

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -53,6 +53,7 @@ test.extend<ExpectedEvents>({
     await expect(chatPanelFrame.getByRole('heading', { name: 'No files found' })).toBeVisible()
 
     // Includes dotfiles after just "."
+    await chatInput.clear()
     await chatInput.fill('@.')
     await expect(chatPanelFrame.getByRole('option', { name: '.mydotfile' })).toBeVisible()
 

--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -39,8 +39,10 @@ test.extend<ExpectedEvents>({
     // Submit three new messages
     await chatInput.fill('One')
     await chatInput.press('Enter')
+    await chatInput.click()
     await chatInput.fill('Two')
     await chatInput.press('Enter')
+    await chatInput.click()
     await chatInput.fill('Three')
     await chatInput.press('Enter')
 

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -61,14 +61,14 @@ test.extend<ExpectedEvents>({
     /* TEST: At-file - Ignored file does not show up as context when using @-mention */
     await chatInput.focus()
     await chatInput.clear()
-    await chatInput.fill('@ignoredByCody')
+    await chatInput.pressSequentially('@ignoredByCody', { delay: 10 })
     await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
     await chatInput.clear()
-    await chatInput.fill('@ignore')
+    await chatInput.pressSequentially('@ignore', { delay: 10 })
+    await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
     await expect(
         chatPanel.getByRole('option', { name: withPlatformSlashes('ignore .cody') })
     ).toBeVisible()
-    await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
 
     /* TEST: Command - Ignored file do not show up with context */
     await page.getByText('Explain Code').hover()

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import { expect } from '@playwright/test'
 import { sidebarExplorer, sidebarSignin } from './common'
 import { type ExpectedEvents, test } from './helpers'
@@ -59,16 +58,13 @@ test.extend<ExpectedEvents>({
     expect(await chatPanel.getByText(/^✨ Context:/).count()).toEqual(0)
 
     /* TEST: At-file - Ignored file does not show up as context when using @-mention */
-    await chatInput.focus()
+    await chatInput.clear()
+    await chatInput.fill('@ignore')
+    await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
+    await expect(chatPanel.getByRole('option', { name: 'ignore .cody' })).toBeVisible()
     await chatInput.clear()
     await chatInput.fill('@ignoredByCody')
     await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
-    await chatInput.clear()
-    await chatInput.fill('@ignore')
-    await expect(
-        chatPanel.getByRole('option', { name: withPlatformSlashes('ignore .cody') })
-    ).toBeVisible()
-    await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
 
     /* TEST: Command - Ignored file do not show up with context */
     await page.getByText('Explain Code').hover()
@@ -78,7 +74,3 @@ test.extend<ExpectedEvents>({
     // A system message shows up to notify users that the file is ignored
     await expect(page.getByText(/^Cannot execute a command in an ignored file./)).toBeVisible()
 })
-
-function withPlatformSlashes(input: string) {
-    return input.replaceAll(path.posix.sep, path.sep)
-}

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -58,15 +58,13 @@ test.extend<ExpectedEvents>({
     expect(await chatPanel.getByText(/^✨ Context:/).count()).toEqual(0)
 
     /* TEST: At-file - Ignored file does not show up as context when using @-mention */
-    await chatInput.focus()
     await chatInput.clear()
-    await chatInput.pressSequentially('@ignoredByCody', { delay: 20 })
+    await chatInput.fill('@ignoredByCody')
     await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
     await chatInput.clear()
-    await chatInput.focus()
-    await chatInput.pressSequentially('@ignore', { delay: 20 })
+    await chatInput.fill('@ignore')
     await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
-    await chatPanel.getByText('ignore.cody').hover()
+    await expect(chatPanel.getByRole('option', { name: 'ignore .cody' })).toBeVisible()
 
     /* TEST: Command - Ignored file do not show up with context */
     await page.getByText('Explain Code').hover()

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import { expect } from '@playwright/test'
 import { sidebarExplorer, sidebarSignin } from './common'
 import { type ExpectedEvents, test } from './helpers'
@@ -61,14 +60,13 @@ test.extend<ExpectedEvents>({
     /* TEST: At-file - Ignored file does not show up as context when using @-mention */
     await chatInput.focus()
     await chatInput.clear()
-    await chatInput.pressSequentially('@ignoredByCody', { delay: 10 })
+    await chatInput.pressSequentially('@ignoredByCody', { delay: 20 })
     await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
     await chatInput.clear()
-    await chatInput.pressSequentially('@ignore', { delay: 10 })
+    await chatInput.focus()
+    await chatInput.pressSequentially('@ignore', { delay: 20 })
     await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
-    await expect(
-        chatPanel.getByRole('option', { name: withPlatformSlashes('ignore .cody') })
-    ).toBeVisible()
+    await chatPanel.getByText('ignore.cody').hover()
 
     /* TEST: Command - Ignored file do not show up with context */
     await page.getByText('Explain Code').hover()
@@ -78,7 +76,3 @@ test.extend<ExpectedEvents>({
     // A system message shows up to notify users that the file is ignored
     await expect(page.getByText(/^Cannot execute a command in an ignored file./)).toBeVisible()
 })
-
-function withPlatformSlashes(input: string) {
-    return input.replaceAll(path.posix.sep, path.sep)
-}

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -59,12 +59,12 @@ test.extend<ExpectedEvents>({
 
     /* TEST: At-file - Ignored file does not show up as context when using @-mention */
     await chatInput.clear()
-    await chatInput.fill('@ignoredByCody')
-    await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
-    await chatInput.clear()
     await chatInput.fill('@ignore')
     await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
     await expect(chatPanel.getByRole('option', { name: 'ignore .cody' })).toBeVisible()
+    await chatInput.clear()
+    await chatInput.fill('@ignoredByCody')
+    await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
 
     /* TEST: Command - Ignored file do not show up with context */
     await page.getByText('Explain Code').hover()

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import { expect } from '@playwright/test'
 import { sidebarExplorer, sidebarSignin } from './common'
 import { type ExpectedEvents, test } from './helpers'
@@ -58,13 +59,16 @@ test.extend<ExpectedEvents>({
     expect(await chatPanel.getByText(/^✨ Context:/).count()).toEqual(0)
 
     /* TEST: At-file - Ignored file does not show up as context when using @-mention */
-    await chatInput.clear()
-    await chatInput.fill('@ignore')
-    await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
-    await expect(chatPanel.getByRole('option', { name: 'ignore .cody' })).toBeVisible()
+    await chatInput.focus()
     await chatInput.clear()
     await chatInput.fill('@ignoredByCody')
     await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
+    await chatInput.clear()
+    await chatInput.fill('@ignore')
+    await expect(
+        chatPanel.getByRole('option', { name: withPlatformSlashes('ignore .cody') })
+    ).toBeVisible()
+    await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
 
     /* TEST: Command - Ignored file do not show up with context */
     await page.getByText('Explain Code').hover()
@@ -74,3 +78,7 @@ test.extend<ExpectedEvents>({
     // A system message shows up to notify users that the file is ignored
     await expect(page.getByText(/^Cannot execute a command in an ignored file./)).toBeVisible()
 })
+
+function withPlatformSlashes(input: string) {
+    return input.replaceAll(path.posix.sep, path.sep)
+}


### PR DESCRIPTION
Attempt to fix the cody-ignore e2e test on Windows that was failing on main. Based on the last commit on main, this is the test that's failing: https://github.com/sourcegraph/cody/actions/runs/8344781538/job/22838057502#step:11:325

![image](https://github.com/sourcegraph/cody/assets/68532117/5d704bba-ae6c-463d-80e0-e201c7c1ca7a)


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

CI

![image](https://github.com/sourcegraph/cody/assets/68532117/3198cf9a-0ee1-4f0e-a103-3f545365463c)


## Next

Fix flaky test: chat-atFile
