### PR TITLE
Remove Cody Pro JetBrains flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -33,9 +33,6 @@ export enum FeatureFlag {
     // Enable smart-throttling for more aggressive request cancellation and lower initial latencies
     CodyAutocompleteSmartThrottle = 'cody-autocomplete-smart-throttle',
 
-    // Enable Cody PLG features on JetBrains
-    CodyProJetBrains = 'cody-pro-jetbrains',
-
     // use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
     UseSscForCodySubscription = 'use-ssc-for-cody-subscription',
 


### PR DESCRIPTION
JetBrains folks: Is the cody-pro-jetbrains flag still used by the jb client? If not we can probably clean it up in the cody repo and the dotcom backend :)

## Test plan

CI