### PR TITLE
rm needless PromptEditor container

### DIFF
--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -506,7 +506,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 <div className={styles.textAreaContainer}>
                     <div className={styles.editorOuterContainer}>
                         <PromptEditor
-                            containerClassName={styles.editorInnerContainer}
                             placeholder={placeholder}
                             onChange={onEditorChange}
                             onFocusChange={setIsEditorFocused}

--- a/vscode/webviews/promptEditor/PromptEditor.module.css
+++ b/vscode/webviews/promptEditor/PromptEditor.module.css
@@ -1,24 +1,4 @@
-/* Container used for autogrowing, based on https://css-tricks.com/the-cleanest-trick-for-autogrowing-textareas/ */
-.container {
-    /* easy way to plop the elements on top of each other and have them both sized based on the tallest one's height */
-    display: grid;
-}
-
-.container::after {
-    /* Note the weird space! Needed to preventy jumpy behavior */
-    content: attr(data-value) ' ';
-
-    /* This is how textarea text behaves */
-    white-space: pre-wrap;
-
-    /* Hidden from view, clicks, and screen readers */
-    visibility: hidden;
-}
-
-
-/* Both elements need the same styling so the height matches */
-.editor,
-.container::after {
+.editor {
     background-color: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
 

--- a/vscode/webviews/promptEditor/PromptEditor.tsx
+++ b/vscode/webviews/promptEditor/PromptEditor.tsx
@@ -14,7 +14,6 @@ import {
 import type { KeyboardEventPluginProps } from './plugins/keyboardEvent'
 
 interface Props extends KeyboardEventPluginProps {
-    containerClassName?: string
     editorClassName?: string
 
     placeholder?: string
@@ -38,7 +37,6 @@ export interface PromptEditorRefAPI {
  * The component for composing and editing prompts.
  */
 export const PromptEditor: FunctionComponent<Props> = ({
-    containerClassName,
     editorClassName,
     placeholder,
     initialEditorState,
@@ -104,23 +102,21 @@ export const PromptEditor: FunctionComponent<Props> = ({
     )
 
     return (
-        <div className={classNames(styles.container, containerClassName)}>
-            <BaseEditor
-                className={classNames(styles.editor, editorClassName, disabled && styles.disabled)}
-                initialEditorState={initialEditorState?.lexicalEditorState ?? null}
-                onChange={onBaseEditorChange}
-                onFocusChange={onFocusChange}
-                editorRef={editorRef}
-                placeholder={placeholder}
-                disabled={disabled}
-                aria-label="Chat message"
-                //
-                // KeyboardEventPluginProps
-                onKeyDown={onKeyDown}
-                onEnterKey={onEnterKey}
-                onEscapeKey={onEscapeKey}
-            />
-        </div>
+        <BaseEditor
+            className={classNames(styles.editor, editorClassName, disabled && styles.disabled)}
+            initialEditorState={initialEditorState?.lexicalEditorState ?? null}
+            onChange={onBaseEditorChange}
+            onFocusChange={onFocusChange}
+            editorRef={editorRef}
+            placeholder={placeholder}
+            disabled={disabled}
+            aria-label="Chat message"
+            //
+            // KeyboardEventPluginProps
+            onKeyDown={onKeyDown}
+            onEnterKey={onEnterKey}
+            onEscapeKey={onEscapeKey}
+        />
     )
 }
 


### PR DESCRIPTION
Lexical editor autogrows on its own. This container was needed for a plain textarea to autogrow.

No behavior/UI change.

## Test plan

CI