### PR TITLE
Hover Commands: enable and disable ghost text and hover on feature flags

### DIFF
--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -98,17 +98,16 @@ export async function getGhostHintEnablement(): Promise<EnabledFeatures> {
     const config = vscode.workspace.getConfiguration('cody')
     const configSettings = config.inspect<boolean>('commandHints.enabled')
     const settingValue = configSettings?.workspaceValue ?? configSettings?.globalValue
+    const featureFlagValue = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyHoverCommands)
 
     // Return the actual configuration setting, if set. Otherwise return the default value from the feature flag.
     return {
         /**
-         * We're not running an A/B test on the "Opt+K to Text".
-         * We can safely set the default of this to `true`.
+         * We want to use the featureFlagValue to toggle settings for EditOrChat & Document for the
+         * HoverCommands A/B test, which will only be enabled if EditOrChat & Document are disabled.
          */
-        EditOrChat: settingValue ?? true,
-        Document:
-            settingValue ??
-            (await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyDocumentHints)),
+        EditOrChat: settingValue ?? featureFlagValue,
+        Document: settingValue ?? featureFlagValue,
         /**
          * We're not running an A/B test on the "Opt+K" to generate text.
          * We can safely set the default of this to `true`.

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -114,8 +114,8 @@ export async function getGhostHintEnablement(): Promise<EnabledFeatures> {
         /**
          * Toggle the default settings for EditOrChat & Document based on the feature flagss for hover commands and ghost text.
          */
-        EditOrChat: settingValue ?? (ghostTextFeatureFlag && !hoverFeatureFlag),
-        Document: settingValue ?? (ghostTextFeatureFlag && !hoverFeatureFlag),
+        EditOrChat: settingValue ?? !hoverFeatureFlag,
+        Document: settingValue ?? !hoverFeatureFlag,
         /**
          * We're not running an A/B test on the "Opt+K" to generate text.
          * We can safely set the default of this to `true`.

--- a/vscode/src/commands/GhostHintDecorator.ts
+++ b/vscode/src/commands/GhostHintDecorator.ts
@@ -100,11 +100,7 @@ type EnabledFeatures = Record<GhostVariant, boolean>
  * NOTE: Ghost Text should be disabled for users in the HoverCommands A/B test treatment group.
  */
 export async function getGhostHintEnablement(): Promise<EnabledFeatures> {
-    const [ghostTextFeatureFlag, hoverFeatureFlag] = await Promise.all([
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyDocumentHints),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyHoverCommands),
-    ])
-
+    const hoverFeatureFlag = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyHoverCommands)
     const config = vscode.workspace.getConfiguration('cody')
     const configSettings = config.inspect<boolean>('commandHints.enabled')
     const settingValue = configSettings?.workspaceValue ?? configSettings?.globalValue

--- a/vscode/src/commands/HoverCommandsProvider.ts
+++ b/vscode/src/commands/HoverCommandsProvider.ts
@@ -12,6 +12,7 @@ import { telemetryService } from '../services/telemetry'
 import { telemetryRecorder } from '../services/telemetry-v2'
 import { logFirstEnrollmentEvent } from '../services/utils/enrollment-event'
 import { execQueryWrapper as execQuery } from '../tree-sitter/query-sdk'
+import { getGhostHintEnablement } from './GhostHintDecorator'
 import { executeHoverChatCommand } from './execute/hover-explain'
 import type { CodyCommandArgs } from './types'
 
@@ -191,11 +192,12 @@ export class HoverCommandsProvider implements vscode.Disposable {
             return false
         }
 
-        // Check if the feature flag is enabled for the user
+        // Check if the feature flag for Hover Command is enabled for the user
         featureFlagProvider
             .evaluateFeatureFlag(this.id)
-            .then(hasFeatureFlag => {
-                this.isInTreatment = hasFeatureFlag
+            .then(async hoverFlag => {
+                const ghostConfig = await getGhostHintEnablement()
+                this.isInTreatment = hoverFlag && !(ghostConfig?.Document || ghostConfig?.EditOrChat)
                 this.isActive = isHoverCommandsEnabled()
                 this.register()
             })


### PR DESCRIPTION
This PR enables the hover commands feature based on a feature flag evaluation. 

The main changes are:
- Get the ghost hint enablement config in HoverCommandsProvider to check if EditOrChat or Document are enabled
- Set the isInTreatment flag in HoverCommandsProvider based on:
  - The hover commands feature flag
  - EditOrChat and Document being disabled in the ghost hint config (control by config settings and feature flag)

This allows us to run an A/B test on the hover commands by enabling it for some users if they have the feature flag and EditOrChat/Document disabled.

The ghost hint config is used to disable EditOrChat and Document as those features conflict with the hover commands. So we want to enable hover commands only if those are off.

This unblocks us from running the planned hover commands A/B test by simply enabling the feature flag for Hover Commands to 100% when we are ready.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Enable and disable feature flags on your account to verify.