### PR TITLE
Chat: improve @mentions on input

### DIFF
--- a/lib/shared/src/mentions/query.ts
+++ b/lib/shared/src/mentions/query.ts
@@ -46,7 +46,7 @@ const VALID_CHARS = '[^' + TRIGGERS + PUNCTUATION + '\\s]'
 
 const MAX_LENGTH = 250
 
-const RANGE_REGEXP = '(?::\\d+-\\d+)?'
+const RANGE_REGEXP = '(?::\\d+(?:-\\d*)?)?'
 
 const AT_MENTIONS_REGEXP = new RegExp(
     '(?<maybeLeadingWhitespace>^|\\s|\\()(?<replaceableString>' +

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -273,7 +273,7 @@ test('@-mention links in transcript message', async ({ page, sidebar }) => {
     await expect(previewTab).toBeVisible()
 })
 
-test.only('@-mention file range', async ({ page, sidebar }) => {
+test('@-mention file range', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
 
     // Open chat.

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -81,6 +81,8 @@ test.extend<ExpectedEvents>({
     await chatInput.fill('Explain @mj')
     await chatPanelFrame.getByRole('option', { name: 'Main.java' }).click()
     await expect(chatInput).toHaveText('Explain @Main.java ')
+    await expect(chatInput.getByText('@Main.java')).not.toHaveClass(/context-item-mention-node/)
+    await chatInput.press('Enter')
     await expect(chatInput.getByText('@Main.java')).toHaveClass(/context-item-mention-node/)
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
@@ -95,6 +97,7 @@ test.extend<ExpectedEvents>({
         chatPanelFrame.getByRole('option', { name: withPlatformSlashes('var.go lib/batches/env') })
     ).toBeVisible()
     await chatInput.press('Tab')
+    await chatInput.press('Tab')
     await expect(chatInput).toHaveText(withPlatformSlashes('Explain @lib/batches/env/var.go '))
     await chatInput.focus()
     await chatInput.pressSequentially('and ')
@@ -107,6 +110,7 @@ test.extend<ExpectedEvents>({
     await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/var\.go/)
     await chatInput.press('ArrowDown') // second item again
     await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/visualize\.go/)
+    await chatInput.press('Tab')
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText(
         withPlatformSlashes(
@@ -135,12 +139,14 @@ test.extend<ExpectedEvents>({
     await chatInput.pressSequentially('@Main.java', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.press('Tab')
+    await chatInput.press('Tab')
     await expect(chatInput).toHaveText('@Main.java ')
 
     // Check pressing tab after typing a partial filename but where that complete
     // filename already exists earlier in the input.
     // https://github.com/sourcegraph/cody/issues/2243
     await chatInput.pressSequentially('and @Main.ja', { delay: 10 })
+    await chatInput.press('Tab')
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText('@Main.java and @Main.java ')
 
@@ -156,6 +162,7 @@ test.extend<ExpectedEvents>({
     await chatInput.press('Space') // 'Explain the | file'
     await chatInput.pressSequentially('@Main', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
+    await chatInput.press('Tab')
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText('Explain the @Main.java file')
     // Confirm the cursor is at the end of the newly added file name with space
@@ -201,6 +208,7 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     // Send a message with an @-mention.
     await chatInput.fill('Explain @mj')
     await chatPanelFrame.getByRole('option', { name: 'Main.java' }).click()
+    await chatInput.press('Enter')
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await expect(chatInput.getByText('@Main.java')).toHaveClass(/context-item-mention-node/)
     await chatInput.press('Enter')
@@ -218,6 +226,7 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await chatInput.press('ArrowUp')
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await chatInput.pressSequentially('and @index.ht')
+    await chatPanelFrame.getByRole('option', { name: 'index.html' }).click()
     await chatPanelFrame.getByRole('option', { name: 'index.html' }).click()
     await expect(chatInput).toHaveText('Explain @Main.java and @index.html')
     await expect(chatInput.getByText('@index.html')).toHaveClass(/context-item-mention-node/)
@@ -237,6 +246,7 @@ test('pressing Enter with @-mention menu open selects item, does not submit mess
     await chatInput.fill('Explain @index.htm')
     await expect(chatPanelFrame.getByRole('option', { name: 'index.html' })).toBeVisible()
     await chatInput.press('Enter')
+    await chatInput.press('Enter')
     await expect(chatInput).toHaveText('Explain @index.html')
     await expect(chatInput.getByText('@index.html')).toHaveClass(/context-item-mention-node/)
 })
@@ -251,6 +261,7 @@ test('@-mention links in transcript message', async ({ page, sidebar }) => {
     await chatInput.fill('Hello @buzz.ts')
     await chatPanelFrame.getByRole('option', { name: 'buzz.ts' }).click()
     await chatInput.press('Enter')
+    await chatInput.press('Enter')
 
     // In the transcript, the @-mention is linked, and clicking the link opens the file.
     const transcriptMessage = chatPanelFrame.getByText('Hello @buzz.ts')
@@ -262,7 +273,7 @@ test('@-mention links in transcript message', async ({ page, sidebar }) => {
     await expect(previewTab).toBeVisible()
 })
 
-test('@-mention file range', async ({ page, sidebar }) => {
+test.only('@-mention file range', async ({ page, sidebar }) => {
     await sidebarSignin(page, sidebar)
 
     // Open chat.
@@ -273,6 +284,8 @@ test('@-mention file range', async ({ page, sidebar }) => {
     await expect(chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' }).click()
     await expect(chatInput).toHaveText('@buzz.ts:2-4 ')
+    // Enter again to turn it into a token
+    await chatInput.press('Enter')
 
     // Submit the message
     await chatInput.press('Enter')
@@ -288,6 +301,7 @@ test('@-mention file range', async ({ page, sidebar }) => {
     await expect(previewTab).toBeVisible()
 })
 
+// NOTE: @symbols does not require double tabbing to select an option.
 test.extend<ExpectedEvents>({
     expectedEvents: ['CodyVSCodeExtension:at-mention:symbol:executed'],
 })('@-mention symbol in chat', async ({ page, sidebar }) => {

--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -105,6 +105,7 @@ test.extend<ExpectedEvents>({
     await expect(chatInput).not.toHaveText('Four')
     await expect(chatFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.press('Tab')
+    await chatInput.press('Tab')
     await expect(chatInput).toHaveText('Explain @Main.java ')
 
     // Enter should submit the message and exit editing mode
@@ -120,6 +121,7 @@ test.extend<ExpectedEvents>({
     await chatInput.focus()
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await chatInput.type('and @vgo', { delay: 50 })
+    await chatInput.press('Tab')
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText(
         withPlatformSlashes('Explain @Main.java and @lib/batches/env/var.go ')

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -176,8 +176,11 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
     // range needs to go to the start (0th character) of line 5. Also, `RangeData` is 0-indexed but
     // display ranges are 1-indexed.
     const rangeText = contextItem.range ? `:${displayLineRange(contextItem.range)}` : ''
-    // Large file cannot be added to the context file list.
     if (contextItem.type === 'file' && !contextItem.isTooLarge) {
+        return `@${displayPath(URI.parse(contextItem.uri))}${rangeText}`
+    }
+    // Large file cannot be added to the context file list unless it has a range.
+    if (contextItem.type === 'file' && contextItem.isTooLarge && rangeText) {
         return `@${displayPath(URI.parse(contextItem.uri))}${rangeText}`
     }
     if (contextItem.type === 'symbol') {

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -209,3 +209,9 @@ export function isSerializedContextItemMentionNode(
 ): node is SerializedContextItemMentionNode {
     return Boolean(node && node.type === ContextItemMentionNode.getType())
 }
+
+export function $createContextItemTextNode(contextItem: ContextItem | SerializedContextItem): TextNode {
+    const atNode = new ContextItemMentionNode(contextItem)
+    const textNode = new TextNode(atNode.__text)
+    return $applyNodeReplacement(textNode)
+}

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -115,7 +115,7 @@ export default function MentionsPlugin(): JSX.Element | null {
                 // This allows users to autocomplete the file path, and provide them with
                 // the options to make additional changes, e.g. add range, before inserting the mention.
                 const textNode = $createContextItemTextNode(selectedOption.item)
-                if (!currentInputText.endsWith(textNode.__text)) {
+                if (!currentInputText.endsWith(textNode.__text) && !currentInputText.startsWith('@#')) {
                     nodeToReplace.replace(textNode)
                     textNode.select()
                     closeMenu()

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -25,6 +25,9 @@ import {
 import { OptionsList } from './OptionsList'
 import { useChatContextItems } from './chatContextClient'
 
+export const RANGE_MATCHES_REGEXP = /:(\d+)?-?(\d+)?$/
+export const LINE_RANGE_REGEXP = /:(\d+)-(\d+)$/
+
 /**
  * Parses the line range (if any) at the end of a string like `foo.txt:1-2`. Because this means "all
  * of lines 1 and 2", the returned range actually goes to the start of line 3 to ensure all of line
@@ -34,7 +37,7 @@ export function parseLineRangeInMention(text: string): {
     textWithoutRange: string
     range?: RangeData
 } {
-    const match = text.match(/:(\d+)-(\d+)$/)
+    const match = text.match(LINE_RANGE_REGEXP)
     if (match === null) {
         return { textWithoutRange: text }
     }

--- a/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
@@ -1,7 +1,7 @@
 import type { ContextItem } from '@sourcegraph/cody-shared'
 import { type FunctionComponent, createContext, useContext, useEffect, useState } from 'react'
 import { getVSCodeAPI } from '../../../utils/VSCodeApi'
-import { parseLineRangeInMention } from './atMentions'
+import { LINE_RANGE_REGEXP, RANGE_MATCHES_REGEXP, parseLineRangeInMention } from './atMentions'
 
 export interface ChatContextClient {
     getChatContextItems(query: string): Promise<ContextItem[]>
@@ -66,9 +66,9 @@ export function useChatContextItems(query: string | null): ContextItem[] | undef
             return
         }
 
-        // If user is typing a line range, keep the current results.
-        if (results?.length && /:(\d+)?(-\d+)?/.test(query)) {
-            if (!/:(\d+)-(\d+)$/.test(query)) {
+        // If user is typing a line range, no need to fetch new chat context items.
+        if (results?.length && RANGE_MATCHES_REGEXP.test(query)) {
+            if (!LINE_RANGE_REGEXP.test(query)) {
                 return
             }
         }

--- a/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/chatContextClient.tsx
@@ -66,6 +66,13 @@ export function useChatContextItems(query: string | null): ContextItem[] | undef
             return
         }
 
+        // If user is typing a line range, keep the current results.
+        if (results?.length && /:(\d+)?(-\d+)?/.test(query)) {
+            if (!/:(\d+)-(\d+)$/.test(query)) {
+                return
+            }
+        }
+
         // Track if the query changed since this request was sent (which would make our results
         // no longer valid).
         let invalidated = false


### PR DESCRIPTION
CLOSE: https://github.com/sourcegraph/cody/issues/3589#issuecomment-2026647366

## Current

Currently, if you add the range after inputting the file name, the title will show up as `No files found`:
![image](https://github.com/sourcegraph/cody/assets/68532117/b7b4e6fb-ca7a-4175-88ff-7eb21c3aa851)

Until you have finished the @-range:

![image](https://github.com/sourcegraph/cody/assets/68532117/12b09103-e674-4392-be8f-d28f65171063)

This means you will have to type the whole file path before you can add the file range. Which means if you pressed space or tab on a selection you won't be able to make any changes and have to restart. 

## Changes 

This PR updates:

1. Menu displays correctly while entering the line range.
2. Autocomplete on select, and then select again to turn the selection into token (for files only. Symbol and uri is not affected).
   - This allows users to edit the file path, e.g. adding range, before it becomes a token

![at](https://github.com/sourcegraph/cody/assets/68532117/64cbe050-ab9e-4280-b5d7-c80021c60d38)

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before

https://github.com/sourcegraph/cody/assets/68532117/9b91c43f-13ef-40b1-898c-cc00c3541f71

### After

https://github.com/sourcegraph/cody/assets/68532117/22314f05-37c9-4f43-878b-9447731f9886
