### PR TITLE
Chat: show enhanced context settings on first chat

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -191,7 +191,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     )
 
     const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
-
+    const isNewInstall = useMemo(() => !userHistory.some(c => c.interactions.length > 0), [userHistory])
     if (!view || !authStatus || !config) {
         return <LoadingPage />
     }
@@ -207,12 +207,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 />
             ) : (
                 <>
-                    <Notices
-                        probablyNewInstall={
-                            !userHistory.filter(chat => chat.interactions.length)?.length
-                        }
-                        vscodeAPI={vscodeAPI}
-                    />
+                    <Notices probablyNewInstall={isNewInstall} vscodeAPI={vscodeAPI} />
                     {errorMessages && (
                         <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />
                     )}
@@ -246,6 +241,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                                         guardrails={attributionEnabled ? guardrails : undefined}
                                         chatIDHistory={chatIDHistory}
                                         isWebviewActive={isWebviewActive}
+                                        isNewInstall={isNewInstall}
                                     />
                                 </EnhancedContextEnabled.Provider>
                             </EnhancedContextContext.Provider>

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -28,6 +28,7 @@ const meta: Meta<typeof Chat> = {
         },
         telemetryService: null as any,
         isTranscriptError: false,
+        isNewInstall: false,
     } satisfies React.ComponentProps<typeof Chat>,
 
     decorators: [WithBorder, VSCodeStoryDecorator],

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -45,6 +45,7 @@ interface ChatboxProps {
     guardrails?: Guardrails
     chatIDHistory: string[]
     isWebviewActive: boolean
+    isNewInstall: boolean
 }
 
 const isMac = isMacOS()
@@ -63,6 +64,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     guardrails,
     chatIDHistory,
     isWebviewActive,
+    isNewInstall,
 }) => {
     const [messageBeingEdited, setMessageBeingEdited] = useState<number | undefined>(undefined)
 
@@ -530,7 +532,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                                 isOpen={isEnhancedContextOpen}
                                 setOpen={onEnhancedContextTogglerClick}
                                 presentationMode={userInfo.isDotComUser ? 'consumer' : 'enterprise'}
-                                isFirstChat={transcript.length < 1}
+                                isFirstChat={isNewInstall}
                             />
                         </div>
                     </div>

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -390,9 +390,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     }, [isOpen])
 
     React.useEffect(() => {
-        if (isFirstChat) {
-            setOpen(true)
-        }
+        setOpen(isFirstChat)
     }, [isFirstChat, setOpen])
 
     // Can't point at and use VSCodeButton type with 'ref'


### PR DESCRIPTION
Follow-up on https://github.com/sourcegraph/cody/pull/3547/files#r1540281243

> @toolmantim We want it to appear on the first chat that's created for first time users, not every time a chat is created.

Update to display enhanced context settings on their first chat (when chat history is empty).

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Clear your chat history, you can see the enhanced context settings opened by default when you open a new chat:

![image](https://github.com/sourcegraph/cody/assets/68532117/010038e9-5067-4359-8fbf-dafcce265fcc)

New chat created with chat history in sidebar will not have enhanced context opened:

![image](https://github.com/sourcegraph/cody/assets/68532117/291b41e6-22e8-4148-a347-78764b248f95)
