### PR TITLE
Autocomplete: use `parser.safeParse()`

### DIFF
--- a/vscode/src/completions/text-processing/parse-completion.ts
+++ b/vscode/src/completions/text-processing/parse-completion.ts
@@ -59,6 +59,10 @@ export function parseCompletion(context: CompletionContext): ParsedCompletion {
         parser,
     })
 
+    if (!treeWithCompletion) {
+        return completion
+    }
+
     const points: ParsedCompletion['points'] = {
         start: asPoint(position),
         end: completionEndPosition,
@@ -94,7 +98,7 @@ interface PasteCompletionParams {
 }
 
 interface PasteCompletionResult {
-    treeWithCompletion: Tree
+    treeWithCompletion?: Tree
     completionEndPosition: Point
 }
 

--- a/vscode/src/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/tree-sitter/parse-tree-cache.ts
@@ -50,7 +50,7 @@ async function parseDocument(document: TextDocument): Promise<void> {
 }
 
 export function updateParseTreeCache(document: TextDocument, parser: WrappedParser): void {
-    const tree = parser.parse(document.getText())
+    const tree = parser.safeParse(document.getText())
     parseTreesPerFile.set(document.uri.toString(), tree)
 }
 
@@ -106,7 +106,7 @@ export function updateParseTreeOnEdit(edit: vscode.TextDocumentChangeEvent): voi
         })
     }
 
-    const updatedTree = parser.parse(document.getText(), tree)
+    const updatedTree = parser.safeParse(document.getText(), tree)
     parseTreesPerFile.set(cacheKey, updatedTree)
 }
 

--- a/vscode/src/tree-sitter/parser.ts
+++ b/vscode/src/tree-sitter/parser.ts
@@ -5,6 +5,7 @@ import type Parser from 'web-tree-sitter'
 
 import { wrapInActiveSpan } from '@sourcegraph/cody-shared'
 import type { Tree } from 'web-tree-sitter'
+import { captureException } from '../services/sentry/sentry'
 import { DOCUMENT_LANGUAGE_TO_GRAMMAR, type SupportedLanguage, isSupportedLanguage } from './grammars'
 import { initQueries } from './query-sdk'
 const ParserImpl = require('web-tree-sitter') as typeof Parser
@@ -46,11 +47,18 @@ async function isRegularFile(uri: vscode.Uri): Promise<boolean> {
     }
 }
 
+type SafeParse = (
+    input: string | Parser.Input,
+    previousTree?: Parser.Tree,
+    options?: Parser.Options
+) => Parser.Tree | undefined
+
 export type WrappedParser = Pick<Parser, 'parse' | 'getLanguage'> & {
     /**
      * Wraps `parser.parse()` call into an OpenTelemetry span.
      */
-    observableParse: Parser['parse']
+    observableParse: SafeParse
+    safeParse: SafeParse
 }
 
 export async function createParser(settings: ParserSettings): Promise<WrappedParser | undefined> {
@@ -82,10 +90,25 @@ export async function createParser(settings: ParserSettings): Promise<WrappedPar
         parser.setTimeoutMicros(70_000)
     }
 
+    const safeParse: SafeParse = (...args) => {
+        try {
+            return parser.parse(...args)
+        } catch (error) {
+            captureException(error)
+
+            if (process.env.NODE_ENV === 'production') {
+                console.error('parser.parse() error:', error)
+            }
+
+            return undefined
+        }
+    }
+
     const wrappedParser: WrappedParser = {
         getLanguage: () => parser.getLanguage(),
         parse: (...args) => parser.parse(...args),
-        observableParse: (...args) => wrapInActiveSpan('parser.parse', () => parser.parse(...args)),
+        observableParse: (...args) => wrapInActiveSpan('parser.parse', () => safeParse(...args)),
+        safeParse,
     }
 
     PARSERS_LOCAL_CACHE[language] = wrappedParser

--- a/vscode/src/tree-sitter/parser.ts
+++ b/vscode/src/tree-sitter/parser.ts
@@ -96,7 +96,7 @@ export async function createParser(settings: ParserSettings): Promise<WrappedPar
         } catch (error) {
             captureException(error)
 
-            if (process.env.NODE_ENV === 'production') {
+            if (process.env.NODE_ENV === 'development') {
                 console.error('parser.parse() error:', error)
             }
 


### PR DESCRIPTION
## Context

- Wrap `parser.parse()` in a try-catch statement, report errors to Sentry and fail gracefully.

## Test plan

CI
