### PR TITLE
bump agent version to test release CI

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -39,9 +39,11 @@ jobs:
           fi
       - run: pnpm build
       - run: pnpm run test
-      - run: pnpm publish --no-git-checks agent
+      - name: Set npm publishing config
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: pnpm publish --no-git-checks agent
       - run: pnpm -C agent run build-agent-binaries
       - name: create release
         id: create_release

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/cody-agent",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "description": "Cody JSON-RPC agent for consistent cross-editor support",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Testing https://github.com/sourcegraph/cody/pull/3671 (will push this to tag `agent-v0.0.4`).

Also fixes the npm auth.

## Test plan

CI