### PR TITLE
Edit: Simplify mode by removing `add`

### DIFF
--- a/vscode/src/edit/types.ts
+++ b/vscode/src/edit/types.ts
@@ -7,7 +7,6 @@ export type EditIntent = 'add' | 'edit' | 'fix' | 'doc' | 'test'
 /**
  * The edit modes that can be used when applying an edit.
  * - 'edit': Modify selected code in place.
- * - 'insert': Insert new code above the selected code.
- * - 'add': Append new code below the selected code.
+ * - 'insert': Insert new code at the selected location.
  */
-export type EditMode = 'edit' | 'insert' | 'add'
+export type EditMode = 'edit' | 'insert'

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -454,7 +454,7 @@ export class FixupController
          */
         let trackedRange = task.selectionRange
 
-        if (task.mode === 'insert' || task.mode === 'add') {
+        if (task.mode === 'insert') {
             const insertionPoint = task.insertionPoint || task.selectionRange.start
             const textLines = lines(task.replacement)
             trackedRange = new vscode.Range(


### PR DESCRIPTION
## Description

We weren't using mode `add` anywhere currently. We also now support changing the insertion point of the `insert` by setting `task.insertionPoint`. Removing this mode will simplify our code.

## Test plan

1. Check build passes
2. Check unit test command works correctly

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
