### PR TITLE
remove opacity from optionlist

### DIFF
--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
@@ -72,7 +72,6 @@
     background-color: var(--vscode-list-hoverBackground);
 }
 .option-item.disabled {
-    opacity: 0.8;
     cursor: default;
 }
 


### PR DESCRIPTION
Address comment in https://github.com/sourcegraph/cody/pull/3619

> let's not change the opacity at all, as we have the label and don't want it to feel disabled. 

Remove opacity from .option-item.disabled

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Simple CSS change