### PR TITLE
Enhanced Context: fix input button toggler

### DIFF
--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -346,15 +346,17 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     const context = useEnhancedContextContext()
     const [enabled, setEnabled] = React.useState<boolean>(useEnhancedContextEnabled())
     const enabledChanged = React.useCallback(
-        (event: any): void => {
-            const shouldEnable = !!event.target.checked
+        (shouldEnable: boolean, source: 'btn' | 'checkbox'): void => {
             if (enabled !== shouldEnable) {
                 events.onEnabledChange(shouldEnable)
                 setEnabled(shouldEnable)
-                // Log when a user clicks on the Enhanced Context toggle
+                // Log when a user clicks on the Enhanced Context toggle. Event names:
+                // Checkbox click: `CodyVSCodeExtension:useEnhancedContextToggler:clicked`
+                // Button click: `CodyVSCodeExtension:useEnhancedContextTogglerBtn:clicked`
+                const eventName = source === 'btn' ? 'Btn' : ''
                 getVSCodeAPI().postMessage({
                     command: 'event',
-                    eventName: 'CodyVSCodeExtension:useEnhancedContextToggler:clicked',
+                    eventName: `CodyVSCodeExtension:useEnhancedContextToggler${eventName}:clicked`,
                     properties: { useEnhancedContext: shouldEnable },
                 })
             }
@@ -422,7 +424,9 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                 <div className={styles.container}>
                     <div>
                         <VSCodeCheckbox
-                            onChange={enabledChanged}
+                            onChange={e =>
+                                enabledChanged((e.target as HTMLInputElement)?.checked, 'checkbox')
+                            }
                             checked={enabled}
                             id="enhanced-context-checkbox"
                             ref={autofocusTarget}
@@ -468,15 +472,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                     styles.settingsIndicator,
                     enabled && styles.settingsIndicatorActive
                 )}
-                onClick={() => {
-                    setEnabled(!enabled)
-                    // Log when a user clicks on the Enhanced Context toggle
-                    getVSCodeAPI().postMessage({
-                        command: 'event',
-                        eventName: 'CodyVSCodeExtension:useEnhancedContextInputToggler:clicked',
-                        properties: { useEnhancedContext: !enabled },
-                    })
-                }}
+                onClick={() => enabledChanged(!enabled, 'btn')}
                 appearance="icon"
                 type="button"
                 title={`${enabled ? 'Disable' : 'Enable'} Enhanced Context`}


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1711540311641009

Reported by @philipp-spiess 
> The updated disable-enhanced-context button doesn’t seem to work on main :grimacing: It’s still pulling in lots of context  for me

This PR updates the PR so that the button and the checkbox use the same function for toggling the setting instead of having separate functions for the same thing.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Disabled

1. Submit a question with the enhanced context button showing as disabled (no background color, with a slash in the middle):

![image](https://github.com/sourcegraph/cody/assets/68532117/86004575-945e-48ca-b331-99271dbd73dd)

2. Confirm enhanced context is not added to your question

![image](https://github.com/sourcegraph/cody/assets/68532117/4fb3d6b5-1ccd-4992-984c-2a1af20a71de)

### Enabled 

3. Submit a question with the enhanced context button showing as enabled (with background color):

![image](https://github.com/sourcegraph/cody/assets/68532117/ab63422a-17ab-40aa-8a35-8d48928469d2)

4. Confirm enhanced context is added to your question

![image](https://github.com/sourcegraph/cody/assets/68532117/30440a8a-bca8-4788-b3da-7a7f0a02a7fa)

5. Both icons status should match

![image](https://github.com/sourcegraph/cody/assets/68532117/bb34955c-ced4-4b83-b08c-4c791cc99315)

![image](https://github.com/sourcegraph/cody/assets/68532117/d4b6928f-d86c-41ae-a7a8-f860a57db32f)
