### PR TITLE
isNewInstall defaults to unknown (undefined) not true

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -45,7 +45,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
         isCodyProUser: false,
     })
 
-    const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>([])
+    const [userHistory, setUserHistory] = useState<SerializedChatTranscript[]>()
     const [chatIDHistory, setChatIDHistory] = useState<string[]>([])
 
     const [errorMessages, setErrorMessages] = useState<string[]>([])
@@ -192,7 +192,10 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     )
 
     const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
-    const isNewInstall = useMemo(() => !userHistory.some(c => c.interactions.length > 0), [userHistory])
+    const isNewInstall = useMemo(
+        () => userHistory && !userHistory.some(c => c.interactions.length > 0),
+        [userHistory]
+    )
     if (!view || !authStatus || !config) {
         return <LoadingPage />
     }

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -42,7 +42,7 @@ interface ChatboxProps {
     guardrails?: Guardrails
     chatIDHistory: string[]
     isWebviewActive: boolean
-    isNewInstall: boolean
+    isNewInstall: boolean | undefined
 }
 
 const isMac = isMacOS()
@@ -524,7 +524,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                                 isOpen={isEnhancedContextOpen}
                                 setOpen={onEnhancedContextTogglerClick}
                                 presentationMode={userInfo.isDotComUser ? 'consumer' : 'enterprise'}
-                                isFirstChat={isNewInstall}
+                                isNewInstall={isNewInstall}
                             />
                         </div>
                     </div>

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -125,7 +125,7 @@ export const SingleTile: StoryObj<typeof EnhancedContextSettings | SingleTileArg
                             isOpen={isOpen}
                             setOpen={setIsOpen}
                             presentationMode={args.presentationMode}
-                            isFirstChat={false}
+                            isNewInstall={false}
                         />
                     </div>
                 </EnhancedContextEventHandlers.Provider>
@@ -162,7 +162,7 @@ export const ConsumerMultipleProviders: StoryObj<typeof EnhancedContextSettings>
                         isOpen={isOpen}
                         setOpen={setIsOpen}
                         presentationMode={EnhancedContextPresentationMode.Consumer}
-                        isFirstChat={false}
+                        isNewInstall={false}
                     />
                 </div>
             </EnhancedContextContext.Provider>
@@ -190,7 +190,7 @@ export const EnterpriseNoRepositories: StoryObj<typeof EnhancedContextSettings> 
                         presentationMode={EnhancedContextPresentationMode.Enterprise}
                         isOpen={isOpen}
                         setOpen={setIsOpen}
-                        isFirstChat={false}
+                        isNewInstall={false}
                     />
                 </div>
             </EnhancedContextContext.Provider>
@@ -255,7 +255,7 @@ export const EnterpriseMultipleRepositories: StoryObj<typeof EnhancedContextSett
                         presentationMode={EnhancedContextPresentationMode.Enterprise}
                         isOpen={isOpen}
                         setOpen={setIsOpen}
-                        isFirstChat={false}
+                        isNewInstall={false}
                     />
                 </div>
             </EnhancedContextContext.Provider>

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -31,7 +31,7 @@ interface EnhancedContextSettingsProps {
     presentationMode: 'consumer' | 'enterprise'
     isOpen: boolean
     setOpen: (open: boolean) => void
-    isFirstChat: boolean
+    isNewInstall: boolean | undefined
 }
 
 function defaultEnhancedContextContext(): EnhancedContextContextT {
@@ -340,7 +340,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     presentationMode,
     isOpen,
     setOpen,
-    isFirstChat,
+    isNewInstall,
 }): React.ReactNode => {
     const events = useEnhancedContextEventHandlers()
     const context = useEnhancedContextContext()
@@ -392,10 +392,10 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     }, [isOpen])
 
     React.useEffect(() => {
-        if (!isOpen && isFirstChat) {
+        if (!isOpen && isNewInstall) {
             setOpen(true)
         }
-    }, [isOpen, isFirstChat, setOpen])
+    }, [isOpen, isNewInstall, setOpen])
 
     // Can't point at and use VSCodeButton type with 'ref'
 
@@ -421,7 +421,6 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                 isOpen={isOpen}
                 onDismiss={handleDismiss}
                 classNames={[popupStyles.popupTrail, styles.popup]}
-                isFirstChat={isFirstChat}
             >
                 <div className={styles.container}>
                     <div>

--- a/vscode/webviews/Notices/index.tsx
+++ b/vscode/webviews/Notices/index.tsx
@@ -5,13 +5,15 @@ import { VersionUpdatedNotice } from './VersionUpdatedNotice'
 import styles from './index.module.css'
 
 interface NoticesProps {
-    probablyNewInstall: boolean
+    probablyNewInstall: boolean | undefined
     vscodeAPI: VSCodeWrapper
 }
 
 export const Notices: React.FunctionComponent<NoticesProps> = ({ probablyNewInstall, vscodeAPI }) => (
     <div className={styles.notices}>
-        <VersionUpdatedNotice probablyNewInstall={probablyNewInstall} />
+        {probablyNewInstall !== undefined && (
+            <VersionUpdatedNotice probablyNewInstall={probablyNewInstall} />
+        )}
         <OnboardingAutocompleteNotice vscodeAPI={vscodeAPI} />
     </div>
 )

--- a/vscode/webviews/Popups/Popup.tsx
+++ b/vscode/webviews/Popups/Popup.tsx
@@ -34,12 +34,11 @@ const Backdrop: React.FunctionComponent<React.PropsWithoutRef<BackdropProps>> = 
 interface PopupFrameProps {
     classNames?: string[]
     actionButtons?: React.ReactNode
-    isFirstChat?: boolean
 }
 
 export const PopupFrame: React.FunctionComponent<
     React.PropsWithChildren<PopupFrameProps & PopupOpenProps>
-> = ({ actionButtons, classNames: extraClassNames, onDismiss, isOpen, children, isFirstChat }) => {
+> = ({ actionButtons, classNames: extraClassNames, onDismiss, isOpen, children }) => {
     const handleKeyUp = (e: React.KeyboardEvent<HTMLDialogElement>): void => {
         if (e.key === 'Escape') {
             e.stopPropagation()


### PR DESCRIPTION
Previously, before the ext host sends the user's chat history, we considered `isNewInstall` to be true. Now, we consider it to be undefined (indeterminate/unknown). Fixes the issue reported by @abeatrix in https://github.com/sourcegraph/cody/pull/3628#issuecomment-2027947292 where the enhanced context settings popup always opened on all chats.

Also renames the prop to be consistent (`isNewInstall`).



## Test plan

Run locally, and ensure that the popup does not display on a non-new install. Flip the value in App.tsx manually and ensure it does show up.