### PR TITLE
remove indirection in vscode webview React components

### DIFF
--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -141,11 +141,6 @@ body[data-vscode-theme-kind='vscode-light'] .transcript-item pre > code {
     opacity: 0.85;
 }
 
-.feedback-buttons {
-    display: flex;
-    flex-direction: row;
-    gap: 0.15rem;
-}
 
 .edit-button {
     border-radius: 0.5rem;
@@ -225,20 +220,6 @@ body[data-vscode-theme-kind='vscode-light'] .transcript-item pre > code {
 
 .submit-button svg {
     opacity: 1;
-}
-
-.thumbs-down-feedback-container {
-    display: flex;
-    align-items: center;
-    gap: calc(var(--spacing) / 4);
-}
-
-.feedback-button[disabled] {
-    /* VSCodeButton's default cursor is not-allowed, but that's different to
-       native VS Code and feels off, especially when it quickly changes to
-       not-allowed after you submit feedback. So we reset it back to the
-       default cursor to fit in nicer with standard VS Code native behaviour */
-    cursor: default;
 }
 
 .text-area-container {

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -15,7 +15,6 @@ import {
 import { useEnhancedContextEnabled } from './chat/components/EnhancedContext'
 
 import { EnhancedContextSettings } from './Components/EnhancedContextSettings'
-import { FileLink } from './Components/FileLink'
 import { Transcript } from './chat/Transcript'
 import { ChatActions } from './chat/components/ChatActions'
 import {
@@ -472,7 +471,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     messageInProgress={messageInProgress}
                     messageBeingEdited={messageBeingEdited}
                     setMessageBeingEdited={setEditMessageState}
-                    fileLinkComponent={FileLink}
                     codeBlocksCopyButtonClassName={styles.codeBlocksCopyButton}
                     codeBlocksInsertButtonClassName={styles.codeBlocksInsertButton}
                     transcriptItemClassName={styles.transcriptItem}

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
+import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
 import {
@@ -12,7 +12,6 @@ import {
     isMacOS,
 } from '@sourcegraph/cody-shared'
 
-import { CODY_FEEDBACK_URL } from '../src/chat/protocol'
 import { useEnhancedContextEnabled } from './chat/components/EnhancedContext'
 
 import { ChatModelDropdownMenu } from './Components/ChatModelDropdownMenu'
@@ -483,7 +482,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     transcriptActionClassName={styles.transcriptAction}
                     className={styles.transcriptContainer}
                     EditButtonContainer={EditButtonContainer}
-                    FeedbackButtonsContainer={FeedbackButtonsContainer}
                     feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     insertButtonOnSubmit={insertButtonOnSubmit}
@@ -627,85 +625,6 @@ const EditButtonContainer: React.FunctionComponent<EditButtonProps> = ({
         <i className="codicon codicon-edit" />
     </VSCodeButton>
 )
-
-export interface FeedbackButtonsProps {
-    className: string
-    disabled?: boolean
-    feedbackButtonsOnSubmit: (text: string) => void
-}
-
-const FeedbackButtonsContainer: React.FunctionComponent<FeedbackButtonsProps> = ({
-    className,
-    feedbackButtonsOnSubmit,
-}) => {
-    const [feedbackSubmitted, setFeedbackSubmitted] = useState('')
-
-    const onFeedbackBtnSubmit = useCallback(
-        (text: string) => {
-            feedbackButtonsOnSubmit(text)
-            setFeedbackSubmitted(text)
-        },
-        [feedbackButtonsOnSubmit]
-    )
-
-    return (
-        <div className={classNames(styles.feedbackButtons, className)}>
-            {!feedbackSubmitted && (
-                <>
-                    <VSCodeButton
-                        className={classNames(styles.feedbackButton)}
-                        appearance="icon"
-                        type="button"
-                        onClick={() => onFeedbackBtnSubmit('thumbsUp')}
-                    >
-                        <i className="codicon codicon-thumbsup" />
-                    </VSCodeButton>
-                    <VSCodeButton
-                        className={classNames(styles.feedbackButton)}
-                        appearance="icon"
-                        type="button"
-                        onClick={() => onFeedbackBtnSubmit('thumbsDown')}
-                    >
-                        <i className="codicon codicon-thumbsdown" />
-                    </VSCodeButton>
-                </>
-            )}
-            {feedbackSubmitted === 'thumbsUp' && (
-                <VSCodeButton
-                    className={classNames(styles.feedbackButton)}
-                    appearance="icon"
-                    type="button"
-                    disabled={true}
-                    title="Thanks for your feedback"
-                >
-                    <i className="codicon codicon-thumbsup" />
-                    <i className="codicon codicon-check" />
-                </VSCodeButton>
-            )}
-            {feedbackSubmitted === 'thumbsDown' && (
-                <span className={styles.thumbsDownFeedbackContainer}>
-                    <VSCodeButton
-                        className={classNames(styles.feedbackButton)}
-                        appearance="icon"
-                        type="button"
-                        disabled={true}
-                        title="Thanks for your feedback"
-                    >
-                        <i className="codicon codicon-thumbsdown" />
-                        <i className="codicon codicon-check" />
-                    </VSCodeButton>
-                    <VSCodeLink
-                        href={String(CODY_FEEDBACK_URL)}
-                        target="_blank"
-                        title="Help improve Cody by providing more feedback about the quality of this response"
-                    >
-                        Give Feedback
-                    </VSCodeLink>
-                </span>
-            )}
-        </div>
-    )
-}
 
 export interface UserAccountInfo {
     isDotComUser: boolean

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -487,7 +487,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     insertButtonOnSubmit={insertButtonOnSubmit}
-                    ChatButtonComponent={ChatButtonComponent}
                     isTranscriptError={isTranscriptError}
                     chatModels={chatModels}
                     onCurrentChatModelChange={onCurrentChatModelChange}
@@ -556,29 +555,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         </div>
     )
 }
-
-export interface ChatButtonProps {
-    label: string
-    action: string
-    onClick: (action: string) => void
-    appearance?: 'primary' | 'secondary' | 'icon'
-}
-
-const ChatButtonComponent: React.FunctionComponent<ChatButtonProps> = ({
-    label,
-    action,
-    onClick,
-    appearance,
-}) => (
-    <VSCodeButton
-        type="button"
-        onClick={() => onClick(action)}
-        className={styles.chatButton}
-        appearance={appearance}
-    >
-        {label}
-    </VSCodeButton>
-)
 
 const submitButtonTypes = {
     user: { icon: 'codicon codicon-arrow-up', title: 'Send Message' },

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -26,7 +26,7 @@ import {
     type SerializedPromptEditorValue,
     serializedPromptEditorStateFromChatMessage,
 } from './promptEditor/PromptEditor'
-import { type VSCodeWrapper, getVSCodeAPI } from './utils/VSCodeApi'
+import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 import styles from './Chat.module.css'
 
@@ -481,7 +481,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     transcriptItemParticipantClassName={styles.transcriptItemParticipant}
                     transcriptActionClassName={styles.transcriptAction}
                     className={styles.transcriptContainer}
-                    EditButtonContainer={EditButtonContainer}
                     feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     insertButtonOnSubmit={insertButtonOnSubmit}
@@ -591,38 +590,6 @@ const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({
                 onAbortMessageInProgress ? submitButtonTypes.abort.icon : submitButtonTypes[type]?.icon
             }
         />
-    </VSCodeButton>
-)
-
-export interface EditButtonProps {
-    className: string
-    disabled?: boolean
-    messageBeingEdited: number | undefined
-    setMessageBeingEdited: (index?: number) => void
-}
-
-const EditButtonContainer: React.FunctionComponent<EditButtonProps> = ({
-    className,
-    messageBeingEdited,
-    setMessageBeingEdited,
-    disabled,
-}) => (
-    <VSCodeButton
-        className={classNames(styles.editButton, className)}
-        appearance="icon"
-        title={disabled ? 'Cannot Edit Command' : 'Edit Your Message'}
-        type="button"
-        disabled={disabled}
-        onClick={() => {
-            setMessageBeingEdited(messageBeingEdited)
-            getVSCodeAPI().postMessage({
-                command: 'event',
-                eventName: 'CodyVSCodeExtension:chatEditButton:clicked',
-                properties: { source: 'chat' },
-            })
-        }}
-    >
-        <i className="codicon codicon-edit" />
     </VSCodeButton>
 )
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -14,7 +14,6 @@ import {
 
 import { useEnhancedContextEnabled } from './chat/components/EnhancedContext'
 
-import { ChatModelDropdownMenu } from './Components/ChatModelDropdownMenu'
 import { EnhancedContextSettings } from './Components/EnhancedContextSettings'
 import { FileLink } from './Components/FileLink'
 import { Transcript } from './chat/Transcript'
@@ -487,7 +486,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     isTranscriptError={isTranscriptError}
                     chatModels={chatModels}
                     onCurrentChatModelChange={onCurrentChatModelChange}
-                    ChatModelDropdownMenu={ChatModelDropdownMenu}
                     userInfo={userInfo}
                     postMessage={postMessage}
                     guardrails={guardrails}

--- a/vscode/webviews/chat/ErrorItem.tsx
+++ b/vscode/webviews/chat/ErrorItem.tsx
@@ -3,9 +3,9 @@ import React, { useCallback } from 'react'
 import { type ChatError, RateLimitError } from '@sourcegraph/cody-shared'
 
 import type { UserAccountInfo } from '../Chat'
-import type { ChatButtonProps } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 
+import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import styles from './ErrorItem.module.css'
 
 /**
@@ -13,15 +13,13 @@ import styles from './ErrorItem.module.css'
  */
 export const ErrorItem: React.FunctionComponent<{
     error: Omit<ChatError, 'isChatErrorGuard'>
-    ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
     userInfo: UserAccountInfo
     postMessage?: ApiPostMessage
-}> = ({ error, ChatButtonComponent, userInfo, postMessage }) => {
+}> = ({ error, userInfo, postMessage }) => {
     if (typeof error !== 'string' && error.name === RateLimitError.errorName && postMessage) {
         return (
             <RateLimitErrorItem
                 error={error as RateLimitError}
-                ChatButtonComponent={ChatButtonComponent}
                 userInfo={userInfo}
                 postMessage={postMessage}
             />
@@ -48,10 +46,9 @@ export const RequestErrorItem: React.FunctionComponent<{
  */
 const RateLimitErrorItem: React.FunctionComponent<{
     error: RateLimitError
-    ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
     userInfo: UserAccountInfo
     postMessage: ApiPostMessage
-}> = ({ error, ChatButtonComponent, userInfo, postMessage }) => {
+}> = ({ error, userInfo, postMessage }) => {
     // Only show Upgrades if both the error said an upgrade was available and we know the user
     // has not since upgraded.
     const isEnterpriseUser = userInfo.isDotComUser !== true
@@ -98,28 +95,27 @@ const RateLimitErrorItem: React.FunctionComponent<{
                             ' Upgrade to Cody Pro for unlimited autocomplete suggestions, chat messages and commands.'}
                     </p>
                 </header>
-                {ChatButtonComponent && (
-                    <div className={styles.actions}>
-                        {canUpgrade && (
-                            <ChatButtonComponent
-                                label="Upgrade"
-                                action=""
-                                onClick={() => onButtonClick('upgrade', 'upgrade')}
-                                appearance="primary"
-                            />
-                        )}
-                        <ChatButtonComponent
-                            label={canUpgrade ? 'See Plans →' : 'Learn More'}
-                            action=""
-                            onClick={() =>
-                                canUpgrade
-                                    ? onButtonClick('upgrade', 'upgrade')
-                                    : onButtonClick('rate-limits', 'learn-more')
-                            }
-                            appearance="secondary"
-                        />
-                    </div>
-                )}
+                <div className={styles.actions}>
+                    {canUpgrade && (
+                        <VSCodeButton
+                            onClick={() => onButtonClick('upgrade', 'upgrade')}
+                            appearance="primary"
+                        >
+                            Upgrade
+                        </VSCodeButton>
+                    )}
+                    <VSCodeButton
+                        type="button"
+                        onClick={() =>
+                            canUpgrade
+                                ? onButtonClick('upgrade', 'upgrade')
+                                : onButtonClick('rate-limits', 'learn-more')
+                        }
+                        appearance="secondary"
+                    >
+                        {canUpgrade ? 'See Plans →' : 'Learn More'}
+                    </VSCodeButton>
+                </div>
                 {error.retryMessage && <p className={styles.retryMessage}>{error.retryMessage}</p>}
             </div>
             {canUpgrade && (

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Transcript } from './Transcript'
-import type { FileLinkProps } from './components/EnhancedContext'
 import { FIXTURE_TRANSCRIPT } from './fixtures'
 
 import { VSCodeWebview } from '../storybook/VSCodeStoryDecorator'
@@ -28,14 +27,11 @@ const meta: Meta<typeof Transcript> = {
 
 export default meta
 
-const FileLink: React.FunctionComponent<FileLinkProps> = ({ uri }) => <>{uri.toString()}</>
-
 export const Simple: StoryObj<typeof meta> = {
     args: {
         messageInProgress: null,
         messageBeingEdited: undefined,
         setMessageBeingEdited: () => {},
-        fileLinkComponent: FileLink,
         transcriptItemClassName: styles.transcriptItem,
         humanTranscriptItemClassName: styles.humanTranscriptItem,
         transcriptItemParticipantClassName: styles.transcriptItemParticipant,

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -15,7 +15,6 @@ import type { ApiPostMessage } from '../Chat'
 import type { CodeBlockActionsProps } from './CodeBlocks'
 
 import { TranscriptItem, type TranscriptItemClassNames } from './TranscriptItem'
-import type { FileLinkProps } from './components/EnhancedContext'
 
 import { ChatModelDropdownMenu } from '../Components/ChatModelDropdownMenu'
 import styles from './Transcript.module.css'
@@ -27,7 +26,6 @@ export const Transcript: React.FunctionComponent<
         messageInProgress: ChatMessage | null
         messageBeingEdited: number | undefined
         setMessageBeingEdited: (index?: number) => void
-        fileLinkComponent: React.FunctionComponent<FileLinkProps>
         className?: string
         feedbackButtonsOnSubmit?: (text: string) => void
         copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
@@ -45,7 +43,6 @@ export const Transcript: React.FunctionComponent<
     messageInProgress,
     messageBeingEdited,
     setMessageBeingEdited,
-    fileLinkComponent,
     className,
     codeBlocksCopyButtonClassName,
     codeBlocksInsertButtonClassName,
@@ -173,7 +170,6 @@ export const Transcript: React.FunctionComponent<
                         showEditButton={message.speaker === 'human'}
                         beingEdited={messageBeingEdited}
                         setBeingEdited={setMessageBeingEdited}
-                        fileLinkComponent={fileLinkComponent}
                         codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
                         codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
                         transcriptItemClassName={transcriptItemClassName}
@@ -218,7 +214,6 @@ export const Transcript: React.FunctionComponent<
                         message={welcomeTranscriptMessage}
                         beingEdited={undefined}
                         inProgress={false}
-                        fileLinkComponent={fileLinkComponent}
                         setBeingEdited={() => {}}
                         showEditButton={false}
                         showFeedbackButtons={false}
@@ -235,7 +230,6 @@ export const Transcript: React.FunctionComponent<
                         inProgress={!!transcript[earlierMessages.length].contextFiles}
                         beingEdited={messageBeingEdited}
                         setBeingEdited={setMessageBeingEdited}
-                        fileLinkComponent={fileLinkComponent}
                         codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
                         codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}
                         transcriptItemClassName={transcriptItemClassName}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -11,7 +11,6 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import type { UserAccountInfo } from '../Chat'
-import type { EditButtonProps } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 import type { ChatModelDropdownMenuProps } from '../Components/ChatModelDropdownMenu'
 import type { CodeBlockActionsProps } from './CodeBlocks'
@@ -30,7 +29,6 @@ export const Transcript: React.FunctionComponent<
         setMessageBeingEdited: (index?: number) => void
         fileLinkComponent: React.FunctionComponent<FileLinkProps>
         className?: string
-        EditButtonContainer?: React.FunctionComponent<EditButtonProps>
         feedbackButtonsOnSubmit?: (text: string) => void
         copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
         insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
@@ -56,7 +54,6 @@ export const Transcript: React.FunctionComponent<
     humanTranscriptItemClassName,
     transcriptItemParticipantClassName,
     transcriptActionClassName,
-    EditButtonContainer,
     feedbackButtonsOnSubmit,
     copyButtonOnSubmit,
     insertButtonOnSubmit,
@@ -178,7 +175,6 @@ export const Transcript: React.FunctionComponent<
                         showEditButton={message.speaker === 'human'}
                         beingEdited={messageBeingEdited}
                         setBeingEdited={setMessageBeingEdited}
-                        EditButtonContainer={EditButtonContainer}
                         fileLinkComponent={fileLinkComponent}
                         codeBlocksCopyButtonClassName={codeBlocksCopyButtonClassName}
                         codeBlocksInsertButtonClassName={codeBlocksInsertButtonClassName}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -12,7 +12,6 @@ import {
 
 import type { UserAccountInfo } from '../Chat'
 import type { EditButtonProps } from '../Chat'
-import type { FeedbackButtonsProps } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 import type { ChatModelDropdownMenuProps } from '../Components/ChatModelDropdownMenu'
 import type { CodeBlockActionsProps } from './CodeBlocks'
@@ -32,7 +31,6 @@ export const Transcript: React.FunctionComponent<
         fileLinkComponent: React.FunctionComponent<FileLinkProps>
         className?: string
         EditButtonContainer?: React.FunctionComponent<EditButtonProps>
-        FeedbackButtonsContainer?: React.FunctionComponent<FeedbackButtonsProps>
         feedbackButtonsOnSubmit?: (text: string) => void
         copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
         insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
@@ -59,7 +57,6 @@ export const Transcript: React.FunctionComponent<
     transcriptItemParticipantClassName,
     transcriptActionClassName,
     EditButtonContainer,
-    FeedbackButtonsContainer,
     feedbackButtonsOnSubmit,
     copyButtonOnSubmit,
     insertButtonOnSubmit,
@@ -189,7 +186,6 @@ export const Transcript: React.FunctionComponent<
                         humanTranscriptItemClassName={humanTranscriptItemClassName}
                         transcriptItemParticipantClassName={transcriptItemParticipantClassName}
                         transcriptActionClassName={transcriptActionClassName}
-                        FeedbackButtonsContainer={FeedbackButtonsContainer}
                         feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
                         copyButtonOnSubmit={copyButtonOnSubmit}
                         insertButtonOnSubmit={insertButtonOnSubmit}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -12,12 +12,12 @@ import {
 
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
-import type { ChatModelDropdownMenuProps } from '../Components/ChatModelDropdownMenu'
 import type { CodeBlockActionsProps } from './CodeBlocks'
 
 import { TranscriptItem, type TranscriptItemClassNames } from './TranscriptItem'
 import type { FileLinkProps } from './components/EnhancedContext'
 
+import { ChatModelDropdownMenu } from '../Components/ChatModelDropdownMenu'
 import styles from './Transcript.module.css'
 
 export const Transcript: React.FunctionComponent<
@@ -34,8 +34,7 @@ export const Transcript: React.FunctionComponent<
         insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
         isTranscriptError?: boolean
         chatModels?: ModelProvider[]
-        ChatModelDropdownMenu?: React.FunctionComponent<ChatModelDropdownMenuProps>
-        onCurrentChatModelChange?: (model: ModelProvider) => void
+        onCurrentChatModelChange: (model: ModelProvider) => void
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails
@@ -59,7 +58,6 @@ export const Transcript: React.FunctionComponent<
     insertButtonOnSubmit,
     isTranscriptError,
     chatModels,
-    ChatModelDropdownMenu,
     onCurrentChatModelChange,
     userInfo,
     postMessage,
@@ -203,7 +201,6 @@ export const Transcript: React.FunctionComponent<
         <div ref={transcriptContainerRef} className={classNames(className, styles.container)}>
             <div ref={scrollAnchoredContainerRef} className={classNames(styles.scrollAnchoredContainer)}>
                 {!!chatModels?.length &&
-                    ChatModelDropdownMenu &&
                     onCurrentChatModelChange &&
                     userInfo &&
                     userInfo.isDotComUser && (

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -11,7 +11,6 @@ import {
 } from '@sourcegraph/cody-shared'
 
 import type { UserAccountInfo } from '../Chat'
-import type { ChatButtonProps } from '../Chat'
 import type { EditButtonProps } from '../Chat'
 import type { FeedbackButtonsProps } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
@@ -37,7 +36,6 @@ export const Transcript: React.FunctionComponent<
         feedbackButtonsOnSubmit?: (text: string) => void
         copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
         insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
-        ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
         isTranscriptError?: boolean
         chatModels?: ModelProvider[]
         ChatModelDropdownMenu?: React.FunctionComponent<ChatModelDropdownMenuProps>
@@ -65,7 +63,6 @@ export const Transcript: React.FunctionComponent<
     feedbackButtonsOnSubmit,
     copyButtonOnSubmit,
     insertButtonOnSubmit,
-    ChatButtonComponent,
     isTranscriptError,
     chatModels,
     ChatModelDropdownMenu,
@@ -197,7 +194,6 @@ export const Transcript: React.FunctionComponent<
                         copyButtonOnSubmit={copyButtonOnSubmit}
                         insertButtonOnSubmit={insertButtonOnSubmit}
                         showFeedbackButtons={index !== 0 && !isTranscriptError && !message.error}
-                        ChatButtonComponent={ChatButtonComponent}
                         userInfo={userInfo}
                         postMessage={postMessage}
                         guardrails={guardrails}
@@ -260,7 +256,6 @@ export const Transcript: React.FunctionComponent<
                         showFeedbackButtons={false}
                         copyButtonOnSubmit={copyButtonOnSubmit}
                         insertButtonOnSubmit={insertButtonOnSubmit}
-                        ChatButtonComponent={ChatButtonComponent}
                         postMessage={postMessage}
                         userInfo={userInfo}
                     />

--- a/vscode/webviews/chat/TranscriptItem.tsx
+++ b/vscode/webviews/chat/TranscriptItem.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 import { type ChatMessage, type Guardrails, reformatBotMessageForChat } from '@sourcegraph/cody-shared'
 
 import type { UserAccountInfo } from '../Chat'
-import type { ChatButtonProps } from '../Chat'
 import type { EditButtonProps } from '../Chat'
 import type { FeedbackButtonsProps } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
@@ -53,7 +52,6 @@ export const TranscriptItem: React.FunctionComponent<
             onAbortMessageInProgress: () => void
         }>
         onAbortMessageInProgress?: () => void
-        ChatButtonComponent?: React.FunctionComponent<ChatButtonProps>
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails
@@ -78,7 +76,6 @@ export const TranscriptItem: React.FunctionComponent<
     showFeedbackButtons,
     copyButtonOnSubmit,
     insertButtonOnSubmit,
-    ChatButtonComponent,
     userInfo,
     postMessage,
     guardrails,
@@ -133,12 +130,7 @@ export const TranscriptItem: React.FunctionComponent<
                 typeof message.error === 'string' ? (
                     <RequestErrorItem error={message.error} />
                 ) : (
-                    <ErrorItem
-                        error={message.error}
-                        ChatButtonComponent={ChatButtonComponent}
-                        userInfo={userInfo}
-                        postMessage={postMessage}
-                    />
+                    <ErrorItem error={message.error} userInfo={userInfo} postMessage={postMessage} />
                 )
             ) : null}
             <div className={classNames(styles.contentPadding, styles.content)}>

--- a/vscode/webviews/chat/TranscriptItem.tsx
+++ b/vscode/webviews/chat/TranscriptItem.tsx
@@ -46,10 +46,6 @@ export const TranscriptItem: React.FunctionComponent<
         showFeedbackButtons: boolean
         copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
         insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
-        abortMessageInProgressComponent?: React.FunctionComponent<{
-            onAbortMessageInProgress: () => void
-        }>
-        onAbortMessageInProgress?: () => void
         userInfo: UserAccountInfo
         postMessage?: ApiPostMessage
         guardrails?: Guardrails

--- a/vscode/webviews/chat/TranscriptItem.tsx
+++ b/vscode/webviews/chat/TranscriptItem.tsx
@@ -11,7 +11,7 @@ import type { CodeBlockActionsProps } from './CodeBlocks'
 import { BlinkingCursor, LoadingContext } from './BlinkingCursor'
 import { CodeBlocks } from './CodeBlocks'
 import { ErrorItem, RequestErrorItem } from './ErrorItem'
-import { EnhancedContext, type FileLinkProps } from './components/EnhancedContext'
+import { EnhancedContext } from './components/EnhancedContext'
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import { serializedPromptEditorStateFromChatMessage } from '../promptEditor/PromptEditor'
@@ -42,7 +42,6 @@ export const TranscriptItem: React.FunctionComponent<
         beingEdited: number | undefined
         setBeingEdited: (index?: number) => void
         showEditButton: boolean
-        fileLinkComponent: React.FunctionComponent<FileLinkProps>
         feedbackButtonsOnSubmit?: (text: string) => void
         showFeedbackButtons: boolean
         copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
@@ -61,7 +60,6 @@ export const TranscriptItem: React.FunctionComponent<
     inProgress,
     beingEdited,
     setBeingEdited,
-    fileLinkComponent,
     transcriptItemClassName,
     humanTranscriptItemClassName,
     transcriptItemParticipantClassName,
@@ -151,7 +149,6 @@ export const TranscriptItem: React.FunctionComponent<
                     {message.contextFiles && message.contextFiles.length > 0 ? (
                         <EnhancedContext
                             contextFiles={message.contextFiles}
-                            fileLinkComponent={fileLinkComponent}
                             className={transcriptActionClassName}
                         />
                     ) : (

--- a/vscode/webviews/chat/TranscriptItem.tsx
+++ b/vscode/webviews/chat/TranscriptItem.tsx
@@ -6,7 +6,6 @@ import { type ChatMessage, type Guardrails, reformatBotMessageForChat } from '@s
 
 import type { UserAccountInfo } from '../Chat'
 import type { EditButtonProps } from '../Chat'
-import type { FeedbackButtonsProps } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
 import type { CodeBlockActionsProps } from './CodeBlocks'
 
@@ -17,6 +16,7 @@ import { EnhancedContext, type FileLinkProps } from './components/EnhancedContex
 
 import { serializedPromptEditorStateFromChatMessage } from '../promptEditor/PromptEditor'
 import styles from './TranscriptItem.module.css'
+import { FeedbackButtons } from './components/FeedbackButtons'
 
 /**
  * CSS class names used for the {@link TranscriptItem} component.
@@ -43,7 +43,6 @@ export const TranscriptItem: React.FunctionComponent<
         EditButtonContainer?: React.FunctionComponent<EditButtonProps>
         showEditButton: boolean
         fileLinkComponent: React.FunctionComponent<FileLinkProps>
-        FeedbackButtonsContainer?: React.FunctionComponent<FeedbackButtonsProps>
         feedbackButtonsOnSubmit?: (text: string) => void
         showFeedbackButtons: boolean
         copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
@@ -71,7 +70,6 @@ export const TranscriptItem: React.FunctionComponent<
     transcriptActionClassName,
     EditButtonContainer,
     showEditButton,
-    FeedbackButtonsContainer,
     feedbackButtonsOnSubmit,
     showFeedbackButtons,
     copyButtonOnSubmit,
@@ -163,24 +161,16 @@ export const TranscriptItem: React.FunctionComponent<
                 </div>
             )}
             {/* Display feedback buttons on assistant messages only */}
-            {!isHumanMessage &&
-                showFeedbackButtons &&
-                FeedbackButtonsContainer &&
-                feedbackButtonsOnSubmit && (
-                    <footer
-                        className={classNames(
-                            styles.footerContainer,
-                            transcriptItemParticipantClassName
-                        )}
-                    >
-                        {/* display edit buttons on last user message, feedback buttons on last assistant message only */}
-                        {/* Hide the feedback buttons during editing mode */}
-                        <FeedbackButtonsContainer
-                            className={styles.feedbackEditButtonsContainer}
-                            feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
-                        />
-                    </footer>
-                )}
+            {!isHumanMessage && showFeedbackButtons && feedbackButtonsOnSubmit && (
+                <footer
+                    className={classNames(styles.footerContainer, transcriptItemParticipantClassName)}
+                >
+                    <FeedbackButtons
+                        className={styles.feedbackEditButtonsContainer}
+                        feedbackButtonsOnSubmit={feedbackButtonsOnSubmit}
+                    />
+                </footer>
+            )}
         </div>
     )
 }

--- a/vscode/webviews/chat/components/EnhancedContext.tsx
+++ b/vscode/webviews/chat/components/EnhancedContext.tsx
@@ -4,6 +4,7 @@ import type { URI } from 'vscode-uri'
 
 import type { ContextItem, RangeData } from '@sourcegraph/cody-shared'
 
+import { FileLink } from '../../Components/FileLink'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
 import { TranscriptAction } from '../actions/TranscriptAction'
 
@@ -25,9 +26,8 @@ export interface FileLinkProps {
 
 export const EnhancedContext: React.FunctionComponent<{
     contextFiles: ContextItem[]
-    fileLinkComponent: React.FunctionComponent<FileLinkProps>
     className?: string
-}> = ({ contextFiles, fileLinkComponent: FileLink, className }) => {
+}> = ({ contextFiles, className }) => {
     if (!contextFiles.length) {
         return
     }

--- a/vscode/webviews/chat/components/FeedbackButtons.module.css
+++ b/vscode/webviews/chat/components/FeedbackButtons.module.css
@@ -1,0 +1,20 @@
+.feedback-buttons {
+    display: flex;
+    flex-direction: row;
+    gap: 0.15rem;
+}
+
+.feedback-button[disabled] {
+    /* VSCodeButton's default cursor is not-allowed, but that's different to
+       native VS Code and feels off, especially when it quickly changes to
+       not-allowed after you submit feedback. So we reset it back to the
+       default cursor to fit in nicer with standard VS Code native behaviour */
+    cursor: default;
+}
+
+.thumbs-down-feedback-container {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--spacing) / 4);
+}
+

--- a/vscode/webviews/chat/components/FeedbackButtons.tsx
+++ b/vscode/webviews/chat/components/FeedbackButtons.tsx
@@ -1,0 +1,84 @@
+import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
+import classNames from 'classnames'
+import { useCallback, useState } from 'react'
+import { CODY_FEEDBACK_URL } from '../../../src/chat/protocol'
+import styles from './FeedbackButtons.module.css'
+
+export interface FeedbackButtonsProps {
+    className: string
+    disabled?: boolean
+    feedbackButtonsOnSubmit: (text: string) => void
+}
+
+export const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = ({
+    className,
+    feedbackButtonsOnSubmit,
+}) => {
+    const [feedbackSubmitted, setFeedbackSubmitted] = useState('')
+
+    const onFeedbackBtnSubmit = useCallback(
+        (text: string) => {
+            feedbackButtonsOnSubmit(text)
+            setFeedbackSubmitted(text)
+        },
+        [feedbackButtonsOnSubmit]
+    )
+
+    return (
+        <div className={classNames(styles.feedbackButtons, className)}>
+            {!feedbackSubmitted && (
+                <>
+                    <VSCodeButton
+                        className={classNames(styles.feedbackButton)}
+                        appearance="icon"
+                        type="button"
+                        onClick={() => onFeedbackBtnSubmit('thumbsUp')}
+                    >
+                        <i className="codicon codicon-thumbsup" />
+                    </VSCodeButton>
+                    <VSCodeButton
+                        className={classNames(styles.feedbackButton)}
+                        appearance="icon"
+                        type="button"
+                        onClick={() => onFeedbackBtnSubmit('thumbsDown')}
+                    >
+                        <i className="codicon codicon-thumbsdown" />
+                    </VSCodeButton>
+                </>
+            )}
+            {feedbackSubmitted === 'thumbsUp' && (
+                <VSCodeButton
+                    className={classNames(styles.feedbackButton)}
+                    appearance="icon"
+                    type="button"
+                    disabled={true}
+                    title="Thanks for your feedback"
+                >
+                    <i className="codicon codicon-thumbsup" />
+                    <i className="codicon codicon-check" />
+                </VSCodeButton>
+            )}
+            {feedbackSubmitted === 'thumbsDown' && (
+                <span className={styles.thumbsDownFeedbackContainer}>
+                    <VSCodeButton
+                        className={classNames(styles.feedbackButton)}
+                        appearance="icon"
+                        type="button"
+                        disabled={true}
+                        title="Thanks for your feedback"
+                    >
+                        <i className="codicon codicon-thumbsdown" />
+                        <i className="codicon codicon-check" />
+                    </VSCodeButton>
+                    <VSCodeLink
+                        href={String(CODY_FEEDBACK_URL)}
+                        target="_blank"
+                        title="Help improve Cody by providing more feedback about the quality of this response"
+                    >
+                        Give Feedback
+                    </VSCodeLink>
+                </span>
+            )}
+        </div>
+    )
+}


### PR DESCRIPTION
- remove indirection for FileLinkComponent
- remove indirection for ChatModelDropdownMenu
- remove indirection for EditButton
- extract FeedbackButtons and remove indirection
- rm needless ChatButtonComponent (it just wrapped VSCodeButton)

## Test plan

CI