### PR TITLE
more retries for windows e2e tests

### DIFF
--- a/vscode/playwright.config.ts
+++ b/vscode/playwright.config.ts
@@ -4,7 +4,7 @@ const isWin = process.platform.startsWith('win')
 
 export default defineConfig({
     workers: 1,
-    retries: 1, // give flaky tests 1 more chance, but we should fix flakiness when we see it
+    retries: isWin ? 4 : 1, // give flaky tests more chances, but we should fix flakiness when we see it
     forbidOnly: !!process.env.CI,
     testDir: 'test/e2e',
     timeout: 30000,


### PR DESCRIPTION
I see a lot of people retrying them. We should fix them to be less flaky, but this will save us time in the meantime.



## Test plan

CI