### PR TITLE
Chat: display excluded @-files in UI

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
@@ -44,6 +44,7 @@ object Constants {
   const val unified = "unified"
   const val selection = "selection"
   const val terminal = "terminal"
+  const val uri = "uri"
   const val file = "file"
   const val symbol = "symbol"
   const val `class` = "class"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
@@ -28,7 +28,7 @@ data class ContextItemFile(
   val repoName: String? = null,
   val revision: String? = null,
   val title: String? = null,
-  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
+  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri
   val type: TypeEnum? = null, // Oneof: file
   val isTooLarge: Boolean? = null,
 ) : ContextItem() {
@@ -45,7 +45,7 @@ data class ContextItemSymbol(
   val repoName: String? = null,
   val revision: String? = null,
   val title: String? = null,
-  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
+  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri
   val type: TypeEnum? = null, // Oneof: symbol
   val symbolName: String? = null,
   val kind: SymbolKind? = null, // Oneof: class, function, method

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemSource.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemSource.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-typealias ContextItemSource = String // One of: embeddings, user, keyword, editor, filename, search, unified, selection, terminal
+typealias ContextItemSource = String // One of: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri
 

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -67,6 +67,9 @@ export enum ContextItemSource {
 
     /** Output from the terminal */
     Terminal = 'terminal',
+
+    /** From URI */
+    Uri = 'uri',
 }
 
 /**

--- a/lib/shared/src/mentions/urlContextItems.ts
+++ b/lib/shared/src/mentions/urlContextItems.ts
@@ -25,7 +25,7 @@ export async function getURLContextItems(
                 uri: url,
                 content,
                 title: tryGetHTMLDocumentTitle(content),
-                source: ContextItemSource.User,
+                source: ContextItemSource.Uri,
             },
         ]
     } catch (error) {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -779,11 +779,14 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         prompter: IPrompter,
         sendTelemetry?: (contextSummary: any) => void
     ): Promise<Message[]> {
-        const maxChars = ModelProvider.getMaxCharsByModel(this.chatModel.modelID)
-        const { prompt, newContextUsed } = await prompter.makePrompt(this.chatModel, maxChars)
+        const { prompt, newContextUsed, newContextIgnored } = await prompter.makePrompt(
+            this.chatModel,
+            ModelProvider.getMaxCharsByModel(this.chatModel.modelID)
+        )
 
         // Update UI based on prompt construction
-        this.chatModel.setLastMessageContext(newContextUsed)
+        // Includes the excluded context items to display in the UI
+        this.chatModel.setLastMessageContext([...newContextUsed, ...(newContextIgnored ?? [])])
 
         if (sendTelemetry) {
             // Create a summary of how many code snippets of each context source are being

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -76,6 +76,7 @@ describe('DefaultPrompter', () => {
                 type: 'file',
                 uri: vscode.Uri.file('/foo/bar'),
                 content: 'foobar',
+                isTooLarge: true,
             },
         ]
 

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -149,7 +149,8 @@ export class PromptBuilder {
         return {
             limitReached,
             used,
-            ignored,
+            // Marks excluded context items as too large to be displayed in UI
+            ignored: ignored.map(c => ({ ...c, isTooLarge: true })),
             duplicate,
         }
     }

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -87,7 +87,7 @@ test.extend<ExpectedEvents>({
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java')).toBeVisible()
-    await expect(chatPanelFrame.getByText(/^✨ Context:/)).toHaveCount(1)
+    await expect(chatPanelFrame.getByText(/^Context:/)).toHaveCount(1)
     await expect(chatInput).not.toHaveText('Explain @Main.java ')
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).not.toBeVisible()
 
@@ -128,7 +128,7 @@ test.extend<ExpectedEvents>({
     ).toBeVisible()
 
     // Ensure explicitly @-included context shows up as enhanced context
-    await expect(chatPanelFrame.getByText(/^✨ Context:/)).toHaveCount(2)
+    await expect(chatPanelFrame.getByText(/^Context:/)).toHaveCount(2)
 
     // Check pressing tab after typing a complete filename.
     // https://github.com/sourcegraph/cody/issues/2200
@@ -209,13 +209,13 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java')).toBeVisible()
-    await expect(chatPanelFrame.getByText(/^✨ Context: 1 file/)).toHaveCount(1)
+    await expect(chatPanelFrame.getByText(/^Context: 1 file/)).toHaveCount(1)
 
     // Edit the just-sent message and resend it. Confirm it is sent with the right context items.
     await chatInput.press('ArrowUp')
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await chatInput.press('Meta+Enter')
-    await expect(chatPanelFrame.getByText(/^✨ Context: 1 file/)).toHaveCount(1)
+    await expect(chatPanelFrame.getByText(/^Context: 1 file/)).toHaveCount(1)
 
     // Edit it again, add a new @-mention, and resend.
     await chatInput.press('ArrowUp')
@@ -227,7 +227,7 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java and @index.html')).toBeVisible()
-    await expect(chatPanelFrame.getByText(/^✨ Context: 2 files/)).toHaveCount(1)
+    await expect(chatPanelFrame.getByText(/^Context: 2 files/)).toHaveCount(1)
 })
 
 test('pressing Enter with @-mention menu open selects item, does not submit message', async ({
@@ -287,11 +287,11 @@ test('@-mention file range', async ({ page, sidebar }) => {
     await chatInput.press('Enter')
 
     // @-file range with the correct line range shows up in the chat view and it opens on click
-    await chatPanelFrame.getByText('✨ Context: 3 lines from 1 file').hover()
-    await chatPanelFrame.getByText('✨ Context: 3 lines from 1 file').click()
+    await chatPanelFrame.getByText('Context: 3 lines from 1 file').hover()
+    await chatPanelFrame.getByText('Context: 3 lines from 1 file').click()
     const chatContext = chatPanelFrame.locator('details').last()
-    await chatContext.getByRole('link', { name: '@buzz.ts:2-4' }).hover()
-    await chatContext.getByRole('link', { name: '@buzz.ts:2-4' }).click()
+    await chatContext.getByRole('link', { name: 'buzz.ts:2-4' }).hover()
+    await chatContext.getByRole('link', { name: 'buzz.ts:2-4' }).click()
     const previewTab = page.getByRole('tab', { name: /buzz.ts, preview, Editor Group/ })
     await previewTab.hover()
     await expect(previewTab).toBeVisible()
@@ -336,11 +336,11 @@ test.extend<ExpectedEvents>({
     await pinnedTab.getByRole('button', { name: /^Close/ }).click()
 
     // @-file with the correct line range shows up in the chat view and it opens on click
-    await chatPanelFrame.getByText('✨ Context: 15 lines from 1 file').hover()
-    await chatPanelFrame.getByText('✨ Context: 15 lines from 1 file').click()
+    await chatPanelFrame.getByText('Context: 15 lines from 1 file').hover()
+    await chatPanelFrame.getByText('Context: 15 lines from 1 file').click()
     const chatContext = chatPanelFrame.locator('details').last()
-    await chatContext.getByRole('link', { name: '@buzz.ts:1-15' }).hover()
-    await chatContext.getByRole('link', { name: '@buzz.ts:1-15' }).click()
+    await chatContext.getByRole('link', { name: 'buzz.ts:1-15' }).hover()
+    await chatContext.getByRole('link', { name: 'buzz.ts:1-15' }).click()
     const previewTab = page.getByRole('tab', { name: /buzz.ts, preview, Editor Group/ })
     await previewTab.hover()
     await expect(previewTab).toBeVisible()

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -57,7 +57,7 @@ test.extend<ExpectedEvents>({
     // Assistant should response to your chat question,
     // but the current file is excluded (ignoredByCody.css) and not on the context list
     await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
-    expect(await chatPanel.getByText(/^✨ Context:/).count()).toEqual(0)
+    expect(await chatPanel.getByText(/^Context:/).count()).toEqual(0)
 
     /* TEST: At-file - Ignored file does not show up as context when using @-mention */
     await chatInput.focus()

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -54,7 +54,7 @@ test.extend<ExpectedEvents>({
 
     // Click on the file link in chat
     const chatContext = chatPanel.locator('details').last()
-    await chatContext.getByRole('link', { name: '@index.html' }).click()
+    await chatContext.getByRole('link', { name: 'index.html' }).click()
 
     // Check if the file is opened
     await expect(page.getByRole('list').getByText('index.html')).toBeVisible()
@@ -66,7 +66,8 @@ test.extend<ExpectedEvents>({
     await expect(page.getByText('Explain Code')).toBeVisible()
     await page.getByText('Explain Code').click()
     await chatPanel.getByText('Context: 20 lines from 1 file').click()
-    await expect(chatPanel.locator('span').filter({ hasText: '@index.html:2-10' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'index.html:2-10' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
     const disabledEditButtons = chatPanel.getByTitle('Cannot Edit Command').locator('i')
     const editLastMessageButton = chatPanel.getByRole('button', { name: /^Edit Last Message/ })
     // Edit button and Edit Last Message are shown on all command messages.
@@ -79,7 +80,7 @@ test.extend<ExpectedEvents>({
     await page.getByText('Find Code Smells').click()
     await expect(chatPanel.getByText('Context: 9 lines from 1 file')).toBeVisible()
     await chatPanel.getByText('Context: 9 lines from 1 file').click()
-    await expect(chatPanel.locator('span').filter({ hasText: '@index.html:2-10' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'index.html:2-10' })).toBeVisible()
     await expect(disabledEditButtons).toHaveCount(0)
     await expect(editLastMessageButton).toBeVisible()
 })

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -165,8 +165,8 @@ test.extend<ExpectedEvents>({
 
     await expect(chatPanel.getByText('Add four context files from the current directory.')).toBeVisible()
     // Show the current file numbers used as context
-    await expect(chatPanel.getByText('✨ Context: 56 lines from 5 files')).toBeVisible()
-    await chatPanel.getByText('✨ Context: 56 lines from 5 files').click()
+    await expect(chatPanel.getByText('Context: 56 lines from 5 files')).toBeVisible()
+    await chatPanel.getByText('Context: 56 lines from 5 files').click()
     // Display the context files to confirm no hidden files are included
     await expect(chatPanel.locator('span').filter({ hasText: '@.mydotfile:1-2' })).not.toBeVisible()
     await expect(chatPanel.locator('span').filter({ hasText: '@error.ts:1-9' })).toBeVisible()
@@ -184,7 +184,7 @@ test.extend<ExpectedEvents>({
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Add lib/batches/env/var.go as context.')).toBeVisible()
     // Should show 2 files with current file added as context
-    await expect(chatPanel.getByText('✨ Context: 12 lines from 2 files')).toBeVisible()
+    await expect(chatPanel.getByText('Context: 12 lines from 2 files')).toBeVisible()
 
     /* Test: context.directory with directory command */
 
@@ -194,8 +194,8 @@ test.extend<ExpectedEvents>({
     await page.getByPlaceholder('Search command to run...').fill('directory')
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Directory has one context file.')).toBeVisible()
-    await expect(chatPanel.getByText('✨ Context: 12 lines from 2 file')).toBeVisible()
-    await chatPanel.getByText('✨ Context: 12 lines from 2 file').click()
+    await expect(chatPanel.getByText('Context: 12 lines from 2 file')).toBeVisible()
+    await chatPanel.getByText('Context: 12 lines from 2 file').click()
     await expect(
         chatPanel.locator('span').filter({ hasText: withPlatformSlashes('@lib/batches/env/var.go:1') })
     ).toBeVisible()
@@ -215,8 +215,8 @@ test.extend<ExpectedEvents>({
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Open tabs as context.')).toBeVisible()
     // The files from the open tabs should be added as context
-    await expect(chatPanel.getByText('✨ Context: 12 lines from 2 files')).toBeVisible()
-    await chatPanel.getByText('✨ Context: 12 lines from 2 files').click()
+    await expect(chatPanel.getByText('Context: 12 lines from 2 files')).toBeVisible()
+    await chatPanel.getByText('Context: 12 lines from 2 files').click()
     await expect(chatContext.getByRole('link', { name: '@index.html:1-11' })).toBeVisible()
     await expect(
         chatContext.getByRole('link', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
@@ -314,8 +314,8 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
 
     // Check the context list to confirm the terminal output is added as file
     const panel = getChatPanel(page)
-    await expect(panel.getByText('✨ Context: 1 line from 2 files')).toBeVisible()
-    await panel.getByText('✨ Context: 1 line from 2 files').click()
+    await expect(panel.getByText('Context: 1 line from 2 files')).toBeVisible()
+    await panel.getByText('Context: 1 line from 2 files').click()
     const chatContext = panel.locator('details').last()
     await expect(
         chatContext.getByRole('link', { name: withPlatformSlashes('@/terminal-output') })

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -168,12 +168,12 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByText('Context: 56 lines from 5 files')).toBeVisible()
     await chatPanel.getByText('Context: 56 lines from 5 files').click()
     // Display the context files to confirm no hidden files are included
-    await expect(chatPanel.locator('span').filter({ hasText: '@.mydotfile:1-2' })).not.toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@error.ts:1-9' })).toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@Main.java:1-9' })).toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@buzz.test.ts:1-12' })).toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@buzz.ts:1-15' })).toBeVisible()
-    await expect(chatPanel.locator('span').filter({ hasText: '@index.html:1-11' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: '.mydotfile:1-2' })).not.toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'error.ts:1-9' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'Main.java:1-9' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'buzz.test.ts:1-12' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'buzz.ts:1-15' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
 
     /* Test: context.filePath with filePath command */
 
@@ -197,12 +197,12 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByText('Context: 12 lines from 2 file')).toBeVisible()
     await chatPanel.getByText('Context: 12 lines from 2 file').click()
     await expect(
-        chatPanel.locator('span').filter({ hasText: withPlatformSlashes('@lib/batches/env/var.go:1') })
+        chatPanel.getByRole('link', { name: withPlatformSlashes('lib/batches/env/var.go:1') })
     ).toBeVisible()
     // Click on the file link should open the 'var.go file in the editor
     const chatContext = chatPanel.locator('details').last()
     await chatContext
-        .getByRole('link', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
+        .getByRole('link', { name: withPlatformSlashes('lib/batches/env/var.go:1') })
         .click()
     await expect(page.getByRole('tab', { name: 'var.go' })).toBeVisible()
 
@@ -217,9 +217,9 @@ test.extend<ExpectedEvents>({
     // The files from the open tabs should be added as context
     await expect(chatPanel.getByText('Context: 12 lines from 2 files')).toBeVisible()
     await chatPanel.getByText('Context: 12 lines from 2 files').click()
-    await expect(chatContext.getByRole('link', { name: '@index.html:1-11' })).toBeVisible()
+    await expect(chatContext.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
     await expect(
-        chatContext.getByRole('link', { name: withPlatformSlashes('@lib/batches/env/var.go:1') })
+        chatContext.getByRole('link', { name: withPlatformSlashes('lib/batches/env/var.go:1') })
     ).toBeVisible()
 })
 
@@ -318,6 +318,6 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
     await panel.getByText('Context: 1 line from 2 files').click()
     const chatContext = panel.locator('details').last()
     await expect(
-        chatContext.getByRole('link', { name: withPlatformSlashes('@/terminal-output') })
+        chatContext.getByRole('link', { name: withPlatformSlashes('/terminal-output') })
     ).toBeVisible()
 })

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -158,7 +158,7 @@ test
     const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
     await chatInput.fill('hello world')
     await chatInput.press('Enter')
-    await expect(chatFrame.getByText(/✨ Context: \d+ lines from 2 files/)).toBeVisible({
+    await expect(chatFrame.getByText(/Context: \d+ lines from 2 files/)).toBeVisible({
         timeout: 10000,
     })
 })

--- a/vscode/webviews/Components/FileLink.module.css
+++ b/vscode/webviews/Components/FileLink.module.css
@@ -9,4 +9,14 @@
     margin: 0;
     text-align: left;
     font-weight: normal;
+    display: inline-block;
+}
+
+.excluded {
+    text-decoration: line-through !important;
+}
+
+.item {
+    display: flex;
+    align-items: center;
 }

--- a/vscode/webviews/Components/FileLink.module.css
+++ b/vscode/webviews/Components/FileLink.module.css
@@ -1,3 +1,8 @@
+.link-container {
+    display: flex;
+    align-items: center;
+}
+
 .link-button {
     background: none;
     border: none;
@@ -14,9 +19,4 @@
 
 .excluded {
     text-decoration: line-through !important;
-}
-
-.item {
-    display: flex;
-    align-items: center;
 }

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -39,7 +39,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
     const pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
     const tooltip = source ? `${pathWithRange} included via ${source}` : pathWithRange
     const { href, target } = webviewOpenURIForContextItem({ uri, range })
-    const warning = 'This file is excluded due to token limit reached'
+    const warning = 'Excluded due to context window limit'
     return (
         <span className="styles.item">
             {isTooLarge && <i className="codicon codicon-warning" />}
@@ -58,10 +58,9 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
 
 function getIconByFileSource(source?: string): string {
     switch (source) {
+        case 'uri':
         case 'user':
             return 'mention'
-        case 'uri':
-            return 'link'
         default:
             return 'sparkle'
     }

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -21,32 +21,34 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
         const repoShortName = repoName?.slice(repoName.lastIndexOf('/') + 1)
         const pathToDisplay = `${repoShortName} ${title}`
         const pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
-        const tooltip = `${repoName} @${revision}\nincluded via search (remote)`
+        const tooltip = `${repoName} @${revision}\nincluded via Enhanced Context (Enterprise Search)`
         return (
-            <a
-                href={uri.toString()}
-                target="_blank"
-                rel="noreferrer"
-                title={tooltip}
-                className={styles.linkButton}
-            >
-                {pathWithRange}
-            </a>
+            <span className="styles.item">
+                <i className={`codicon codicon-${icon}`} title={getFileSourceIconTitle(source)} />
+                <a
+                    href={uri.toString()}
+                    target="_blank"
+                    rel="noreferrer"
+                    title={tooltip}
+                    className={styles.linkButton}
+                >
+                    {pathWithRange}
+                </a>
+            </span>
         )
     }
 
     const pathToDisplay = `${displayPath(uri)}`
     const pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
-    const tooltip = source ? `${pathWithRange} included via ${source}` : pathWithRange
     const { href, target } = webviewOpenURIForContextItem({ uri, range })
     const warning = 'Excluded due to context window limit'
     return (
         <span className="styles.item">
-            {isTooLarge && <i className="codicon codicon-warning" />}
-            <i className={`codicon codicon-${icon}`} />
+            {isTooLarge && <i className="codicon codicon-warning" title={warning} />}
+            <i className={`codicon codicon-${icon}`} title={getFileSourceIconTitle(source)} />
             <a
                 className={classNames(styles.linkButton, isTooLarge && styles.excluded)}
-                title={isTooLarge ? warning : tooltip}
+                title={isTooLarge ? warning : pathWithRange}
                 href={href}
                 target={target}
             >
@@ -63,5 +65,30 @@ function getIconByFileSource(source?: string): string {
             return 'mention'
         default:
             return 'sparkle'
+    }
+}
+
+function getFileSourceIconTitle(source?: string): string {
+    const displayText = getFileSourceDisplayText(source)
+    return `Included via ${displayText}`
+}
+
+function getFileSourceDisplayText(source?: string): string {
+    switch (source) {
+        case 'unified':
+            return 'Enhanced Context (Enterprise Search)'
+        case 'search':
+        case 'symf':
+            return 'Enhanced Context (Search)'
+        case 'embeddings':
+            return 'Enhanced Context (Embeddings)'
+        case 'editor':
+            return 'Editor Context'
+        case 'selection':
+            return 'Selection'
+        case 'user':
+            return '@-mention'
+        default:
+            return source ?? 'Enhanced Context'
     }
 }

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -43,7 +43,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
     const { href, target } = webviewOpenURIForContextItem({ uri, range })
     const warning = 'Excluded due to context window limit'
     return (
-        <span className="styles.item">
+        <span className={styles.linkContainer}>
             {isTooLarge && <i className="codicon codicon-warning" title={warning} />}
             <i className={`codicon codicon-${icon}`} title={getFileSourceIconTitle(source)} />
             <a

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import type React from 'react'
 
 import { displayLineRange, displayPath, webviewOpenURIForContextItem } from '@sourcegraph/cody-shared'
@@ -12,7 +13,9 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
     repoName,
     title,
     revision,
+    isTooLarge,
 }) => {
+    const icon = getIconByFileSource(source)
     if (source === 'unified') {
         // This is a remote search result.
         const repoShortName = repoName?.slice(repoName.lastIndexOf('/') + 1)
@@ -32,13 +35,34 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
         )
     }
 
-    const pathToDisplay = `@${displayPath(uri)}`
+    const pathToDisplay = `${displayPath(uri)}`
     const pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
     const tooltip = source ? `${pathWithRange} included via ${source}` : pathWithRange
     const { href, target } = webviewOpenURIForContextItem({ uri, range })
+    const warning = 'This file is excluded due to token limit reached'
     return (
-        <a className={styles.linkButton} title={tooltip} href={href} target={target}>
-            {pathWithRange}
-        </a>
+        <span className="styles.item">
+            {isTooLarge && <i className="codicon codicon-warning" />}
+            <i className={`codicon codicon-${icon}`} />
+            <a
+                className={classNames(styles.linkButton, isTooLarge && styles.excluded)}
+                title={isTooLarge ? warning : tooltip}
+                href={href}
+                target={target}
+            >
+                {pathWithRange}
+            </a>
+        </span>
     )
+}
+
+function getIconByFileSource(source?: string): string {
+    switch (source) {
+        case 'user':
+            return 'mention'
+        case 'uri':
+            return 'link'
+        default:
+            return 'sparkle'
+    }
 }

--- a/vscode/webviews/chat/components/EnhancedContext.tsx
+++ b/vscode/webviews/chat/components/EnhancedContext.tsx
@@ -41,16 +41,7 @@ export const EnhancedContext: React.FunctionComponent<{
         }
     }
 
-    // Enhanced Context are context added by one of Cody's context fetchers.
-    // NOTE: sparkle should only be added to messages that use enhanced context.
-    // NOTE: Core chat commands (e.g. /explain and /smell) use local context only.
-    // Check if the filteredFiles only contain local context (non-enhanced context).
-    const localContextType = ['user', 'uri', 'selection', 'terminal', 'editor']
-    const localContextOnly = usedContext.every(file =>
-        localContextType.includes(file.source || file.type)
-    )
-    const sparkle = localContextOnly ? '' : '✨ '
-    const prefix = sparkle + 'Context: '
+    const prefix = 'Context: '
     // It checks if file.range exists first before accessing start and end.
     // If range doesn't exist, it adds 0 lines for that file.
     const lineCount = usedContext.reduce(

--- a/vscode/webviews/chat/components/EnhancedContext.tsx
+++ b/vscode/webviews/chat/components/EnhancedContext.tsx
@@ -60,7 +60,8 @@ export const EnhancedContext: React.FunctionComponent<{
     const files = `${fileCount} file${fileCount > 1 ? 's' : ''}`
     let title = lineCount ? `${lines} from ${files}` : `${files}`
     if (excludedAtContext.length) {
-        title = `${title} - ⚠️ ${excludedAtContext.length} mentiones excluded`
+        const excludedAtUnit = excludedAtContext.length === 1 ? 'mention' : 'mentions'
+        title = `${title} - ⚠️ ${excludedAtContext.length} ${excludedAtUnit} excluded`
     }
 
     return (

--- a/vscode/webviews/chat/components/EnhancedContext.tsx
+++ b/vscode/webviews/chat/components/EnhancedContext.tsx
@@ -19,6 +19,7 @@ export interface FileLinkProps {
     source?: string
     range?: RangeData
     title?: string
+    isTooLarge?: boolean
 }
 
 export const EnhancedContext: React.FunctionComponent<{
@@ -30,17 +31,29 @@ export const EnhancedContext: React.FunctionComponent<{
         return
     }
 
+    const usedContext = []
+    const excludedAtContext = []
+    for (const f of contextFiles) {
+        if (f.type === 'file' && f.source === 'user' && f.isTooLarge) {
+            excludedAtContext.push(f)
+        } else {
+            usedContext.push(f)
+        }
+    }
+
     // Enhanced Context are context added by one of Cody's context fetchers.
     // NOTE: sparkle should only be added to messages that use enhanced context.
     // NOTE: Core chat commands (e.g. /explain and /smell) use local context only.
     // Check if the filteredFiles only contain local context (non-enhanced context).
-    const localContextType = ['user', 'selection', 'terminal', 'editor']
-    const localContextOnly = contextFiles.every(file => localContextType.includes(file.type))
+    const localContextType = ['user', 'uri', 'selection', 'terminal', 'editor']
+    const localContextOnly = usedContext.every(file =>
+        localContextType.includes(file.source || file.type)
+    )
     const sparkle = localContextOnly ? '' : '✨ '
     const prefix = sparkle + 'Context: '
     // It checks if file.range exists first before accessing start and end.
     // If range doesn't exist, it adds 0 lines for that file.
-    const lineCount = contextFiles.reduce(
+    const lineCount = usedContext.reduce(
         (total, file) =>
             total +
             (file.range
@@ -51,10 +64,13 @@ export const EnhancedContext: React.FunctionComponent<{
                 : 0),
         0
     )
-    const fileCount = new Set(contextFiles.map(file => file.uri.toString())).size
+    const fileCount = new Set(usedContext.map(file => file.uri.toString())).size
     const lines = `${lineCount} line${lineCount > 1 ? 's' : ''}`
     const files = `${fileCount} file${fileCount > 1 ? 's' : ''}`
-    const title = lineCount ? `${lines} from ${files}` : `${files}`
+    let title = lineCount ? `${lines} from ${files}` : `${files}`
+    if (excludedAtContext.length) {
+        title = `${title} - ⚠️ ${excludedAtContext.length} mentiones excluded`
+    }
 
     return (
         <TranscriptAction
@@ -73,6 +89,7 @@ export const EnhancedContext: React.FunctionComponent<{
                         source={file.source}
                         range={file.range}
                         title={file.title}
+                        isTooLarge={file.type === 'file' && file.isTooLarge && file.source === 'user'}
                     />
                 ),
             }))}


### PR DESCRIPTION
![image](https://github.com/sourcegraph/cody/assets/68532117/b1c7046e-073c-4622-9941-4ad92b4cfb44)

Update context list to match [figma design ](https://www.figma.com/file/jEsnzgsf0hNuJbqB9pKaGm/VS-Code---Cody---Commands-up-front-and-ChatGPT%2B%2B?type=design&node-id=1826-40270&mode=design&t=uR9EdiEEMOLHwOsN-0)

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Expected behavior:

- @-mentioned items that are excluded should show up in the UI

![image](https://github.com/sourcegraph/cody/assets/68532117/7c70fcc4-4a41-46e4-8fb5-af86d65cb061)

- excluded enhanced context will not show up in UI
- no sparkle icon next to context for non-enhanced context items

![image](https://github.com/sourcegraph/cody/assets/68532117/8cd68b77-f340-421f-96e7-3ddc56b92172)
Ex

- context mixed with enhanced context items will display sparkle next to Context:

![image](https://github.com/sourcegraph/cody/assets/68532117/cb10390d-ab15-4b3f-a9af-8641a718aff4)




