### PR TITLE
Chat: update @-input token background

### DIFF
--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
@@ -1,6 +1,7 @@
 .context-item-mention-node {
-    background-color: rgba(200, 200, 200, 0.2);
     color: var(--link-foreground);
+    background: color-mix(in srgb, currentColor 15%, transparent);
+    border-radius: 3px;
 }
 
 body[data-vscode-theme-kind='vscode-high-contrast-light'] .context-item-mention-node {

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
@@ -1,21 +1,6 @@
 .context-item-mention-node {
+    background-color: rgba(200, 200, 200, 0.2);
     color: var(--link-foreground);
-    position: relative;
-
-}
-
-.context-item-mention-node::before {
-    content: '';
-    background-color: var(--link-foreground);
-    border-radius: 3px;
-    outline: 1px solid var(--link-foreground);
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    opacity: 0.2;
-    pointer-events: none
 }
 
 body[data-vscode-theme-kind='vscode-high-contrast-light'] .context-item-mention-node {


### PR DESCRIPTION
Address issue from https://github.com/sourcegraph/cody/pull/3501#issuecomment-2018037797

Remove `.context-item-mention-node::before` that sets background color with opacity, set `background-color` to `rgba(200, 200, 200, 0.2);` to add blurred background instead.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before 

![image](https://github.com/sourcegraph/cody/assets/68532117/a9c420b7-4d2f-4cf5-bd6f-abcd3e32d28f)


### After

![image](https://github.com/sourcegraph/cody/assets/68532117/f001d892-816c-47ce-9a9c-fe9f1ffd785b)
