### PR TITLE
pass chatModels and onCurrentChatModelChange through React context

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -3,7 +3,7 @@ import { DEFAULT_CHAT_MODEL_TOKEN_LIMIT, DEFAULT_FAST_MODEL_TOKEN_LIMIT } from '
 import { ModelUsage } from './types'
 
 // The models must first be added to the custom chat models list in https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/completions/httpapi/chat.go?L48-51
-export const DEFAULT_DOT_COM_MODELS = [
+export const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
     {
         title: 'Claude 2.0',
         model: 'anthropic/claude-2.0',

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -27,6 +27,7 @@ import { LoadingPage } from './LoadingPage'
 import type { View } from './NavBar'
 import { Notices } from './Notices'
 import { LoginSimplified } from './OnboardingExperiment'
+import { type ChatModelContext, ChatModelContextProvider } from './chat/models/chatModelContext'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 import { updateDisplayPathEnvInfoForWebview } from './utils/displayPathEnvInfo'
 import { createWebviewTelemetryService } from './utils/telemetry'
@@ -199,6 +200,27 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     const telemetryService = useMemo(() => createWebviewTelemetryService(vscodeAPI), [vscodeAPI])
     const isNewInstall = useMemo(() => !userHistory?.some(c => c?.interactions?.length), [userHistory])
 
+    const onCurrentChatModelChange = useCallback(
+        (selected: ModelProvider): void => {
+            if (!chatModels || !setChatModels) {
+                return
+            }
+            vscodeAPI.postMessage({
+                command: 'chatModel',
+                model: selected.model,
+            })
+            const updatedChatModels = chatModels.map(m =>
+                m.model === selected.model ? { ...m, default: true } : { ...m, default: false }
+            )
+            setChatModels(updatedChatModels)
+        },
+        [chatModels, vscodeAPI]
+    )
+    const chatModelContext = useMemo<ChatModelContext>(
+        () => ({ chatModels, onCurrentChatModelChange }),
+        [chatModels, onCurrentChatModelChange]
+    )
+
     // Wait for all the data to be loaded before rendering Chat View
     if (!view || !authStatus || !config) {
         return <LoadingPage />
@@ -235,23 +257,23 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                         >
                             <EnhancedContextContext.Provider value={enhancedContextStatus}>
                                 <EnhancedContextEnabled.Provider value={enhancedContextEnabled}>
-                                    <Chat
-                                        chatEnabled={chatEnabled}
-                                        userInfo={userAccountInfo}
-                                        messageInProgress={messageInProgress}
-                                        transcript={transcript}
-                                        vscodeAPI={vscodeAPI}
-                                        telemetryService={telemetryService}
-                                        isTranscriptError={isTranscriptError}
-                                        chatModels={chatModels}
-                                        setChatModels={setChatModels}
-                                        welcomeMessage={welcomeMessageMarkdown}
-                                        guardrails={attributionEnabled ? guardrails : undefined}
-                                        chatIDHistory={chatIDHistory}
-                                        isWebviewActive={isWebviewActive}
-                                        isNewInstall={isNewInstall}
-                                        userContextFromSelection={userContextFromSelection}
-                                    />
+                                    <ChatModelContextProvider value={chatModelContext}>
+                                        <Chat
+                                            chatEnabled={chatEnabled}
+                                            userInfo={userAccountInfo}
+                                            messageInProgress={messageInProgress}
+                                            transcript={transcript}
+                                            vscodeAPI={vscodeAPI}
+                                            telemetryService={telemetryService}
+                                            isTranscriptError={isTranscriptError}
+                                            welcomeMessage={welcomeMessageMarkdown}
+                                            guardrails={attributionEnabled ? guardrails : undefined}
+                                            chatIDHistory={chatIDHistory}
+                                            isWebviewActive={isWebviewActive}
+                                            isNewInstall={isNewInstall}
+                                            userContextFromSelection={userContextFromSelection}
+                                        />
+                                    </ChatModelContextProvider>
                                 </EnhancedContextEnabled.Provider>
                             </EnhancedContextContext.Provider>
                         </EnhancedContextEventHandlers.Provider>

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -1,4 +1,3 @@
-import { DEFAULT_DOT_COM_MODELS } from '@sourcegraph/cody-shared/src/models/dotcom'
 import type { Meta, StoryObj } from '@storybook/react'
 import { Chat } from './Chat'
 import { FIXTURE_TRANSCRIPT, FIXTURE_USER_ACCOUNT_INFO } from './chat/fixtures'
@@ -21,7 +20,6 @@ const meta: Meta<typeof Chat> = {
         messageInProgress: null,
         chatIDHistory: [],
         chatEnabled: true,
-        chatModels: DEFAULT_DOT_COM_MODELS,
         userInfo: FIXTURE_USER_ACCOUNT_INFO,
         isWebviewActive: true,
         vscodeAPI: {

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -9,7 +9,6 @@ import {
     type ChatMessage,
     type ContextItem,
     type Guardrails,
-    type ModelProvider,
     type TelemetryService,
     isMacOS,
 } from '@sourcegraph/cody-shared'
@@ -37,8 +36,6 @@ interface ChatboxProps {
     vscodeAPI: Pick<VSCodeWrapper, 'postMessage' | 'onMessage'>
     telemetryService: TelemetryService
     isTranscriptError: boolean
-    setChatModels?: (models: ModelProvider[]) => void
-    chatModels?: ModelProvider[]
     userInfo: UserAccountInfo
     guardrails?: Guardrails
     chatIDHistory: string[]
@@ -56,8 +53,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     vscodeAPI,
     telemetryService,
     isTranscriptError,
-    setChatModels,
-    chatModels,
     chatEnabled,
     userInfo,
     guardrails,
@@ -122,23 +117,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
             }
         },
         [addEnhancedContext, messageBeingEdited, vscodeAPI]
-    )
-
-    const onCurrentChatModelChange = useCallback(
-        (selected: ModelProvider): void => {
-            if (!chatModels || !setChatModels) {
-                return
-            }
-            vscodeAPI.postMessage({
-                command: 'chatModel',
-                model: selected.model,
-            })
-            const updatedChatModels = chatModels.map(m =>
-                m.model === selected.model ? { ...m, default: true } : { ...m, default: false }
-            )
-            setChatModels(updatedChatModels)
-        },
-        [chatModels, setChatModels, vscodeAPI]
     )
 
     const feedbackButtonsOnSubmit = useCallback(
@@ -491,8 +469,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     copyButtonOnSubmit={copyButtonOnSubmit}
                     insertButtonOnSubmit={insertButtonOnSubmit}
                     isTranscriptError={isTranscriptError}
-                    chatModels={chatModels}
-                    onCurrentChatModelChange={onCurrentChatModelChange}
                     userInfo={userInfo}
                     postMessage={postMessage}
                     guardrails={guardrails}

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -4,7 +4,6 @@ import { Transcript } from './Transcript'
 import { FIXTURE_TRANSCRIPT, FIXTURE_USER_ACCOUNT_INFO } from './fixtures'
 
 import { RateLimitError, errorToChatError } from '@sourcegraph/cody-shared'
-import { DEFAULT_DOT_COM_MODELS } from '@sourcegraph/cody-shared/src/models/dotcom'
 import type { ComponentProps } from 'react'
 import { URI } from 'vscode-uri'
 import { VSCodeWebview } from '../storybook/VSCodeStoryDecorator'
@@ -33,8 +32,6 @@ const meta: Meta<typeof Transcript> = {
         feedbackButtonsOnSubmit: () => {},
         copyButtonOnSubmit: () => {},
         insertButtonOnSubmit: () => {},
-        chatModels: DEFAULT_DOT_COM_MODELS,
-        onCurrentChatModelChange: () => {},
         userInfo: FIXTURE_USER_ACCOUNT_INFO,
         postMessage: () => {},
     } satisfies ComponentProps<typeof Transcript>,

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -13,8 +13,6 @@ const PROPS: Omit<ComponentProps<typeof Transcript>, 'transcript'> = {
     feedbackButtonsOnSubmit: () => {},
     copyButtonOnSubmit: () => {},
     insertButtonOnSubmit: () => {},
-    chatModels: [],
-    onCurrentChatModelChange: () => {},
     userInfo: FIXTURE_USER_ACCOUNT_INFO,
     postMessage: () => {},
 }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -3,12 +3,7 @@ import { type FunctionComponent, useEffect, useRef } from 'react'
 
 import classNames from 'classnames'
 
-import {
-    type ChatMessage,
-    type Guardrails,
-    type ModelProvider,
-    renderCodyMarkdown,
-} from '@sourcegraph/cody-shared'
+import { type ChatMessage, type Guardrails, renderCodyMarkdown } from '@sourcegraph/cody-shared'
 
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
@@ -20,6 +15,7 @@ import styles from './Transcript.module.css'
 import { Cell } from './cells/Cell'
 import { ContextCell } from './cells/contextCell/ContextCell'
 import { MessageCell } from './cells/messageCell/MessageCell'
+import { useChatModelContext, useCurrentChatModel } from './models/chatModelContext'
 
 export const Transcript: React.FunctionComponent<{
     transcript: ChatMessage[]
@@ -32,8 +28,6 @@ export const Transcript: React.FunctionComponent<{
     copyButtonOnSubmit: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit: CodeBlockActionsProps['insertButtonOnSubmit']
     isTranscriptError?: boolean
-    chatModels?: ModelProvider[]
-    onCurrentChatModelChange: (model: ModelProvider) => void
     userInfo: UserAccountInfo
     postMessage?: ApiPostMessage
     guardrails?: Guardrails
@@ -48,8 +42,6 @@ export const Transcript: React.FunctionComponent<{
     copyButtonOnSubmit,
     insertButtonOnSubmit,
     isTranscriptError,
-    chatModels,
-    onCurrentChatModelChange,
     userInfo,
     postMessage,
     guardrails,
@@ -137,7 +129,8 @@ export const Transcript: React.FunctionComponent<{
         lastInteractionMessages = transcript.slice(lastHumanMessageIndex)
     }
 
-    const chatModel = chatModels?.find(m => m.default) ?? chatModels?.at(0)
+    const { chatModels, onCurrentChatModelChange } = useChatModelContext()
+    const chatModel = useCurrentChatModel()
 
     const messageToTranscriptItem =
         (offset: number) =>

--- a/vscode/webviews/chat/models/chatModelContext.tsx
+++ b/vscode/webviews/chat/models/chatModelContext.tsx
@@ -1,0 +1,21 @@
+import type { ModelProvider } from '@sourcegraph/cody-shared'
+import { createContext, useContext } from 'react'
+
+/** React context data for the chat model choice. */
+export interface ChatModelContext {
+    chatModels?: ModelProvider[]
+    onCurrentChatModelChange?: (model: ModelProvider) => void
+}
+
+const context = createContext<ChatModelContext>({})
+
+export const ChatModelContextProvider = context.Provider
+
+export function useChatModelContext(): ChatModelContext {
+    return useContext(context)
+}
+
+export function useCurrentChatModel(): ModelProvider | undefined {
+    const { chatModels } = useChatModelContext()
+    return chatModels?.find(model => model.default) ?? chatModels?.[0]
+}

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
@@ -1,10 +1,16 @@
 import type { Decorator } from '@storybook/react'
 
-import { isWindows, setDisplayPathEnvInfo } from '@sourcegraph/cody-shared'
+import {
+    DEFAULT_DOT_COM_MODELS,
+    type ModelProvider,
+    isWindows,
+    setDisplayPathEnvInfo,
+} from '@sourcegraph/cody-shared'
 import classNames from 'classnames'
-import type { CSSProperties } from 'react'
+import { type CSSProperties, useState } from 'react'
 import { URI } from 'vscode-uri'
 import '../../node_modules/@vscode/codicons/dist/codicon.css'
+import { type ChatModelContext, ChatModelContextProvider } from '../chat/models/chatModelContext'
 import { WithChatContextClient } from '../promptEditor/plugins/atMentions/chatContextClient'
 import { dummyChatContextClient } from '../promptEditor/plugins/atMentions/fixtures'
 import styles from './VSCodeStoryDecorator.module.css'
@@ -38,9 +44,23 @@ export function VSCodeDecorator(className: string | undefined, style?: CSSProper
     document.body.dataset.vscodeThemeKind = 'vscode-dark'
     return story => (
         <div className={classNames(styles.container, className)} style={style}>
-            <WithChatContextClient value={dummyChatContextClient}>{story()}</WithChatContextClient>
+            <WithChatContextClient value={dummyChatContextClient}>
+                <ChatModelContextProvider value={useDummyChatModelContext()}>
+                    {story()}
+                </ChatModelContextProvider>
+            </WithChatContextClient>
         </div>
     )
+}
+
+function useDummyChatModelContext(): ChatModelContext {
+    const [chatModels, setChatModels] = useState(DEFAULT_DOT_COM_MODELS)
+    const onCurrentChatModelChange = (value: ModelProvider): void => {
+        setChatModels(chatModels =>
+            chatModels.map(model => ({ ...model, default: model.model === value.model }))
+        )
+    }
+    return { chatModels, onCurrentChatModelChange }
 }
 
 if (!(window as any).acquireVsCodeApi) {


### PR DESCRIPTION
This makes it so more of the exthost<->webview RPC code lives in App.tsx, which is fitting. It also simplifies the props we need to pass down.

We did the same thing for enhanced context a couple months ago.

## Test plan

CI