### PR TITLE
Semgrep: improved Semgrep scan params, upgraded GH action version

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -15,13 +15,13 @@ jobs:
       image: returntocorp/semgrep
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Checkout semgrep-rules repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: sourcegraph/security-semgrep-rules
           token: ${{ secrets.GH_SEMGREP_SAST_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Run Semgrep SAST Scan
         run: |
           mv semgrep-rules ../
-          semgrep ci -f ../semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif
+          semgrep ci -f ../semgrep-rules/semgrep-rules/ --metrics=off --oss-only --suppress-errors --sarif -o results.sarif --exclude='semgrep-rules' --baseline-commit "$(git merge-base main HEAD)" || true
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
This PR attempts to improve semgrep scans, (tested this config on `sourcegraph/sourcegraph`)

- Moved checkout script github action to v4 for semgrep
- Moved to v3 for uploading sarif file action script
- optimized few semgrep params to match `sourcegraph/sourcegraph` config to scan only changed files

reference: https://github.com/sourcegraph/security/issues/1286

## Test plan

- CI 🟢 
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
