### PR TITLE
do not strip intentional newlines in chat transcript items

### DIFF
--- a/lib/shared/src/chat/markdown.ts
+++ b/lib/shared/src/chat/markdown.ts
@@ -47,6 +47,7 @@ const DOMPURIFY_CONFIG = {
         'h4',
         'h5',
         'h6',
+        'br',
     ],
     ALLOWED_URI_REGEXP,
     FORBID_ATTR: [


### PR DESCRIPTION
Partial fix for https://github.com/sourcegraph/cody/issues/3483. Makes it so that the Markdown is rendered literally with newlines as typed, instead of all being jammed on 1 line. (It does not render the user's code in backticks as code.)

Here is how it looks (not ideal because of the lack of rendering, but better than seen in #3483 since the newlines are preserved):

<img width="650" alt="image" src="https://github.com/sourcegraph/cody/assets/1976/3c39c628-9021-4655-8738-8be6e7235246">


## Test plan

Type a message with triple-backtick then newline then multiple lines of code. Confirm that the newlines are preserved when the message is displayed in the transcript.