### PR TITLE
feat: "Report Issue" command for filing bug reports inside VS Code

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,6 +15,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Added buttons in the chat input box for enabling/disabling Enhanced Context. [pull/3547](https://github.com/sourcegraph/cody/pull/3547)
 - Edit: Display warnings for large @-mentioned files during selection. [pull/3494](https://github.com/sourcegraph/cody/pull/3494)
 - Edit: Automatically show open tabs as available options when triggering an @-mention. [pull/3494](https://github.com/sourcegraph/cody/pull/3494)
+- `Cody Help: Report Issue` command to easily file a pre-filled GitHub issue form for reporting bugs and issues directly inside VS Code. The `Cody Help: Report Issue` command is accessible from the command palette and the `...` menu in the Cody Support sidebar. [pull/3624](https://github.com/sourcegraph/cody/pull/3624)
 
 ### Fixed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -15,7 +15,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Added buttons in the chat input box for enabling/disabling Enhanced Context. [pull/3547](https://github.com/sourcegraph/cody/pull/3547)
 - Edit: Display warnings for large @-mentioned files during selection. [pull/3494](https://github.com/sourcegraph/cody/pull/3494)
 - Edit: Automatically show open tabs as available options when triggering an @-mention. [pull/3494](https://github.com/sourcegraph/cody/pull/3494)
-- `Cody Help: Report Issue` command to easily file a pre-filled GitHub issue form for reporting bugs and issues directly inside VS Code. The `Cody Help: Report Issue` command is accessible from the command palette and the `...` menu in the Cody Support sidebar. [pull/3624](https://github.com/sourcegraph/cody/pull/3624)
+- `Cody Debug: Report Issue` command to easily file a pre-filled GitHub issue form for reporting bugs and issues directly inside VS Code. The `Cody Debug: Report Issue` command is accessible from the command palette and the `...` menu in the Cody Support sidebar. [pull/3624](https://github.com/sourcegraph/cody/pull/3624)
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -512,8 +512,8 @@
         "when": "!config.cody.debug.verbose"
       },
       {
-        "command": "cody.support.reportIssue",
-        "category": "Cody Help",
+        "command": "cody.debug.reportIssue",
+        "category": "Cody Debug",
         "group": "Debug",
         "title": "Report Issue"
       }
@@ -752,7 +752,7 @@
           "group": "8_cody@2"
         },
         {
-          "command": "cody.support.reportIssue",
+          "command": "cody.debug.reportIssue",
           "when": "view == cody.support.tree.view",
           "group": "9_cody@1"
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -74,7 +74,7 @@
     "directory": "vscode"
   },
   "bugs": {
-    "url": "https://github.com/sourcegraph/cody/issues"
+    "url": "https://github.com/sourcegraph/cody/issues/new?&labels=bug&projects=sourcegraph&template=bug_report.yml&title=bug:"
   },
   "homepage": "https://sourcegraph.com/docs/cody",
   "badges": [
@@ -510,6 +510,12 @@
         "group": "Debug",
         "title": "Enable Debug Mode",
         "when": "!config.cody.debug.verbose"
+      },
+      {
+        "command": "cody.support.reportIssue",
+        "category": "Cody Help",
+        "group": "Debug",
+        "title": "Report Issue"
       }
     ],
     "keybindings": [
@@ -744,6 +750,11 @@
           "command": "cody.debug.outputChannel",
           "when": "view == cody.support.tree.view",
           "group": "8_cody@2"
+        },
+        {
+          "command": "cody.support.reportIssue",
+          "when": "view == cody.support.tree.view",
+          "group": "9_cody@1"
         },
         {
           "command": "cody.search.index-update",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -74,7 +74,7 @@
     "directory": "vscode"
   },
   "bugs": {
-    "url": "https://github.com/sourcegraph/cody/issues/new?&labels=bug&projects=sourcegraph&template=bug_report.yml&title=bug:"
+    "url": "https://github.com/sourcegraph/cody/issues"
   },
   "homepage": "https://sourcegraph.com/docs/cody",
   "badges": [

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -534,7 +534,7 @@ const register = async (
         vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri)),
         vscode.commands.registerCommand('cody.debug.outputChannel', () => openCodyOutputChannel()),
         vscode.commands.registerCommand('cody.debug.enable.all', () => enableDebugMode()),
-        vscode.commands.registerCommand('cody.support.reportIssue', () => openCodyIssueReporter()),
+        vscode.commands.registerCommand('cody.debug.reportIssue', () => openCodyIssueReporter()),
         new CharactersLogger()
     )
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -15,6 +15,7 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import type { DefaultCodyCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import { openCodyIssueReporter } from '../webviews/utils/reportIssue'
 import { ContextProvider } from './chat/ContextProvider'
 import type { MessageProviderOptions } from './chat/MessageProvider'
 import { ChatManager, CodyChatPanelViewType } from './chat/chat-view/ChatManager'
@@ -533,6 +534,7 @@ const register = async (
         vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri)),
         vscode.commands.registerCommand('cody.debug.outputChannel', () => openCodyOutputChannel()),
         vscode.commands.registerCommand('cody.debug.enable.all', () => enableDebugMode()),
+        vscode.commands.registerCommand('cody.support.reportIssue', () => openCodyIssueReporter()),
         new CharactersLogger()
     )
 

--- a/vscode/webviews/utils/reportIssue.ts
+++ b/vscode/webviews/utils/reportIssue.ts
@@ -15,13 +15,16 @@ const issueBody = `## Extension Information
 <!-- Do not remove the pre-filled information below -->
 - Cody Version: ${packageJson.version}
 - VS Code Version: ${vscode.version}
-- Host: ${vscode.env.appHost}
+- Extension Host: ${vscode.env.appHost}
 
 ##  Steps to Reproduce
 <!-- A detailed description of the issue -->
 1.
 2.
 3.
+
+## Expected Behaviour
+<!-- A detailed description of what you expected to happen -->
 
 ## Logs
 <!-- Attach logs from the 'Cody Debug: Export Logs' command -->

--- a/vscode/webviews/utils/reportIssue.ts
+++ b/vscode/webviews/utils/reportIssue.ts
@@ -1,0 +1,28 @@
+import * as vscode from 'vscode'
+
+import packageJson from '../../package.json'
+
+export function openCodyIssueReporter() {
+    void vscode.commands.executeCommand('workbench.action.openIssueReporter', {
+        extensionId: `${packageJson.publisher}.${packageJson.name}`,
+        issueBody,
+        issueTitle: 'bug: ',
+        uri: packageJson.bugs,
+    })
+}
+
+const issueBody = `## Extension Information
+<!-- Do not remove the pre-filled information below -->
+- Cody Version: ${packageJson.version}
+- VS Code Version: ${vscode.version}
+- Host: ${vscode.env.appHost}
+
+##  Steps to Reproduce
+<!-- A detailed description of the issue -->
+1.
+2.
+3.
+
+## Logs
+<!-- Attach logs from the 'Cody Debug: Export Logs' command -->
+`


### PR DESCRIPTION
New "Report Issue" command to allow users to file Github issues with the editor through the built-in `Issue Reporter`.

<img width="1589" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/c59fd4de-1f57-4a5e-b6e8-be436d1b58a9">


This commit adds a new command to the *VS Code Issue Reporter* and the *Cody support sidebar* to allow users to easily report issues to us with pre-filled system info. 
- The "Report Issue" command opens the *VS Code Issue Reporter* with `Cody version`, `VS Code Version` and `Host` pre-filled.

Summary of Changes:
- Updated our bug link for filing GitHub issue with relevant labels, project, and template for bug reports.
- Added a new command `cody.debug.reportIssue` under `contributes.commands` to register the "Report Issue" command.
- Added a new menu item under `view/item/context` to display the "Report Issue" command in the Cody support sidebar.

- Updated `vscode/src/main.ts`:
  - Imported the `openCodyIssueReporter` function from `../webviews/utils/reportIssue`.
  - Registered the `cody.debug.reportIssue` command to execute the `openCodyIssueReporter` function when invoked.


## Test plan

![image](https://github.com/sourcegraph/cody/assets/68532117/b8f77f5c-e398-4750-abbd-10b228f1f4fb)


1. Open the Cody extension in VS Code.
2. Execute the "Cody Debug: Report Issue" command from the command palette.
3. Verify that a new window opens with Cody Version and VS Code Version pre-filled in the body.
<img width="1953" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/cde48a15-2937-4a28-86e1-882e9a0e62d1">
4. Typing in the title would show you if a similar issues have been reported
<img width="1812" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/d2407f50-37a0-4cb8-a876-727188d577db">
5. Ability to include system information with the issue
<img width="1802" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/88ae70d3-e081-4faa-b1b0-419aac7e8b92">
6. Submit the bug report by clicking on the `Create on Github`button to confirm your issue has been created inside the cody repository
7. Verify the `Report Issue` option is also available in the support sidebar `...` menu
<img width="857" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/66ce594b-e2bf-40f7-8376-1fc34967c37f">
