### PR TITLE
clean up VS Code storybooks, make them use the default VS Code dark theme colors

### DIFF
--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -1,21 +1,21 @@
-import type { ComponentMeta, ComponentStoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 
 import { defaultAuthStatus } from '../src/chat/protocol'
 
 import { App } from './App'
-import { VSCodeStoryDecorator, WithBorder } from './storybook/VSCodeStoryDecorator'
+import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
-const meta: ComponentMeta<typeof App> = {
+const meta: Meta<typeof App> = {
     title: 'cody/App',
     component: App,
 
-    decorators: [WithBorder, VSCodeStoryDecorator],
+    decorators: [VSCodeWebview],
 }
 
 export default meta
 
-export const Simple: ComponentStoryObj<typeof App> = {
+export const Simple: StoryObj<typeof meta> = {
     render: () => <App vscodeAPI={dummyVSCodeAPI} />,
 }
 

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { defaultAuthStatus } from '../src/chat/protocol'
 
+import { DEFAULT_DOT_COM_MODELS } from '@sourcegraph/cody-shared/src/models/dotcom'
 import { App } from './App'
 import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
@@ -41,6 +42,24 @@ const dummyVSCodeAPI: VSCodeWrapper = {
                 endpoint: 'https://example.com',
             },
             workspaceFolderUris: [],
+        })
+        cb({ type: 'chatModels', models: DEFAULT_DOT_COM_MODELS })
+        cb({
+            type: 'history',
+            localHistory: {
+                chat: {
+                    a: {
+                        id: 'a',
+                        lastInteractionTimestamp: '2024-03-29',
+                        interactions: [
+                            {
+                                humanMessage: { speaker: 'human', text: 'Hello, world!' },
+                                assistantMessage: { speaker: 'assistant', text: 'Hi!' },
+                            },
+                        ],
+                    },
+                },
+            },
         })
         return () => {}
     },

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Chat } from './Chat'
 import { FIXTURE_TRANSCRIPT } from './chat/fixtures'
-import { VSCodeStoryDecorator, WithBorder } from './storybook/VSCodeStoryDecorator'
+import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
 
 const meta: Meta<typeof Chat> = {
     title: 'cody/Chat',
@@ -31,8 +31,8 @@ const meta: Meta<typeof Chat> = {
         isNewInstall: false,
     } satisfies React.ComponentProps<typeof Chat>,
 
-    decorators: [WithBorder, VSCodeStoryDecorator],
-} as Meta
+    decorators: [VSCodeWebview],
+}
 
 export default meta
 

--- a/vscode/webviews/ChatErrorNotice.story.tsx
+++ b/vscode/webviews/ChatErrorNotice.story.tsx
@@ -1,40 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
-import classNames from 'classnames'
 
 import { RateLimitError } from '@sourcegraph/cody-shared'
-import type { ChatButtonProps } from './Chat'
 import { ErrorItem } from './chat/ErrorItem'
 
-import { VSCodeStoryDecorator } from './storybook/VSCodeStoryDecorator'
-
-import chatStyles from './Chat.module.css'
-import transcriptItemStyles from './chat/TranscriptItem.module.css'
+import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
 
 const meta: Meta<typeof ErrorItem> = {
     title: 'cody/Chat Error Item',
     component: ErrorItem,
-    decorators: [VSCodeStoryDecorator],
-    parameters: {
-        backgrounds: {
-            default: 'vscode',
-            values: [
-                {
-                    name: 'vscode',
-                    value: 'var(--vscode-sideBar-background)',
-                },
-            ],
-        },
-    },
+    decorators: [VSCodeWebview],
     render: args => (
-        <div
-            className={classNames(
-                transcriptItemStyles.row,
-                chatStyles.transcriptItem,
-                transcriptItemStyles.assistantRow
-            )}
-            style={{ border: '1px solid var(--vscode-sideBarSectionHeader-border)' }}
-        >
+        <div style={{ position: 'relative', padding: '1rem' }}>
             <ErrorItem {...args} />
         </div>
     ),
@@ -43,22 +19,6 @@ const meta: Meta<typeof ErrorItem> = {
 export default meta
 
 type Story = StoryObj<typeof ErrorItem>
-
-const ChatButton: React.FunctionComponent<ChatButtonProps> = ({
-    label,
-    action,
-    onClick,
-    appearance,
-}) => (
-    <VSCodeButton
-        type="button"
-        onClick={() => onClick(action)}
-        className={chatStyles.chatButton}
-        appearance={appearance}
-    >
-        {label}
-    </VSCodeButton>
-)
 
 export const ChatRateLimitFree: Story = {
     args: {
@@ -74,7 +34,6 @@ export const ChatRateLimitFree: Story = {
             isDotComUser: true,
             isCodyProUser: false,
         },
-        ChatButtonComponent: ChatButton,
     },
 }
 
@@ -92,6 +51,5 @@ export const ChatRateLimitPro: Story = {
             isDotComUser: true,
             isCodyProUser: true,
         },
-        ChatButtonComponent: ChatButton,
     },
 }

