### PR TITLE
Chat: Fix message input placeholder overflow

### DIFF
--- a/vscode/webviews/promptEditor/BaseEditor.module.css
+++ b/vscode/webviews/promptEditor/BaseEditor.module.css
@@ -38,6 +38,7 @@
     text-overflow: ellipsis;
     top: 0;
     left: 0;
+    right: 5px;
     user-select: none;
     white-space: nowrap;
     display: inline-block;


### PR DESCRIPTION
Updates the placeholder styles so it doesn't go over the enhanced context button. Future improvement (which I couldn't get to work) would be to set a `title` so that it shows the full label on hover.

| Before | After|
| - | - |
| ![CleanShot 2024-03-27 at 14 07 19@2x](https://github.com/sourcegraph/cody/assets/153/48656f0e-ce4f-419d-adc0-95a84accf44a) | ![CleanShot 2024-03-27 at 14 06 38@2x](https://github.com/sourcegraph/cody/assets/153/d745a9f6-30ea-4271-8541-bf08c8e370e0) |

## Test plan

- Opened chat
- Resized chat
- Verified ellipsis