### PR TITLE
Properly handle one or more ndjson records coming from Ollama

### DIFF
--- a/lib/shared/src/ollama/chat-client.ts
+++ b/lib/shared/src/ollama/chat-client.ts
@@ -73,7 +73,7 @@ export function ollamaChatClient(
             const textDecoder = new TextDecoder()
             const decoded = textDecoder.decode(value, { stream: true })
             // handle one or more ndjson records
-            const parsedLines = decoded.split('\n').map(JSON.parse) as OllamaGenerateResponse[]
+            const parsedLines = decoded.split('\n').map(m => JSON.parse(m)) as OllamaGenerateResponse[]
             for (const parsedLine of parsedLines) {
                 if (parsedLine.message) {
                     insertText += parsedLine.message.content

--- a/lib/shared/src/ollama/chat-client.ts
+++ b/lib/shared/src/ollama/chat-client.ts
@@ -72,11 +72,13 @@ export function ollamaChatClient(
 
             const textDecoder = new TextDecoder()
             const decoded = textDecoder.decode(value, { stream: true })
-            const parsedLine = JSON.parse(decoded) as OllamaGenerateResponse
-
-            if (parsedLine.message) {
-                insertText += parsedLine.message.content
-                cb.onChange(insertText)
+            // handle one or more ndjson records
+            const parsedLines = decoded.match(/.+/g).map(JSON.parse)
+            for (const parsedLine of parsedLines) {
+                if (parsedLine.message) {
+                    insertText += parsedLine.message.content
+                    cb.onChange(insertText)
+                }
             }
         }
 

--- a/lib/shared/src/ollama/chat-client.ts
+++ b/lib/shared/src/ollama/chat-client.ts
@@ -73,7 +73,13 @@ export function ollamaChatClient(
             const textDecoder = new TextDecoder()
             const decoded = textDecoder.decode(value, { stream: true })
             // handle one or more ndjson records
-            const parsedLines = decoded.match(/.+/g).map(JSON.parse)
+            const matches = decoded.match(/.+/g)
+            let parsedLines: OllamaGenerateResponse[] = [];
+            if (matches !== null) {
+                parsedLines = matches.map(line => {
+                    return JSON.parse(line) as OllamaGenerateResponse
+                });
+            }
             for (const parsedLine of parsedLines) {
                 if (parsedLine.message) {
                     insertText += parsedLine.message.content

--- a/lib/shared/src/ollama/chat-client.ts
+++ b/lib/shared/src/ollama/chat-client.ts
@@ -73,7 +73,13 @@ export function ollamaChatClient(
             const textDecoder = new TextDecoder()
             const decoded = textDecoder.decode(value, { stream: true })
             // handle one or more ndjson records
-            const parsedLines = decoded.split('\n').map(m => JSON.parse(m)) as OllamaGenerateResponse[]
+            const matches = decoded.match(/.+/g)
+            let parsedLines: OllamaGenerateResponse[] = [];
+            if (matches !== null) {
+                parsedLines = matches.map(line => {
+                    return JSON.parse(line) as OllamaGenerateResponse
+                });
+            }
             for (const parsedLine of parsedLines) {
                 if (parsedLine.message) {
                     insertText += parsedLine.message.content

--- a/lib/shared/src/ollama/chat-client.ts
+++ b/lib/shared/src/ollama/chat-client.ts
@@ -73,13 +73,7 @@ export function ollamaChatClient(
             const textDecoder = new TextDecoder()
             const decoded = textDecoder.decode(value, { stream: true })
             // handle one or more ndjson records
-            const matches = decoded.match(/.+/g)
-            let parsedLines: OllamaGenerateResponse[] = [];
-            if (matches !== null) {
-                parsedLines = matches.map(line => {
-                    return JSON.parse(line) as OllamaGenerateResponse
-                });
-            }
+            const parsedLines = decoded.split('\n').map(JSON.parse) as OllamaGenerateResponse[]
             for (const parsedLine of parsedLines) {
                 if (parsedLine.message) {
                     insertText += parsedLine.message.content

--- a/lib/shared/src/ollama/chat.test.ts
+++ b/lib/shared/src/ollama/chat.test.ts
@@ -1,0 +1,233 @@
+import { describe, test, expect, vi } from 'vitest'
+import { ollamaChatClient } from './chat-client'
+import type {
+    CompletionCallbacks,
+    CompletionParameters,
+} from '../sourcegraph-api/completions/types'
+import type { CompletionLogger } from '../sourcegraph-api/completions/client'
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+describe('renderMarkdown', () => {
+    test('single record', async () => {
+        const mockStream = () => {
+            const data = [
+              '{"message": { "role": "assistant", "content": " Hi" }}',
+            ];
+            return new ReadableStream({
+              start(controller) {
+                data.forEach((chunk) => {
+                    const encoded = new TextEncoder().encode(chunk);
+                    controller.enqueue(encoded);
+                });
+                controller.close();
+              }
+            });
+        }
+        global.fetch = vi.fn<any[]>(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: {
+                    'content-type': 'application/x-ndjson',
+                },
+                body: mockStream(),
+            })
+        )
+        const params: CompletionParameters = {
+            model: 'ollama/gpt2',
+            messages: [
+                { speaker: 'human', text: 'Hello' },
+            ],
+            temperature: 0.7,
+            topK: 50,
+            topP: 0.9,
+            maxTokensToSample: 100,
+        }
+        const completionsEndpoint = 'http://localhost:8080/api/chat'
+        const logger: CompletionLogger = {
+            startCompletion: vi.fn(),
+        }
+        const cb: CompletionCallbacks = {
+            onComplete: vi.fn(),
+            onChange: vi.fn(),
+            onError: vi.fn(),
+        }
+        ollamaChatClient(params, cb, completionsEndpoint, logger)
+        await delay(1000)
+        expect(fetch).toHaveBeenCalledWith(
+            'http://localhost:11434/api/chat',
+            {
+                method: 'POST',
+                body: JSON.stringify({
+                    model: 'gpt2',
+                    messages: [
+                        { role: 'user', content: 'Hello' },
+                    ],
+                    options: {
+                        temperature: 0.7,
+                        top_k: 50,
+                        top_p: 0.9,
+                        tfs_z: 100,
+                    },
+                }),
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            }
+        )
+        expect(cb.onComplete).toHaveBeenCalledTimes(1)
+        expect(cb.onError).not.toHaveBeenCalled()
+        expect(cb.onChange).toHaveBeenCalledTimes(1)
+        expect(cb.onChange).toHaveBeenCalledWith(' Hi')
+    })
+    test('multiple records', async () => {
+        const mockStream = () => {
+            const data = [
+              '{"message": { "role": "assistant", "content": " Hi" }}\n',
+              '{"message": { "role": "assistant", "content": " There!" }}',
+            ];
+            return new ReadableStream({
+              start(controller) {
+                data.forEach((chunk) => {
+                    const encoded = new TextEncoder().encode(chunk);
+                    controller.enqueue(encoded);
+                });
+                controller.close();
+              }
+            });
+        }
+        global.fetch = vi.fn<any[]>(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: {
+                    'content-type': 'application/x-ndjson',
+                },
+                body: mockStream(),
+            })
+        )
+        const params: CompletionParameters = {
+            model: 'ollama/gpt2',
+            messages: [
+                { speaker: 'human', text: 'Hello' },
+            ],
+            temperature: 0.7,
+            topK: 50,
+            topP: 0.9,
+            maxTokensToSample: 100,
+        }
+        const completionsEndpoint = 'http://localhost:8080/api/chat'
+        const logger: CompletionLogger = {
+            startCompletion: vi.fn(),
+        }
+        const cb: CompletionCallbacks = {
+            onComplete: vi.fn(),
+            onChange: vi.fn(),
+            onError: vi.fn(),
+        }
+        ollamaChatClient(params, cb, completionsEndpoint, logger)
+        await delay(1000)
+        expect(fetch).toHaveBeenCalledWith(
+            'http://localhost:11434/api/chat',
+            {
+                method: 'POST',
+                body: JSON.stringify({
+                    model: 'gpt2',
+                    messages: [
+                        { role: 'user', content: 'Hello' },
+                    ],
+                    options: {
+                        temperature: 0.7,
+                        top_k: 50,
+                        top_p: 0.9,
+                        tfs_z: 100,
+                    },
+                }),
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            }
+        )
+        expect(cb.onComplete).toHaveBeenCalledTimes(1)
+        expect(cb.onError).not.toHaveBeenCalled()
+        expect(cb.onChange).toHaveBeenCalledTimes(2)
+        expect(cb.onChange).toHaveBeenCalledWith(' Hi')
+        expect(cb.onChange).toHaveBeenCalledWith(' Hi There!')
+    })
+
+    test('multiple records, with trailing <cr>', async () => {
+        const mockStream = () => {
+            const data = [
+              '{"message": { "role": "assistant", "content": " Hi" }}\n',
+              '{"message": { "role": "assistant", "content": " There!" }}\n',
+            ];
+            return new ReadableStream({
+              start(controller) {
+                data.forEach((chunk) => {
+                    const encoded = new TextEncoder().encode(chunk);
+                    controller.enqueue(encoded);
+                });
+                controller.close();
+              }
+            });
+        }
+        global.fetch = vi.fn<any[]>(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: {
+                    'content-type': 'application/x-ndjson',
+                },
+                body: mockStream(),
+            })
+        )
+        const params: CompletionParameters = {
+            model: 'ollama/gpt2',
+            messages: [
+                { speaker: 'human', text: 'Hello' },
+            ],
+            temperature: 0.7,
+            topK: 50,
+            topP: 0.9,
+            maxTokensToSample: 100,
+        }
+        const completionsEndpoint = 'http://localhost:8080/api/chat'
+        const logger: CompletionLogger = {
+            startCompletion: vi.fn(),
+        }
+        const cb: CompletionCallbacks = {
+            onComplete: vi.fn(),
+            onChange: vi.fn(),
+            onError: vi.fn(),
+        }
+        ollamaChatClient(params, cb, completionsEndpoint, logger)
+        await delay(1000)
+        expect(fetch).toHaveBeenCalledWith(
+            'http://localhost:11434/api/chat',
+            {
+                method: 'POST',
+                body: JSON.stringify({
+                    model: 'gpt2',
+                    messages: [
+                        { role: 'user', content: 'Hello' },
+                    ],
+                    options: {
+                        temperature: 0.7,
+                        top_k: 50,
+                        top_p: 0.9,
+                        tfs_z: 100,
+                    },
+                }),
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            }
+        )
+        expect(cb.onComplete).toHaveBeenCalledTimes(1)
+        expect(cb.onError).not.toHaveBeenCalled()
+        expect(cb.onChange).toHaveBeenCalledTimes(2)
+        expect(cb.onChange).toHaveBeenCalledWith(' Hi')
+        expect(cb.onChange).toHaveBeenCalledWith(' Hi There!')
+    })
+})


### PR DESCRIPTION
## Test plan

The bug was verified using an isolated version of lib/shared/src/ollama/chat-client.ts running against a fast, local ollama server.  The changes were made and verified against same ollama server.

The issue is triggered very consistently by setting "cody.experimental.ollamaChat": true, and using a fast local Ollama setup, perhaps using llama2:7b or as small and fast a model as you can find.  Then ask a question with a reasonably long answer like "why is the sky blue?".  You should see the answer halt somewhere in the middle and Cody chat is then "frozen" and cannot be aborted.  The only recovery is to delete the chat and start a new one.  The reason this happens is that if Cody does not read the stream fast enough, it gets '{...}\n{...}' in reader.read() and then JSON.parse bombs.  The existing code does not accommodate x-ndjson, which is what Ollama is sending.    Probably all other LLM providers too.

can-ndjson-stream is a library that could be used, but I thought a no-dependency solution would be more acceptable as a PR.  You might read this background article: https://andreitopli.medium.com/working-with-newline-delimited-json-using-can-ndjson-stream-in-typescript-983016d51d4a

Added testcase: lib/shared/src/ollama/chat.test.ts