### PR TITLE
Chat: sync models at activation

### DIFF
--- a/lib/shared/src/models/index.test.ts
+++ b/lib/shared/src/models/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 import { ModelProvider } from '../models/index'
-import { DEFAULT_FAST_MODEL_TOKEN_LIMIT, tokensToChars } from '../prompt/constants'
+import { DEFAULT_CHAT_MODEL_TOKEN_LIMIT, tokensToChars } from '../prompt/constants'
 import { DOTCOM_URL } from '../sourcegraph-api/environments'
 import { DEFAULT_DOT_COM_MODELS } from './dotcom'
 import { ModelUsage } from './types'
@@ -12,7 +12,7 @@ describe('getMaxCharsByModel', () => {
 
     it('returns default token limit for unknown model', () => {
         const maxChars = ModelProvider.getMaxCharsByModel('unknown-model')
-        expect(maxChars).toEqual(tokensToChars(DEFAULT_FAST_MODEL_TOKEN_LIMIT))
+        expect(maxChars).toEqual(tokensToChars(DEFAULT_CHAT_MODEL_TOKEN_LIMIT))
     })
 
     it('returns max token limit for known chat model', () => {
@@ -23,7 +23,7 @@ describe('getMaxCharsByModel', () => {
     it('returns default token limit for unknown model - Enterprise user', () => {
         ModelProvider.getProviders(ModelUsage.Chat, false, 'https://example.com')
         const maxChars = ModelProvider.getMaxCharsByModel('unknown-model')
-        expect(maxChars).toEqual(tokensToChars(DEFAULT_FAST_MODEL_TOKEN_LIMIT))
+        expect(maxChars).toEqual(tokensToChars(DEFAULT_CHAT_MODEL_TOKEN_LIMIT))
     })
 
     it('returns max token limit for known model - Enterprise user', () => {

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_FAST_MODEL_TOKEN_LIMIT, tokensToChars } from '../prompt/constants'
-import { DEFAULT_DOT_COM_MODELS } from './dotcom'
 import type { ModelUsage } from './types'
 import { fetchLocalOllamaModels, getModelInfo } from './utils'
 
@@ -42,7 +41,7 @@ export class ModelProvider {
     /**
      * Providers available on the user's Sourcegraph instance
      */
-    private static primaryProviders: ModelProvider[] = DEFAULT_DOT_COM_MODELS
+    private static primaryProviders: ModelProvider[] = []
     /**
      * Providers available from user's local instances, e.g. Ollama
      */

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FAST_MODEL_TOKEN_LIMIT, tokensToChars } from '../prompt/constants'
+import { DEFAULT_CHAT_MODEL_TOKEN_LIMIT, tokensToChars } from '../prompt/constants'
 import type { ModelUsage } from './types'
 import { fetchLocalOllamaModels, getModelInfo } from './utils'
 
@@ -25,7 +25,7 @@ export class ModelProvider {
         public readonly usage: ModelUsage[],
         // The maximum number of tokens that can be processed by the model in a single request.
         // NOTE: A token is equivalent to 4 characters/bytes.
-        public readonly maxToken: number = DEFAULT_FAST_MODEL_TOKEN_LIMIT
+        public readonly maxToken: number = DEFAULT_CHAT_MODEL_TOKEN_LIMIT
     ) {
         const { provider, title } = getModelInfo(model)
         this.provider = provider
@@ -92,6 +92,6 @@ export class ModelProvider {
      */
     public static getMaxCharsByModel(modelID: string): number {
         const model = ModelProvider.providers.find(m => m.model === modelID)
-        return tokensToChars(model?.maxToken || DEFAULT_FAST_MODEL_TOKEN_LIMIT)
+        return tokensToChars(model?.maxToken || DEFAULT_CHAT_MODEL_TOKEN_LIMIT)
     }
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -312,9 +312,11 @@ const register = async (
     })
 
     // Sync initial auth status
-    await chatManager.syncAuthStatus(authProvider.getAuthStatus())
+    const initAuthStatus = authProvider.getAuthStatus()
+    syncModelProviders(initAuthStatus)
+    await chatManager.syncAuthStatus(initAuthStatus)
     ModelProvider.onConfigChange(initialConfig.experimentalOllamaChat)
-    statusBar.syncAuthStatus(authProvider.getAuthStatus())
+    statusBar.syncAuthStatus(initAuthStatus)
 
     const commandsManager = platform.createCommandsProvider?.()
     setCommandController(commandsManager)

--- a/vscode/src/models/utils.ts
+++ b/vscode/src/models/utils.ts
@@ -11,7 +11,11 @@ import * as vscode from 'vscode'
  * or fallback to the limit from the authentication status if not configured.
  */
 export function syncModelProviders(authStatus: AuthStatus): void {
-    if (authStatus.endpoint && isDotCom(authStatus.endpoint)) {
+    if (!authStatus.endpoint) {
+        return
+    }
+
+    if (isDotCom(authStatus.endpoint)) {
         ModelProvider.setProviders(DEFAULT_DOT_COM_MODELS)
         return
     }
@@ -22,6 +26,9 @@ export function syncModelProviders(authStatus: AuthStatus): void {
     // This is similiar to the behavior we had before introducing the new chat and allows BYOK
     // customers to set a model of their choice without us having to map it to a known model on
     // the client.
+    //
+    // NOTE: If authStatus?.configOverwrites?.chatModel is empty, we will not set any model providers.
+    // Which means it will fallback to use the default model on the server.
     if (authStatus?.configOverwrites?.chatModel) {
         const codyConfig = vscode.workspace.getConfiguration('cody')
         const tokenLimitConfig = codyConfig?.get<number>('provider.limit.prompt')


### PR DESCRIPTION
Context:

Fix issues where `syncModelProviders` is not run during the extension activation event.

Currently, we only run `syncModelProviders()` on authStatus change, which means this will not run if the listeners are mounted after the authStatus has been created at activation time. 
- This PR updates to run `syncModelProviders()` after adding  `syncModelProviders()` to the authStatus listener.
- Also updated to only default to .com models if endpoint is dotcom to prevent enterprise using .com models
- If there is a chatModel override in the auth status config, use that to set a single model provider. This allows BYOK customers to configure their own model.
- Fallback to using the default model on the server if no model providers are set.
- Updated to use the default chat model token limit instead of fast model token limit for chat models


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Connect to an Enterprise instance
2. Submit a new question
3. Check output channel to confirm if the model id is showing up correctly.