### PR TITLE
Cherry-pick code review feedback missing from #3445

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -335,10 +335,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerNotification('textDocument/didFocus', (document: ProtocolTextDocument) => {
             function isEmpty(range: Range | undefined): boolean {
-                return !range || range === new vscode.Range(0, 0, 0, 0)
+                return !range || range == new vscode.Range(0, 0, 0, 0)
             }
             const documentWithUri = ProtocolTextDocumentWithUri.fromDocument(document)
-            // If the caller elided the content, as is the sensible thing to do, reconstruct it here.
+            // If the caller elided the content, reconstruct it here.
             const cachedDocument = this.workspace.getDocumentFromUriString(
                 documentWithUri.uri.toString()
             )

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -38,7 +38,7 @@ import type { CompletionItemID } from '../../vscode/src/completions/logger'
 import { getDocumentSections } from '../../vscode/src/editor/utils/document-sections'
 import type { ExtensionClient } from '../../vscode/src/extension-client'
 import { IndentationBasedFoldingRangeProvider } from '../../vscode/src/lsp/foldingRanges'
-import type { CommandResult, EditCommandResult } from '../../vscode/src/main'
+import type { CommandResult } from '../../vscode/src/main'
 import type { FixupTask } from '../../vscode/src/non-stop/FixupTask'
 import type { FixupActor, FixupFileCollection } from '../../vscode/src/non-stop/roles'
 import type { FixupControlApplicator } from '../../vscode/src/non-stop/strategies'
@@ -776,30 +776,11 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('editCommands/code', params => {
             const args = { configuration: { ...params } }
-            const taskThenable = vscode.commands.executeCommand<FixupTask | undefined>(
-                'cody.command.edit-code',
-                args
+            return this.createEditTask(
+                vscode.commands
+                    .executeCommand<FixupTask | undefined>('cody.command.edit-code', args)
+                    .then(task => task && { type: 'edit', task })
             )
-            // Wrap the task in a Thenable that returns a CommandResult, required by createEditTask().
-            const commandResultThenable: Thenable<CommandResult | undefined> = new Promise(
-                (resolve, reject) => {
-                    taskThenable.then(
-                        task => {
-                            if (task) {
-                                const editCommandResult: EditCommandResult = { type: 'edit', task: task }
-                                resolve(editCommandResult)
-                            } else {
-                                resolve(undefined)
-                            }
-                        },
-                        error => {
-                            reject(error)
-                        }
-                    )
-                }
-            )
-
-            return this.createEditTask(commandResultThenable)
         })
 
         this.registerAuthenticatedRequest('commands/smell', () => {

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -335,7 +335,13 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerNotification('textDocument/didFocus', (document: ProtocolTextDocument) => {
             function isEmpty(range: Range | undefined): boolean {
-                return !range || range == new vscode.Range(0, 0, 0, 0)
+                return (
+                    !range ||
+                    (range.start.line === 0 &&
+                        range.start.character === 0 &&
+                        range.end.line === 0 &&
+                        range.end.character === 0)
+                )
             }
             const documentWithUri = ProtocolTextDocumentWithUri.fromDocument(document)
             // If the caller elided the content, reconstruct it here.

--- a/lib/shared/src/commands/types.ts
+++ b/lib/shared/src/commands/types.ts
@@ -13,6 +13,7 @@ export enum DefaultChatCommands {
 export enum DefaultEditCommands {
     Test = 'test', // Generate unit tests with inline edit
     Doc = 'doc', // Generate documentation with inline edit
+    Edit = 'edit', // Edit code with inline edit
 }
 
 // The blueprint of a Cody Custom Command

--- a/vscode/src/commands/execute/doc.ts
+++ b/vscode/src/commands/execute/doc.ts
@@ -82,9 +82,7 @@ function getDocumentableRange(editor: vscode.TextEditor): {
 
 /**
  * The command that generates a new docstring for the selected code.
- * When calls, the command will be executed as an inline-edit command.
- *
- * Context: add by the edit command
+ * When called, the command will be executed as an inline-edit command.
  */
 export async function executeDocCommand(
     args?: Partial<CodyCommandArgs>

--- a/vscode/src/commands/execute/edit.ts
+++ b/vscode/src/commands/execute/edit.ts
@@ -1,23 +1,20 @@
 import { DefaultEditCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 import { type ExecuteEditArguments, executeEdit } from '../../edit/execute'
 import { getEditor } from '../../editor/active-editor'
 import type { EditCommandResult } from '../../main'
 
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
-
 export async function executeEditCommand(
     args: ExecuteEditArguments
 ): Promise<EditCommandResult | undefined> {
-    return wrapInActiveSpan('command.test', async span => {
+    return wrapInActiveSpan('command.edit', async span => {
         span.setAttribute('sampled', true)
-        const instruction = args.configuration?.instruction // get the instruction
-        const editor = getEditor()?.active // get the active editor
-        const document = editor?.document // get the document from the editor
+        const instruction = args.configuration?.instruction
+        const document = getEditor()?.active?.document
         if (!document || !instruction) {
             return
         }
 
-        // execute the edit with the provided configuration
         return {
             type: 'edit',
             task: await executeEdit({
@@ -27,7 +24,7 @@ export async function executeEditCommand(
                     document,
                     mode: 'edit',
                 },
-                source: DefaultEditCommands.Test,
+                source: DefaultEditCommands.Edit,
             } satisfies ExecuteEditArguments),
         }
     })


### PR DESCRIPTION
#3445 on stevey/extension-client-api-rebased landed without 3 code review feedback commits that went to stevey/extension-client-api. This cherry picks these back to main.

## Test plan

CI