### PR TITLE
rm now-invalid storybook option

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -30,7 +30,7 @@
     "release": "ts-node-transpile-only ./scripts/release.ts",
     "download-wasm": "ts-node-transpile-only ./scripts/download-wasm-modules.ts",
     "release:dry-run": "pnpm run download-wasm && CODY_RELEASE_DRY_RUN=1 ts-node ./scripts/release.ts",
-    "storybook": "storybook dev -p 6007 --no-open --no-version-updates --no-release-notes",
+    "storybook": "storybook dev -p 6007 --no-open --no-version-updates",
     "test:e2e": "tsc --build && node dist/tsc/test/e2e/install-deps.js && pnpm run -s build:dev:desktop && playwright test",
     "test:integration": "tsc --build ./test/integration && pnpm run -s build:dev:desktop && node --inspect -r ts-node/register dist/tsc/test/integration/main.js",
     "test:unit": "vitest",


### PR DESCRIPTION
Fixes the following problem when running `pnpm -C vscode storybook`:

```
error: unknown option '--no-release-notes'
```

A dependency bump upgraded the storybook package to a version that removed this command-line argument.



## Test plan

CI