### PR TITLE
Edit: Remove ghost hint feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -44,9 +44,6 @@ export enum FeatureFlag {
     // When enabled, fuses embeddings and symf context for chat.
     CodyChatFusedContext = 'cody-chat-fused-context',
 
-    // Show command hints alongside editor selections. "Opt+K to Edit, Opt+L to Chat"
-    CodyCommandHints = 'cody-command-hints',
-
     // Show document hints above a symbol if the users' cursor is there. "Opt+D to Document"
     CodyDocumentHints = 'cody-document-hints',
 


### PR DESCRIPTION
## Description

This is now set to 100%. Will also remove the `cody-command-hints` feature from dotcom

## Test plan

Check that the ghost text appears by default, when it has not already been set in settings

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
