### PR TITLE
Sentry: More aggressive filtering on errors

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -770,7 +770,7 @@ function lineAndCharCount({ insertText }: InlineCompletionItem): {
 const TEN_MINUTES = 1000 * 60 * 10
 const errorCounts: Map<string, number> = new Map()
 export function logError(error: Error): void {
-    if (!shouldErrorBeReported(error)) {
+    if (!shouldErrorBeReported(error, false)) {
         return
     }
 

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -35,7 +35,7 @@ export abstract class SentryService {
 
     private prepareReconfigure(): void {
         try {
-            const isProd = process.env.NODE_ENV !== 'production'
+            const isProd = process.env.NODE_ENV === 'production'
 
             // Used to enable Sentry reporting in the development environment.
             const isSentryEnabled = process.env.ENABLE_SENTRY === 'true'

--- a/vscode/src/services/sentry/sentry.ts
+++ b/vscode/src/services/sentry/sentry.ts
@@ -35,7 +35,7 @@ export abstract class SentryService {
 
     private prepareReconfigure(): void {
         try {
-            const isProd = process.env.NODE_ENV === 'production'
+            const isProd = process.env.NODE_ENV !== 'production'
 
             // Used to enable Sentry reporting in the development environment.
             const isSentryEnabled = process.env.ENABLE_SENTRY === 'true'
@@ -90,7 +90,7 @@ export function shouldErrorBeReported(error: unknown, insideAgent: boolean): boo
     }
 
     // Silencing our #1 reported error
-    if (isError(error) && error.message?.includes("Unexpected token '<', \"<!DOCTYPE")) {
+    if (isError(error) && error.message?.includes("Unexpected token '<'")) {
         return false
     }
 


### PR DESCRIPTION
This is an attempt to reduce the load of Sentry issues. There are two general patterns I've observed:

- The filter we have for our #1 error is not working (the one that is defined in the project settings) so we're adding it in code instead.
- The other top 3 errors all happen _in other extensions_. You can see this by looking at the stack trace. None of this have the Cody extension in its trace. I believe we can gate against this by investigating the trace.

See https://sourcegraph.sentry.io/issues/?groupStatsPeriod=auto&project=4505743319564288&query=&referrer=issue-list&sort=freq&statsPeriod=30d for more details.

## Test plan

- Stepped through the debugger and looked at traces in Sentry to derive this setup