### PR TITLE
more idiomatic use of VSCodeDropdown

### DIFF
--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -27,14 +27,13 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
     userInfo,
 }) => {
     const [currentModel, setCurrentModel] = useState(models.find(m => m.default) || models[0])
-    const currentModelIndex = models.indexOf(models.find(m => m.default) || models[0])
     const dropdownRef = useRef<DropdownProps>(null)
 
     const isCodyProUser = userInfo.isDotComUser && userInfo.isCodyProUser
     const isEnterpriseUser = !userInfo.isDotComUser
     const showCodyProBadge = !isEnterpriseUser && !isCodyProUser
 
-    const handleChange = useCallback(
+    const onChange = useCallback(
         (event: any): void => {
             const selectedModel = models[event.target?.selectedIndex]
             if (showCodyProBadge && selectedModel.codyProOnly) {
@@ -88,8 +87,8 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
                 ref={dropdownRef}
                 disabled={disabled}
                 className={styles.dropdownContainer}
-                onChange={handleChange}
-                selectedIndex={currentModelIndex}
+                onChange={onChange}
+                value={currentModel.model}
                 aria-label="Choose a model"
                 {...(!disabled && enabledDropdownProps)}
             >
@@ -97,7 +96,7 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
                     <VSCodeOption
                         className={styles.option}
                         key={option.model}
-                        id={index.toString()}
+                        value={option.model}
                         title={
                             isModelDisabled(option.codyProOnly)
                                 ? `Upgrade to Cody Pro to use ${option.title}`


### PR DESCRIPTION
`selectedIndex` is not how you are supposed to set the initial value (although there is no documentation about this, only https://github.com/microsoft/vscode-webview-ui-toolkit/issues/433). Instead, use `value` just as you would for an HTML select element. This fixes an issue where in some cases (seen only in our storybooks), the dropdown would show the first item as selected, not the `selectedIndex`th item.



## Test plan

CI