### PR TITLE
Chat: Fix enhance context settings bug

### DIFF
--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -192,12 +192,13 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     )
 
     const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
-    const isNewInstall = useMemo(() => !userHistory?.some(c => c?.interactions?.length), [userHistory])
 
-    // Wait for all the data to be loaded before rendering Chat View
+    // Wait for all the required data to be loaded before rendering Chat View
     if (!view || !authStatus || !config || !userHistory) {
         return <LoadingPage />
     }
+
+    const isNewInstall = useMemo(() => !userHistory.some(c => c?.interactions?.length), [userHistory])
 
     return (
         <div className="outer-container">

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -192,11 +192,10 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     )
 
     const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
-    const isNewInstall = useMemo(
-        () => userHistory && !userHistory.some(c => c.interactions.length > 0),
-        [userHistory]
-    )
-    if (!view || !authStatus || !config) {
+    const isNewInstall = useMemo(() => !userHistory?.some(c => c?.interactions?.length), [userHistory])
+
+    // Wait for all the data to be loaded before rendering Chat View
+    if (!view || !authStatus || !config || !userHistory) {
         return <LoadingPage />
     }
 
@@ -211,7 +210,7 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 />
             ) : (
                 <>
-                    <Notices probablyNewInstall={isNewInstall} vscodeAPI={vscodeAPI} />
+                    <Notices probablyNewInstall={userHistory && isNewInstall} vscodeAPI={vscodeAPI} />
                     {errorMessages && (
                         <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />
                     )}

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -192,13 +192,12 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     )
 
     const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
+    const isNewInstall = useMemo(() => !userHistory?.some(c => c?.interactions?.length), [userHistory])
 
-    // Wait for all the required data to be loaded before rendering Chat View
-    if (!view || !authStatus || !config || !userHistory) {
+    // Wait for all the data to be loaded before rendering Chat View
+    if (!view || !authStatus || !config) {
         return <LoadingPage />
     }
-
-    const isNewInstall = useMemo(() => !userHistory.some(c => c?.interactions?.length), [userHistory])
 
     return (
         <div className="outer-container">
@@ -211,11 +210,11 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                 />
             ) : (
                 <>
-                    <Notices probablyNewInstall={userHistory && isNewInstall} vscodeAPI={vscodeAPI} />
+                    {userHistory && <Notices probablyNewInstall={isNewInstall} vscodeAPI={vscodeAPI} />}
                     {errorMessages && (
                         <ErrorBanner errors={errorMessages} setErrors={setErrorMessages} />
                     )}
-                    {view === 'chat' && (
+                    {view === 'chat' && userHistory && (
                         <EnhancedContextEventHandlers.Provider
                             value={{
                                 onChooseRemoteSearchRepo,

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -42,7 +42,7 @@ interface ChatboxProps {
     guardrails?: Guardrails
     chatIDHistory: string[]
     isWebviewActive: boolean
-    isNewInstall: boolean | undefined
+    isNewInstall: boolean
 }
 
 const isMac = isMacOS()
@@ -66,7 +66,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     const [messageBeingEdited, setMessageBeingEdited] = useState<number | undefined>(undefined)
 
     // Display the enhanced context settings on first chats
-    const [isEnhancedContextOpen, setIsEnhancedContextOpen] = useState(false)
+    const [isEnhancedContextOpen, setIsEnhancedContextOpen] = useState(isNewInstall)
 
     const editorRef = useRef<PromptEditorRefAPI>(null)
     const setEditorState = useCallback((state: SerializedPromptEditorState | null) => {

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -413,6 +413,9 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     // is open). This makes it so that the user can immediately start typing to Cody after invoking
     // `Cody: Focus on Chat View` with the keyboard.
     useEffect(() => {
+        // Focus the input when the enhanced context settings modal is closed
+        setInputFocus(!isEnhancedContextOpen)
+        // Add window focus event listener to focus the input when the window is focused
         const handleFocus = (): void => {
             if (document.getSelection()?.isCollapsed && !isEnhancedContextOpen) {
                 setInputFocus(true)

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -387,7 +387,11 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     const autofocusTarget = React.useRef<any>(null)
     React.useEffect(() => {
         if (isOpen) {
-            autofocusTarget.current?.focus()
+            // Set focus to the checkbox when the popup is opened
+            // after a 100ms delay to ensure the popup is fully rendered
+            setTimeout(() => {
+                autofocusTarget.current?.focus()
+            }, 100)
         }
     }, [isOpen])
 
@@ -395,7 +399,6 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     const restoreFocusTarget = React.useRef<any>(null)
     const handleDismiss = React.useCallback(() => {
         setOpen(false)
-        restoreFocusTarget.current?.focus()
     }, [setOpen])
 
     const onKeyDown = React.useCallback(

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -391,14 +391,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
         }
     }, [isOpen])
 
-    React.useEffect(() => {
-        if (!isOpen && isNewInstall) {
-            setOpen(true)
-        }
-    }, [isOpen, isNewInstall, setOpen])
-
     // Can't point at and use VSCodeButton type with 'ref'
-
     const restoreFocusTarget = React.useRef<any>(null)
     const handleDismiss = React.useCallback(() => {
         setOpen(false)


### PR DESCRIPTION
FIX & CLOSE https://github.com/sourcegraph/cody/issues/3646

Issue: the Enhanced Context settings would remain open for all new users (user without chat history) 

Root cause: Cause by the useEffect logic where we will open the Enhanced Settings for new users on every `isOpen` value change.

Proposed fix in this PR:
- Makes sure the value for userHistory is loaded before we render the Chat component
- Start the `isOpen` value in the Chat component with the `isNewInstall` value so that we won't need to use `useEffect` to handle this logic

(also looking into why this wasn’t caught by our e2e tests, will update it in a follow-up PR)

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green CI. 

For Manual testing:
1. Clear your chat history
2. Open a new chat to verify the enhanced context settings is opened by default
3. Verify you can close the enhanced context settings 
4. Submit a question
5. Verify the window remains closed
6. Open a new chat
7. Verify the window doesn't show up