### PR TITLE
Chat: skip invalid at-mention request

### DIFF
--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -12,6 +12,7 @@ import { type ExpectedEvents, test, withPlatformSlashes } from './helpers'
 test.extend<ExpectedEvents>({
     expectedEvents: [
         'CodyInstalled',
+        // This is fired on empty @-mention query for open tabs context
         'CodyVSCodeExtension:at-mention:executed',
         'CodyVSCodeExtension:at-mention:file:executed',
     ],
@@ -267,7 +268,9 @@ test('@-mention links in transcript message', async ({ page, sidebar }) => {
     await expect(previewTab).toBeVisible()
 })
 
-test('@-mention file range', async ({ page, sidebar }) => {
+test.extend<ExpectedEvents>({
+    expectedEvents: ['CodyVSCodeExtension:at-mention:file:executed'],
+})('@-mention file range', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
 
     // Open chat.
@@ -296,11 +299,7 @@ test('@-mention file range', async ({ page, sidebar }) => {
 })
 
 test.extend<ExpectedEvents>({
-    expectedEvents: [
-        'CodyInstalled',
-        'CodyVSCodeExtension:at-mention:executed',
-        'CodyVSCodeExtension:at-mention:symbol:executed',
-    ],
+    expectedEvents: ['CodyVSCodeExtension:at-mention:symbol:executed'],
 })('@-mention symbol in chat', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
 

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -14,7 +14,6 @@ test.extend<ExpectedEvents>({
         'CodyInstalled',
         // This is fired on empty @-mention query for open tabs context
         'CodyVSCodeExtension:at-mention:executed',
-        'CodyVSCodeExtension:at-mention:file:executed',
     ],
 })('@-mention file in chat', async ({ page, sidebar }) => {
     // This test requires that the window be focused in the OS window manager because it deals with
@@ -279,7 +278,8 @@ test.extend<ExpectedEvents>({
     const chatInput = chatPanelFrame.getByRole('textbox', { name: 'Chat message' })
 
     // Type a file with range.
-    await chatInput.fill('@buzz.ts:2-4')
+    // Use pressSequentially to simulate typing to trigger the expected event as we only log once on first character.
+    await chatInput.pressSequentially('@buzz.ts:2-4')
     await expect(chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' }).click()
     await expect(chatInput).toHaveText('@buzz.ts:2-4 ')

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -14,6 +14,8 @@ test.extend<ExpectedEvents>({
         'CodyInstalled',
         // This is fired on empty @-mention query for open tabs context
         'CodyVSCodeExtension:at-mention:executed',
+        // Log once on the first character entered for an @-mention query, e.g. "@."
+        'CodyVSCodeExtension:at-mention:file:executed',
     ],
 })('@-mention file in chat', async ({ page, sidebar }) => {
     // This test requires that the window be focused in the OS window manager because it deals with
@@ -267,9 +269,7 @@ test('@-mention links in transcript message', async ({ page, sidebar }) => {
     await expect(previewTab).toBeVisible()
 })
 
-test.extend<ExpectedEvents>({
-    expectedEvents: ['CodyVSCodeExtension:at-mention:file:executed'],
-})('@-mention file range', async ({ page, sidebar }) => {
+test('@-mention file range', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
 
     // Open chat.
@@ -278,8 +278,7 @@ test.extend<ExpectedEvents>({
     const chatInput = chatPanelFrame.getByRole('textbox', { name: 'Chat message' })
 
     // Type a file with range.
-    // Use pressSequentially to simulate typing to trigger the expected event as we only log once on first character.
-    await chatInput.pressSequentially('@buzz.ts:2-4')
+    await chatInput.fill('@buzz.ts:2-4')
     await expect(chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' }).click()
     await expect(chatInput).toHaveText('@buzz.ts:2-4 ')

--- a/vscode/test/e2e/update-notice.test.ts
+++ b/vscode/test/e2e/update-notice.test.ts
@@ -38,9 +38,6 @@ test('existing installs should show the update toast when the last dismissed ver
     // Use chat.
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
     let chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
-    const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
-    await chatInput.fill('hey buddy')
-    await chatInput.press('Enter')
 
     // Forge an older dismissed version into local storage.
     expect(
@@ -49,6 +46,10 @@ test('existing installs should show the update toast when the last dismissed ver
             return localStorage.getItem(versionUpdateStorageKey)
         }, versionUpdateStorageKey)
     ).toBe('0.7')
+
+    const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
+    await chatInput.fill('hey buddy')
+    await chatInput.press('Enter')
 
     // Wait for this chat to be available in the sidebar
     const chatHistoryEntry = page.getByRole('treeitem', { name: 'hey buddy' })

--- a/vscode/test/e2e/update-notice.test.ts
+++ b/vscode/test/e2e/update-notice.test.ts
@@ -38,6 +38,9 @@ test('existing installs should show the update toast when the last dismissed ver
     // Use chat.
     await page.getByRole('button', { name: 'New Chat', exact: true }).click()
     let chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
+    const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
+    await chatInput.fill('hey buddy')
+    await chatInput.press('Enter')
 
     // Forge an older dismissed version into local storage.
     expect(
@@ -46,10 +49,6 @@ test('existing installs should show the update toast when the last dismissed ver
             return localStorage.getItem(versionUpdateStorageKey)
         }, versionUpdateStorageKey)
     ).toBe('0.7')
-
-    const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
-    await chatInput.fill('hey buddy')
-    await chatInput.press('Enter')
 
     // Wait for this chat to be available in the sidebar
     const chatHistoryEntry = page.getByRole('treeitem', { name: 'hey buddy' })

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -74,7 +74,7 @@ export class MentionTypeaheadOption extends MenuOption {
 export default function MentionsPlugin(): JSX.Element | null {
     const [editor] = useLexicalComposerContext()
 
-    const [query, setQuery] = useState('')
+    const [query, setQuery] = useState<string | null>(null)
 
     const { x, y, refs, strategy, update } = useFloating({
         placement: 'top-start',
@@ -116,7 +116,7 @@ export default function MentionsPlugin(): JSX.Element | null {
         [editor]
     )
 
-    const onQueryChange = useCallback((query: string | null) => setQuery(query ?? ''), [])
+    const onQueryChange = useCallback((query: string | null) => setQuery(query), [])
 
     return (
         <LexicalTypeaheadMenuPlugin<MentionTypeaheadOption>
@@ -157,7 +157,7 @@ export default function MentionsPlugin(): JSX.Element | null {
                                 className={classNames(styles.popover)}
                             >
                                 <OptionsList
-                                    query={query}
+                                    query={query ?? ''}
                                     options={options}
                                     selectedIndex={selectedIndex}
                                     setHighlightedIndex={setHighlightedIndex}

--- a/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
@@ -54,10 +54,18 @@ function useChatContextClient(): ChatContextClient {
 }
 
 /** Hook to get the chat context items for the given query. */
-export function useChatContextItems(query: string): ContextItem[] | undefined {
+export function useChatContextItems(query: string | null): ContextItem[] | undefined {
     const chatContextClient = useChatContextClient()
     const [results, setResults] = useState<ContextItem[]>()
+    // biome-ignore lint/correctness/useExhaustiveDependencies: we only want to run this when query changes.
     useEffect(() => {
+        // An empty query is a valid query that we use to get open tabs context,
+        // while a null query means this is not an at-mention query.
+        if (query === null) {
+            setResults(undefined)
+            return
+        }
+
         // Track if the query changed since this request was sent (which would make our results
         // no longer valid).
         let invalidated = false
@@ -80,6 +88,6 @@ export function useChatContextItems(query: string): ContextItem[] | undefined {
         return () => {
             invalidated = true
         }
-    }, [chatContextClient, query])
+    }, [query])
     return results
 }


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/cody/pull/3489

Backgroud: While debugging the cancellation token issue yesterday ([slack](https://sourcegraph.slack.com/archives/C05AGQYD528/p1710984547497189?thread_ts=1710973220.764839&cid=C05AGQYD528)), I noticed the `handleGetUserContextFilesCandidates`function was unexpectedly getting called with an empty query when the chat view is first mounted, or when the input box is re-focused after closing the @ mention box.

This pull request addresses an issue in the `atMentions` plugin where empty and null query states were not handled correctly. The changes ensure that the plugin distinguishes between a valid empty query used for retrieving open tabs context and a null query indicating a non-mention scenario that we can skip.

- Improved handling of empty and null query states in the `atMentions` plugin.
- Clearer distinction between valid empty queries and non-mention scenarios.
- Reduced unnecessary re-rendering by limiting the `useEffect` dependency array in the `useChatContextItems` hook to `query`.

### Changes

- Update the `query` state in the `MentionsPlugin` component to be of type `string | null` instead of `string`.
- Modify the `onQueryChange` callback to directly set the `query` state without fallback to an empty string.
- In the `useChatContextItems` hook:
  - Add a check to set the `results` state to `undefined` when the `query` is null, indicating a non-mention scenario.
  - Update the `useEffect` dependency to include the `query` variable only, as we only want to rerender on query change.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Verify that the `atMentions` plugin behaves correctly when the query is empty (retrieving open tabs context) and when the query is null (non-mention scenario).
- Ensure that the typeahead menu and options are displayed and updated appropriately based on the query state.
- Green CI