### PR TITLE
Telemetry: update menu clicks

### DIFF
--- a/vscode/src/commands/menus/index.ts
+++ b/vscode/src/commands/menus/index.ts
@@ -9,20 +9,30 @@ import { telemetryService } from '../../services/telemetry'
 import { telemetryRecorder } from '../../services/telemetry-v2'
 import { executeChat } from '../execute/ask'
 import { openCustomCommandDocsLink } from '../services/custom-commands'
+import type { CodyCommandArgs } from '../types'
 import { type CustomCommandsBuilder, CustomCommandsBuilderMenu } from './command-builder'
 import { type CommandMenuButton, CommandMenuSeperator, CommandMenuTitleItem } from './items'
 import type { CommandMenuItem } from './types'
 
 export async function showCommandMenu(
     type: 'default' | 'custom' | 'config',
-    customCommands: CodyCommand[]
+    customCommands: CodyCommand[],
+    args?: CodyCommandArgs
 ): Promise<void> {
     const items: CommandMenuItem[] = []
     const configOption = CommandMenuOption.config
     const addOption = CommandMenuOption.add
 
-    telemetryService.log(`CodyVSCodeExtension:menu:command:${type}:clicked`)
-    telemetryRecorder.recordEvent(`cody.menu:command:${type}`, 'clicked')
+    // Log Command Menu opened event
+    const source = args?.source
+    telemetryService.log(
+        `CodyVSCodeExtension:menu:command:${type}:clicked`,
+        { source },
+        { hasV2Event: true }
+    )
+    telemetryRecorder.recordEvent(`cody.menu:command:${type}`, 'clicked', {
+        privateMetadata: { source },
+    })
 
     // Add items to menus accordingly:
     // 1. default: contains default commands and custom commands

--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -5,6 +5,7 @@ import { CodyCommandMenuItems } from '..'
 import { TreeViewProvider } from '../../services/tree-views/TreeViewProvider'
 import { getContextFileFromShell } from '../context/shell'
 import { showCommandMenu } from '../menus'
+import type { CodyCommandArgs } from '../types'
 import { getDefaultCommandsMap } from '../utils/get-commands'
 import { CustomCommandsManager, openCustomCommandDocsLink } from './custom-commands'
 
@@ -32,9 +33,9 @@ export class CommandsProvider implements vscode.Disposable {
 
         // Cody Command Menus
         this.disposables.push(
-            vscode.commands.registerCommand('cody.menu.commands', () => this?.menu('default')),
-            vscode.commands.registerCommand('cody.menu.custom-commands', () => this?.menu('custom')),
-            vscode.commands.registerCommand('cody.menu.commands-settings', () => this?.menu('config')),
+            vscode.commands.registerCommand('cody.menu.commands', a => this?.menu('default', a)),
+            vscode.commands.registerCommand('cody.menu.custom-commands', a => this?.menu('custom', a)),
+            vscode.commands.registerCommand('cody.menu.commands-settings', a => this?.menu('config', a)),
             vscode.commands.registerCommand('cody.commands.open.doc', () => openCustomCommandDocsLink())
         )
 
@@ -42,14 +43,14 @@ export class CommandsProvider implements vscode.Disposable {
         this.refresh()
     }
 
-    private async menu(type: 'custom' | 'config' | 'default'): Promise<void> {
+    private async menu(type: 'custom' | 'config' | 'default', args?: CodyCommandArgs): Promise<void> {
         const customCommands = await this.getCustomCommands()
         const commandArray = [...customCommands].map(command => command[1])
         if (type === 'custom' && !commandArray.length) {
-            return showCommandMenu('config', commandArray)
+            return showCommandMenu('config', commandArray, args)
         }
 
-        await showCommandMenu(type, commandArray)
+        await showCommandMenu(type, commandArray, args)
     }
 
     /**

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -22,6 +22,7 @@ import { getEditor } from '../../editor/active-editor'
 import { editModel } from '../../models'
 import { type TextChange, updateRangeMultipleChanges } from '../../non-stop/tracked-range'
 import type { AuthProvider } from '../../services/AuthProvider'
+import { telemetryService } from '../../services/telemetry'
 import { telemetryRecorder } from '../../services/telemetry-v2'
 import { executeEdit } from '../execute'
 import type { EditIntent } from '../types'
@@ -81,6 +82,9 @@ export const getInput = async (
     if (!editor) {
         return null
     }
+
+    telemetryService.log('CodyVSCodeExtension:menu:edit:clicked', { source }, { hasV2Event: true })
+    telemetryRecorder.recordEvent('cody.menu:edit', 'clicked', { privateMetadata: { source } })
 
     const initialCursorPosition = editor.selection.active
     let activeRange = initialValues.initialExpandedRange || initialValues.initialRange


### PR DESCRIPTION
Changes:
- add telemetry for disabling hover commands
- Log event on edit menu open
- Add event source for general command menu events

These changes aim to provide better visibility and tracking of the hover commands feature's usage, particularly when it is disabled for users in the treatment group. 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Telemetry change