### PR TITLE
Command: Fix log format

### DIFF
--- a/vscode/src/commands/HoverCommandsProvider.ts
+++ b/vscode/src/commands/HoverCommandsProvider.ts
@@ -115,17 +115,13 @@ class HoverCommandsProvider implements vscode.Disposable {
 
         // Create contents for the hover with clickable commands
         const contents = new vscode.MarkdownString(
-            '$(cody-logo) ' +
-                commands
-                    .filter(c => c.enabled)
-                    .map(c => createHoverCommandTitle(c.id, c.title))
-                    .join(' | ')
+            '$(cody-logo) ' + commands.map(c => createHoverCommandTitle(c.id, c.title)).join(' | ')
         )
         contents.supportThemeIcons = true
         contents.isTrusted = true
 
         // Log the visibility of the hover commands
-        const args = { commands: commands.filter(c => c.enabled).join(','), languageId: doc.languageId }
+        const args = { commands: commands.map(c => c.title).join(', '), languageId: doc.languageId }
         telemetryService.log('CodyVSCodeExtension:hoverCommands:visible', args, { hasV2Event: true })
         telemetryRecorder.recordEvent('cody.hoverCommands', 'visible', { privateMetadata: args })
 
@@ -168,7 +164,7 @@ class HoverCommandsProvider implements vscode.Disposable {
             return []
         }
 
-        return Object.values(commandsOnHovers)
+        return Object.values(commandsOnHovers).filter(c => c.enabled)
     }
 
     /**


### PR DESCRIPTION
This commit resolves an issue where the telemetry logging for hover commands was displaying "[object Object],[object Object],[object Object]" instead of the actual command titles.

1. Telemetry Logging Fix:

The previous implementation was logging the entire command objects as strings, resulting in the "[object Object]" output.
To fix this, the commit changes the way command titles are extracted and logged.
Instead of joining the command objects directly, the map function is used to extract the title property from each command object.
The resulting array of command titles is then joined with ', ' as the separator and logged.

2. Rendering Optimization:

As a side effect of the telemetry logging fix, the rendering of hover commands has also been optimized.
The createHoverCommandTitle function is now mapped directly over the commands array, eliminating the need for an additional filter operation.
The resulting array of command titles is joined with the ' | ' separator to create the hover content string.

3. Filtering Enabled Commands:

The getCommandsOnHovers function now filters out disabled commands before returning the values.
This ensures that only enabled commands are displayed in the hover and logged.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before

```
█ logEvent: CodyVSCodeExtension:hoverCommands:visible  {
  "details": "VSCode",
  "properties": {
    "commands": "[object Object],[object Object],[object Object]",
    "languageId": "typescript"
  },
  "opts": {
    "hasV2Event": true
  }
}
```


### After

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:hoverCommands:visible  {
  "details": "VSCode",
  "properties": {
    "commands": "Explain Code, Document Code, Edit Code",
    "languageId": "typescript"
  },
  "opts": {
    "hasV2Event": true
  }
}
```