### PR TITLE
Edit: Log diagnostic code and source for fix commands

### DIFF
--- a/vscode/src/code-actions/fixup.ts
+++ b/vscode/src/code-actions/fixup.ts
@@ -58,6 +58,12 @@ export class FixupCodeAction implements vscode.CodeActionProvider {
                 {
                     configuration: { instruction, range, intent: 'fix', document },
                     source,
+                    telemetryMetadata: {
+                        diagnostics: diagnostics.map(diagnostic => ({
+                            code: diagnostic.code,
+                            source: diagnostic.source,
+                        })),
+                    },
                 } satisfies ExecuteEditArguments,
             ],
             title: 'Ask Cody to Fix',

--- a/vscode/src/edit/execute.ts
+++ b/vscode/src/edit/execute.ts
@@ -20,6 +20,9 @@ export interface ExecuteEditArguments {
         insertionPoint?: vscode.Position
     }
     source?: ChatEventSource
+    telemetryMetadata?: {
+        [key: string]: unknown
+    }
 }
 
 /**

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -67,6 +67,7 @@ export class EditManager implements vscode.Disposable {
              * E.g. triggering this command via the command palette, right-click menus
              **/
             source = 'editor',
+            telemetryMetadata,
         } = args
         const configFeatures = await ConfigFeaturesSingleton.getInstance().getConfigFeatures()
         if (!configFeatures.commands) {
@@ -167,6 +168,7 @@ export class EditManager implements vscode.Disposable {
             intent: task.intent,
             mode: task.mode,
             source: task.source,
+            ...telemetryMetadata,
         }
         telemetryService.log(`CodyVSCodeExtension:command:${eventName}:executed`, legacyMetadata, {
             hasV2Event: true,


### PR DESCRIPTION
## Description

This PR:
- Adds telemetry logging for the diagnostic when "Ask Cody to Fix" is executed
- We log the diagnostic code (e.g. `1233`) and the source (e.g. `ts`)

## Test plan

1. Run "Ask Cody to FIx"
2. View telemetry logs

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
