### PR TITLE
Chat: add enhanced context tooltip to Transcript

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -493,6 +493,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     userInfo={userInfo}
                     postMessage={postMessage}
                     guardrails={guardrails}
+                    setIsEnhancedContextOpen={setIsEnhancedContextOpen}
                 />
             }
             <form className={classNames(styles.inputRow)}>

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -61,7 +61,7 @@ export interface EnhancedContextEventHandlersT {
     onShouldBuildSymfIndex: (provider: LocalSearchProvider) => void
 }
 
-function useEnhancedContextContext(): EnhancedContextContextT {
+export function useEnhancedContextContext(): EnhancedContextContextT {
     return React.useContext(EnhancedContextContext)
 }
 

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -44,6 +44,7 @@ export const Transcript: React.FunctionComponent<
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails
+        setIsEnhancedContextOpen?: (value: boolean) => void
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptContent({
     transcript,
@@ -72,6 +73,7 @@ export const Transcript: React.FunctionComponent<
     userInfo,
     postMessage,
     guardrails,
+    setIsEnhancedContextOpen,
 }) {
     // Scroll the last human message to the top whenever a new human message is received as input.
     const transcriptContainerRef = useRef<HTMLDivElement>(null)
@@ -200,6 +202,7 @@ export const Transcript: React.FunctionComponent<
                         userInfo={userInfo}
                         postMessage={postMessage}
                         guardrails={guardrails}
+                        setIsEnhancedContextOpen={setIsEnhancedContextOpen}
                     />
                 </div>
             )

--- a/vscode/webviews/chat/TranscriptItem.module.css
+++ b/vscode/webviews/chat/TranscriptItem.module.css
@@ -194,3 +194,7 @@
                 0 1px 0 var(--vscode-sideBarSectionHeader-border),
                 0 0 2rem var(--vscode-widget-shadow);
 }
+
+.enhanced-context-tooltip {
+    margin-top: 0.5rem;
+}

--- a/vscode/webviews/chat/TranscriptItem.tsx
+++ b/vscode/webviews/chat/TranscriptItem.tsx
@@ -16,6 +16,8 @@ import { CodeBlocks } from './CodeBlocks'
 import { ErrorItem, RequestErrorItem } from './ErrorItem'
 import { EnhancedContext, type FileLinkProps } from './components/EnhancedContext'
 
+import { VSCodeLink } from '@vscode/webview-ui-toolkit/react'
+import { useEnhancedContextContext } from '../Components/EnhancedContextSettings'
 import { serializedPromptEditorStateFromChatMessage } from '../promptEditor/PromptEditor'
 import styles from './TranscriptItem.module.css'
 
@@ -57,6 +59,7 @@ export const TranscriptItem: React.FunctionComponent<
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails
+        setIsEnhancedContextOpen?: (value: boolean) => void
     } & TranscriptItemClassNames
 > = React.memo(function TranscriptItemContent({
     index,
@@ -82,6 +85,7 @@ export const TranscriptItem: React.FunctionComponent<
     userInfo,
     postMessage,
     guardrails,
+    setIsEnhancedContextOpen,
 }) {
     // A boolean indicating whether the message was sent by a human speaker.
     const isHumanMessage = message.speaker === 'human'
@@ -91,6 +95,9 @@ export const TranscriptItem: React.FunctionComponent<
     const isItemBeingEdited = beingEdited === index
 
     const displayMarkdown = useDisplayMarkdown(message)
+    const enhancedContextConfigured = useEnhancedContextContext()?.groups?.[0]?.providers?.some(
+        p => p.state === 'ready'
+    )
 
     return (
         <div
@@ -170,6 +177,16 @@ export const TranscriptItem: React.FunctionComponent<
                     )}
                 </div>
             )}
+            {isHumanMessage && !enhancedContextConfigured && setIsEnhancedContextOpen && (
+                <div className={styles.enhancedContextTooltip}>
+                    <VSCodeLink onClick={() => setIsEnhancedContextOpen(true)}>
+                        {userInfo.isDotComUser
+                            ? '→ Enable Embeddings for this Repository...'
+                            : '→ Choose Repositories to use as Context...'}
+                    </VSCodeLink>
+                </div>
+            )}
+
             {/* Display feedback buttons on assistant messages only */}
             {!isHumanMessage &&
                 showFeedbackButtons &&


### PR DESCRIPTION
Implement design from https://github.com/sourcegraph/cody/issues/2839#issuecomment-2005238585

![image](https://github.com/sourcegraph/cody/assets/68532117/3f6026ad-d231-4d4f-988a-7727dc338775)


These changes introduce a new feature that allows users to toggle the enhanced context panel and display additional information or tooltips related to the enhanced context feature within the chat interface.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Open a repository that doesn't have symf and embeddings enabled.
2. Ask Cody a question
3. You should see a tooltip under the human message that opens the enhanced context settings on click

Enterprise users:

![Screenshot 2024-03-26 at 5 59 29 PM](https://github.com/sourcegraph/cody/assets/68532117/0a5892e6-e553-4cc0-b02c-74e0ee16498b)

PLG users:

![image](https://github.com/sourcegraph/cody/assets/68532117/4a0a6835-4936-4771-92c6-0f70d8a81791)


