### PR TITLE
Autocomplete: add singleline stop sequences

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,9 +10,11 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-Chat: Large file cannot be added via @-mention. [pull/3531](https://github.com/sourcegraph/cody/pull/3531)
+- Chat: Large file cannot be added via @-mention. [pull/3531](https://github.com/sourcegraph/cody/pull/3531)
 
 ### Changed
+
+- Autocomplete: Subsequent new lines are added to the singleline stop sequences. [pull/3549](https://github.com/sourcegraph/cody/pull/3549)
 
 ## [1.10.0]
 

--- a/vscode/src/completions/get-inline-completions-tests/models.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/models.test.ts
@@ -19,6 +19,12 @@ describe('[getInlineCompletions] models', () => {
             })
             expect(requests[0].stopSequences).toMatchInlineSnapshot(`
               [
+                "
+
+              ",
+                "
+
+              ",
                 "<fim_prefix>",
                 "<fim_suffix>",
                 "<fim_middle>",
@@ -41,6 +47,12 @@ describe('[getInlineCompletions] models', () => {
             // Keeps stop sequences array unchanged
             expect(requests[0].stopSequences).toMatchInlineSnapshot(`
               [
+                "
+
+              ",
+                "
+
+              ",
                 "<fim_prefix>",
                 "<fim_suffix>",
                 "<fim_middle>",

--- a/vscode/src/completions/providers/anthropic.ts
+++ b/vscode/src/completions/providers/anthropic.ts
@@ -45,7 +45,11 @@ import {
     standardContextSizeHints,
 } from './provider'
 
-export const SINGLE_LINE_STOP_SEQUENCES = [anthropic.HUMAN_PROMPT, CLOSING_CODE_TAG]
+export const SINGLE_LINE_STOP_SEQUENCES = [
+    anthropic.HUMAN_PROMPT,
+    CLOSING_CODE_TAG,
+    MULTILINE_STOP_SEQUENCE,
+]
 
 export const MULTI_LINE_STOP_SEQUENCES = [
     anthropic.HUMAN_PROMPT,

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -114,7 +114,7 @@ function getMaxContextTokens(model: FireworksModel): number {
 }
 
 const lineNumberDependentCompletionParams = getLineNumberDependentCompletionParams({
-    singlelineStopSequences: [],
+    singlelineStopSequences: ['\n\n', '\n\r\n'],
     multilineStopSequences: ['\n\n', '\n\r\n'],
 })
 

--- a/vscode/src/completions/providers/unstable-openai.ts
+++ b/vscode/src/completions/providers/unstable-openai.ts
@@ -37,7 +37,7 @@ import {
 } from './provider'
 
 const lineNumberDependentCompletionParams = getLineNumberDependentCompletionParams({
-    singlelineStopSequences: [CLOSING_CODE_TAG],
+    singlelineStopSequences: [CLOSING_CODE_TAG, MULTILINE_STOP_SEQUENCE],
     multilineStopSequences: [CLOSING_CODE_TAG, MULTILINE_STOP_SEQUENCE],
 })
 


### PR DESCRIPTION
Adding `\n\n` as a stop sequence for singleline completions. I suspect this is one of the reasons for [higher-than-expected upstream char counts](https://redash.sgdev.org/queries/485/source#1003) in the StarCoder2 experiment.

## Test plan

CI
