### PR TITLE
Test: fix flaky e2e tests related to count

### DIFF
--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -37,15 +37,16 @@ test.extend<ExpectedEvents>({
     const startNewChatButton = chatFrame.getByTitle('Start New Chat')
 
     // Submit three new messages
-    await chatInput.fill('One')
-    await chatInput.press('Enter')
-    await chatInput.fill('Two')
-    await chatInput.press('Enter')
-    await chatInput.fill('Three')
-    await chatInput.press('Enter')
-
     // Three edit buttons should show up, one per each message submitted
     const editButtons = chatFrame.locator('.codicon-edit')
+    await chatInput.fill('One')
+    await chatInput.press('Enter')
+    await expect(editButtons).toHaveCount(1)
+    await chatInput.fill('Two')
+    await chatInput.press('Enter')
+    await expect(editButtons).toHaveCount(2)
+    await chatInput.fill('Three')
+    await chatInput.press('Enter')
     await expect(editButtons).toHaveCount(3)
 
     // Click on the first edit button to get into the editing mode

--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -41,12 +41,13 @@ test.extend<ExpectedEvents>({
     const editButtons = chatFrame.locator('.codicon-edit')
     await chatInput.fill('One')
     await chatInput.press('Enter')
-    await expect(editButtons).toHaveCount(1)
+    await expect(chatFrame.getByText('One')).toBeVisible()
     await chatInput.fill('Two')
     await chatInput.press('Enter')
-    await expect(editButtons).toHaveCount(2)
+    await expect(chatFrame.getByText('Two')).toBeVisible()
     await chatInput.fill('Three')
     await chatInput.press('Enter')
+    await expect(chatFrame.getByText('Three')).toBeVisible()
     await expect(editButtons).toHaveCount(3)
 
     // Click on the first edit button to get into the editing mode

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -15,6 +15,7 @@ test.extend<ExpectedEvents>({
     // list of events we expect this test to log, add to this list as needed
     expectEvents: [
         'CodyInstalled',
+        'CodyVSCodeExtension:codyIgnore:hasFile',
         'CodyVSCodeExtension:Auth:failed',
         'CodyVSCodeExtension:auth:clickOtherSignInOptions',
         'CodyVSCodeExtension:login:clicked',

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -20,18 +20,13 @@ test.extend<ExpectedEvents>({
     // list of events we expect this test to log, add to this list as needed
     expectedEvents: [
         'CodyInstalled',
-        'CodyVSCodeExtension:Auth:failed',
-        'CodyVSCodeExtension:login:clicked',
-        'CodyVSCodeExtension:auth:clickOtherSignInOptions',
-        'CodyVSCodeExtension:auth:selectSigninMenu',
-        'CodyVSCodeExtension:auth:fromToken',
         'CodyVSCodeExtension:Auth:connected',
         'CodyVSCodeExtension:menu:command:custom:clicked',
         'CodyVSCodeExtension:menu:custom:build:clicked',
         'CodyVSCodeExtension:command:custom:build:executed',
+        'CodyVSCodeExtension:command:custom:executed',
         'CodyVSCodeExtension:chat-question:submitted',
         'CodyVSCodeExtension:chat-question:executed',
-        'CodyVSCodeExtension:command:custom:executed',
     ],
 })('create a new user command via the custom commands menu', async ({ page, sidebar }) => {
     // Sign into Cody
@@ -108,17 +103,15 @@ test.extend<ExpectedEvents>({
     await page.getByLabel('Custom Commands').locator('a').click()
     await page.getByText('Cody: Custom Commands (Beta)').hover()
     await expect(page.getByText('Cody: Custom Commands (Beta)')).toBeVisible()
-    const newCommandMenuItem = page.getByLabel('tools  ATestCommand, The test command has been created')
-    const newCommandSidebarItem = page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a')
-    await newCommandMenuItem.hover()
-    await newCommandSidebarItem.hover()
-    await expect(page.getByText(commandName)).toHaveCount(2) // one in sidebar, and one in menu
-    await newCommandMenuItem.hover()
-    await expect(newCommandMenuItem).toBeVisible()
-    await newCommandSidebarItem.hover()
-    await expect(newCommandSidebarItem).toBeVisible()
-    await newCommandMenuItem.click()
+    await page.getByPlaceholder('Search command to run...').click()
+    await page.getByPlaceholder('Search command to run...').fill(commandName)
 
+    // The new command should show up in sidebar and on the menu
+    expect((await page.getByText(commandName).all()).length).toBeGreaterThan(1)
+    // The new command shows up in the sidebar
+    await expect(page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a')).toBeVisible()
+    // Click the new command on the menu to execute it
+    await page.getByLabel('tools  ATestCommand, The test command has been created').click()
     // Confirm the command prompt is displayed in the chat panel on execution
     const chatPanel = page.frameLocator('iframe.webview').last().frameLocator('iframe')
     await expect(chatPanel.getByText(prompt)).toBeVisible()


### PR DESCRIPTION
Attempt to fix the flaky e2e tests.

### custom-commands.test.ts

Notice we were expecting the new command to show up on the sidebar and in the menu, so we originally were expecting 2 elements with the new command name:
```
await expect(page.getByText(commandName)).toHaveCount(2)
```
However, in the screenshot captured from the recordings shown below, the same command name will also appear in the background in the editor and on hover, leading the test to fail. To fix this, i've updated the test to expect any number greater than 1, and then click on the actual element to make sure they show up in the expected places.

![image](https://github.com/sourcegraph/cody/assets/68532117/86e9b2b3-02a0-4d46-a5e8-102d6ca8337e)


### chat-edits.test.ts

In some failed recordings, I noticed the `await expect(editButtons).toHaveCount(3)` would fail because the third message wasn't submitted because the second message was still in process. To fix this, i've added additional checks after each message is submitted to ensure the request was completed before we move to the next one.

The test 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green CI
