### PR TITLE
longer e2e test timeout

### DIFF
--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     retries: 1, // give flaky tests 1 more chance, but we should fix flakiness when we see it
     forbidOnly: !!process.env.CI,
     testDir: 'test/e2e',
-    timeout: isWin ? 30000 : 20000,
+    timeout: 30000,
     expect: {
         timeout: isWin ? 5000 : 3000,
     },


### PR DESCRIPTION
I am seeing some e2e tests (`create a new user command via the custom commands menu` most often) take slightly more than 20 seconds to complete sometimes, which leads to them timing out. As long as we keep the expect timeout reasonably low and don't have a lot of `await page.waitForTimeout(...)` calls, it is not necessarily bad to have long e2e tests, and the alternative is that people will slice one logical test into two, which is bad in general.



## Test plan

CI