--- a/vscode/webviews/Components/ChatModelDropdownMenu.story.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.story.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { DOTCOM_URL, ModelProvider } from '@sourcegraph/cody-shared'
 
-import { VSCodeStoryDecorator } from '../storybook/VSCodeStoryDecorator'
+import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 
 import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
 import { ChatModelDropdownMenu } from './ChatModelDropdownMenu'
@@ -10,21 +10,10 @@ import { ChatModelDropdownMenu } from './ChatModelDropdownMenu'
 const meta: Meta<typeof ChatModelDropdownMenu> = {
     title: 'cody/Chat Model Dropdown',
     component: ChatModelDropdownMenu,
-    decorators: [VSCodeStoryDecorator],
+    decorators: [VSCodeStandaloneComponent],
     args: {
         models: ModelProvider.getProviders(ModelUsage.Chat, true, String(DOTCOM_URL)),
         disabled: false,
-    },
-    parameters: {
-        backgrounds: {
-            default: 'vscode',
-            values: [
-                {
-                    name: 'vscode',
-                    value: 'var(--vscode-sideBar-background)',
-                },
-            ],
-        },
     },
 }
 
@@ -37,6 +26,15 @@ export const FreeUser: Story = {
         userInfo: {
             isDotComUser: true,
             isCodyProUser: false,
+        },
+    },
+}
+
+export const ProUser: Story = {
+    args: {
+        userInfo: {
+            isDotComUser: true,
+            isCodyProUser: true,
         },
     },
 }

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -15,7 +15,7 @@ import {
 } from './EnhancedContextSettings'
 
 const meta: Meta<typeof EnhancedContextSettings> = {
-    title: 'cody/Enhanced Context',
+    title: 'cody/Enhanced Context Settings',
     component: EnhancedContextSettings,
     decorators: [VSCodeStandaloneComponent],
 }

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -1,10 +1,11 @@
-import { useArgs, useState } from '@storybook/preview-api'
+import { useArgs } from '@storybook/preview-api'
 import type { Meta, StoryObj } from '@storybook/react'
 
 import type { ContextProvider, LocalEmbeddingsProvider, SearchProvider } from '@sourcegraph/cody-shared'
 
