### PR TITLE
Chat: clarify tooltip for remote search context

### DIFF
--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -18,7 +18,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
         const repoShortName = repoName?.slice(repoName.lastIndexOf('/') + 1)
         const pathToDisplay = `${repoShortName} ${title}`
         const pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
-        const tooltip = `${repoName} @${revision}\nincluded via Search`
+        const tooltip = `${repoName} @${revision}\nincluded via search (remote)`
         return (
             <a
                 href={uri.toString()}


### PR DESCRIPTION
Small UI change.

Update the tooltip for file links included via remote search to explicitly mention "search (remote)" for unified context to improve clarity and make it easier to identify the search, as currently, we are showing it as `via Search` which overlaps with the search results from `symf`. 

|  symf context | unified context   |
|---|---|
| ![image](https://github.com/sourcegraph/cody/assets/68532117/d8e64b98-9368-48fa-bbf5-b99f66c039cf)  |  ![image](https://github.com/sourcegraph/cody/assets/68532117/927873c9-49a3-49f5-9954-59625cf9be2b)  |


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/927873c9-49a3-49f5-9954-59625cf9be2b)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/45902d0e-fdea-4f72-8f2d-9490df74b1d6)
