### PR TITLE
Edit: Remove show diff CTA for insertions

### DIFF
--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -10,6 +10,7 @@ import { CodyTaskState } from '../utils'
 export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
     const codeLensRange = new vscode.Range(task.selectionRange.start, task.selectionRange.start)
     const isTest = task.intent === 'test'
+    const isEdit = task.mode === 'edit'
     switch (task.state) {
         case CodyTaskState.pending:
         case CodyTaskState.working: {
@@ -41,7 +42,10 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
             if (isTest) {
                 return [accept, undo]
             }
-            return [accept, retry, undo, showDiff]
+            if (isEdit) {
+                return [accept, retry, undo, showDiff]
+            }
+            return [accept, retry, undo]
         }
         case CodyTaskState.error: {
             const title = getErrorLens(codeLensRange, task)


### PR DESCRIPTION
## Description

We do not compute a diff for insertions, as we're only inserting new code.

We can likely rework this as part of https://github.com/sourcegraph/cody/issues/3510, to decorate the text as a diff _insertion_.

For now, we're just omitting the CTA for insertions

## Test plan

1. Do an insertion (e.g. document code), check "Show diff" doesn't appear
2. Do an edit, check "Show diff" appears and functions correctly

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

closes https://github.com/sourcegraph/cody/issues/3509
