### PR TITLE
Docs: remove Inline chat section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,6 @@ See [cody.dev](https://about.sourcegraph.com/cody?utm_source=github.com&utm_medi
 
 > <img src="https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody-completions-may2023-optim-sm2.gif" width=400>
 
-**Inline chat**
-
-> <img src="https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody_inline_June23-sm.gif" width=400>
-
 **Codebase-wide chat:**
 
 > <img src="https://storage.googleapis.com/sourcegraph-assets/website/Product%20Animations/GIFS/cody-chat-may2023-optim.gif" width=400>


### PR DESCRIPTION
docs: Remove Inline chat section from README

The Inline chat section and its associated image have been removed from the README file as they are no longer supported.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Docs update