-import { VSCodeStoryDecorator } from '../storybook/VSCodeStoryDecorator'
+import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 
+import { useState } from 'react'
 import {
     EnhancedContextContext,
     EnhancedContextEventHandlers,
@@ -16,18 +17,7 @@ import {
 const meta: Meta<typeof EnhancedContextSettings> = {
     title: 'cody/Enhanced Context',
     component: EnhancedContextSettings,
-    decorators: [VSCodeStoryDecorator],
-    parameters: {
-        backgrounds: {
-            default: 'vscode',
-            values: [
-                {
-                    name: 'vscode',
-                    value: 'var(--vscode-sideBar-background)',
-                },
-            ],
-        },
-    },
+    decorators: [VSCodeStandaloneComponent],
 }
 
 export default meta
@@ -133,7 +123,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
                     >
                         <EnhancedContextSettings
                             isOpen={isOpen}
-                            setOpen={() => setIsOpen(!isOpen)}
+                            setOpen={setIsOpen}
                             presentationMode={args.presentationMode}
                             isFirstChat={false}
                         />
@@ -170,7 +160,7 @@ export const ConsumerMultipleProviders: StoryObj<typeof EnhancedContextSettings>
                 >
                     <EnhancedContextSettings
                         isOpen={isOpen}
-                        setOpen={() => setIsOpen(!isOpen)}
+                        setOpen={setIsOpen}
                         presentationMode={EnhancedContextPresentationMode.Consumer}
                         isFirstChat={false}
                     />
@@ -199,7 +189,7 @@ export const EnterpriseNoRepositories: StoryObj<typeof EnhancedContextSettings> 
                     <EnhancedContextSettings
                         presentationMode={EnhancedContextPresentationMode.Enterprise}
                         isOpen={isOpen}
-                        setOpen={() => setIsOpen(!isOpen)}
+                        setOpen={setIsOpen}
                         isFirstChat={false}
                     />
                 </div>
@@ -264,7 +254,7 @@ export const EnterpriseMultipleRepositories: StoryObj<typeof EnhancedContextSett
                     <EnhancedContextSettings
                         presentationMode={EnhancedContextPresentationMode.Enterprise}
                         isOpen={isOpen}
-                        setOpen={() => setIsOpen(!isOpen)}
+                        setOpen={setIsOpen}
                         isFirstChat={false}
                     />
                 </div>

--- a/vscode/webviews/OnboardingExperiment.story.tsx
+++ b/vscode/webviews/OnboardingExperiment.story.tsx
@@ -3,13 +3,13 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared'
 
 import { LoginSimplified } from './OnboardingExperiment'
-import { VSCodeStoryDecorator } from './storybook/VSCodeStoryDecorator'
+import { VSCodeSidebar } from './storybook/VSCodeStoryDecorator'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 const meta: Meta<typeof LoginSimplified> = {
     title: 'cody/Onboarding',
     component: LoginSimplified,
-    decorators: [VSCodeStoryDecorator],
+    decorators: [VSCodeSidebar],
 }
 
 export default meta
@@ -23,26 +23,22 @@ const vscodeAPI: VSCodeWrapper = {
 
 export const Login: StoryObj<typeof LoginSimplified> = {
     render: () => (
-        <div style={{ background: 'rgb(28, 33, 40)' }}>
-            <LoginSimplified
-                simplifiedLoginRedirect={() => {}}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-                uiKindIsWeb={false}
-                vscodeAPI={vscodeAPI}
-            />
-        </div>
+        <LoginSimplified
+            simplifiedLoginRedirect={() => {}}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            uiKindIsWeb={false}
+            vscodeAPI={vscodeAPI}
+        />
     ),
 }
 
 export const LoginWeb: StoryObj<typeof LoginSimplified> = {
     render: () => (
-        <div style={{ background: 'rgb(28, 33, 40)' }}>
-            <LoginSimplified
-                simplifiedLoginRedirect={() => {}}
-                telemetryService={NOOP_TELEMETRY_SERVICE}
-                uiKindIsWeb={true}
-                vscodeAPI={vscodeAPI}
-            />
-        </div>
+        <LoginSimplified
+            simplifiedLoginRedirect={() => {}}
+            telemetryService={NOOP_TELEMETRY_SERVICE}
+            uiKindIsWeb={true}
+            vscodeAPI={vscodeAPI}
+        />
     ),
 }

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -4,7 +4,7 @@ import { Transcript } from './Transcript'
 import type { FileLinkProps } from './components/EnhancedContext'
 import { FIXTURE_TRANSCRIPT } from './fixtures'
 
-import { VSCodeStoryDecorator } from '../storybook/VSCodeStoryDecorator'
+import { VSCodeWebview } from '../storybook/VSCodeStoryDecorator'
 import styles from './Transcript.story.module.css'
 
 const meta: Meta<typeof Transcript> = {
@@ -23,7 +23,7 @@ const meta: Meta<typeof Transcript> = {
         transcript: FIXTURE_TRANSCRIPT.simple,
     },
 
-    decorators: [VSCodeStoryDecorator],
+    decorators: [VSCodeWebview],
 }
 
 export default meta

--- a/vscode/webviews/chat/components/ChatActions.story.tsx
+++ b/vscode/webviews/chat/components/ChatActions.story.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { VSCodeStoryDecorator } from '../../storybook/VSCodeStoryDecorator'
+import { VSCodeStandaloneComponent } from '../../storybook/VSCodeStoryDecorator'
 import { ChatActions } from './ChatActions'
 
 const meta: Meta<typeof ChatActions> = {
@@ -18,7 +18,7 @@ const meta: Meta<typeof ChatActions> = {
         onRestoreLastChatClick: () => {},
     },
 
-    decorators: [VSCodeStoryDecorator],
+    decorators: [VSCodeStandaloneComponent],
 } as Meta
 
 export default meta

--- a/vscode/webviews/promptEditor/BaseEditor.story.tsx
+++ b/vscode/webviews/promptEditor/BaseEditor.story.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import type { EditorState } from 'lexical'
 import { useState } from 'react'
-import { VSCodeStoryDecorator } from '../storybook/VSCodeStoryDecorator'
+import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 import { BaseEditor, editorStateToText } from './BaseEditor'
 import styles from './BaseEditor.story.module.css'
 
@@ -16,7 +16,7 @@ const meta: Meta<typeof BaseEditor> = {
         className: styles.editor,
     } as React.ComponentProps<typeof BaseEditor>,
 
-    decorators: [VSCodeStoryDecorator],
+    decorators: [VSCodeStandaloneComponent],
 } as Meta
 
 export default meta

--- a/vscode/webviews/promptEditor/PromptEditor.story.tsx
+++ b/vscode/webviews/promptEditor/PromptEditor.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { type FunctionComponent, useState } from 'react'
-import { VSCodeStoryDecorator } from '../storybook/VSCodeStoryDecorator'
+import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 import styles from './BaseEditor.story.module.css'
 import { PromptEditor, type SerializedPromptEditorState } from './PromptEditor'
 import { FILE_MENTION_EDITOR_STATE_FIXTURE } from './fixtures'
@@ -15,7 +15,7 @@ const meta: Meta<typeof PromptEditor> = {
         editorClassName: styles.editor,
     } satisfies React.ComponentProps<typeof PromptEditor>,
 
-    decorators: [VSCodeStoryDecorator],
+    decorators: [VSCodeStandaloneComponent],
 } as Meta
 
 export default meta

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.story.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.story.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { URI } from 'vscode-uri'
 
 import type { ContextItem } from '@sourcegraph/cody-shared'
-import { VSCodeStoryDecorator, WithBorder } from '../../../storybook/VSCodeStoryDecorator'
+import { VSCodeDecorator } from '../../../storybook/VSCodeStoryDecorator'
 import { OptionsList } from './OptionsList'
 import { MentionTypeaheadOption } from './atMentions'
 
@@ -16,9 +16,14 @@ const meta: Meta<typeof OptionsList> = {
         selectedIndex: null,
         selectOptionAndCleanUp: () => {},
         setHighlightedIndex: () => {},
-    } as React.ComponentProps<typeof OptionsList>,
+    } satisfies React.ComponentProps<typeof OptionsList>,
 
