### PR TITLE
WIP Chat: provide guidance on answering

### DIFF
--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -2,9 +2,7 @@ import { supportsFastPath } from '../models/utils'
 import type { Message } from '../sourcegraph-api'
 
 export function getSimplePreamble(model: string, preInstruction?: string | undefined): Message[] {
-    const intro = `You are Cody, an AI coding assistant from Sourcegraph.${
-        preInstruction ? ` ${preInstruction}` : ''
-    }`
+    const intro = 'You are Cody, an AI coding assistant from Sourcegraph.'
 
     if (supportsFastPath(model)) {
         return [

--- a/lib/shared/src/chat/preamble.ts
+++ b/lib/shared/src/chat/preamble.ts
@@ -2,7 +2,9 @@ import { supportsFastPath } from '../models/utils'
 import type { Message } from '../sourcegraph-api'
 
 export function getSimplePreamble(model: string, preInstruction?: string | undefined): Message[] {
-    const intro = 'You are Cody, an AI coding assistant from Sourcegraph.'
+    const intro = `You are Cody, an AI coding assistant from Sourcegraph.${
+        preInstruction ? ` ${preInstruction}` : ''
+    }`
 
     if (supportsFastPath(model)) {
         return [

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -133,7 +133,7 @@ export {
     SURROUNDING_LINES,
     tokensToChars,
 } from './prompt/constants'
-export { PromptMixin, newPromptMixin } from './prompt/prompt-mixin'
+export { PromptMixin } from './prompt/prompt-mixin'
 export * from './prompt/templates'
 export {
     truncateText,

--- a/lib/shared/src/prompt/prompt-mixin.ts
+++ b/lib/shared/src/prompt/prompt-mixin.ts
@@ -1,13 +1,7 @@
 import type { ChatMessage } from '../chat/transcript/messages'
 
-// Reminds Cody of its identity.
-const identity = 'Reply as Cody, a coding assistant developed by Sourcegraph.'
-// Helps with hallucinations.
-const hallucinate = 'Never make assumptions nor provide misleading or hypothetical examples.'
-// To avoid starting responses with "Unfortunately..." when context is available.
-const rule = 'Answer in high-level using shared context. If more context needed, note that at the end.'
-
-const CODY_INTRO_PROMPT = `(${identity} ${hallucinate})`
+// Avoid responses that start with "Unfortunately..." when context is provided.
+const rule = 'Answer in high-level using shared context. If more context needed, tell me at the end.'
 
 /**
  * Prompt mixins elaborate every prompt presented to the LLM.
@@ -15,11 +9,14 @@ const CODY_INTRO_PROMPT = `(${identity} ${hallucinate})`
  */
 export class PromptMixin {
     private static mixins: PromptMixin[] = []
-    private static defaultMixin: PromptMixin = new PromptMixin(rule || CODY_INTRO_PROMPT)
+    private static defaultMixin: PromptMixin = new PromptMixin(rule)
 
+    /**
+     * Add custom prompt mixin to prepend to all human messages.
+     */
     public static addMixin(prompt: string): void {
         if (prompt) {
-            PromptMixin.mixins = [new PromptMixin(prompt)]
+            PromptMixin.mixins.push(new PromptMixin(prompt))
         }
     }
 

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -4,6 +4,7 @@ import {
     type ChatMessage,
     type ContextItem,
     type Message,
+    PromptMixin,
     type SerializedChatInteraction,
     type SerializedChatTranscript,
     errorToChatError,
@@ -105,8 +106,17 @@ export class SimpleChatModel {
         this.messages.splice(index)
     }
 
+    /**
+     * Returns a readonly copy of the messages array with prompt mixins applied to the last human message.
+     */
     public getMessages(): readonly ChatMessage[] {
-        return this.messages
+        // Use copy to avoid promptMixin modifying the original messages used for serialization.
+        const messages = [...this.messages]
+        const lastHumanIndex = this.getLastSpeakerMessageIndex('human')
+        if (lastHumanIndex !== undefined) {
+            messages[lastHumanIndex] = PromptMixin.mixInto(messages[lastHumanIndex])
+        }
+        return messages
     }
 
     public getChatTitle(): string {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -10,7 +10,6 @@ import {
     featureFlagProvider,
     graphqlClient,
     isDotCom,
-    newPromptMixin,
     setLogger,
 } from '@sourcegraph/cody-shared'
 
@@ -95,9 +94,7 @@ export async function start(
                 const config = await getFullConfig()
                 await onConfigurationChange(config)
                 platform.onConfigurationChange?.(config)
-                if (config.chatPreInstruction) {
-                    PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
-                }
+                PromptMixin.addMixin(config.chatPreInstruction)
             }
         })
     )
@@ -132,10 +129,7 @@ const register = async (
     // Could we use the `initialConfig` instead?
     const workspaceConfig = vscode.workspace.getConfiguration()
     const config = getConfiguration(workspaceConfig)
-
-    if (config.chatPreInstruction) {
-        PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
-    }
+    PromptMixin.addMixin(config.chatPreInstruction)
 
     parseAllVisibleDocuments()
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -6,7 +6,6 @@ import {
     ConfigFeaturesSingleton,
     type ConfigurationWithAccessToken,
     ModelProvider,
-    PromptMixin,
     featureFlagProvider,
     graphqlClient,
     isDotCom,
@@ -94,7 +93,6 @@ export async function start(
                 const config = await getFullConfig()
                 await onConfigurationChange(config)
                 platform.onConfigurationChange?.(config)
-                PromptMixin.addMixin(config.chatPreInstruction)
             }
         })
     )
@@ -129,7 +127,6 @@ const register = async (
     // Could we use the `initialConfig` instead?
     const workspaceConfig = vscode.workspace.getConfiguration()
     const config = getConfiguration(workspaceConfig)
-    PromptMixin.addMixin(config.chatPreInstruction)
 
     parseAllVisibleDocuments()
 


### PR DESCRIPTION
RE: https://github.com/sourcegraph/cody/issues/3331

I tried asking different models the same question "tell me about the architecture of this repo" to see which models would start their response with "Unfortunately" when enough context is provided, and found the following models have the same issue as #3331 :
- Claude 3 Haiku
- Claude Instant
- Claude 2.1
- GPT 3.5 Turbo

This PR adds a prompt that mixes into each chat question to provide the LLM with simple guidance on how to answer the question. From my manually testings, this prompt works on all the models we currently support, and hopefully would help with all the models we support in the future as well as enterprise users that use their own model.

The goal is to improve overall response quality across different models.

Also did some minor clean-up works.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Claude 3 Haiku:

#### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/e7f51794-2506-4001-9083-fc721473c9d5)

#### After

![image](https://github.com/sourcegraph/cody/assets/68532117/14558c61-7994-4088-ae6d-fd4813eb616b)

### Claude Instant:

#### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/59072365-8397-4731-bcde-842f8b721bf2)

#### After

![image](https://github.com/sourcegraph/cody/assets/68532117/d5080004-56b4-4ea9-ab49-0ba8f463fd1c)

### Claude 2.1

#### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/259980ad-fa4c-4e26-96b7-137d540bc545)

#### After

![image](https://github.com/sourcegraph/cody/assets/68532117/a23c64b2-e800-49f8-9cb9-08375c40d31d)

### GPT 3.5 Turbo

#### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/3d209f04-a8dd-4b22-8616-967bc581bd57)

#### After

![image](https://github.com/sourcegraph/cody/assets/68532117/fe0c9d3c-7828-4e58-9a0b-1b9fc4b38cc1)
