### PR TITLE
pass secretStorage instead of using global singleton

### DIFF
--- a/vscode/src/chat/MessageProvider.ts
+++ b/vscode/src/chat/MessageProvider.ts
@@ -3,6 +3,7 @@ import type { ChatClient, Guardrails } from '@sourcegraph/cody-shared'
 import type { VSCodeEditor } from '../editor/vscode-editor'
 import type { AuthProvider } from '../services/AuthProvider'
 
+import type { SecretStorage } from '../services/SecretStorageProvider'
 import type { ContextProvider } from './ContextProvider'
 
 /**
@@ -16,6 +17,7 @@ export interface MessageProviderOptions {
     chat: ChatClient
     guardrails: Guardrails
     editor: VSCodeEditor
+    secretStorage: SecretStorage
     authProvider: AuthProvider
     contextProvider: ContextProvider
 }

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -18,7 +18,7 @@ import {
     getConfigEnumValues,
 } from './configuration-keys'
 import { localStorage } from './services/LocalStorageProvider'
-import { getAccessToken } from './services/SecretStorageProvider'
+import { type SecretStorage, getAccessToken } from './services/SecretStorageProvider'
 
 interface ConfigGetter {
     get<T>(section: (typeof CONFIG_KEY)[ConfigKeys], defaultValue?: T): T
@@ -208,12 +208,14 @@ function sanitizeCodebase(codebase: string | undefined): string {
     return codebase.replace(protocolRegexp, '').trim().replace(trailingSlashRegexp, '')
 }
 
-export const getFullConfig = async (): Promise<ConfigurationWithAccessToken> => {
+export async function getFullConfig(
+    secretStorage: SecretStorage
+): Promise<ConfigurationWithAccessToken> {
     const config = getConfiguration()
     const isTesting = process.env.CODY_TESTING === 'true'
     const serverEndpoint =
         localStorage?.getEndpoint() || (isTesting ? 'http://localhost:49300/' : DOTCOM_URL.href)
-    const accessToken = (await getAccessToken()) || null
+    const accessToken = (await getAccessToken(secretStorage)) || null
     return { ...config, accessToken, serverEndpoint }
 }
 

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -28,7 +28,7 @@ import { closeAuthProgressIndicator } from '../auth/auth-progress-indicator'
 import { AuthMenu, showAccessTokenInputBox, showInstanceURLInputBox } from './AuthMenus'
 import { getAuthReferralCode } from './AuthProviderSimplified'
 import { localStorage } from './LocalStorageProvider'
-import { secretStorage } from './SecretStorageProvider'
+import type { SecretStorage } from './SecretStorageProvider'
 import { telemetryService } from './telemetry'
 
 type Listener = (authStatus: AuthStatus) => void
@@ -48,7 +48,8 @@ export class AuthProvider {
         private config: Pick<
             ConfigurationWithAccessToken,
             'serverEndpoint' | 'accessToken' | 'customHeaders'
-        >
+        >,
+        private readonly secretStorage: SecretStorage
     ) {
         this.authStatus.endpoint = 'init'
         this.loadEndpointHistory()
@@ -57,7 +58,7 @@ export class AuthProvider {
     // Sign into the last endpoint the user was signed into, if any
     public async init(): Promise<void> {
         let lastEndpoint = localStorage?.getEndpoint() || this.config.serverEndpoint
-        let token = (await secretStorage.get(lastEndpoint || '')) || this.config.accessToken
+        let token = (await this.secretStorage.get(lastEndpoint || '')) || this.config.accessToken
         logDebug(
             'AuthProvider:init',
             token?.trim() ? 'Token recovered from secretStorage' : 'No token found in secretStorage'
@@ -67,7 +68,7 @@ export class AuthProvider {
             // signing them in to dotcom.
             logDebug('AuthProvider:init', 'redirecting App-signed in user to dotcom')
             lastEndpoint = DOTCOM_URL.toString()
-            token = (await secretStorage.get(lastEndpoint)) || null
+            token = (await this.secretStorage.get(lastEndpoint)) || null
         }
         logDebug('AuthProvider:init:lastEndpoint', lastEndpoint)
 
@@ -126,7 +127,7 @@ export class AuthProvider {
             default: {
                 // Auto log user if token for the selected instance was found in secret
                 const selectedEndpoint = item.uri
-                const token = await secretStorage.get(selectedEndpoint)
+                const token = await this.secretStorage.get(selectedEndpoint)
                 let authStatus = await this.auth({
                     endpoint: selectedEndpoint,
                     token: token || null,
@@ -238,7 +239,7 @@ export class AuthProvider {
 
     // Log user out of the selected endpoint (remove token from secret)
     private async signout(endpoint: string): Promise<void> {
-        await secretStorage.deleteToken(endpoint)
+        await this.secretStorage.deleteToken(endpoint)
         await localStorage.deleteEndpoint()
         await this.auth({ endpoint, token: null })
         this.authStatus.endpoint = ''
@@ -373,7 +374,7 @@ export class AuthProvider {
 
     // Set auth status in case of reload
     public async reloadAuthStatus(): Promise<void> {
-        this.config = await getFullConfig()
+        this.config = await getFullConfig(this.secretStorage)
         await this.auth({
             endpoint: this.config.serverEndpoint,
             token: this.config.accessToken,
@@ -474,7 +475,7 @@ export class AuthProvider {
         }
         await localStorage.saveEndpoint(endpoint)
         if (token) {
-            await secretStorage.storeToken(endpoint, token)
+            await this.secretStorage.storeToken(endpoint, token)
         }
         this.loadEndpointHistory()
     }


### PR DESCRIPTION
`secretStorage` is not intended by the VS Code extension API to be a global. It is passed to the `activate` function. I believe this is because VS Code's extension API designers felt it was important to be explicit about which parts of your code have access to the secrets, to avoid mistakes.

## Test plan

CI