### PR TITLE
Make `chat/models` request `chatID`-agnostic

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ModelUsage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ModelUsage.kt
@@ -1,7 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-data class Chat_ModelsParams(
-  val modelUsage: ModelUsage? = null, // Oneof: chat, edit
-)
+typealias ModelUsage = String // One of: chat, edit
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -852,7 +852,11 @@ export class Agent extends MessageHandler implements ExtensionClient {
         })
 
         this.registerAuthenticatedRequest('chat/models', async ({ modelUsage }) => {
-            const providers = ModelProvider.getProviders(modelUsage)
+            const authStatus = await vscode.commands.executeCommand<AuthStatus>('cody.auth.status')
+            const providers = ModelProvider.getProviders(
+                modelUsage,
+                authStatus.isDotCom && !authStatus.userCanUpgrade
+            )
             return { models: providers ?? [] }
         })
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -851,15 +851,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
             )
         })
 
-        this.registerAuthenticatedRequest('chat/models', async ({ id }) => {
-            const panel = this.webPanels.getPanelOrError(id)
-            if (panel.models) {
-                return { models: panel.models, remoteRepos: panel.remoteRepos }
-            }
-            await this.receiveWebviewMessage(id, {
-                command: 'get-chat-models',
-            })
-            return { models: panel.models ?? [] }
+        this.registerAuthenticatedRequest('chat/models', async ({ modelUsage }) => {
+            const providers = ModelProvider.getProviders(modelUsage)
+            return { models: providers ?? [] }
         })
 
         this.registerAuthenticatedRequest('chat/export', async () => {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -336,6 +336,7 @@ describe('Agent', () => {
             for (let i = 0; i < NUMBER_OF_CHATS_TO_RESTORE; i++) {
                 const myDate = new Date(date.getTime() + i * 60 * 1000)
                 await client.request('chat/restore', {
+                    modelID: 'anthropic/claude-2.0',
                     messages: [
                         { text: 'What model are you?', speaker: 'human', contextFiles: [] },
                         {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { isWindows } from '@sourcegraph/cody-shared'
 
+import { ModelUsage } from '@sourcegraph/cody-shared/dist/models/types'
 import { URI } from 'vscode-uri'
 import { TestClient, asTranscriptMessage } from './TestClient'
 import { decodeURIs } from './decodeURIs'
@@ -265,7 +266,7 @@ describe('Agent', () => {
             //  and assert that it can retrieve my name from the transcript.
             const {
                 models: [model],
-            } = await client.request('chat/models', { id: id1 })
+            } = await client.request('chat/models', { modelUsage: ModelUsage.Chat })
 
             const id2 = await client.request('chat/restore', {
                 modelID: model.model,

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -16,6 +16,7 @@ import type {
 } from '@sourcegraph/telemetry'
 import type * as vscode from 'vscode'
 
+import type { ModelUsage } from '@sourcegraph/cody-shared/dist/models/types'
 import type { ExtensionMessage, WebviewMessage } from '../chat/protocol'
 import type { CompletionBookkeepingEvent } from '../completions/logger'
 import type { Repo } from '../context/repo-fetcher'
@@ -52,7 +53,7 @@ export type ClientRequests = {
     // send a chat message via `chat/submitMessage`.
     'chat/restore': [{ modelID?: string | null; messages: ChatMessage[]; chatID: string }, string]
 
-    'chat/models': [{ id: string }, { models: ModelProvider[] }]
+    'chat/models': [{ modelUsage: ModelUsage }, { models: ModelProvider[] }]
     'chat/export': [null, ChatExportResult[]]
     'chat/remoteRepos': [{ id: string }, { remoteRepos?: Repo[] }]
 


### PR DESCRIPTION
`id` param is redundant for `chat/models` request and it complicates logic in the jetbrains client. This PR remove that param from the request.

JetBrains part: https://github.com/sourcegraph/jetbrains/pull/1207

