### PR TITLE
Error when receing an SSE response that does not contain any SSE event

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -36,6 +36,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Improve StarCoder2 Ollama support. [pull/3452](https://github.com/sourcegraph/cody/pull/3452)
 - Command: Enhanced the context provided to the Test command to help the language model determine the appropriate testing framework to use. [pull/3344](https://github.com/sourcegraph/cody/pull/3344)
 - Autocomplete: Upgrade tree-sitter grammars and add Dart support. [pull/3476](https://github.com/sourcegraph/cody/pull/3476)
+- Properly throw an error when attempting to parse an incomplete SSE stream with the nodeClient. [pull/3479](https://github.com/sourcegraph/cody/pull/3479)
 
 ## [1.8.3]
 


### PR DESCRIPTION
We have observed cases where the response of the SSE endpoint did not contain any SSE events (and was thus malformed). This PR makes it so that in this case we still yield an error and log the actual body in verbose mode.

## Test plan

- Apply a change to the sg server like this

```diff
diff --git a/internal/completions/httpapi/handler.go b/internal/completions/httpapi/handler.go
index 50fb45bcd77..afc1080a63a 100644
--- a/internal/completions/httpapi/handler.go
+++ b/internal/completions/httpapi/handler.go
@@ -204,6 +204,8 @@ func newSwitchingResponseHandler(logger log.Logger, db database.DB, feature type
        nonStreamer := newNonStreamingResponseHandler(logger, db, feature)
        streamer := newStreamingResponseHandler(logger, db, feature)
        return func(ctx context.Context, requestParams types.CompletionRequestParameters, cc types.CompletionsClient, w http.ResponseWriter, userStore database.UserStore, test guardrails.AttributionTest) {
+               w.Write([]byte("oh this is malformed huh? too bad"))
+               return
                if requestParams.IsStream(feature) {
                        streamer(ctx, requestParams, cc, w, userStore, test)
                } else {
```

- Observe that we see an error now instead of a hanging request
<img width="1174" alt="Screenshot 2024-03-20 at 16 04 11" src="https://github.com/sourcegraph/cody/assets/458591/75a11966-13b0-42ed-9812-f2a3645e960d">
