### PR TITLE
import from @sourcegraph/cody-shared not `/{src,dist}/...` subpath

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -7,9 +7,8 @@ import * as vscode from 'vscode'
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
-import { isWindows } from '@sourcegraph/cody-shared'
+import { ModelUsage, isWindows } from '@sourcegraph/cody-shared'
 
-import { ModelUsage } from '@sourcegraph/cody-shared/dist/models/types'
 import { URI } from 'vscode-uri'
 import { TestClient, asTranscriptMessage } from './TestClient'
 import { decodeURIs } from './decodeURIs'

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import * as uuid from 'uuid'
 import type * as vscode from 'vscode'
 
-import { logDebug, logError } from '@sourcegraph/cody-shared'
+import { extensionForLanguage, logDebug, logError } from '@sourcegraph/cody-shared'
 
 // <VERY IMPORTANT - PLEASE READ>
 // This file must not import any module that transitively imports from 'vscode'.
@@ -44,7 +44,6 @@ import {
 
 import { emptyDisposable } from '../../vscode/src/testutils/emptyDisposable'
 
-import { extensionForLanguage } from '@sourcegraph/cody-shared/src/common/languages'
 import { AgentQuickPick } from './AgentQuickPick'
 import { AgentTabGroups } from './AgentTabGroups'
 import { AgentWorkspaceConfiguration } from './AgentWorkspaceConfiguration'

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -1,11 +1,17 @@
 // Add anything else here that needs to be used outside of this library.
 
 export { ModelProvider } from './models'
-export type { ChatModel, EditModel } from './models/types'
+export { type ChatModel, type EditModel, ModelUsage } from './models/types'
+export { DEFAULT_DOT_COM_MODELS } from './models/dotcom'
 export { BotResponseMultiplexer } from './chat/bot-response-multiplexer'
 export { ChatClient } from './chat/chat'
 export { ignores, isCodyIgnoredFile } from './cody-ignore/context-filter'
-export { CODY_IGNORE_POSIX_GLOB, type IgnoreFileContent } from './cody-ignore/ignore-helper'
+export {
+    IgnoreHelper,
+    CODY_IGNORE_POSIX_GLOB,
+    type IgnoreFileContent,
+    CODY_IGNORE_URI_PATH,
+} from './cody-ignore/ignore-helper'
 export { renderCodyMarkdown } from './chat/markdown'
 export { getSimplePreamble } from './chat/preamble'
 export type {
@@ -37,23 +43,25 @@ export type {
     RemoteSearchProvider,
     SearchProvider,
 } from './codebase-context/context-status'
-export type {
-    ContextItem,
-    ContextItemFile,
-    ContextItemSource as ContextFileSource,
-    ContextItemSymbol,
-    ContextFileType,
-    ContextMessage,
-    SymbolKind,
+export {
+    type ContextItem,
+    type ContextItemFile,
+    ContextItemSource,
+    type ContextItemWithContent,
+    type ContextItemSymbol,
+    type ContextFileType,
+    type ContextMessage,
+    type SymbolKind,
 } from './codebase-context/messages'
 export type { CodyCommand, CodyCommandContext, CodyCommandType } from './commands/types'
-export { type DefaultCodyCommands, DefaultChatCommands } from './commands/types'
+export { type DefaultCodyCommands, DefaultChatCommands, DefaultEditCommands } from './commands/types'
 export { dedupeWith, isDefined, isErrorLike, pluralize } from './common'
 export { type RangeData, toRangeData, displayLineRange, displayRange } from './common/range'
 export {
     ProgrammingLanguage,
     languageFromFilename,
     markdownCodeBlockLanguageIDForFilename,
+    extensionForLanguage,
 } from './common/languages'
 export { renderMarkdown, escapeHTML } from './common/markdown'
 export { posixFilePaths } from './common/path'
@@ -127,6 +135,8 @@ export {
 export {
     MAX_BYTES_PER_FILE,
     MAX_CURRENT_FILE_TOKENS,
+    CHARS_PER_TOKEN,
+    ANSWER_TOKENS,
     MAX_HUMAN_INPUT_TOKENS,
     NUM_CODE_RESULTS,
     NUM_TEXT_RESULTS,
@@ -191,7 +201,14 @@ export type { TelemetryRecorder } from './telemetry-v2/TelemetryRecorderProvider
 export { EventLogger } from './telemetry/EventLogger'
 export type { ExtensionDetails } from './telemetry/EventLogger'
 export { testFileUri } from './test/path-helpers'
-export { addTraceparent, getActiveTraceAndSpanId, wrapInActiveSpan } from './tracing'
+export {
+    addTraceparent,
+    getActiveTraceAndSpanId,
+    wrapInActiveSpan,
+    recordErrorToSpan,
+    tracer,
+    logResponseHeadersToSpan,
+} from './tracing'
 export { convertGitCloneURLToCodebaseName, isError } from './utils'
 export type { CurrentUserCodySubscription } from './sourcegraph-api/graphql/client'
 export * from './auth/types'

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -8,6 +8,7 @@ import {
     type FeatureFlagProvider,
     type Guardrails,
     ModelProvider,
+    ModelUsage,
     featureFlagProvider,
 } from '@sourcegraph/cody-shared'
 
@@ -20,7 +21,6 @@ import { TreeViewProvider } from '../../services/tree-views/TreeViewProvider'
 import type { MessageProviderOptions } from '../MessageProvider'
 import type { ExtensionMessage } from '../protocol'
 
-import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import type { ContextRankingController } from '../../local-context/context-ranking'
 import { chatHistory } from './ChatHistoryManager'

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -2,16 +2,20 @@ import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
 import {
+    ANSWER_TOKENS,
     type ChatClient,
     type ChatEventSource,
     type ChatMessage,
     ConfigFeaturesSingleton,
     type ContextItem,
+    type ContextItemWithContent,
     FeatureFlag,
     type FeatureFlagProvider,
     type Guardrails,
+    MAX_BYTES_PER_FILE,
     type Message,
     ModelProvider,
+    ModelUsage,
     type SerializedChatInteraction,
     type SerializedChatTranscript,
     Typewriter,
@@ -21,7 +25,10 @@ import {
     isError,
     isFileURI,
     isRateLimitError,
+    recordErrorToSpan,
     reformatBotMessageForChat,
+    tokensToChars,
+    tracer,
 } from '@sourcegraph/cody-shared'
 
 import type { View } from '../../../webviews/NavBar'
@@ -48,14 +55,6 @@ import { countGeneratedCode, getContextWindowLimitInBytes } from '../utils'
 
 import type { Span } from '@opentelemetry/api'
 import { captureException } from '@sentry/core'
-import type { ContextItemWithContent } from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
-import {
-    ANSWER_TOKENS,
-    MAX_BYTES_PER_FILE,
-    tokensToChars,
-} from '@sourcegraph/cody-shared/src/prompt/constants'
-import { recordErrorToSpan, tracer } from '@sourcegraph/cody-shared/src/tracing'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import type { Repo } from '../../context/repo-fetcher'
 import type { RemoteRepoPicker } from '../../context/repo-picker'

--- a/vscode/src/chat/chat-view/context.test.ts
+++ b/vscode/src/chat/chat-view/context.test.ts
@@ -1,5 +1,4 @@
-import { type ContextItem, testFileUri } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import { type ContextItem, ContextItemSource, testFileUri } from '@sourcegraph/cody-shared'
 import { describe, expect, it } from 'vitest'
 import { fuseContext } from './context'
 

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import {
     type ConfigurationUseContext,
     type ContextItem,
+    ContextItemSource,
     MAX_BYTES_PER_FILE,
     NUM_CODE_RESULTS,
     NUM_TEXT_RESULTS,
@@ -13,7 +14,6 @@ import {
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import type { RemoteSearch } from '../../context/remote-search'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { ContextRankingController } from '../../local-context/context-ranking'

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import {
     type ChatMessage,
     type ContextItem,
+    type ContextItemWithContent,
     type Message,
     getSimplePreamble,
     wrapInActiveSpan,
@@ -10,7 +11,6 @@ import {
 
 import { logDebug } from '../../log'
 
-import type { ContextItemWithContent } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { PromptBuilder } from '../../prompt-builder'
 import type { SimpleChatModel } from './SimpleChatModel'
 import { sortContextItems } from './agentContextSorting'

--- a/vscode/src/commands/CommandsController.ts
+++ b/vscode/src/commands/CommandsController.ts
@@ -9,7 +9,7 @@ import { CommandRunner } from './services/runner'
 import type { CodyCommandArgs } from './types'
 import { fromSlashCommand } from './utils/common'
 
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
+import { wrapInActiveSpan } from '@sourcegraph/cody-shared'
 /**
  * Handles commands execution with commands from CommandsProvider
  * Provides additional prompt management and execution logic

--- a/vscode/src/commands/context/current-file.ts
+++ b/vscode/src/commands/context/current-file.ts
@@ -1,11 +1,11 @@
 import {
     type ContextItem,
+    ContextItemSource,
     MAX_CURRENT_FILE_TOKENS,
     logError,
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import * as vscode from 'vscode'
 import { getEditor } from '../../editor/active-editor'
 

--- a/vscode/src/commands/context/directory.ts
+++ b/vscode/src/commands/context/directory.ts
@@ -1,11 +1,11 @@
 import {
     type ContextItem,
+    ContextItemSource,
     MAX_CURRENT_FILE_TOKENS,
     logError,
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import * as vscode from 'vscode'
 import { type URI, Utils } from 'vscode-uri'
 import { getEditor } from '../../editor/active-editor'

--- a/vscode/src/commands/context/file-path.ts
+++ b/vscode/src/commands/context/file-path.ts
@@ -1,11 +1,11 @@
 import {
     type ContextItem,
+    ContextItemSource,
     MAX_CURRENT_FILE_TOKENS,
     logError,
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 

--- a/vscode/src/commands/context/selection.ts
+++ b/vscode/src/commands/context/selection.ts
@@ -1,11 +1,11 @@
 import {
     type ContextItem,
+    ContextItemSource,
     MAX_CURRENT_FILE_TOKENS,
     logError,
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { getEditor } from '../../editor/active-editor'
 import { getSmartSelection } from '../../editor/utils'
 

--- a/vscode/src/commands/context/shell.ts
+++ b/vscode/src/commands/context/shell.ts
@@ -9,11 +9,11 @@ import { logError } from '../../log'
 import path from 'node:path/posix'
 import {
     type ContextItem,
+    ContextItemSource,
     MAX_CURRENT_FILE_TOKENS,
     truncateText,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 
 const _exec = promisify(exec)
 

--- a/vscode/src/commands/execute/doc.ts
+++ b/vscode/src/commands/execute/doc.ts
@@ -1,14 +1,12 @@
 import * as vscode from 'vscode'
 
-import { logDebug } from '@sourcegraph/cody-shared'
-import { DefaultEditCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import { DefaultEditCommands, logDebug, wrapInActiveSpan } from '@sourcegraph/cody-shared'
 import { defaultCommands } from '.'
 import { type ExecuteEditArguments, executeEdit } from '../../edit/execute'
 import { getEditor } from '../../editor/active-editor'
 import type { EditCommandResult } from '../../main'
 import type { CodyCommandArgs } from '../types'
 
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 import { getEditLineSelection } from '../../edit/utils/edit-selection'
 import { execQueryWrapper } from '../../tree-sitter/query-sdk'
 

--- a/vscode/src/commands/execute/edit.ts
+++ b/vscode/src/commands/execute/edit.ts
@@ -1,5 +1,4 @@
-import { DefaultEditCommands } from '@sourcegraph/cody-shared/src/commands/types'
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
+import { DefaultEditCommands, wrapInActiveSpan } from '@sourcegraph/cody-shared'
 import { type ExecuteEditArguments, executeEdit } from '../../edit/execute'
 import { getEditor } from '../../editor/active-editor'
 import type { EditCommandResult } from '../../main'

--- a/vscode/src/commands/execute/explain.ts
+++ b/vscode/src/commands/execute/explain.ts
@@ -1,5 +1,11 @@
-import { type ContextItem, displayLineRange, displayPath, logDebug } from '@sourcegraph/cody-shared'
-import { DefaultChatCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import {
+    type ContextItem,
+    DefaultChatCommands,
+    displayLineRange,
+    displayPath,
+    logDebug,
+    wrapInActiveSpan,
+} from '@sourcegraph/cody-shared'
 import { defaultCommands } from '.'
 import type { ChatCommandResult } from '../../main'
 import { telemetryService } from '../../services/telemetry'
@@ -10,7 +16,6 @@ import type { CodyCommandArgs } from '../types'
 import { type ExecuteChatArguments, executeChat } from './ask'
 
 import type { Span } from '@opentelemetry/api'
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 
 /**
  * Generates the prompt and context files with arguments for the 'explain' command.

--- a/vscode/src/commands/execute/hover.ts
+++ b/vscode/src/commands/execute/hover.ts
@@ -1,14 +1,11 @@
-import { displayPath, logDebug } from '@sourcegraph/cody-shared'
-import { DefaultChatCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import { DefaultChatCommands, displayPath, logDebug, wrapInActiveSpan } from '@sourcegraph/cody-shared'
 import type { ChatCommandResult } from '../../main'
 import { telemetryService } from '../../services/telemetry'
 import { telemetryRecorder } from '../../services/telemetry-v2'
-import type { CodyCommandArgs } from '../types'
-import { type ExecuteChatArguments, executeChat } from './ask'
-
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 import { getContextFileFromUri } from '../context/file-path'
 import { getContextFileFromCursor } from '../context/selection'
+import type { CodyCommandArgs } from '../types'
+import { type ExecuteChatArguments, executeChat } from './ask'
 
 async function hoverChatCommand(args: Partial<CodyCommandArgs>): Promise<ExecuteChatArguments> {
     const { uri, range, additionalInstruction } = args

--- a/vscode/src/commands/execute/index.ts
+++ b/vscode/src/commands/execute/index.ts
@@ -2,7 +2,7 @@ import {
     DefaultChatCommands,
     type DefaultCodyCommands,
     DefaultEditCommands,
-} from '@sourcegraph/cody-shared/src/commands/types'
+} from '@sourcegraph/cody-shared'
 import type { CommandResult } from '../../main'
 import { executeDocCommand } from './doc'
 import { executeExplainCommand } from './explain'

--- a/vscode/src/commands/execute/smell.ts
+++ b/vscode/src/commands/execute/smell.ts
@@ -1,5 +1,11 @@
-import { type ContextItem, displayLineRange, displayPath, logDebug } from '@sourcegraph/cody-shared'
-import { DefaultChatCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import {
+    type ContextItem,
+    DefaultChatCommands,
+    displayLineRange,
+    displayPath,
+    logDebug,
+    wrapInActiveSpan,
+} from '@sourcegraph/cody-shared'
 import { defaultCommands } from '.'
 import type { ChatCommandResult } from '../../main'
 import { telemetryService } from '../../services/telemetry'
@@ -9,7 +15,6 @@ import type { CodyCommandArgs } from '../types'
 import { type ExecuteChatArguments, executeChat } from './ask'
 
 import type { Span } from '@opentelemetry/api'
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 
 /**
  * Generates the prompt and context files with arguments for the 'smell' command.

--- a/vscode/src/commands/execute/terminal.ts
+++ b/vscode/src/commands/execute/terminal.ts
@@ -1,12 +1,10 @@
-import { DefaultChatCommands, logDebug } from '@sourcegraph/cody-shared'
+import { DefaultChatCommands, logDebug, wrapInActiveSpan } from '@sourcegraph/cody-shared'
 import type { ChatCommandResult } from '../../main'
 import { telemetryService } from '../../services/telemetry'
 import { telemetryRecorder } from '../../services/telemetry-v2'
 import { executeChat } from './ask'
 
 import * as uuid from 'uuid'
-
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 
 interface TerminalOutputArguments {
     name: string

--- a/vscode/src/commands/execute/test-case.ts
+++ b/vscode/src/commands/execute/test-case.ts
@@ -1,13 +1,15 @@
-import { type ContextItem, logError } from '@sourcegraph/cody-shared'
-import { DefaultEditCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import {
+    type ContextItem,
+    DefaultEditCommands,
+    logError,
+    wrapInActiveSpan,
+} from '@sourcegraph/cody-shared'
 import { Range } from 'vscode'
 import { type ExecuteEditArguments, executeEdit } from '../../edit/execute'
 import { getEditor } from '../../editor/active-editor'
 import type { EditCommandResult } from '../../main'
 import { getContextFilesForAddingUnitTestCases } from '../context/unit-test-case'
 import type { CodyCommandArgs } from '../types'
-
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 
 /**
  * Adds generated test cases to the selected test suite inline.

--- a/vscode/src/commands/execute/test-chat.ts
+++ b/vscode/src/commands/execute/test-chat.ts
@@ -1,4 +1,4 @@
-import { type ContextItem, logDebug, logError } from '@sourcegraph/cody-shared'
+import { type ContextItem, logDebug, logError, wrapInActiveSpan } from '@sourcegraph/cody-shared'
 import { getEditor } from '../../editor/active-editor'
 import type { ChatCommandResult } from '../../main'
 import { telemetryService } from '../../services/telemetry'
@@ -9,7 +9,6 @@ import type { CodyCommandArgs } from '../types'
 import { type ExecuteChatArguments, executeChat } from './ask'
 
 import type { Span } from '@opentelemetry/api'
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 
 /**
  * Generates the prompt and context files with arguments for the '/test' command in Chat.

--- a/vscode/src/commands/execute/test-edit.ts
+++ b/vscode/src/commands/execute/test-edit.ts
@@ -1,5 +1,9 @@
-import { type ContextItem, logError } from '@sourcegraph/cody-shared'
-import { DefaultEditCommands } from '@sourcegraph/cody-shared/src/commands/types'
+import {
+    type ContextItem,
+    DefaultEditCommands,
+    logError,
+    wrapInActiveSpan,
+} from '@sourcegraph/cody-shared'
 import { defaultCommands } from '.'
 import { type ExecuteEditArguments, executeEdit } from '../../edit/execute'
 import { getEditor } from '../../editor/active-editor'
@@ -9,8 +13,6 @@ import type { CodyCommandArgs } from '../types'
 
 import type { URI } from 'vscode-uri'
 import { isTestFileForOriginal } from '../utils/test-commands'
-
-import { wrapInActiveSpan } from '@sourcegraph/cody-shared/src/tracing'
 
 /**
  * Command that generates a new test file for the selected code with unit tests added.

--- a/vscode/src/commands/utils/create-context-file.ts
+++ b/vscode/src/commands/utils/create-context-file.ts
@@ -1,5 +1,9 @@
-import { type ContextItem, MAX_CURRENT_FILE_TOKENS, truncateText } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
+import {
+    type ContextItem,
+    ContextItemSource,
+    MAX_CURRENT_FILE_TOKENS,
+    truncateText,
+} from '@sourcegraph/cody-shared'
 
 import * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -18,15 +18,13 @@ import {
     isAbortError,
     isNodeResponse,
     isRateLimitError,
+    logResponseHeadersToSpan,
+    recordErrorToSpan,
+    tracer,
 } from '@sourcegraph/cody-shared'
 
 import { SpanStatusCode } from '@opentelemetry/api'
 import { fetch } from '@sourcegraph/cody-shared/src/fetch'
-import {
-    logResponseHeadersToSpan,
-    recordErrorToSpan,
-    tracer,
-} from '@sourcegraph/cody-shared/src/tracing'
 
 /**
  * Access the code completion LLM APIs via a Sourcegraph server instance.

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -1,12 +1,17 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
-import { ignores, isCodyIgnoredFile, testFileUri, uriBasename } from '@sourcegraph/cody-shared'
+import {
+    CODY_IGNORE_URI_PATH,
+    ignores,
+    isCodyIgnoredFile,
+    testFileUri,
+    uriBasename,
+} from '@sourcegraph/cody-shared'
 
 import { getCurrentDocContext } from '../get-current-doc-context'
 import { documentAndPosition } from '../test-helpers'
 import type { ContextRetriever, ContextSnippet } from '../types'
 
-import { CODY_IGNORE_URI_PATH } from '@sourcegraph/cody-shared/src/cody-ignore/ignore-helper'
 import { Utils } from 'vscode-uri'
 import { ContextMixer } from './context-mixer'
 import type { ContextStrategyFactory } from './context-strategy'

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -19,7 +19,10 @@ import {
     isAbortError,
     isNodeResponse,
     isRateLimitError,
+    logResponseHeadersToSpan,
+    recordErrorToSpan,
     tokensToChars,
+    tracer,
 } from '@sourcegraph/cody-shared'
 
 import { fetch } from '@sourcegraph/cody-shared/src/fetch'
@@ -29,11 +32,6 @@ import type { ContextSnippet } from '../types'
 import { forkSignal, generatorWithTimeout, zipGenerators } from '../utils'
 
 import { SpanStatusCode } from '@opentelemetry/api'
-import {
-    logResponseHeadersToSpan,
-    recordErrorToSpan,
-    tracer,
-} from '@sourcegraph/cody-shared/src/tracing'
 import { logDebug } from '../../log'
 import { createRateLimitErrorFromResponse } from '../client'
 import {

--- a/vscode/src/context/remote-search.ts
+++ b/vscode/src/context/remote-search.ts
@@ -4,6 +4,7 @@ import {
     type ContextGroup,
     type ContextItem,
     type ContextItemFile,
+    ContextItemSource,
     type ContextSearchResult,
     type ContextStatusProvider,
     type Disposable,
@@ -12,7 +13,6 @@ import {
     isError,
 } from '@sourcegraph/cody-shared'
 
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import type { URI } from 'vscode-uri'
 import { getCodebaseFromWorkspaceUri } from '../repository/repositoryHelpers'
 import type * as repofetcher from './repo-fetcher'

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -2,6 +2,7 @@ import type * as vscode from 'vscode'
 
 import {
     type ContextItem,
+    ContextItemSource,
     type ContextMessage,
     MAX_CURRENT_FILE_TOKENS,
     populateCodeContextTemplate,
@@ -14,7 +15,6 @@ import {
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { EditIntent } from '../types'
 
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { fillInContextItemContent } from '../../editor/utils/editor-context'
 import { PROMPT_TOPICS } from './constants'
 

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -1,5 +1,4 @@
-import { type AuthStatus, ModelProvider } from '@sourcegraph/cody-shared'
-import { type EditModel, ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
+import { type AuthStatus, type EditModel, ModelProvider, ModelUsage } from '@sourcegraph/cody-shared'
 import type { EditIntent } from '../types'
 
 export function getEditModelsForUser(authStatus: AuthStatus): ModelProvider[] {

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
 import {
+    CHARS_PER_TOKEN,
     type ContextItem,
     type ContextItemFile,
     type Editor,
@@ -12,7 +13,6 @@ import {
     uriBasename,
 } from '@sourcegraph/cody-shared'
 
-import { CHARS_PER_TOKEN } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { fillInContextItemContent, filterLargeFiles, getFileContextFiles } from './editor-context'
 
 vi.mock('lodash/throttle', () => ({ default: vi.fn(fn => fn) }))

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -3,11 +3,13 @@ import throttle from 'lodash/throttle'
 import * as vscode from 'vscode'
 
 import {
-    type ContextFileSource,
+    CHARS_PER_TOKEN,
     type ContextFileType,
     type ContextItem,
     type ContextItemFile,
+    ContextItemSource,
     type ContextItemSymbol,
+    type ContextItemWithContent,
     type Editor,
     MAX_CURRENT_FILE_TOKENS,
     type SymbolKind,
@@ -19,11 +21,6 @@ import {
     isWindows,
 } from '@sourcegraph/cody-shared'
 
-import {
-    ContextItemSource,
-    type ContextItemWithContent,
-} from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { CHARS_PER_TOKEN } from '@sourcegraph/cody-shared/src/prompt/constants'
 import { getOpenTabsUris } from '.'
 import { isURLContextFeatureFlagEnabled } from '../../chat/context/chatContext'
 import { toVSCodeRange } from '../../common/range'
@@ -191,7 +188,7 @@ export async function getOpenTabsContextFile(charsLimit?: number): Promise<Conte
 
 function createContextFileFromUri(
     uri: vscode.Uri,
-    source: ContextFileSource,
+    source: ContextItemSource,
     type: 'symbol',
     selectionRange: vscode.Range,
     kind: SymbolKind,
@@ -199,13 +196,13 @@ function createContextFileFromUri(
 ): ContextItemSymbol[]
 function createContextFileFromUri(
     uri: vscode.Uri,
-    source: ContextFileSource,
+    source: ContextItemSource,
     type: 'file',
     selectionRange?: vscode.Range
 ): ContextItemFile[]
 function createContextFileFromUri(
     uri: vscode.Uri,
-    source: ContextFileSource,
+    source: ContextItemSource,
     type: ContextFileType,
     selectionRange?: vscode.Range,
     kind?: SymbolKind,

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -5,6 +5,7 @@ import type {
     ChatMessage,
     CurrentUserCodySubscription,
     ModelProvider,
+    ModelUsage,
     SerializedChatTranscript,
     event,
 } from '@sourcegraph/cody-shared'
@@ -16,7 +17,6 @@ import type {
 } from '@sourcegraph/telemetry'
 import type * as vscode from 'vscode'
 
-import type { ModelUsage } from '@sourcegraph/cody-shared/dist/models/types'
 import type { ExtensionMessage, WebviewMessage } from '../chat/protocol'
 import type { CompletionBookkeepingEvent } from '../completions/logger'
 import type { Repo } from '../context/repo-fetcher'

--- a/vscode/src/local-context/context-ranking.ts
+++ b/vscode/src/local-context/context-ranking.ts
@@ -3,13 +3,13 @@ import * as path from 'node:path'
 import {
     type ConfigurationWithAccessToken,
     type ContextItem,
+    ContextItemSource,
     type EmbeddingsSearchResult,
     type FileURI,
     isDotCom,
     isFileURI,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 import type { RankContextItem, RankerPrediction } from '../jsonrpc/context-ranking-protocol'

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -5,6 +5,7 @@ import {
     type ChatEventSource,
     ConfigFeaturesSingleton,
     type ConfigurationWithAccessToken,
+    type DefaultCodyCommands,
     ModelProvider,
     PromptMixin,
     featureFlagProvider,
@@ -14,7 +15,6 @@ import {
     setLogger,
 } from '@sourcegraph/cody-shared'
 
-import type { DefaultCodyCommands } from '@sourcegraph/cody-shared/src/commands/types'
 import { openCodyIssueReporter } from '../webviews/utils/reportIssue'
 import { ContextProvider } from './chat/ContextProvider'
 import type { MessageProviderOptions } from './chat/MessageProvider'

--- a/vscode/src/models/utils.ts
+++ b/vscode/src/models/utils.ts
@@ -1,6 +1,9 @@
-import { type AuthStatus, ModelProvider } from '@sourcegraph/cody-shared'
-import { DEFAULT_DOT_COM_MODELS } from '@sourcegraph/cody-shared/src/models/dotcom'
-import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
+import {
+    type AuthStatus,
+    DEFAULT_DOT_COM_MODELS,
+    ModelProvider,
+    ModelUsage,
+} from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 
 /**

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -1,12 +1,12 @@
 import {
     type ChatMessage,
     type ContextItem,
+    ContextItemSource,
     type ContextMessage,
     type Message,
     isCodyIgnoredFile,
     toRangeData,
 } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 import { SHA256 } from 'crypto-js'
 import { renderContextItem } from './utils'
 

--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -1,11 +1,11 @@
 import {
     type ContextItem,
+    ContextItemSource,
     type ContextMessage,
     populateCodeContextTemplate,
     populateContextTemplateFromText,
     populateCurrentSelectedCodeContextTemplate,
 } from '@sourcegraph/cody-shared'
-import { ContextItemSource } from '@sourcegraph/cody-shared/src/codebase-context/messages'
 
 import { URI } from 'vscode-uri'
 

--- a/vscode/src/test-support.ts
+++ b/vscode/src/test-support.ts
@@ -1,6 +1,4 @@
-import type { ChatMessage } from '@sourcegraph/cody-shared'
-
-import type { IgnoreHelper } from '@sourcegraph/cody-shared/src/cody-ignore/ignore-helper'
+import type { ChatMessage, IgnoreHelper } from '@sourcegraph/cody-shared'
 import type { SimpleChatPanelProvider } from './chat/chat-view/SimpleChatPanelProvider'
 
 // A one-slot channel which lets readers block on a value being

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { defaultAuthStatus } from '../src/chat/protocol'
 
-import { DEFAULT_DOT_COM_MODELS } from '@sourcegraph/cody-shared/src/models/dotcom'
+import { DEFAULT_DOT_COM_MODELS } from '@sourcegraph/cody-shared'
 import { App } from './App'
 import { VSCodeWebview } from './storybook/VSCodeStoryDecorator'
 import type { VSCodeWrapper } from './utils/VSCodeApi'

--- a/vscode/webviews/Components/ChatModelDropdownMenu.story.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.story.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 
 import { VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 
-import { DEFAULT_DOT_COM_MODELS } from '@sourcegraph/cody-shared/src/models/dotcom'
+import { DEFAULT_DOT_COM_MODELS } from '@sourcegraph/cody-shared'
 import { ChatModelDropdownMenu } from './ChatModelDropdownMenu'
 
 const meta: Meta<typeof ChatModelDropdownMenu> = {


### PR DESCRIPTION
Importing from `@sourcegraph/cody-shared/src/...` does not cause any problems and is generally because something is not exported in `lib/shared/src/index.ts`. But importing from `@sourcegraph/cody-shared/dist/...` DOES cause problems in some cases (such as agent tests) because the same module can be loaded twice, once from the bundled `dist/index.js` and once from the specifically imported module. We used to have an ESLint rule `no-restricted-imports` that banned this, but surprisingly and unfortunately, Biome does not support such a rule. In the meantime, I'm just cleaning up most instances of subpath imports so that any new ones introduced do stand out.



## Test plan

CI