### PR TITLE
Persistence Tracker: Treat removed events as `difference: 100`

### DIFF
--- a/vscode/src/common/persistence-tracker/index.test.ts
+++ b/vscode/src/common/persistence-tracker/index.test.ts
@@ -228,7 +228,7 @@ describe('PersistenceTracker', () => {
         vi.advanceTimersToNextTimer()
         expect(onRemoveSpy).toHaveBeenCalledWith({
             id: '123',
-            difference: 100,
+            difference: 1,
         })
         expect(onPresentSpy).not.toHaveBeenCalled()
     })

--- a/vscode/src/common/persistence-tracker/index.test.ts
+++ b/vscode/src/common/persistence-tracker/index.test.ts
@@ -228,6 +228,7 @@ describe('PersistenceTracker', () => {
         vi.advanceTimersToNextTimer()
         expect(onRemoveSpy).toHaveBeenCalledWith({
             id: '123',
+            difference: 100,
         })
         expect(onPresentSpy).not.toHaveBeenCalled()
     })

--- a/vscode/src/common/persistence-tracker/index.ts
+++ b/vscode/src/common/persistence-tracker/index.ts
@@ -120,7 +120,7 @@ export class PersistenceTracker<T = string> implements vscode.Disposable {
             // Text was fully deleted
             this.logger.onRemoved({
                 id: trackedInsertion.id,
-                difference: 100,
+                difference: 1,
                 metadata: trackedInsertion.metadata,
             })
         } else {

--- a/vscode/src/common/persistence-tracker/index.ts
+++ b/vscode/src/common/persistence-tracker/index.ts
@@ -118,7 +118,11 @@ export class PersistenceTracker<T = string> implements vscode.Disposable {
 
         if (latestText.length === 0) {
             // Text was fully deleted
-            this.logger.onRemoved({ id: trackedInsertion.id, metadata: trackedInsertion.metadata })
+            this.logger.onRemoved({
+                id: trackedInsertion.id,
+                difference: 100,
+                metadata: trackedInsertion.metadata,
+            })
         } else {
             const maxLength = Math.max(initialText.length, latestText.length)
             const editOperations = levenshtein(initialText, latestText)

--- a/vscode/src/common/persistence-tracker/types.ts
+++ b/vscode/src/common/persistence-tracker/types.ts
@@ -19,7 +19,7 @@ export interface PersistenceRemovedEventPayload<T = string> {
     /** An ID to uniquely identify an accepted insertion. */
     id: T
     /** Levenshtein distance between the current document state and the accepted completion */
-    difference: 100
+    difference: 1
     /** Attached metadata to the insertion */
     metadata?: PersistenceEventMetadata
 }

--- a/vscode/src/common/persistence-tracker/types.ts
+++ b/vscode/src/common/persistence-tracker/types.ts
@@ -18,6 +18,8 @@ export interface PersistencePresentEventPayload<T = string> {
 export interface PersistenceRemovedEventPayload<T = string> {
     /** An ID to uniquely identify an accepted insertion. */
     id: T
+    /** Levenshtein distance between the current document state and the accepted completion */
+    difference: 100
     /** Attached metadata to the insertion */
     metadata?: PersistenceEventMetadata
 }

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -241,13 +241,13 @@ export function logCompletionPersistenceRemovedEvent(params: PersistenceRemovedE
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
     writeCompletionEvent(
-        'persistence:removed',
+        'persistence:present',
         {
             version: 0,
             metadata,
             privateMetadata,
         },
-        params
+        { ...params, difference: 100 }
     )
 }
 function logCompletionNoResponseEvent(params: NoResponseEventPayload): void {

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -247,7 +247,7 @@ export function logCompletionPersistenceRemovedEvent(params: PersistenceRemovedE
             metadata,
             privateMetadata,
         },
-        { ...params, difference: 100 }
+        params
     )
 }
 function logCompletionNoResponseEvent(params: NoResponseEventPayload): void {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -49,12 +49,13 @@ export class FixupController
             })
             telemetryRecorder.recordEvent('cody.fixup.persistence', 'present', safeMetadata)
         },
-        onRemoved: ({ metadata, ...event }) => {
+        onRemoved: ({ metadata, id }) => {
+            const event = { id, difference: 100 }
             const safeMetadata = splitSafeMetadata({ ...event, ...metadata })
-            telemetryService.log('CodyVSCodeExtension:fixup:persistence:removed', safeMetadata, {
+            telemetryService.log('CodyVSCodeExtension:fixup:persistence:present', safeMetadata, {
                 hasV2Event: true,
             })
-            telemetryRecorder.recordEvent('cody.fixup.persistence', 'removed', safeMetadata)
+            telemetryRecorder.recordEvent('cody.fixup.persistence', 'present', safeMetadata)
         },
     })
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -49,8 +49,7 @@ export class FixupController
             })
             telemetryRecorder.recordEvent('cody.fixup.persistence', 'present', safeMetadata)
         },
-        onRemoved: ({ metadata, id }) => {
-            const event = { id, difference: 100 }
+        onRemoved: ({ metadata, ...event }) => {
             const safeMetadata = splitSafeMetadata({ ...event, ...metadata })
             telemetryService.log('CodyVSCodeExtension:fixup:persistence:present', safeMetadata, {
                 hasV2Event: true,


### PR DESCRIPTION
## Description

This PR updates the persistence tracker to log `persistence:present` events with a difference of `100` when an insertion is completely removed.

This should make our analytics more accurate

## Test plan

1. Make a completion or "insert" edit
2. Delete the inserted text
3. Check the correct telemetry event is logged after 30 secs

Confirmed:
```
logEvent (telemetry disabled): CodyVSCodeExtension:completion:persistence:present  {
  "details": "VSCode",
  "properties": {
    "id": "b0e0030a-4a6f-482d-bd20-7ec3f595f046",
    "difference": 100
  },
  "opts": {
    "agent": true,
    "hasV2Event": true
  }
}
```

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
