### PR TITLE
Chat: remove double tab token

### DIFF
--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -245,7 +245,6 @@ test('pressing Enter with @-mention menu open selects item, does not submit mess
     await chatInput.fill('Explain @index.htm')
     await expect(chatPanelFrame.getByRole('option', { name: 'index.html' })).toBeVisible()
     await chatInput.press('Enter')
-    await chatInput.press('Enter')
     await expect(chatInput).toHaveText('Explain @index.html')
     await expect(chatInput.getByText('@index.html')).toHaveClass(/context-item-mention-node/)
 })

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -87,8 +87,6 @@ test.extend<ExpectedEvents>({
     await chatInput.fill('Explain @mj')
     await chatPanelFrame.getByRole('option', { name: 'Main.java' }).click()
     await expect(chatInput).toHaveText('Explain @Main.java ')
-    await expect(chatInput.getByText('@Main.java')).not.toHaveClass(/context-item-mention-node/)
-    await chatInput.press('Enter')
     await expect(chatInput.getByText('@Main.java')).toHaveClass(/context-item-mention-node/)
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
@@ -104,7 +102,6 @@ test.extend<ExpectedEvents>({
         chatPanelFrame.getByRole('option', { name: withPlatformSlashes('var.go lib/batches/env') })
     ).toBeVisible()
     await chatInput.press('Tab')
-    await chatInput.press('Tab')
     await expect(chatInput).toHaveText(withPlatformSlashes('Explain @lib/batches/env/var.go '))
     await chatInput.focus()
     await chatInput.pressSequentially('and ')
@@ -117,7 +114,6 @@ test.extend<ExpectedEvents>({
     await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/var\.go/)
     await chatInput.press('ArrowDown') // second item again
     await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/visualize\.go/)
-    await chatInput.press('Tab')
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText(
         withPlatformSlashes(
@@ -146,14 +142,12 @@ test.extend<ExpectedEvents>({
     await chatInput.pressSequentially('@Main.java', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.press('Tab')
-    await chatInput.press('Tab')
     await expect(chatInput).toHaveText('@Main.java ')
 
     // Check pressing tab after typing a partial filename but where that complete
     // filename already exists earlier in the input.
     // https://github.com/sourcegraph/cody/issues/2243
     await chatInput.pressSequentially('and @Main.ja', { delay: 10 })
-    await chatInput.press('Tab')
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText('@Main.java and @Main.java ')
 
@@ -169,7 +163,6 @@ test.extend<ExpectedEvents>({
     await chatInput.press('Space') // 'Explain the | file'
     await chatInput.pressSequentially('@Main', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
-    await chatInput.press('Tab')
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText('Explain the @Main.java file')
     // Confirm the cursor is at the end of the newly added file name with space
@@ -215,7 +208,6 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     // Send a message with an @-mention.
     await chatInput.fill('Explain @mj')
     await chatPanelFrame.getByRole('option', { name: 'Main.java' }).click()
-    await chatInput.press('Enter')
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await expect(chatInput.getByText('@Main.java')).toHaveClass(/context-item-mention-node/)
     await chatInput.press('Enter')
@@ -234,7 +226,6 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await chatInput.press('ArrowUp')
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await chatInput.pressSequentially('and @index.ht')
-    await chatPanelFrame.getByRole('option', { name: 'index.html' }).click()
     await chatPanelFrame.getByRole('option', { name: 'index.html' }).click()
     await expect(chatInput).toHaveText('Explain @Main.java and @index.html')
     await expect(chatInput.getByText('@index.html')).toHaveClass(/context-item-mention-node/)
@@ -269,7 +260,6 @@ test('@-mention links in transcript message', async ({ page, sidebar }) => {
     await chatInput.fill('Hello @buzz.ts')
     await chatPanelFrame.getByRole('option', { name: 'buzz.ts' }).click()
     await chatInput.press('Enter')
-    await chatInput.press('Enter')
 
     // In the transcript, the @-mention is linked, and clicking the link opens the file.
     const transcriptMessage = chatPanelFrame.getByText('Hello @buzz.ts')
@@ -292,8 +282,6 @@ test('@-mention file range', async ({ page, sidebar }) => {
     await expect(chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' }).click()
     await expect(chatInput).toHaveText('@buzz.ts:2-4 ')
-    // Enter again to turn it into a token
-    await chatInput.press('Enter')
 
     // Submit the message
     await chatInput.press('Enter')

--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -105,7 +105,6 @@ test.extend<ExpectedEvents>({
     await expect(chatInput).not.toHaveText('Four')
     await expect(chatFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.press('Tab')
-    await chatInput.press('Tab')
     await expect(chatInput).toHaveText('Explain @Main.java ')
 
     // Enter should submit the message and exit editing mode
@@ -121,7 +120,6 @@ test.extend<ExpectedEvents>({
     await chatInput.focus()
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await chatInput.type('and @vgo', { delay: 50 })
-    await chatInput.press('Tab')
     await chatInput.press('Tab')
     await expect(chatInput).toHaveText(
         withPlatformSlashes('Explain @Main.java and @lib/batches/env/var.go ')

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -18,10 +18,7 @@ import {
     scanForMentionTriggerInUserTextInput,
 } from '@sourcegraph/cody-shared'
 import classNames from 'classnames'
-import {
-    $createContextItemMentionNode,
-    $createContextItemTextNode,
-} from '../../nodes/ContextItemMentionNode'
+import { $createContextItemMentionNode } from '../../nodes/ContextItemMentionNode'
 import { OptionsList } from './OptionsList'
 import { useChatContextItems } from './chatContextClient'
 
@@ -111,17 +108,6 @@ export default function MentionsPlugin(): JSX.Element | null {
                 if (!currentInputText) {
                     return
                 }
-                // On first selection, add the selected option as text.
-                // This allows users to autocomplete the file path, and provide them with
-                // the options to make additional changes, e.g. add range, before inserting the mention.
-                const textNode = $createContextItemTextNode(selectedOption.item)
-                if (!currentInputText.endsWith(textNode.__text) && !currentInputText.startsWith('@#')) {
-                    nodeToReplace.replace(textNode)
-                    textNode.select()
-                    closeMenu()
-                    return
-                }
-
                 const mentionNode = $createContextItemMentionNode(selectedOption.item)
                 nodeToReplace?.replace(mentionNode)
                 const spaceAfter = $createTextNode(' ')


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1712006002459869

This reverts the change in #3606 that update  @-mentions to require double tabbing.

Will address the original issue in https://github.com/sourcegraph/cody/pull/3619

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green CI. 