### PR TITLE
Chat: hide language extensions warning for @-symbol query with 3chars+

### DIFF
--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -54,7 +54,7 @@ export const OptionsList: FunctionComponent<
                           ? options.length > 0 || !mentionQuery.text.length
                                 ? 'Search for a symbol to include...'
                                 : 'No symbols found' +
-                                  (mentionQuery.text.length > 1
+                                  (mentionQuery.text.length < 3
                                       ? ' (language extensions may be loading)'
                                       : '')
                           : options.length > 0


### PR DESCRIPTION
Address comment in https://github.com/sourcegraph/cody/pull/3531#pullrequestreview-1959266608

> I wouldn't show the "(language extensions may be loading)" above two characters

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Type the query with more than 2 chars and check if the "(language extensions may be loading)" warning text shows up. It shouldn't