### PR TITLE
E2E Test: Detect detached state instead of hidden

### DIFF
--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -302,10 +302,9 @@ test.extend<ExpectedEvents>({
     await page.getByRole('tab', { name: 'buzz.ts' }).click()
 
     // Wait for the tsserver to become ready: when loading status disappears
-    await expect(page.getByRole('button', { name: 'Editor Language Status: Loading' })).toBeVisible()
-    await page.waitForSelector('button[aria-label="Editor Language Status: Loading"]', {
-        state: 'hidden',
-    })
+    const langServerLoadingState = 'Editor Language Status: Loading'
+    await expect(page.getByRole('button', { name: langServerLoadingState })).toBeVisible()
+    await page.waitForSelector(`button[aria-label="${langServerLoadingState}"]`, { state: 'detached' })
 
     // Go back to the Cody chat tab
     await page.getByRole('tab', { name: 'New Chat' }).click()
@@ -322,7 +321,7 @@ test.extend<ExpectedEvents>({
 
     // Clicking on a file in the selector should autocomplete the file in chat input with added space
     await chatInput.clear()
-    await chatInput.pressSequentially('@#fizzb', { delay: 10 })
+    await chatInput.pressSequentially('@#fizzb', { delay: 200 })
     await expect(chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' }).click()
     await expect(chatInput).toHaveText('@buzz.ts:1-15#fizzbuzz() ')


### PR DESCRIPTION
Looking at the failing chat-atFile.test.ts e2e test, it looks like the tests often fail because we perform the search before symbols are available in the workspace.

I updated the test in my last PR to wait for the language server loading state to disappear before we move on to the next step, but it looks like the selector was incorrect

![image](https://github.com/sourcegraph/cody/assets/68532117/bfb384c3-6515-4943-bc42-323a83749277)


```
  1) chat-atFile.test.ts:293:3 › @-mention symbol in chat ──────────────────────────────────────────

    Error: Timed out 5000ms waiting for expect(locator).toBeVisible()

    Locator: frameLocator('iframe.webview').last().frameLocator('iframe').getByRole('option', { name: 'fizzbuzz()' })
    Expected: visible
    Received: hidden
    Call log:
      - expect.toBeVisible with timeout 5000ms
      - waiting for frameLocator('iframe.webview').last().frameLocator('iframe').getByRole('option', { name: 'fizzbuzz()' })


      324 |     await chatInput.clear()
      325 |     await chatInput.pressSequentially('@#fizzb', { delay: 10 })
    > 326 |     await expect(chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' })).toBeVisible()
          |                                                                              ^
      327 |     await chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' }).click()
      328 |     await expect(chatInput).toHaveText('@buzz.ts:1-15#fizzbuzz() ')
      329 |

        at D:\a\cody\cody\vscode\test\e2e\chat-atFile.test.ts:326:78
```



## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
