### PR TITLE
Sidebar: fix custom commands on click

### DIFF
--- a/vscode/src/services/SidebarCommands.ts
+++ b/vscode/src/services/SidebarCommands.ts
@@ -24,6 +24,12 @@ export function registerSidebarCommands(): vscode.Disposable[] {
 
     return [
         vscode.commands.registerCommand('cody.sidebar.commands', (feature: string, command: string) => {
+            // For Custom Commands
+            if (command === 'cody.action.command') {
+                logSidebarClick('custom')
+                void vscode.commands.executeCommand(command, feature, { source: 'sidebar' })
+                return
+            }
             logSidebarClick(feature)
             void vscode.commands.executeCommand(command, { source: 'sidebar' })
         }),

--- a/vscode/src/services/tree-views/commands.ts
+++ b/vscode/src/services/tree-views/commands.ts
@@ -25,7 +25,7 @@ export function getCommandTreeItems(customCommands: CodyCommand[]): CodyTreeItem
                     command =>
                         new CodyTreeItem(command.key, command.key, 'tools', {
                             command: 'cody.sidebar.commands',
-                            args: ['custom', 'cody.action.command'],
+                            args: [command.key, 'cody.action.command'],
                         })
                 )
             } catch (e) {

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -179,12 +179,9 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
 
     /* Test: context.filePath with filePath command */
-
-    await page.getByRole('treeitem', { name: 'Custom Commands' }).locator('a').click()
-    await expect(page.getByPlaceholder('Search command to run...')).toBeVisible()
-    await page.getByPlaceholder('Search command to run...').click()
-    await page.getByPlaceholder('Search command to run...').fill('filePath')
-    await page.keyboard.press('Enter')
+    // Locate the filePath command in the tree view and execute it from there to verify
+    // custom commands are working in the sidebar
+    await page.getByRole('treeitem', { name: 'filePath' }).locator('a').click()
     await expect(chatPanel.getByText('Add lib/batches/env/var.go as context.')).toBeVisible()
     // Should show 2 files with current file added as context
     await expectContextCellCounts(contextCell, { files: 2, lines: 12 })


### PR DESCRIPTION
Fix issue introduced by https://github.com/sourcegraph/cody/pull/3708 (my bad)

Right now custom commands on Sidebar are not working.

In SidebarCommands.ts, a new condition is added to the cody.sidebar.commands command handler. If the command is cody.action.command, it logs the sidebar click event with the label 'custom', and then executes the command with the feature name and a source parameter set to 'sidebar'.

In commands.ts, the getCommandTreeItems function is updated to pass the command key as the first argument to the cody.sidebar.commands command, instead of the hardcoded 'custom' string.

These changes allow for custom commands to be executed from the sidebar, with the ability to pass additional arguments and track the source of the command execution. The custom commands can be defined and registered elsewhere in the extension, and will now be accessible through the sidebar.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Click on a custom command on the sidebar to ensure it's working.
- This behavior is now covered by the new e2e test change as well.

NOTE: No Changelog required as the PR that introduced the bug is not released