-    decorators: [WithBorder, VSCodeStoryDecorator],
+    decorators: [
+        VSCodeDecorator(undefined, {
+            maxWidth: '300px',
+            border: 'solid 1px var(--vscode-dropdown-border)',
+        }),
+    ],
 }
 
 export default meta

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
@@ -1,10 +1,12 @@
-/**
-* CSS styles for storybooks to define variables and otherwise resemble the VS Code.
-*/
+@import './vscode-dark-theme.css';
+
+:root {
+    --vscode-font-size: 13px;
+    --vscode-font-family: -apple-system, BlinkMacSystemFont, 'Ubuntu', 'Droid Sans', 'Segoe WPC', 'Segoe UI', sans-serif;
+}
 
 body {
-    font-family: var(--vscode-font-family);
-    background-color: var(--vscode-sideBar-background);
+    background-color: var(--vscode-editor-background);
 }
 
 vscode-button::part(control) {
@@ -12,221 +14,27 @@ vscode-button::part(control) {
 }
 
 .container {
-    max-width: 600px;
-    margin: 2rem auto;
     font-size: var(--vscode-font-size);
     font-family: var(--vscode-font-family);
     color: var(--vscode-editor-foreground);
-    background-color: var(--vscode-editor-background);
+    height: 100%;
 }
 
 .container a {
-    color: var(--vscode-link-color);
+    color: var(--vscode-textLink-foreground);
     text-decoration: none;
 }
 
-.test-dark-sidebar {
-    background-color: rgba(28 33 40 100%);
+.container--webview {
+    max-width: 80%;
+    margin: 2rem auto;
+    background-color: var(--vscode-editor-background);
+    border: solid 1px var(--vscode-tab-border);
 }
 
-.test-dark-sidebar-bottom {
-    background: var(--vscode-sideBar-background);
-    height: 60vh;
-    display: flex;
-    align-items: end;
-}
-
-/**
- * Define any --vscode-* CSS variables needed. These differ per theme and don't need to be
- * an exact match for any particular VS Code theme. They just need to be good enough.
- *
- * References:
- * https://sourcegraph.com/github.com/microsoft/vscode/-/blob/extensions/theme-defaults/themes/dark_modern.json
- * https://wiki.scn.sap.com/wiki/display/Img/Colour+List
- */
-
-:root {
-    --vscode-button-background: #007acc;
-    --vscode-button-secondaryBackground: #3a3d41;
-    --vscode-button-secondaryForeground: #ffffff;
-    --vscode-button-secondaryHoverBackground: #45494e;
-    --vscode-checkbox-background: #313131;
-    --vscode-checkbox-border: #3c3c3c;
-    --vscode-editor-background: #151c28;
-    --vscode-editor-font-size: 12px;
-    --vscode-editor-foreground: var(--foreground);
-    --vscode-focusBorder: #4daafc;
-    --vscode-font-size: 13px;
-    --vscode-font-family: -apple-system, BlinkMacSystemFont, 'Ubuntu', 'Droid Sans', 'Segoe WPC', 'Segoe UI', sans-serif;
-    --type-ramp-base-font-size: 13px;
-    --type-ramp-base-line-height: normal;
-    --vscode-input-background: #313131;
-    --vscode-input-foreground: #cccccc;
-    --vscode-input-border: #555555;
-    --vscode-inputOption-activeBorder: #2488db;
-    --vscode-inputOption-hoverBackground: rgb(90 93 94 / 50%);
-    --vscode-inputOption-activeBackground: rgb(36 137 219 / 51%);
-    --vscode-inputOption-activeForeground: #ffffff;
-    --vscode-inputValidation-errorBackground: #ff000033;
-    --vscode-inputValidation-errorBorder: #ff0000;
-    --vscode-link-color: #4daafc;
-    --vscode-list-hoverForeground: #ffffff;
-    --vscode-list-activeSelectionBackground: #2222dd;
-    --vscode-list-inactiveSelectionBackground: #555555;
-    --vscode-list-inactiveSelectionForeground: #ffffff;
-    --vscode-list-dropBackground: #062f4a;
-    --vscode-list-focusBackground: #2222dd;
-    --vscode-list-hoverBackground: #2222dd;
-    --vscode-list-activeSelectionForeground: #ffffff;
-    --vscode-list-warningForeground: #855600;
-    --vscode-problemsErrorIcon-foreground: #f48771;
-    --vscode-quickInput-background: #222222;
-    --vscode-quickInput-foreground: #cccccc;
-    --vscode-pickerGroup-border: #3c3c3c;
-    --vscode-sideBar-background: #181818;
-    --vscode-sideBar-foreground: #cccccc;
-    --vscode-sideBarSectionHeader-border: #ffffff33;
-    --vscode-sideBarTitle-foreground: #ffffffcc;
-    --vscode-tab-activeForeground: #ffffff;
-    --vscode-tab-inactiveBackground: #00000033;
-    --vscode-tab-inactiveForeground: #ffffff77;
-    --vscode-textLink-foreground: #4daafc;
-    --vscode-widget-shadow: rgba(0 0 0 0.2);
-    --vscode-widget-border: #555555;
-    --vscode-dropdown-background: #222222;
-    --vscode-dropdown-foreground: #cccccc;
-    --vscode-dropdown-listBackground: #1f1f1f;
-    --vscode-quickInputList-focusBackground: #2222dd;
-}
-
-@font-face {
-    font-family: codicon;
-    font-display: block;
-    src: url('./codicon.ttf') format('truetype');
-}
-
-:global .codicon[class*='codicon-'] {
-    font: normal normal normal 16px/1 codicon;
-    display: inline-block;
-    text-decoration: none;
-    text-rendering: auto;
-    text-align: center;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    user-select: none;
-}
-
-:global .codicon-modifier-disabled {
-    opacity: 0.5;
-}
-
-:global .codicon-sync.codicon-modifier-spin:local,
-:global .codicon-loading.codicon-modifier-spin:local,
-:global .codicon-gear.codicon-modifier-spin:local {
-    animation: codicon-spin 1.5s steps(30) infinite;
-}
-
-@keyframes codicon-spin {
-    100% {
-        transform: rotate(360deg);
-    }
-}
-
-/* If your Storybook is missing a glyph, add a definition here. See
- * https://github.com/microsoft/vscode-codicons/blob/main/dist/codicon.css
- */
-:global .codicon-check::before {
-    content: '\eab2';
-}
-
-:global .codicon-circle-outline::before {
-    content: '\eabc';
-}
-
-:global .codicon-circle-slash::before {
-    content: '\eabd';
-}
-
-:global .codicon-close::before {
-    content: '\ea76';
-}
-
-:global .codicon-folder::before {
-    content: '\ea83';
-}
-
-:global .codicon-gear::before {
-    content: '\eaf8';
-}
-
-:global .codicon-link::before {
-    content: '\eb15';
-}
-
-:global .codicon-loading::before {
-    content: '\eb19';
-}
-
-:global .codicon-repo-forked::before {
-    content: '\ea63';
-}
-
-:global .codicon-rocket::before {
-    content: '\eb44';
-}
-
-:global .codicon-settings::before {
-    content: '\eb52';
-}
-
-:global .codicon-stop-circle::before {
-    content: '\eba5';
-}
-
-:global .codicon-symbol-folder::before {
-    content: '\ea83';
-}
-
-:global .codicon-terminal::before {
-    content: '\ea85';
-}
-
-:global .codicon-thumbsdown::before {
-    content: '\eb6b';
-}
-
-:global .codicon-thumbsup::before {
-    content: '\eb6c';
-}
-
-:global .codicon-trash::before {
-    content: '\ea81';
-}
-
-:global .codicon-info::before {
-    content: '\ea74';
-}
-
-:global .codicon-database::before {
-    content: '\eace';
-}
-
-:global .codicon-sparkle::before {
-    content: '\ec10';
-}
-
-:global .codicon-symbol-structure::before {
-    content: '\ea91';
-}
-
-:global .codicon-symbol-method::before {
-    content: '\ea8c';
-}
-
-:global .codicon-edit::before {
-    content: '\ea73';
-}
-
-:global .codicon-arrow-up::before {
-    content: '\eaa1';
+.container-sidebar {
+    max-width: 400px;
+    margin: 2rem auto;
+    background-color: var(--vscode-sideBar-background);
+    border: solid 1px var(--vscode-sideBar-border);
 }

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
@@ -1,7 +1,10 @@
 import type { Decorator } from '@storybook/react'
 
 import { isWindows, setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
+import classNames from 'classnames'
+import type { CSSProperties } from 'react'
 import { URI } from 'vscode-uri'
+import '../../node_modules/@vscode/codicons/dist/codicon.css'
 import { WithChatContextClient } from '../promptEditor/plugins/atMentions/chatContextClient'
 import { dummyChatContextClient } from '../promptEditor/plugins/atMentions/fixtures'
 import styles from './VSCodeStoryDecorator.module.css'
@@ -12,16 +15,29 @@ setDisplayPathEnvInfo({
 })
 
 /**
- * A decorator for storybooks that makes them look like they're running in VS Code.
+ * A decorator that displays a story as though it's in a VS Code webview panel, with VS Code theme
+ * colors applied.
  */
-export const VSCodeStoryDecorator: Decorator = story => (
-    <div className={styles.container}>
-        <WithChatContextClient value={dummyChatContextClient}>{story()}</WithChatContextClient>
-    </div>
-)
+export const VSCodeWebview: Decorator = VSCodeDecorator(styles.containerWebview)
 
-export const WithBorder: Decorator = story => (
-    <div className={styles.container} style={{ border: 'solid 1px #333' }}>
-        {story()}
-    </div>
-)
+/**
+ * A decorator that displays a story as though it's in the VS Code sidebar, with VS Code theme
+ * colors applied.
+ */
+export const VSCodeSidebar: Decorator = VSCodeDecorator(styles.containerSidebar)
+
+/**
+ * A decorator that displays a story with VS Code theme colors applied.
+ */
+export const VSCodeStandaloneComponent: Decorator = VSCodeDecorator(undefined)
+
+/**
+ * A customizable decorator for components with VS Code theme colors applied.
+ */
+export function VSCodeDecorator(className: string | undefined, style?: CSSProperties): Decorator {
+    return story => (
+        <div className={classNames(styles.container, className)} style={style}>
+            <WithChatContextClient value={dummyChatContextClient}>{story()}</WithChatContextClient>
+        </div>
+    )
+}

--- a/vscode/webviews/storybook/vscode-dark-theme.css
+++ b/vscode/webviews/storybook/vscode-dark-theme.css
@@ -1,0 +1,127 @@
+/*
+We want to use the default VS Code theme colors here for accuracy and consistency. To regenerate
+this theme CSS from VS Code, go to https://vscode.dev and run the following JavaScript in the
+devtools console:
+
+const lines = [':root {']
+for (const [name, value] of document.querySelector('.monaco-workbench').computedStyleMap()) {
+    if (/^--vscode-(button|foreground|checkbox|editor|focusBorder|font|input|inputOption|inputValidation|link|list|problemsErrorIcon|quickInput|pickerGroup|sideBar|sideBarTitle|sideBarSectionHeader|tab|textLink|widget|dropdown|quickInputList)-/.test(name)){
+        lines.push(`    ${name}: ${value};`);
+    }
+}
+lines.push('}')
+console.log(lines.join('\n'))
+*/
+
+:root {
+    --vscode-button-background: #0078d4;
+    --vscode-button-border: rgba(255, 255, 255, 0.07);
+    --vscode-button-foreground: #ffffff;
+    --vscode-button-hoverBackground: #026ec1;
+    --vscode-button-secondaryBackground: #313131;
+    --vscode-button-secondaryForeground: #cccccc;
+    --vscode-button-secondaryHoverBackground: #3c3c3c;
+    --vscode-button-separator: rgba(255, 255, 255, 0.4);
+    --vscode-checkbox-background: #313131;
+    --vscode-checkbox-border: #3c3c3c;
+    --vscode-checkbox-foreground: #cccccc;
+    --vscode-checkbox-selectBackground: #202020;
+    --vscode-checkbox-selectBorder: #cccccc;
+    --vscode-dropdown-background: #313131;
+    --vscode-dropdown-border: #3c3c3c;
+    --vscode-dropdown-foreground: #cccccc;
+    --vscode-dropdown-listBackground: #1f1f1f;
+    --vscode-editor-background: #1f1f1f;
+    --vscode-editor-findMatchBackground: #9e6a03;
+    --vscode-editor-findMatchHighlightBackground: rgba(234, 92, 0, 0.33);
+    --vscode-editor-findRangeHighlightBackground: rgba(58, 61, 65, 0.4);
+    --vscode-editor-focusedStackFrameHighlightBackground: rgba(122, 189, 122, 0.3);
+    --vscode-editor-foldBackground: rgba(38, 79, 120, 0.3);
+    --vscode-editor-foreground: #cccccc;
+    --vscode-editor-hoverHighlightBackground: rgba(38, 79, 120, 0.25);
+    --vscode-editor-inactiveSelectionBackground: #3a3d41;
+    --vscode-editor-inlineValuesBackground: rgba(255, 200, 0, 0.2);
+    --vscode-editor-inlineValuesForeground: rgba(255, 255, 255, 0.5);
+    --vscode-editor-lineHighlightBorder: #282828;
+    --vscode-editor-linkedEditingBackground: rgba(255, 0, 0, 0.3);
+    --vscode-editor-rangeHighlightBackground: rgba(255, 255, 255, 0.04);
+    --vscode-editor-selectionBackground: #264f78;
+    --vscode-editor-selectionHighlightBackground: rgba(173, 214, 255, 0.15);
+    --vscode-editor-snippetFinalTabstopHighlightBorder: #525252;
+    --vscode-editor-snippetTabstopHighlightBackground: rgba(124, 124, 124, 0.3);
+    --vscode-editor-stackFrameHighlightBackground: rgba(255, 255, 0, 0.2);
+    --vscode-editor-symbolHighlightBackground: rgba(234, 92, 0, 0.33);
+    --vscode-editor-wordHighlightBackground: rgba(87, 87, 87, 0.72);
+    --vscode-editor-wordHighlightStrongBackground: rgba(0, 73, 114, 0.72);
+    --vscode-editor-wordHighlightTextBackground: rgba(87, 87, 87, 0.72);
+    --vscode-input-background: #313131;
+    --vscode-input-border: #3c3c3c;
+    --vscode-input-foreground: #cccccc;
+    --vscode-input-placeholderForeground: #989898;
+    --vscode-inputOption-activeBackground: rgba(36, 137, 219, 0.51);
+    --vscode-inputOption-activeBorder: #2488db;
+    --vscode-inputOption-activeForeground: #ffffff;
+    --vscode-inputOption-hoverBackground: rgba(90, 93, 94, 0.5);
+    --vscode-inputValidation-errorBackground: #5a1d1d;
+    --vscode-inputValidation-errorBorder: #be1100;
+    --vscode-inputValidation-infoBackground: #063b49;
+    --vscode-inputValidation-infoBorder: #007acc;
+    --vscode-inputValidation-warningBackground: #352a05;
+    --vscode-inputValidation-warningBorder: #b89500;
+    --vscode-list-activeSelectionBackground: #04395e;
+    --vscode-list-activeSelectionForeground: #ffffff;
+    --vscode-list-activeSelectionIconForeground: #ffffff;
+    --vscode-list-deemphasizedForeground: #8c8c8c;
+    --vscode-list-dropBackground: #383b3d;
+    --vscode-list-dropBetweenBackground: #cccccc;
+    --vscode-list-errorForeground: #f88070;
+    --vscode-list-filterMatchBackground: rgba(234, 92, 0, 0.33);
+    --vscode-list-focusHighlightForeground: #2aaaff;
+    --vscode-list-focusOutline: #0078d4;
+    --vscode-list-highlightForeground: #2aaaff;
+    --vscode-list-hoverBackground: #2a2d2e;
+    --vscode-list-inactiveSelectionBackground: #37373d;
+    --vscode-list-invalidItemForeground: #b89500;
+    --vscode-list-warningForeground: #cca700;
+    --vscode-pickerGroup-border: #3c3c3c;
+    --vscode-pickerGroup-foreground: #3794ff;
+    --vscode-problemsErrorIcon-foreground: #f14c4c;
+    --vscode-quickInput-background: #222222;
+    --vscode-quickInput-foreground: #cccccc;
+    --vscode-quickInputList-focusBackground: #04395e;
+    --vscode-quickInputList-focusForeground: #ffffff;
+    --vscode-quickInputList-focusIconForeground: #ffffff;
+    --vscode-sideBar-background: #181818;
+    --vscode-sideBar-border: #2b2b2b;
+    --vscode-sideBar-dropBackground: rgba(83, 89, 93, 0.5);
+    --vscode-sideBar-foreground: #cccccc;
+    --vscode-sideBarSectionHeader-background: #181818;
+    --vscode-sideBarSectionHeader-border: #2b2b2b;
+    --vscode-sideBarSectionHeader-foreground: #cccccc;
+    --vscode-sideBarTitle-foreground: #cccccc;
+    --vscode-tab-activeBackground: #1f1f1f;
+    --vscode-tab-activeBorder: #1f1f1f;
+    --vscode-tab-activeBorderTop: #0078d4;
+    --vscode-tab-activeForeground: #ffffff;
+    --vscode-tab-activeModifiedBorder: #3399cc;
+    --vscode-tab-border: #2b2b2b;
+    --vscode-tab-dragAndDropBorder: #ffffff;
+    --vscode-tab-hoverBackground: #1f1f1f;
+    --vscode-tab-inactiveBackground: #181818;
+    --vscode-tab-inactiveForeground: #9d9d9d;
+    --vscode-tab-inactiveModifiedBorder: rgba(51, 153, 204, 0.5);
+    --vscode-tab-lastPinnedBorder: rgba(204, 204, 204, 0.2);
+    --vscode-tab-unfocusedActiveBackground: #1f1f1f;
+    --vscode-tab-unfocusedActiveBorder: #1f1f1f;
+    --vscode-tab-unfocusedActiveBorderTop: #2b2b2b;
+    --vscode-tab-unfocusedActiveForeground: rgba(255, 255, 255, 0.5);
+    --vscode-tab-unfocusedActiveModifiedBorder: rgba(51, 153, 204, 0.5);
+    --vscode-tab-unfocusedHoverBackground: #1f1f1f;
+    --vscode-tab-unfocusedInactiveBackground: #181818;
+    --vscode-tab-unfocusedInactiveForeground: rgba(157, 157, 157, 0.5);
+    --vscode-tab-unfocusedInactiveModifiedBorder: rgba(51, 153, 204, 0.25);
+    --vscode-textLink-activeForeground: #4daafc;
+    --vscode-textLink-foreground: #4daafc;
+    --vscode-widget-border: #313131;
+    --vscode-widget-shadow: rgba(0, 0, 0, 0.36);
+}


### PR DESCRIPTION
Now, the VS Code storybooks use the actual VS Code dark theme CSS variables from https://vscode.dev instead of using a manually maintained list.

Only storybook code is affected.

## Test plan

CI