### PR TITLE
build and release cody-agent in CI

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -1,0 +1,99 @@
+name: agent-release
+
+on:
+  push:
+    tags:
+      - agent-v*
+
+jobs:
+  release:
+    if: github.repository == 'sourcegraph/cody'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # for publishing the release
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .tool-versions
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
+        with:
+          run_install: true
+      - name: get release version
+        id: release_version
+        run: |
+          TAGGED_VERSION="${GITHUB_REF/refs\/tags\/agent-v/}"
+
+          if [[ ! "${TAGGED_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "Invalid version tag '${TAGGED_VERSION}'"
+            exit 1
+          fi
+
+          echo "EXT_VERSION=${TAGGED_VERSION}" >> $GITHUB_ENV
+          WRITTEN_VERSION="$(cat agent/package.json | jq '.version' -r)"
+
+          if [[ "${TAGGED_VERSION}" != "${WRITTEN_VERSION}" ]]; then
+            echo "Release tag and version in agent/package.json do not match: '${TAGGED_VERSION}' vs. '${WRITTEN_VERSION}'"
+            exit 1
+          fi
+      - run: pnpm build
+      - run: pnpm run test
+      - run: pnpm run publish --no-git-checks agent
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: pnpm -C agent run build-agent-binaries
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Cody Agent ${{ env.EXT_VERSION }}
+          draft: false
+      - name: upload release asset (linux-arm64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./agent/dist/agent-linux-arm64
+          asset_name: cody-agent-linux-arm64-${{ env.EXT_VERSION }}
+          asset_content_type: application/octet-stream
+      - name: upload release asset (linux-x64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./agent/dist/agent-linux-x64
+          asset_name: cody-agent-linux-x64-${{ env.EXT_VERSION }}
+          asset_content_type: application/octet-stream
+      - name: upload release asset (macos-arm64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./agent/dist/agent-macos-arm64
+          asset_name: cody-agent-macos-arm64-${{ env.EXT_VERSION }}
+          asset_content_type: application/octet-stream
+      - name: upload release asset (macos-x64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./agent/dist/agent-macos-x64
+          asset_name: cody-agent-macos-x64-${{ env.EXT_VERSION }}
+          asset_content_type: application/octet-stream
+      - name: upload release asset (win-x64)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./agent/dist/agent-win-x64
+          asset_name: cody-agent-win-x64-${{ env.EXT_VERSION }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -13,8 +13,8 @@ jobs:
     permissions:
       contents: write # for publishing the release
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
       - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes

--- a/agent/README.md
+++ b/agent/README.md
@@ -4,6 +4,15 @@ The `@sourcegraph/cody-agent` package implements a JSON-RPC server to interact
 with Cody via stdout/stdin. This package is intended to be used by
 non-ECMAScript clients such as the JetBrains and NeoVim plugins.
 
+## Releases
+
+Cody Agent releases are available:
+
+- as self-contained executables for various platforms at [Cody Agent releases](https://github.com/sourcegraph/cody/releases) on GitHub
+- from the `@sourcegraph/cody-agent` npm package (`npx @sourcegraph/cody-agent help`)
+
+To build and publish a release using GitHub Actions, bump the version number in the agent's [package.json](package.json) and then push to the `agent-vN.N.N` tag (where `N.N.N` is that version number).
+
 ## Protocol
 
 The protocol is defined in the file [`protocol.ts`](../vscode/src/jsonrpc/agent-protocol.ts). The TypeScript code is the single source of truth of what JSON-RPC methods are

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,7 +1,6 @@
 {
-  "private": true,
-  "name": "@sourcegraph/agent",
-  "version": "0.0.1",
+  "name": "@sourcegraph/cody-agent",
+  "version": "0.0.2",
   "description": "Cody JSON-RPC agent for consistent cross-editor support",
   "license": "Apache-2.0",
   "repository": {
@@ -19,9 +18,10 @@
     "agent": "pnpm run build && node dist/index.js",
     "agent:debug": "pnpm run build && CODY_AGENT_TRACE_PATH=/tmp/agent.json CODY_AGENT_DEBUG_REMOTE=true node --enable-source-maps ./dist/index.js",
     "build-ts": "tsc --build",
-    "build-agent-binaries": "pnpm run build && pkg  --compress GZip --no-bytecode --public-packages \"*\" --public . --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
+    "build-agent-binaries": "pnpm run build && pkg --compress GZip --no-bytecode --public-packages \"*\" --public . --out-path ${AGENT_EXECUTABLE_TARGET_DIRECTORY:-dist}",
     "test-agent-binary": "esbuild ./scripts/test-agent-binary.ts --bundle --platform=node --alias:vscode=./src/vscode-shim.ts --outdir=dist && node ./dist/test-agent-binary.js",
-    "test": "vitest"
+    "test": "vitest",
+    "prepublishOnly": "pnpm run build"
   },
   "pkg": {
     "targets": [
@@ -34,6 +34,7 @@
     "assets": "dist/*.{wasm,map}"
   },
   "bin": "dist/index.js",
+  "files": ["dist/index.js", "dist/index.js.map", "dist/*.wasm"],
   "dependencies": {
     "@pollyjs/core": "^6.0.6",
     "@pollyjs/persister": "^6.0.6",

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import type { Command } from 'commander'
 
 console.log = console.error


### PR DESCRIPTION
Cody Agent releases are available:

- as self-contained executables for various platforms at [Cody Agent releases](https://github.com/sourcegraph/cody/releases) on GitHub
- from the `@sourcegraph/cody-agent` npm package (`npx @sourcegraph/cody-agent help`)

To build and publish a release using GitHub Actions, bump the version number in the agent's [package.json](package.json) and then push to the `agent-vN.N.N` tag (where `N.N.N` is that version number).

NOTE: The macOS binaries are NOT code-signed. They will not work without code-signing.

## Test plan

Merge and attempt to push to the `agent-v*` tag.