### PR TITLE
Chat: fix at symbol title

### DIFF
--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -315,9 +315,15 @@ test.extend<ExpectedEvents>({
     // Go back to the Cody chat tab
     await page.getByRole('tab', { name: 'New Chat' }).click()
 
-    // Symbol empty state
+    // Symbol empty state shows tooltip to search for a symbol
     await chatInput.fill('@#')
-    await expect(chatPanelFrame.getByRole('heading', { name: /No symbols found/ })).toBeVisible()
+    await expect(
+        chatPanelFrame.getByRole('heading', { name: /^Search for a symbol to include/ })
+    ).toBeVisible()
+
+    // Symbol empty symbol results updates tooltip title to show no symbols found
+    await chatInput.fill('@#invalide')
+    await expect(chatPanelFrame.getByRole('heading', { name: /^No symbols found/ })).toBeVisible()
 
     // Clicking on a file in the selector should autocomplete the file in chat input with added space
     await chatInput.fill('@#fizzb')

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
@@ -23,6 +23,7 @@
 }
 
 .item {
+    display: flex;
     min-height: calc(var(--item-height) - 2*var(--item-padding-y));
     padding: var(--item-padding-y) var(--item-padding-x);
 }
@@ -103,3 +104,6 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .option-item.selected {
     opacity: 0.7;
 }
 
+.title-help-icon {
+    margin-left: 0.25rem;
+}

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -35,7 +35,7 @@ export const OptionsList: FunctionComponent<
                     : mentionQuery.type === 'symbol'
                       ? options.length > 0 || mentionQuery.text.length < 2
                             ? 'Search for a symbol to include...'
-                            : 'No symbols found'
+                            : 'No symbols found (make sure workspace symbols are available)'
                       : options.length > 0
                           ? 'Search for a file to include...'
                           : 'No files found'}

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -33,13 +33,9 @@ export const OptionsList: FunctionComponent<
                 {mentionQuery.type === 'empty'
                     ? 'Search for a file to include, or type # for symbols...'
                     : mentionQuery.type === 'symbol'
-                      ? options.length > 0
+                      ? options.length > 0 || mentionQuery.text.length < 2
                             ? 'Search for a symbol to include...'
-                            : `No symbols found${
-                                  mentionQuery.text.length <= 2
-                                      ? ' (try installing language extensions and opening a file)'
-                                      : ''
-                              }`
+                            : 'No symbols found'
                       : options.length > 0
                           ? 'Search for a file to include...'
                           : 'No files found'}

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -30,15 +30,23 @@ export const OptionsList: FunctionComponent<
     return (
         <div className={styles.container}>
             <h3 className={classNames(styles.item, styles.helpItem)}>
-                {mentionQuery.type === 'empty'
-                    ? 'Search for a file to include, or type # for symbols...'
-                    : mentionQuery.type === 'symbol'
-                      ? options.length > 0 || mentionQuery.text.length < 2
-                            ? 'Search for a symbol to include...'
-                            : 'No symbols found (make sure workspace symbols are available)'
-                      : options.length > 0
-                          ? 'Search for a file to include...'
-                          : 'No files found'}
+                <span>
+                    {mentionQuery.type === 'empty'
+                        ? 'Search for a file to include, or type # for symbols...'
+                        : mentionQuery.type === 'symbol'
+                          ? options.length > 0 || !mentionQuery.text.length
+                                ? 'Search for a symbol to include...'
+                                : 'No symbols found '
+                          : options.length > 0
+                              ? 'Search for a file to include...'
+                              : 'No files found'}
+                </span>
+                {mentionQuery.type === 'symbol' && !options.length && !!mentionQuery.text.length && (
+                    <i
+                        className={classNames('codicon codicon-question', styles.titleHelpIcon)}
+                        title="Please try opening a file to make sure symbols are ready and available in your workspace."
+                    />
+                )}
                 <br />
             </h3>
             {options.length > 0 && (

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -36,17 +36,14 @@ export const OptionsList: FunctionComponent<
                         : mentionQuery.type === 'symbol'
                           ? options.length > 0 || !mentionQuery.text.length
                                 ? 'Search for a symbol to include...'
-                                : 'No symbols found '
+                                : 'No symbols found' +
+                                  (mentionQuery.text.length > 1
+                                      ? ' (language extensions may be loading)'
+                                      : '')
                           : options.length > 0
                               ? 'Search for a file to include...'
                               : 'No files found'}
                 </span>
-                {mentionQuery.type === 'symbol' && !options.length && !!mentionQuery.text.length && (
-                    <i
-                        className={classNames('codicon codicon-question', styles.titleHelpIcon)}
-                        title="Please try opening a file to make sure symbols are ready and available in your workspace."
-                    />
-                )}
                 <br />
             </h3>
             {options.length > 0 && (


### PR DESCRIPTION
https://github.com/sourcegraph/cody/issues/3530

A user on Discord has reported that Cody is incorrectly showing an error message "No symbols found (try installing language extensions and opening a file)":

![image](https://github.com/sourcegraph/cody/assets/68532117/5222ea6a-6b36-4f45-b112-879b05d59b6c)

This error message/tooltip is incorrect as the result is expected to be empty when the query is empty, and not required to have a file opened for symbol search, this PR reverts the tooltip back to `'Search for a symbol to include...'` to display on start-up screen.



## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Type `@#` in the input, you should see `'Search for a symbol to include...'`
- `No symbols found` is displayed when no result is returned after typing more than 1 character

![image](https://github.com/sourcegraph/cody/assets/68532117/3c177463-69e7-4c2e-8e78-3ebc73944f9e)

![image](https://github.com/sourcegraph/cody/assets/68532117/cdda297a-6d49-47b4-ba35-454637d7a87e)
