### PR TITLE
Log context clicks

### DIFF
--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -4,6 +4,7 @@ import type React from 'react'
 import { displayLineRange, displayPath, webviewOpenURIForContextItem } from '@sourcegraph/cody-shared'
 import type { FileLinkProps } from '../chat/components/EnhancedContext'
 
+import { getVSCodeAPI } from '../utils/VSCodeApi'
 import styles from './FileLink.module.css'
 
 export const FileLink: React.FunctionComponent<FileLinkProps> = ({
@@ -15,6 +16,14 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
     revision,
     isTooLarge,
 }) => {
+    function logContextOpening() {
+        getVSCodeAPI().postMessage({
+            command: 'event',
+            eventName: 'CodyVSCodeExtension:fileLink:clicked',
+            properties: { source },
+        })
+    }
+
     const icon = getIconByFileSource(source)
     if (source === 'unified') {
         // This is a remote search result.
@@ -25,12 +34,14 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
         return (
             <span className="styles.item">
                 <i className={`codicon codicon-${icon}`} title={getFileSourceIconTitle(source)} />
+                {/* biome-ignore lint/a11y/useValidAnchor: The onClick handler is only used for logging */}
                 <a
                     href={uri.toString()}
                     target="_blank"
                     rel="noreferrer"
                     title={tooltip}
                     className={styles.linkButton}
+                    onClick={logContextOpening}
                 >
                     {pathWithRange}
                 </a>
@@ -46,11 +57,13 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
         <span className={styles.linkContainer}>
             {isTooLarge && <i className="codicon codicon-warning" title={warning} />}
             <i className={`codicon codicon-${icon}`} title={getFileSourceIconTitle(source)} />
+            {/* biome-ignore lint/a11y/useValidAnchor: The onClick handler is only used for logging */}
             <a
                 className={classNames(styles.linkButton, isTooLarge && styles.excluded)}
                 title={isTooLarge ? warning : pathWithRange}
                 href={href}
                 target={target}
+                onClick={logContextOpening}
             >
                 {pathWithRange}
             </a>

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -16,10 +16,10 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
     revision,
     isTooLarge,
 }) => {
-    function logContextOpening() {
+    function logFileLinkClicked() {
         getVSCodeAPI().postMessage({
             command: 'event',
-            eventName: 'CodyVSCodeExtension:fileLink:clicked',
+            eventName: 'CodyVSCodeExtension:chat:context:fileLink:clicked',
             properties: { source },
         })
     }
@@ -41,7 +41,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
                     rel="noreferrer"
                     title={tooltip}
                     className={styles.linkButton}
-                    onClick={logContextOpening}
+                    onClick={logFileLinkClicked}
                 >
                     {pathWithRange}
                 </a>
@@ -63,7 +63,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps> = ({
                 title={isTooLarge ? warning : pathWithRange}
                 href={href}
                 target={target}
-                onClick={logContextOpening}
+                onClick={logFileLinkClicked}
             >
                 {pathWithRange}
             </a>

--- a/vscode/webviews/chat/actions/TranscriptAction.tsx
+++ b/vscode/webviews/chat/actions/TranscriptAction.tsx
@@ -19,10 +19,11 @@ export const TranscriptAction: React.FunctionComponent<{
     title: string | { verb: string; object: string; tooltip?: string }
     steps: TranscriptActionStep[]
     className?: string
-}> = ({ title, steps, className }) => {
+    onClick?: () => void
+}> = ({ title, steps, className, onClick }) => {
     return (
         <details className={classNames(className, styles.container)}>
-            <summary>
+            <summary onClick={onClick} onKeyDown={onClick}>
                 {typeof title === 'string' ? (
                     title
                 ) : (

--- a/vscode/webviews/chat/components/EnhancedContext.tsx
+++ b/vscode/webviews/chat/components/EnhancedContext.tsx
@@ -4,6 +4,7 @@ import type { URI } from 'vscode-uri'
 
 import type { ContextItem, RangeData } from '@sourcegraph/cody-shared'
 
+import { getVSCodeAPI } from '../../utils/VSCodeApi'
 import { TranscriptAction } from '../actions/TranscriptAction'
 
 export const EnhancedContextEnabled: React.Context<boolean> = React.createContext(true)
@@ -64,6 +65,18 @@ export const EnhancedContext: React.FunctionComponent<{
         title = `${title} - ⚠️ ${excludedAtContext.length} ${excludedAtUnit} excluded`
     }
 
+    function logContextOpening() {
+        getVSCodeAPI().postMessage({
+            command: 'event',
+            eventName: 'CodyVSCodeExtension:chat:context:opened',
+            properties: {
+                lineCount,
+                fileCount,
+                excludedAtContext: excludedAtContext.length,
+            },
+        })
+    }
+
     return (
         <TranscriptAction
             title={{
@@ -85,6 +98,7 @@ export const EnhancedContext: React.FunctionComponent<{
                     />
                 ),
             }))}
+            onClick={logContextOpening}
             className={className}
         />
     )


### PR DESCRIPTION
Adds logging for when users click on context items

## Test plan

Ask a question and click on context items:

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:chat:context:opened  {
  "details": "VSCode",
  "properties": {
    "lineCount": 558,
    "fileCount": 16,
    "excludedAtContext": 0
  }
}
█ logEvent (telemetry disabled): CodyVSCodeExtension:chat:context:fileLink:clicked  {
  "details": "VSCode",
  "properties": {
    "source": "embeddings"
  }
}
```