### PR TITLE
Autocomplete: Add Claude 3 Haiku A/B test

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -17,6 +17,8 @@ export enum FeatureFlag {
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-llama-code-13b',
     // Enable StarCoder2 7b and 15b as the default model via Fireworks
     CodyAutocompleteStarCoder2Hybrid = 'cody-autocomplete-starcoder2-hybrid',
+    // Enables Claude 3 if the user is in our holdout group
+    CodyAutocompleteClaude3 = 'cody-autocomplete-claude-3',
     // Enables the bfg-mixed context retriever that will combine BFG with the default local editor
     // context.
     CodyAutocompleteContextBfgMixed = 'cody-autocomplete-context-bfg-mixed',

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -60,7 +60,7 @@ const lineNumberDependentCompletionParams = getLineNumberDependentCompletionPara
 
 let isOutdatedSourcegraphInstanceWithoutAnthropicAllowlist = false
 
-interface AnthropicOptions {
+export interface AnthropicOptions {
     model?: string // The model identifier that is being used by the server's site config.
     maxContextTokens?: number
     client: Pick<CodeCompletionsClient, 'complete'>
@@ -299,6 +299,7 @@ function isAllowlistedModel(model: string | undefined): boolean {
         case 'anthropic/claude-instant-1.2':
         case 'anthropic/claude-instant-v1':
         case 'anthropic/claude-instant-1':
+        case 'anthropic/claude-3-haiku-20240307':
             return true
     }
     return false

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -8,7 +8,7 @@ import {
 
 import { logError } from '../../log'
 
-import { createProviderConfig as createAnthropicProviderConfig } from './anthropic'
+import { AnthropicOptions, createProviderConfig as createAnthropicProviderConfig } from './anthropic'
 import { createProviderConfig as createExperimentalOllamaProviderConfig } from './experimental-ollama'
 import {
     type FireworksOptions,
@@ -47,7 +47,7 @@ export async function createProviderConfig(
                 })
             }
             case 'anthropic': {
-                return createAnthropicProviderConfig({ client })
+                return createAnthropicProviderConfig({ client, model })
             }
             case 'experimental-ollama':
             case 'unstable-ollama': {
@@ -126,16 +126,17 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
     configuredProvider: string | null
 ): Promise<{
     provider: string
-    model?: FireworksOptions['model']
+    model?: FireworksOptions['model'] | AnthropicOptions['model']
 } | null> {
     if (configuredProvider) {
         return { provider: configuredProvider }
     }
 
-    const [starCoder2Hybrid, starCoderHybrid, llamaCode13B] = await Promise.all([
+    const [starCoder2Hybrid, starCoderHybrid, llamaCode13B, claude3] = await Promise.all([
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
         featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
     ])
 
     if (llamaCode13B) {
@@ -148,6 +149,10 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
 
     if (starCoderHybrid) {
         return { provider: 'fireworks', model: 'starcoder-hybrid' }
+    }
+
+    if (claude3) {
+        return { provider: 'anthropic', model: 'anthropic/claude-3-haiku-20240307' }
     }
 
     return null

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -8,7 +8,10 @@ import {
 
 import { logError } from '../../log'
 
-import { AnthropicOptions, createProviderConfig as createAnthropicProviderConfig } from './anthropic'
+import {
+    type AnthropicOptions,
+    createProviderConfig as createAnthropicProviderConfig,
+} from './anthropic'
 import { createProviderConfig as createExperimentalOllamaProviderConfig } from './experimental-ollama'
 import {
     type FireworksOptions,


### PR DESCRIPTION
Adds an A/B test for Claude 3 Haiku for Autocomplete in our holdout group.

## Test plan

manually overwrite the feature flags on the client and observe the right request being made
<img width="1425" alt="Screenshot 2024-03-25 at 13 52 02" src="https://github.com/sourcegraph/cody/assets/458591/83fc0428-ff10-41ec-b911-40c65f0b0e0c">
