### PR TITLE
Add cross-platform clojure file extension

### DIFF
--- a/agent/src/language-file-extensions.json
+++ b/agent/src/language-file-extensions.json
@@ -6,7 +6,7 @@
   "applescript": ["applescript", "scpt"],
   "beancount": ["beancount"],
   "bibtex": ["bib"],
-  "clojure": ["clj", "cljs", "cljx"],
+  "clojure": ["clj", "cljs", "cljx", "cljc"],
   "cmake": ["cmake", "cmake.in", "in"],
   "coffescript": ["coffee", "cake", "cson", "cjsx", "iced"],
   "cpp": ["c", "cc", "cpp", "cxx", "c++", "h++", "hh", "h", "hpp", "pc", "pcc"],


### PR DESCRIPTION
The listed [.cljx](https://clojure.org/guides/reader_conditionals#_cljx) extension is for a deprecated 3rd party format, while the newer .cljc extension corresponds to the official cross-platform format.

## Test plan

I don't see any tests for the legacy extension, so I'm not sure what tests are appropriate.
