### PR TITLE
use same font-family as @vscode/webview-ui-toolkit/react in storybooks for consistency

### DIFF
--- a/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
@@ -2,7 +2,7 @@
 
 :root {
     --vscode-font-size: 13px;
-    --vscode-font-family: -apple-system, BlinkMacSystemFont, 'Ubuntu', 'Droid Sans', 'Segoe WPC', 'Segoe UI', sans-serif;
+    --vscode-font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 }
 
 body {


### PR DESCRIPTION
Otherwise, components like VSCodeButton use a different font-family from the rest of the storybook.



## Test plan

CI