### PR TITLE
Edit: Remove old shortcut

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -30,6 +30,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: The Enhanced Context Settings modal is opened by default for the first chat session. [pull/3547](https://github.com/sourcegraph/cody/pull/3547)
 - Add information on which Cody tier is being used to analytics events. [pull/3508](https://github.com/sourcegraph/cody/pull/3508)
 - Chat: Claude 3 Sonnet is now the default model for every Cody Free or Pro user. [pull/3575](https://github.com/sourcegraph/cody/pull/3575)
+- Edit: Removed a previous Edit shortcut (`Shift+Cmd/Ctrl+v`), use `Opt/Alt+K` to trigger Edits. [pull/3591](https://github.com/sourcegraph/cody/pull/3591)
 
 ## [1.10.0]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -535,12 +535,6 @@
       },
       {
         "command": "cody.command.edit-code",
-        "key": "ctrl+shift+v",
-        "mac": "shift+cmd+v",
-        "when": "cody.activated && !editorReadonly"
-      },
-      {
-        "command": "cody.command.edit-code",
         "key": "alt+k",
         "when": "cody.activated && !editorReadonly"
       },


### PR DESCRIPTION
## Description

We can fully move over to Opt/Alt+K now. And we have the ghost text set to 100% for hints.

Didn't find any other references to this shortcut

## Test plan

1. Try shortcut
2. Check it doesn't trigger edits

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
