### PR TITLE
Custom Commands: Show context command errors in the notification message for easier debugging

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Large file cannot be added via @-mention. [pull/3531](https://github.com/sourcegraph/cody/pull/3531)
 - Chat: Handle empty chat message input and prevent submission of empty messages. [pull/3554](https://github.com/sourcegraph/cody/pull/3554)
 - Chat: Warnings are now displayed correctly for large files in the @-mention file selection list. [pull/3526](https://github.com/sourcegraph/cody/pull/3526)
+- Custom Commands: Errors when running context command scripts now show the error output in the notification message. [pull/3565](https://github.com/sourcegraph/cody/pull/3565)
 
 ### Changed
 

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -58,9 +58,7 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
         } catch (error) {
             // Handles errors and empty output
             logError('getContextFileFromShell', 'failed', { verbose: error })
-            void vscode.window.showErrorMessage('Command Failed: Make sure the command works locally.', {
-                detail: String(error),
-            })
+            void vscode.window.showErrorMessage((error as Error).message)
             throw new Error('Failed to get shell output for Custom Command.')
         }
     })

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -58,7 +58,9 @@ export async function getContextFileFromShell(command: string): Promise<ContextI
         } catch (error) {
             // Handles errors and empty output
             logError('getContextFileFromShell', 'failed', { verbose: error })
-            void vscode.window.showErrorMessage('Command Failed: Make sure the command works locally.')
+            void vscode.window.showErrorMessage('Command Failed: Make sure the command works locally.', {
+                detail: String(error),
+            })
             throw new Error('Failed to get shell output for Custom Command.')
         }
     })


### PR DESCRIPTION
If a custom command has problems running a context command, this adds the error output to the error notification, allowing you to more quickly debug the issue and try again.

| Before | After |
| - | - |
| ![CleanShot 2024-03-27 at 11 40 25@2x](https://github.com/sourcegraph/cody/assets/153/1282b53f-7138-4729-9546-59544e235ed3) | ![CleanShot 2024-03-27 at 11 39 37@2x](https://github.com/sourcegraph/cody/assets/153/e4ab6559-6b14-4d3f-8a00-27007227fb7b) |

```json
{
	"broken-command": {
	  "description": "Totes broken",
	  "prompt": "This aint gonna work",
	  "context": {
		"command": "command that doesnt work"
	  }
	}
}
```

## Test plan

- Manually tested