### PR TITLE
update: share at mention logics between edit and chat

### DIFF
--- a/vscode/src/chat/context/constants.ts
+++ b/vscode/src/chat/context/constants.ts
@@ -1,7 +1,8 @@
-export const GENERAL_HELP_LABEL = 'Search for a file to include, or type # to search symbols...'
+export const GENERAL_HELP_LABEL = 'Search for a file to include, or type # for symbols...'
 export const FILE_HELP_LABEL = 'Search for a file to include...'
 export const SYMBOL_HELP_LABEL = 'Search for a symbol to include...'
 export const NO_MATCHES_LABEL = 'No matches found'
+export const NO_SYMBOL_MATCHES_HELP_LABEL = ' (try installing language extensions and opening a file)'
 export const FILE_TOO_LARGE_LABEL = 'File too large. Type @# to choose a symbol.'
 
 export const QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX = '\u00A0\u00A0\u00A0\u00A0\u00A0'

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -8,6 +8,13 @@ import {
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 
+import {
+    FILE_HELP_LABEL,
+    FILE_TOO_LARGE_LABEL,
+    GENERAL_HELP_LABEL,
+    NO_MATCHES_LABEL,
+    SYMBOL_HELP_LABEL,
+} from '../../chat/context/constants'
 import { ACCOUNT_UPGRADE_URL } from '../../chat/protocol'
 import { commands as defaultCommands } from '../../commands/execute/cody.json'
 import { getEditor } from '../../editor/active-editor'
@@ -19,13 +26,6 @@ import { executeEdit } from '../execute'
 import type { EditIntent } from '../types'
 import { isGenerateIntent } from '../utils/edit-intent'
 import { getEditModelsForUser } from '../utils/edit-models'
-import {
-    FILE_HELP_LABEL,
-    FILE_TOO_LARGE_LABEL,
-    GENERAL_HELP_LABEL,
-    NO_MATCHES_LABEL,
-    SYMBOL_HELP_LABEL,
-} from './constants'
 import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './get-items/constants'
 import { getDocumentInputItems } from './get-items/document'
 import { DOCUMENT_ITEM, MODEL_ITEM, RANGE_ITEM, TEST_ITEM, getEditInputItems } from './get-items/edit'

--- a/vscode/src/edit/input/get-items/model.ts
+++ b/vscode/src/edit/input/get-items/model.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode'
 
 import type { EditModel, ModelProvider } from '@sourcegraph/cody-shared'
-import { QUICK_PICK_ITEM_CHECKED_PREFIX, QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX } from '../constants'
+import {
+    QUICK_PICK_ITEM_CHECKED_PREFIX,
+    QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX,
+} from '../../../chat/context/constants'
 import type { GetItemsResult } from '../quick-pick'
 import type { EditModelItem } from './types'
 

--- a/vscode/src/edit/input/get-items/range.ts
+++ b/vscode/src/edit/input/get-items/range.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode'
+import {
+    QUICK_PICK_ITEM_CHECKED_PREFIX,
+    QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX,
+} from '../../../chat/context/constants'
 import { isGenerateIntent } from '../../utils/edit-intent'
 import { getEditSmartSelection } from '../../utils/edit-selection'
-import { QUICK_PICK_ITEM_CHECKED_PREFIX, QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX } from '../constants'
 import type { EditInputInitialValues } from '../get-input'
 import type { GetItemsResult } from '../quick-pick'
 import { CURSOR_RANGE_ITEM, EXPANDED_RANGE_ITEM, SELECTION_RANGE_ITEM } from './constants'

--- a/vscode/src/edit/input/utils.ts
+++ b/vscode/src/edit/input/utils.ts
@@ -1,6 +1,9 @@
 import { type ContextItem, displayLineRange, displayPath } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
-import { QUICK_PICK_ITEM_CHECKED_PREFIX, QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX } from './constants'
+import {
+    QUICK_PICK_ITEM_CHECKED_PREFIX,
+    QUICK_PICK_ITEM_EMPTY_INDENT_PREFIX,
+} from '../../chat/context/constants'
 
 /**
  * Removes the string after the last '@' character in the given string.
@@ -21,6 +24,9 @@ export function removeAfterLastAt(str: string): string {
  */
 export function getLabelForContextItem(item: ContextItem): string {
     const isFileType = item.type === 'file'
+    if (isFileType && item.title) {
+        return `Add context from: ${item.title}`
+    }
     const rangeLabel = item.range ? `:${displayLineRange(item.range)}` : ''
     if (isFileType) {
         return `${displayPath(item.uri)}${rangeLabel}`

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -8,6 +8,14 @@ import {
 } from '@sourcegraph/cody-shared'
 import classNames from 'classnames'
 import { type FunctionComponent, useEffect, useRef } from 'react'
+import {
+    FILE_HELP_LABEL,
+    FILE_TOO_LARGE_LABEL,
+    GENERAL_HELP_LABEL,
+    NO_MATCHES_LABEL,
+    NO_SYMBOL_MATCHES_HELP_LABEL,
+    SYMBOL_HELP_LABEL,
+} from '../../../../src/chat/context/constants'
 import styles from './OptionsList.module.css'
 import type { MentionTypeaheadOption } from './atMentions'
 
@@ -31,18 +39,15 @@ export const OptionsList: FunctionComponent<
         <div className={styles.container}>
             <h3 className={classNames(styles.item, styles.helpItem)}>
                 {mentionQuery.type === 'empty'
-                    ? 'Search for a file to include, or type # for symbols...'
+                    ? GENERAL_HELP_LABEL
                     : mentionQuery.type === 'symbol'
                       ? options.length > 0
-                            ? 'Search for a symbol to include...'
-                            : `No symbols found${
-                                  mentionQuery.text.length <= 2
-                                      ? ' (try installing language extensions and opening a file)'
-                                      : ''
-                              }`
+                            ? SYMBOL_HELP_LABEL
+                            : NO_MATCHES_LABEL +
+                              (mentionQuery.text.length <= 2 && NO_SYMBOL_MATCHES_HELP_LABEL)
                       : options.length > 0
-                          ? 'Search for a file to include...'
-                          : 'No files found'}
+                          ? FILE_HELP_LABEL
+                          : NO_MATCHES_LABEL}
                 <br />
             </h3>
             {options.length > 0 && (
@@ -85,10 +90,7 @@ const Item: FunctionComponent<{
         item.type === 'file'
             ? `${range ? `Lines ${range} · ` : ''}${dirname === '.' ? '' : dirname}`
             : displayPath(item.uri) + `:${range}`
-    const warning =
-        item.type === 'file' && item.isTooLarge
-            ? 'File too large. Type @# to choose a symbol.'
-            : undefined
+    const warning = item.type === 'file' && item.isTooLarge ? FILE_TOO_LARGE_LABEL : undefined
 
     return (
         // biome-ignore lint/a11y/useKeyWithClickEvents:


### PR DESCRIPTION
Follow up on my command in https://github.com/sourcegraph/cody/pull/3494

Updated to share the duplicated at-mention labels and logic to fetch for at-mention context items between edit and chat.

This also adds the missing support for URL as context item to Edit:

![image](https://github.com/sourcegraph/cody/assets/68532117/823cc2b8-2eb0-495f-a266-8183f758d598)


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green CI