### PR TITLE
Chat: Handle empty chat message input

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: Large file cannot be added via @-mention. [pull/3531](https://github.com/sourcegraph/cody/pull/3531)
+- Chat: Handle empty chat message input and prevent submission of empty messages. [pull/3554](https://github.com/sourcegraph/cody/pull/3554)
 
 ### Changed
 

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -24,8 +24,15 @@ test.extend<ExpectedEvents>({
     const chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
     const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
 
-    // Test that Ctrl+Arrow jumps by a word.
+    // Test that empty chat messages cannot be submitted.
+    await chatInput.fill(' ')
+    await chatInput.press('Enter')
+    await expect(chatInput).toHaveText(' ')
+    await chatInput.press('Backspace')
     await chatInput.clear()
+
+    // Test that Ctrl+Arrow jumps by a word.
+    await chatInput.focus()
     await chatInput.type('One')
     await chatInput.press('Control+ArrowLeft')
     await chatInput.type('Two')

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -74,7 +74,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     // The only PromptEditor state we really need to track in our own state is whether it's empty.
     const [isEmptyEditorValue, setIsEmptyEditorValue] = useState(true)
     const onEditorChange = useCallback((value: SerializedPromptEditorValue): void => {
-        setIsEmptyEditorValue(value.text === '')
+        setIsEmptyEditorValue(!value?.text?.trim())
     }, [])
 
     const onAbortMessageInProgress = useCallback(() => {
@@ -89,7 +89,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 throw new Error('Chat has no editorRef')
             }
             const editorValue = editorRef.current.getSerializedValue()
-
+            if (!editorValue.text.trim()) {
+                throw new Error('Chat message cannot be empty')
+            }
             // Handle edit requests
             if (submitType === 'edit') {
                 if (messageBeingEdited === undefined) {


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/3520

This commit addresses an issue where the Chat component was not properly handling empty input values in the PromptEditor. The changes made in this commit are:

In the onEditorChange callback function, the condition for setting the isEmptyEditorValue state has been updated to check if the trimmed text property of the SerializedPromptEditorValue object is an empty string or not. This ensures that the isEmptyEditorValue state accurately reflects whether the editor has any non-whitespace content or not.

In the onAbortMessageInProgress callback function, a new check has been added to throw an error if the trimmed text property of the SerializedPromptEditorValue object is an empty string. This prevents the user from submitting an empty chat message.

These changes improve the user experience by providing better validation and error handling for empty chat messages. It also ensures that the isEmptyEditorValue state accurately reflects the editor's content, which could be used for other purposes within the component.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Added e2e test to cover this.

1. Create a chat message with empty spaces
2. You should not be able to submit the chat message

### Before

You can submit a chat message that consists whitespace only, causing cody gateway to return error

![image](https://github.com/sourcegraph/cody/assets/68532117/9207e30f-391a-4387-807e-463cc6e6fd9d)

![image](https://github.com/sourcegraph/cody/assets/68532117/ef4fac03-ca66-466e-822e-df3a17834470)

### After

You can not send a chat messages that is empty or whitespace only

![image](https://github.com/sourcegraph/cody/assets/68532117/b213f164-a0da-43e4-81f7-1466d1fc14dd)
