### PR TITLE
Chat: update at-mention input token color

### DIFF
--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
@@ -1,3 +1,17 @@
 .context-item-mention-node {
-    background-color: var(--vscode-list-dropBackground);
+    color: var(--link-foreground);
+    position: relative;
+
+}
+.context-item-mention-node::before {
+    content: '';
+    background-color: var(--link-foreground);
+    border-radius: 3px;
+    outline: 1px solid var(--link-foreground);
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    opacity: 0.2;
 }

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
@@ -3,6 +3,7 @@
     position: relative;
 
 }
+
 .context-item-mention-node::before {
     content: '';
     background-color: var(--link-foreground);
@@ -14,4 +15,10 @@
     left: 0;
     right: 0;
     opacity: 0.2;
+    pointer-events: none
+}
+
+body[data-vscode-theme-kind='vscode-high-contrast-light'] .context-item-mention-node {
+    background-color: var(--code-background);
+    color: var(--code-foreground);
 }


### PR DESCRIPTION
Updates the color for the at-mention input tokens to make it more obvious to user. Right now it's hard to tell between a token and regular input.

Co-author with @toolmantim 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before 

![image](https://github.com/sourcegraph/cody/assets/68532117/fa76ed1b-3c99-4d08-886a-0e9b21bc5ce0)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/a849c632-9581-4f70-915a-5e8bba758919)
