### PR TITLE
Edit: Log telemetry events for `fix` separately

### DIFF
--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -160,7 +160,8 @@ export class EditManager implements vscode.Disposable {
         // Log the default edit command name for doc intent or test mode
         const isDocCommand = configuration.intent === 'doc' ? 'doc' : undefined
         const isUnitTestCommand = configuration.intent === 'test' ? 'test' : undefined
-        const eventName = isDocCommand ?? isUnitTestCommand ?? 'edit'
+        const isFixCommand = configuration.intent === 'fix' ? 'fix' : undefined
+        const eventName = isDocCommand ?? isUnitTestCommand ?? isFixCommand ?? 'edit'
         telemetryService.log(
             `CodyVSCodeExtension:command:${eventName}:executed`,
             { source },

--- a/vscode/test/e2e/code-actions.test.ts
+++ b/vscode/test/e2e/code-actions.test.ts
@@ -42,7 +42,7 @@ test.extend<ExpectedEvents>({
 test.extend<ExpectedEvents>({
     // list of events we expect this test to log, add to this list as needed
     expectedEvents: [
-        'CodyVSCodeExtension:command:edit:executed',
+        'CodyVSCodeExtension:command:fix:executed',
         'CodyVSCodeExtension:fixupResponse:hasCode',
         'CodyVSCodeExtension:fixup:applied',
     ],


### PR DESCRIPTION
## Description

Currently we log "fix" as an `edit:executed` event:

I think it's better to separate this out in our telemetry, so we have better insight into command usage. We already do this for `doc` and `test`:

<img width="314" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/50f777a0-e955-42df-b78b-194e19c8b1ad">


## Test plan

1. Run a code action fix
2. Check that `fix:executed` is sent instead of `edit:executed`

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
