### PR TITLE
E2E: Fix helper function for file opening

### DIFF
--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -35,8 +35,14 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:chat-question:executed',
     ],
 })('create a new user command via the custom commands menu', async ({ page, sidebar }) => {
-    // Sign into Cody
     await sidebarSignin(page, sidebar)
+
+    // Minimize other sidebar items to make room for the command view,
+    // else the test will fail because the Custom Command button is not visible
+    await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()
+    await page.getByLabel('Natural Language Search (Beta) Section').click()
+    await page.getByLabel('Settings & Support Section').click()
+    await page.getByLabel('Chats Section').click()
 
     // Open the File Explorer view from the sidebar
     await sidebarExplorer(page).click()
@@ -47,17 +53,7 @@ test.extend<ExpectedEvents>({
 
     // Bring the cody sidebar to the foreground
     await page.click('.badge[aria-label="Cody"]')
-
-    // Open the new chat panel
-    await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()
-
-    // Minimize other sidebar items to make room for the command view,
-    // else the test will fail because the Custom Command button is not visible
-    await page.getByLabel('Natural Language Search (Beta) Section').click()
-    await page.getByLabel('Settings & Support Section').click()
-    await page.getByLabel('Chats Section').click()
-
-    // Click the Custom Commands button in the Command view
+    // Click the Custom Commands button in the Sidebar to open the Custom Commands menu
     await page.getByText('Custom Commands').click()
 
     const commandName = 'ATestCommand'
@@ -139,8 +135,14 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:chat-question:executed',
     ],
 })('execute custom commands with context defined in cody.json', async ({ page, sidebar }) => {
-    // Sign into Cody
     await sidebarSignin(page, sidebar)
+
+    // Minimize other sidebar items to make room for the command view,
+    // else the test will fail because the Custom Command button is not visible
+    await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()
+    await page.getByLabel('Natural Language Search (Beta) Section').click()
+    await page.getByLabel('Settings & Support Section').click()
+    await page.getByLabel('Chats Section').click()
 
     // Open the File Explorer view from the sidebar
     await sidebarExplorer(page).click()
@@ -153,13 +155,6 @@ test.extend<ExpectedEvents>({
 
     // Open the chat sidebar to click on the Custom Command option
     // Search for the command defined in cody.json and execute it
-    await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()
-
-    // Minimize other sidebar items to make room for the command view,
-    // else the test will fail because the Custom Command button is not visible
-    await page.getByLabel('Natural Language Search (Beta) Section').click()
-    await page.getByLabel('Settings & Support Section').click()
-    await page.getByLabel('Chats Section').click()
 
     /* Test: context.currentDir with currentDir command */
     await page.getByRole('treeitem', { name: 'Custom Commands' }).locator('a').click()
@@ -242,8 +237,14 @@ test.extend<ExpectedEvents>({
         'CodyVSCodeExtension:menu:command:config:clicked',
     ],
 })('open and delete cody.json from the custom command menu', async ({ page, sidebar }) => {
-    // Sign into Cody
     await sidebarSignin(page, sidebar)
+
+    // Minimize other sidebar items to make room for the command view,
+    // else the test will fail because the Custom Command button is not visible
+    await expect(page.getByText('Chat alongside your code, attach files,')).toBeVisible()
+    await page.getByLabel('Natural Language Search (Beta) Section').click()
+    await page.getByLabel('Settings & Support Section').click()
+    await page.getByLabel('Chats Section').click()
 
     // Open the File Explorer view from the sidebar
     await sidebarExplorer(page).click()
@@ -253,12 +254,6 @@ test.extend<ExpectedEvents>({
     await page.getByRole('tab', { name: 'cody.json' }).hover()
 
     await page.click('.badge[aria-label="Cody"]')
-
-    // Minimize other sidebar items to make room for the command view,
-    // else the test will fail because the Custom Command button is not visible
-    await page.getByLabel('Natural Language Search (Beta) Section').click()
-    await page.getByLabel('Settings & Support Section').click()
-    await page.getByLabel('Chats Section').click()
 
     // Check button click to open the cody.json file in the editor
     // const label = 'gear  Configure Custom Commands..., Manage your custom reusable commands, settings'

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -345,10 +345,10 @@ export async function openFile(page: Page, filename: string): Promise<void> {
     await page.getByPlaceholder(/Search files by name/).click()
     await page.keyboard.type(`${filename}`)
     // Makes sure the file is visible in the file picker
-    expect(page.locator('a').filter({ hasText: filename })).toBeVisible()
+    await expect(page.locator('a').filter({ hasText: filename })).toBeVisible()
     await page.keyboard.press('Enter')
     // Makes sure the file is opened in the editor
-    await page.getByRole('tab').getByText(filename).click()
+    await expect(page.getByRole('tab', { name: filename })).toBeVisible()
 }
 
 // Starts a new panel chat and returns a FrameLocator for the chat.

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -338,13 +338,17 @@ export function spawn(...args: Parameters<typeof child_process.spawn>): Promise<
 
 // Uses VSCode command palette to open a file by typing its name.
 export async function openFile(page: Page, filename: string): Promise<void> {
+    const metaKey = getMetaKeyByOS()
     // Open a file from the file picker
-    await page.keyboard.down('Control')
-    await page.keyboard.down('Shift')
-    await page.keyboard.press('P')
-    await page.keyboard.up('Shift')
-    await page.keyboard.up('Control')
-    await page.keyboard.type(`${filename}\n`)
+    await page.keyboard.press(`${metaKey}+P`)
+    // Makes sure the file picker input box has the focus
+    await page.getByPlaceholder(/Search files by name/).click()
+    await page.keyboard.type(`${filename}`)
+    // Makes sure the file is visible in the file picker
+    expect(page.locator('a').filter({ hasText: filename })).toBeVisible()
+    await page.keyboard.press('Enter')
+    // Makes sure the file is opened in the editor
+    await page.getByRole('tab').getByText(filename).click()
 }
 
 // Starts a new panel chat and returns a FrameLocator for the chat.

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -90,6 +90,7 @@ test.extend<helpers.WorkspaceDirectory>({
         })
     },
 })('non-git repositories should explain lack of embeddings', async ({ page, sidebar }) => {
+    await sidebar.getByRole('button', { name: 'Sign In to Your Enterprise Instance' }).hover()
     await openFile(page, 'main.c')
     await sidebarSignin(page, sidebar)
     // The Enhanced Context settings is opened on first chat by default
@@ -105,6 +106,7 @@ test.extend<helpers.WorkspaceDirectory>({
 })
 
 test('git repositories without a remote should explain the issue', async ({ page, sidebar }) => {
+    await sidebar.getByRole('button', { name: 'Sign In to Your Enterprise Instance' }).hover()
     await openFile(page, 'main.c')
     await sidebarSignin(page, sidebar)
     const chatFrame = await newChat(page)
@@ -135,6 +137,7 @@ test
             'CodyVSCodeExtension:chat-question:executed',
         ],
     })('should be able to index, then search, a git repository', async ({ page, sidebar }) => {
+    await sidebar.getByRole('button', { name: 'Sign In to Your Enterprise Instance' }).hover()
     await openFile(page, 'main.c')
     await sidebarSignin(page, sidebar)
     const chatFrame = await newChat(page)


### PR DESCRIPTION
This commit update the `openFile` helper function in the VSCode extension E2E tests to fix the incorrect logic and make it more robust and cross-platform compatible. 

This is to fix the local-embeddings e2e test that has been flaky on Windows because the `openFile` helper function which only works on Windows

Update to use the correct shortkey for opening a file from the file picker:
- Currently using `Control+P+Shift` which is to open the command palette
  - Control shouldn't work on Mac as well, so the tests were actually not opening the file before this change
- Updated to use `MetaKey+P` correctly. 
- Add check to ensure the extension was loaded before we try opening a file to prevent other windows from stealing focus
- Add checks to make sure the file is opened before we move onto the next step

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

E2E test passing.
Green CI

### Before

You can see after pressing `Control+P+Shift`, the file picker wasn't invoked on Mac:

![image](https://github.com/sourcegraph/cody/assets/68532117/03d3e0f3-f37a-4569-a87f-3a7980561b69)


### After

The file picker shows up after the `MetaKey+P` step:

![image](https://github.com/sourcegraph/cody/assets/68532117/35cf7f44-59bc-4493-bab7-ab60326ceb4c)

