### PR TITLE
fix always opening EnhancedContextSettings on first chat

### DIFF
--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -392,8 +392,10 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     }, [isOpen])
 
     React.useEffect(() => {
-        setOpen(isFirstChat)
-    }, [isFirstChat, setOpen])
+        if (!isOpen && isFirstChat) {
+            setOpen(true)
+        }
+    }, [isOpen, isFirstChat, setOpen])
 
     // Can't point at and use VSCodeButton type with 'ref'
 


### PR DESCRIPTION
Previously, it would forcibly close the popover if the component re-rendered (for some reason) on a non-first chat. I have not seen this bug actually occur in real usage.



## Test plan

CI