### PR TITLE
E2E Test: Add e2e test for the "Cody Chat: Add context" command

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -481,8 +481,7 @@
       },
       {
         "command": "cody.chat.context.add",
-        "category": "Cody",
-        "group": "Cody",
+        "group": "Chat",
         "title": "Cody Chat: Add context",
         "icon": "$(new-file)",
         "when": "cody.activated && editorTextFocus && editorHasSelection"

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -136,6 +136,11 @@ export class ChatManager implements vscode.Disposable {
     }
 
     private async sendSelectionToChat(): Promise<void> {
+        telemetryService.log('CodyVSCodeExtension:addChatContext:clicked', undefined, {
+            hasV2Event: true,
+        })
+        telemetryRecorder.recordEvent('cody.addChatContext', 'clicked')
+
         const provider = await this.chatPanelsManager.getActiveChatPanel()
         await provider?.handleGetUserEditorContext()
     }

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -9,7 +9,7 @@ import {
     sidebarExplorer,
     sidebarSignin,
 } from './common'
-import { type ExpectedEvents, test, withPlatformSlashes } from './helpers'
+import { type ExpectedEvents, getMetaKeyByOS, test, withPlatformSlashes } from './helpers'
 
 // See chat-atFile.test.md for the expected behavior for this feature.
 //
@@ -356,4 +356,47 @@ test.extend<ExpectedEvents>({
     const previewTab = page.getByRole('tab', { name: /buzz.ts, preview, Editor Group/ })
     await previewTab.hover()
     await expect(previewTab).toBeVisible()
+})
+
+test.extend<ExpectedEvents>({
+    expectedEvents: [
+        'CodyVSCodeExtension:addChatContext:clicked',
+        'CodyVSCodeExtension:addChatContext:clicked',
+    ],
+})('add selected code as @-mention with "Cody Chat: Add context"', async ({ page, sidebar }) => {
+    await sidebarSignin(page, sidebar)
+
+    // Open the buzz.ts file to highlight line 2-13 in the editor
+    await sidebarExplorer(page).click()
+    await page.getByRole('treeitem', { name: 'buzz.ts' }).locator('a').dblclick()
+    await page.getByRole('tab', { name: 'buzz.ts' }).click()
+    await page.getByText('2', { exact: true }).click()
+    await page.getByText('13').click({
+        modifiers: ['Shift'],
+    })
+
+    // Open the Command Palette and run the "Cody Chat: Add context" command
+    const metaKey = getMetaKeyByOS()
+    await page.keyboard.press(`${metaKey}+Shift+P`)
+    const commandPaletteInputBox = page.getByPlaceholder('Type the name of a command to run.')
+    await expect(commandPaletteInputBox).toBeVisible()
+    await commandPaletteInputBox.fill('>Cody Chat: Add context')
+    await page.locator('a').filter({ hasText: 'Cody Chat: Add context' }).click()
+
+    // Verify the chat input has the selected code as an @-mention item
+    const chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
+    const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
+    await expect(chatInput).toHaveText('@buzz.ts:2-13 ')
+
+    // Repeat the above steps to add another code selection as an @-mention item.
+    // The chat input should have the new code selections appended as @-mention items
+    // instead of replacing the existing one or adding to a new chat.
+    await page.getByRole('tab', { name: 'buzz.ts' }).click()
+    await page.getByText('4', { exact: true }).click()
+    await page.getByText('6', { exact: true }).click({ modifiers: ['Shift'] })
+    await page.keyboard.press(`${metaKey}+Shift+P`)
+    await expect(commandPaletteInputBox).toBeVisible()
+    await commandPaletteInputBox.fill('>Cody Chat: Add context')
+    await page.locator('a').filter({ hasText: 'Cody Chat: Add context' }).click()
+    await expect(chatInput).toHaveText('@buzz.ts:2-13 @buzz.ts:4-6 ')
 })


### PR DESCRIPTION
Pull Request Description:

This commit introduces telemetry events to track when the "Cody Chat: Add context" command is used. It also adds a e2e test to cover the feature. The main changes are listed below.

Add Telemetry Events:

- In ChatManager.ts, two new telemetry events are logged when the "Add context" command is triggered:
- CodyVSCodeExtension:addChatContext:clicked
- cody.addChatContext (recorded using telemetryRecorder)

Improve "Add context" Command:

- In package.json, the "Cody Chat: Add context" command is moved from the "Cody" category to the "Chat" group for better organization and discoverability.

New E2e Tests:

- In chat-atFile.test.ts, a new test case is added to verify the behavior of the "Cody Chat: Add context" command. The test checks if the selected code is correctly added as an @-mention item in the chat input box. It also tests appending multiple code selections as @-mention items without replacing the existing ones or creating a new chat.
- The new test case expects the CodyVSCodeExtension:addChatContext:clicked telemetry event to be logged twice (once for each code selection added as an @-mention item).

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green e2e test on CI