### PR TITLE
Menu: hide disabled feature flag item

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -26,7 +26,6 @@ export interface Configuration {
     codeActions: boolean
     commandHints: boolean
     commandCodeLenses: boolean
-    editorTitleCommandIcon: boolean
 
     /**
      * Autocomplete

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -33,6 +33,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Auth: Enable the new onboarding flow that does not require the redirect back to VS Code for everyone. [pull/3574](https://github.com/sourcegraph/cody/pull/3574)
 - Chat: Claude 3 Sonnet is now the default model for every Cody Free or Pro user. [pull/3575](https://github.com/sourcegraph/cody/pull/3575)
 - Edit: Removed a previous Edit shortcut (`Shift+Cmd/Ctrl+v`), use `Opt/Alt+K` to trigger Edits. [pull/3591](https://github.com/sourcegraph/cody/pull/3591)
+- Commands: The `Editor Title Icon` configuration option has been removed from the Cody Settings menu. Users can configure the title bar icon by right-clicking on the title bar. [pull/3677](https://github.com/sourcegraph/cody/pull/3677)
 
 ## [1.10.2]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -321,14 +321,14 @@
       },
       {
         "command": "cody.menu.custom-commands",
-        "category": "Cody Command",
+        "category": "Cody Menu",
         "title": "Custom Commands",
         "icon": "$(tools)",
         "when": "cody.activated && workspaceFolderCount > 0"
       },
       {
         "command": "cody.menu.commands-settings",
-        "category": "Cody Command",
+        "category": "Cody Settings",
         "title": "Custom Commands Settings",
         "icon": "$(gear)",
         "when": "cody.activated"
@@ -399,8 +399,8 @@
       },
       {
         "command": "cody.menu.commands",
-        "category": "Cody",
-        "title": "Commands",
+        "category": "Cody Menu",
+        "title": "Cody Commands",
         "when": "cody.activated",
         "icon": "$(cody-logo)"
       },
@@ -783,7 +783,7 @@
       "editor/title": [
         {
           "command": "cody.menu.commands",
-          "when": "cody.activated && config.cody.editorTitleCommandIcon && !editorReadonly && (resourceScheme == file || activeWebviewPanelId == cody.chatPanel)",
+          "when": "cody.activated && !editorReadonly && (resourceScheme == file || activeWebviewPanelId == cody.chatPanel)",
           "group": "navigation",
           "visibility": "visible"
         },
@@ -894,12 +894,6 @@
               "plaintext": false
             }
           ]
-        },
-        "cody.editorTitleCommandIcon": {
-          "order": 7,
-          "type": "boolean",
-          "markdownDescription": "Adds a Cody icon to the editor title menu for quick access to Cody commands.",
-          "default": true
         },
         "cody.commandCodeLenses": {
           "order": 8,

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -35,7 +35,6 @@ export type Config = Pick<
     | 'commandCodeLenses'
     | 'experimentalSimpleChatContext'
     | 'experimentalSymfContext'
-    | 'editorTitleCommandIcon'
     | 'internalUnstable'
     | 'experimentalChatContextRanker'
 >

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -37,8 +37,6 @@ describe('getConfiguration', () => {
                         return { '*': true }
                     case 'cody.commandCodeLenses':
                         return true
-                    case 'cody.editorTitleCommandIcon':
-                        return true
                     case 'cody.experimental.guardrails':
                         return true
                     case 'cody.codeActions.enabled':
@@ -130,7 +128,6 @@ describe('getConfiguration', () => {
             experimentalSupercompletions: false,
             experimentalSymfContext: true,
             experimentalTracing: true,
-            editorTitleCommandIcon: true,
             experimentalGuardrails: true,
             experimentalOllamaChat: true,
             codeActions: true,

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -101,7 +101,6 @@ export function getConfiguration(
         chatPreInstruction: config.get(CONFIG_KEY.chatPreInstruction, ''),
         editPreInstruction: config.get(CONFIG_KEY.editPreInstruction, ''),
         commandCodeLenses: config.get(CONFIG_KEY.commandCodeLenses, false),
-        editorTitleCommandIcon: config.get(CONFIG_KEY.editorTitleCommandIcon, true),
         autocompleteAdvancedProvider,
         autocompleteAdvancedModel: config.get<string | null>(CONFIG_KEY.autocompleteAdvancedModel, null),
         autocompleteCompleteSuggestWidgetSelection: config.get(

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -167,28 +167,11 @@ export function createStatusBar(): CodyStatusBar {
                 c => c.codeActions
             ),
             await createFeatureToggle(
-                'Editor Title Icon',
-                undefined,
-                'Enable Cody to appear in editor title menu for quick access to Cody commands',
-                'cody.editorTitleCommandIcon',
-                c => c.editorTitleCommandIcon
-            ),
-            await createFeatureToggle(
                 'Code Lenses',
                 undefined,
                 'Enable Code Lenses in documents for quick access to Cody commands',
                 'cody.commandCodeLenses',
                 c => c.commandCodeLenses
-            ),
-            await createFeatureToggle(
-                'Command Hints',
-                undefined,
-                'Enable hints for Cody commands such as "Opt+K to Edit" or "Opt+D to Document"',
-                'cody.commandHints.enabled',
-                async () => {
-                    const enablement = await getGhostHintEnablement()
-                    return enablement.Document || enablement.EditOrChat || enablement.Generate
-                }
             ),
             ...(hoverCommandsProvider.getEnablement()
                 ? [
@@ -200,7 +183,18 @@ export function createStatusBar(): CodyStatusBar {
                           () => isHoverCommandsEnabled()
                       ),
                   ]
-                : []),
+                : [
+                      await createFeatureToggle(
+                          'Command Hints',
+                          undefined,
+                          'Enable hints for Cody commands such as "Opt+K to Edit" or "Opt+D to Document"',
+                          'cody.commandHints.enabled',
+                          async () => {
+                              const enablement = await getGhostHintEnablement()
+                              return enablement.Document || enablement.EditOrChat || enablement.Generate
+                          }
+                      ),
+                  ]),
 
             await createFeatureToggle(
                 'Search Context',

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -813,7 +813,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
         '*': true,
     },
     commandCodeLenses: false,
-    editorTitleCommandIcon: true,
     experimentalGuardrails: false,
     experimentalSimpleChatContext: true,
     experimentalSupercompletions: false,

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -319,7 +319,7 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
     await page.locator('a').filter({ hasText: 'index.js' }).click()
 
     // Run the custom command that uses terminal output as context
-    await page.getByRole('button', { name: 'Commands' }).click()
+    await page.getByRole('button', { name: 'Cody Commands' }).click()
     const menuInputBox = page.getByPlaceholder('Search for a command or enter your question here...')
     await expect(menuInputBox).toBeVisible()
     await menuInputBox.fill('shellOutput')

--- a/vscode/test/e2e/command-edit.test.ts
+++ b/vscode/test/e2e/command-edit.test.ts
@@ -33,7 +33,7 @@ test.extend<ExpectedEvents>({
     await page.keyboard.press('ArrowDown')
 
     // Enter instruction in the command palette via clicking on the Cody Icon
-    await page.getByRole('button', { name: 'Commands' }).click()
+    await page.getByRole('button', { name: 'Cody Commands' }).click()
     await page.getByRole('option', { name: 'Edit code' }).click()
 
     const inputBox = page.getByPlaceholder(/^Enter edit instructions \(type @ to include code/)

--- a/vscode/test/e2e/fixup-decorator.test.ts
+++ b/vscode/test/e2e/fixup-decorator.test.ts
@@ -42,7 +42,7 @@ test.skip('decorations from un-applied Cody changes appear', async ({ page, side
     await page.keyboard.press('ArrowDown')
 
     // Open the command palette by clicking on the Cody Icon
-    await page.getByRole('button', { name: 'Commands' }).click()
+    await page.getByRole('button', { name: 'Cody Commands' }).click()
     // Navigate to fixup input
     await page.getByRole('option', { name: 'Edit code' }).click()
 

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -268,7 +268,6 @@ async function buildWorkSpaceSettings(
     const settings = {
         'cody.serverEndpoint': 'http://localhost:49300',
         'cody.commandCodeLenses': true,
-        'cody.editorTitleCommandIcon': true,
         ...extraSettings,
     }
     // create a temporary directory with settings.json and add to the workspaceDirectory

--- a/vscode/test/fixtures/multi-root.code-workspace
+++ b/vscode/test/fixtures/multi-root.code-workspace
@@ -12,7 +12,6 @@
         // included in fixtures\workspace\.vscode\settings.json!
         "cody.serverEndpoint": "http://localhost:49300",
         "cody.commandCodeLenses": true,
-        "cody.editorTitleCommandIcon": true,
         "cody.experimental.symfContext": false,
         "cody.internal.unstable": true
     }


### PR DESCRIPTION
Updated the settings menu with the following changes:

1. Show `Commands on Hover` & `Command Hints` in settings menu based on the feature flag for the Hover Commands A/B Test value
2. The toggle for enabling/disabling the Cody icon in the editor title menu has been removed.
 Reason: This option can be easily configuration through the title bar by right-clicking on it
All the relevant settings have also been removed
![image](https://github.com/sourcegraph/cody/assets/68532117/1731e60b-16f0-41f8-b0fe-3d72c50da560)


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

User without the feature flag for `Hover Commands A/B test` should **not** see the setting option for `Commands on Hover`
![image](https://github.com/sourcegraph/cody/assets/68532117/4ddd3329-bd28-47a7-abdf-b1dc7307a326)

User with the feature flag for `Hover Commands A/B test` should **not** see the setting option for `Command Hints`
![image](https://github.com/sourcegraph/cody/assets/68532117/5082bb07-d4a7-45bb-bcde-b84935dc1f32)