### PR TITLE
E2E Test: fix flaky custom command test

### DIFF
--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -265,8 +265,12 @@ test.extend<ExpectedEvents>({
     await page.locator('a').filter({ hasText: 'Open Workspace Settings (JSON)' }).hover()
     await expect(page.getByRole('button', { name: 'Open or Create Settings File' })).toBeVisible()
     await page.getByRole('button', { name: 'Open or Create Settings File' }).click()
+
+    // Close file.
+    const codyJSONFileTab = page.getByRole('tab', { name: 'cody.json' })
     await page.getByRole('tab', { name: 'cody.json' }).hover()
-    await expect(page.getByRole('tab', { name: 'cody.json' })).toBeVisible()
+    await expect(codyJSONFileTab).toBeVisible()
+    await codyJSONFileTab.getByRole('button', { name: /^Close/ }).click()
 
     // Check button click to delete the cody.json file from the workspace tree view
     await customCommandSidebar.click()
@@ -275,18 +279,20 @@ test.extend<ExpectedEvents>({
     await page.locator('a').filter({ hasText: 'Open Workspace Settings (JSON)' }).hover()
     await page.getByRole('button', { name: 'Delete Settings File' }).hover()
     await page.getByRole('button', { name: 'Delete Settings File' }).click()
-
     // Because we have turned off notification, we will need to check the notification center
-    // for the confirmation message.
+    // for the deletion-confirmation message.
     await page.getByRole('button', { name: 'Do Not Disturb' }).click()
-    await page.getByRole('button', { name: /^Move to / }).click()
+    await page.getByRole('button', { name: /^Move to / }).click() // Move to trash on Mac and bin on Windows
 
-    // The opened cody.json file should be shown as "Deleted"
-    await expect(page.getByRole('list').getByLabel(/cody.json(.*)Deleted$/)).toBeVisible()
+    // Confirm cody.json has been deleted from workspace
+    await sidebarExplorer(page).click()
+    await expect(page.getByRole('treeitem', { name: 'cody.json' }).locator('a')).not.toBeVisible()
 
     // Open the cody.json from User Settings
+
     // NOTE: This is expected to fail locally if you currently have User commands configured
     await page.waitForTimeout(100)
+    await page.click('.badge[aria-label="Cody"]')
     await customCommandSidebar.click()
     await page.locator('a').filter({ hasText: 'Open User Settings (JSON)' }).hover()
     await page.getByRole('button', { name: 'Open or Create Settings File' }).hover()


### PR DESCRIPTION
Small improvement for the custom command e2e tests

Recording shows that the custom command e2e test often fails because the unexpected file wasn't closed. This PR attempts to fix the test by closing the old file before it continues to the next step.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green CI

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/e4f6c537-a01c-4d07-a7ef-d43e496ef979)


![image](https://github.com/sourcegraph/cody/assets/68532117/f3159e2f-8056-4ae4-98a6-29f493e66680)
