### PR TITLE
VS Code: add remote context filters provider

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -181,6 +181,8 @@ export {
     type BrowserOrNodeResponse,
     type GraphQLAPIClientConfig,
     type LogEventMode,
+    type ContextFiltersResult,
+    type CodyContextFilterItem,
 } from './sourcegraph-api/graphql/client'
 export type {
     CodyLLMSiteConfiguration,

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -11,6 +11,7 @@ import { isError } from '../../utils'
 import { DOTCOM_URL, isDotCom } from '../environments'
 
 import {
+    CONTEXT_FILTERS_QUERY,
     CONTEXT_SEARCH_QUERY,
     CURRENT_SITE_CODY_CONFIG_FEATURES,
     CURRENT_SITE_CODY_LLM_CONFIGURATION,
@@ -180,6 +181,22 @@ export interface ContextSearchResult {
     startLine: number
     endLine: number
     content: string
+}
+
+export interface ContextFiltersResult {
+    include: CodyContextFilterItem[]
+    exclude: CodyContextFilterItem[]
+}
+
+export interface CodyContextFilterItem {
+    repoNamePattern: string
+    // Not implemented
+    filePathPattern?: string
+}
+
+const EMPTY_CONTEXT_FILTERS: ContextFiltersResult = {
+    include: [],
+    exclude: [],
 }
 
 interface SearchAttributionResults {
@@ -513,6 +530,24 @@ export class SourcegraphGraphQLAPIClient {
                 }))
             )
         )
+    }
+
+    public async contextFilters(): Promise<ContextFiltersResult | null | Error> {
+        const response =
+            await this.fetchSourcegraphAPI<APIResponse<ContextFiltersResult | null>>(
+                CONTEXT_FILTERS_QUERY
+            )
+
+        const result = extractDataOrError(response, data => data)
+
+        if (result instanceof Error) {
+            // Ignore errors caused by outdated Sourcegraph API instances.
+            if (hasOutdatedAPIErrorMessages(result)) {
+                return EMPTY_CONTEXT_FILTERS
+            }
+        }
+
+        return result
     }
 
     /**
@@ -871,9 +906,7 @@ export class ConfigFeaturesSingleton {
         const previousConfigFeatures = this.configFeatures
         this.configFeatures = this.fetchConfigFeatures().catch((error: Error) => {
             // Ignore fetcherrors as older SG instances will always face this because their GQL is outdated
-            if (
-                !(error.message.includes('FetchError') || error.message.includes('Cannot query field'))
-            ) {
+            if (!hasOutdatedAPIErrorMessages(error)) {
                 logError('ConfigFeaturesSingleton', 'refreshConfigFeatures', error.message)
             }
             // In case of an error, return previously fetched value
@@ -910,3 +943,7 @@ export type LogEventMode =
     | 'dotcom-only' // only log to dotcom
     | 'connected-instance-only' // only log to the connected instance
     | 'all' // log to both dotcom AND the connected instance
+
+function hasOutdatedAPIErrorMessages(error: Error): boolean {
+    return error.message.includes('FetchError') || error.message.includes('Cannot query field')
+}

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -194,9 +194,14 @@ export interface CodyContextFilterItem {
     filePathPattern?: string
 }
 
-const EMPTY_CONTEXT_FILTERS: ContextFiltersResult = {
+const INCLUDE_EVERYTHING_CONTEXT_FILTERS: ContextFiltersResult = {
     include: [],
     exclude: [],
+}
+
+const EXCLUDE_EVERYTHING_CONTEXT_FILTERS: ContextFiltersResult = {
+    include: [],
+    exclude: [{ repoNamePattern: '*' }],
 }
 
 interface SearchAttributionResults {
@@ -541,10 +546,15 @@ export class SourcegraphGraphQLAPIClient {
         const result = extractDataOrError(response, data => data)
 
         if (result instanceof Error) {
+            logError('SourcegraphGraphQLAPIClient', 'contextFilters', result.message)
+
             // Ignore errors caused by outdated Sourcegraph API instances.
             if (hasOutdatedAPIErrorMessages(result)) {
-                return EMPTY_CONTEXT_FILTERS
+                return INCLUDE_EVERYTHING_CONTEXT_FILTERS
             }
+
+            // Exclude everything in case of an unexpected error.
+            return EXCLUDE_EVERYTHING_CONTEXT_FILTERS
         }
 
         return result

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -191,7 +191,7 @@ export interface ContextFiltersResult {
 export interface CodyContextFilterItem {
     repoNamePattern: string
     // Not implemented
-    filePathPattern?: string
+    filePathPatterns?: string[]
 }
 
 const INCLUDE_EVERYTHING_CONTEXT_FILTERS: ContextFiltersResult = {
@@ -201,7 +201,7 @@ const INCLUDE_EVERYTHING_CONTEXT_FILTERS: ContextFiltersResult = {
 
 const EXCLUDE_EVERYTHING_CONTEXT_FILTERS: ContextFiltersResult = {
     include: [],
-    exclude: [{ repoNamePattern: '*' }],
+    exclude: [{ repoNamePattern: '.*' }],
 }
 
 interface SearchAttributionResults {

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -546,8 +546,6 @@ export class SourcegraphGraphQLAPIClient {
         const result = extractDataOrError(response, data => data)
 
         if (result instanceof Error) {
-            logError('SourcegraphGraphQLAPIClient', 'contextFilters', result.message)
-
             // Ignore errors caused by outdated Sourcegraph API instances.
             if (hasOutdatedAPIErrorMessages(result)) {
                 return INCLUDE_EVERYTHING_CONTEXT_FILTERS

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -152,6 +152,20 @@ query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $
     }
 }`
 
+export const CONTEXT_FILTERS_QUERY = `
+query ContextFilters {
+	site {
+        codyContextFilters {
+            exclude {
+                repoNamePattern
+            }
+            include {
+                repoNamePattern
+            }
+        }
+	}
+}`
+
 export const SEARCH_ATTRIBUTION_QUERY = `
 query SnippetAttribution($snippet: String!) {
     snippetAttribution(snippet: $snippet) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -390,6 +390,9 @@ importers:
       parse-git-diff:
         specifier: ^0.0.14
         version: 0.0.14
+      re2:
+        specifier: ^1.20.10
+        version: 1.20.10
       semver:
         specifier: ^7.5.4
         version: 7.6.0
@@ -3031,7 +3034,6 @@ packages:
       strip-ansi-cjs: /strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: /wrap-ansi@7.0.0
-    dev: true
 
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -3454,11 +3456,31 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.6.0
 
+  /@npmcli/agent@2.2.2:
+    resolution: {integrity: sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      agent-base: 7.1.0
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
+      lru-cache: 10.2.0
+      socks-proxy-agent: 8.0.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@npmcli/fs@2.1.2:
     resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       '@gar/promisify': 1.1.3
+      semver: 7.6.0
+    dev: false
+
+  /@npmcli/fs@3.1.0:
+    resolution: {integrity: sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
       semver: 7.6.0
     dev: false
 
@@ -3813,7 +3835,6 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
     requiresBuild: true
-    dev: true
 
   /@playwright/browser-chromium@1.39.0:
     resolution: {integrity: sha512-s1WPO0qOE7PIZcdcJEd4CHQgXf9rOwy00Den8DsXTI26n/Eqa2HzFSbLRE1Eh2nIJZFSGyKLbopHR0HkT8ClZw==}
@@ -5762,6 +5783,11 @@ packages:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: false
 
+  /abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: false
+
   /abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -5842,6 +5868,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /agent-base@7.1.1:
+    resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
+    engines: {node: '>= 14'}
+    dependencies:
+      debug: 4.3.4(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /agentkeepalive@4.3.0:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
@@ -5881,7 +5916,6 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -5904,7 +5938,6 @@ packages:
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
-    dev: true
 
   /anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -6428,6 +6461,24 @@ packages:
       - bluebird
     dev: false
 
+  /cacache@18.0.2:
+    resolution: {integrity: sha512-r3NU8h/P+4lVUHfeRw1dtgQYar3DZMm4/cm2bZgOvrFC/su7budSOeqh52VJIC4U4iG1WWwV6vRW0znqBvxNuw==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      '@npmcli/fs': 3.1.0
+      fs-minipass: 3.0.3
+      glob: 10.3.10
+      lru-cache: 10.2.0
+      minipass: 7.0.4
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      p-map: 4.0.0
+      ssri: 10.0.5
+      tar: 6.2.0
+      unique-filename: 3.0.0
+    dev: false
+
   /cache-base@1.0.1:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
     engines: {node: '>=0.10.0'}
@@ -6937,7 +6988,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
   /crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
@@ -7404,7 +7454,6 @@ packages:
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: true
 
   /easy-table@1.2.0:
     resolution: {integrity: sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==}
@@ -7822,6 +7871,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /exponential-backoff@3.1.1:
+    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
+    dev: false
+
   /express@4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
     engines: {node: '>= 0.10.0'}
@@ -8160,7 +8213,6 @@ packages:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
-    dev: true
 
   /form-data@3.0.0:
     resolution: {integrity: sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==}
@@ -8245,6 +8297,13 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       minipass: 3.3.5
+
+  /fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      minipass: 7.0.4
+    dev: false
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -8419,7 +8478,6 @@ packages:
       minimatch: 9.0.3
       minipass: 7.0.3
       path-scurry: 1.10.1
-    dev: true
 
   /glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
@@ -8849,7 +8907,6 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -8868,7 +8925,6 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -8977,6 +9033,11 @@ packages:
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
     dev: true
+
+  /install-artifact-from-github@1.3.5:
+    resolution: {integrity: sha512-gZHC7f/cJgXz7MXlHFBxPVMsvIbev1OQN1uKQYKVJDydGNm9oYf9JstbU4Atnh/eSvk41WtEovoRm+8IF686xg==}
+    hasBin: true
+    dev: false
 
   /internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
@@ -9376,7 +9437,6 @@ packages:
   /isexe@3.1.1:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
-    dev: true
 
   /isobject@2.1.0:
     resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
@@ -9414,7 +9474,6 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-    dev: true
 
   /jake@10.8.7:
     resolution: {integrity: sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==}
@@ -9971,12 +10030,10 @@ packages:
   /lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /lru-cache@10.2.0:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -10067,6 +10124,25 @@ packages:
       ssri: 9.0.1
     transitivePeerDependencies:
       - bluebird
+      - supports-color
+    dev: false
+
+  /make-fetch-happen@13.0.0:
+    resolution: {integrity: sha512-7ThobcL8brtGo9CavByQrQi+23aIfgYU++wg4B87AIS8Rb2ZBt/MEaDqzA00Xwv/jUjAjYkLHjVolYuTLKda2A==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    dependencies:
+      '@npmcli/agent': 2.2.2
+      cacache: 18.0.2
+      http-cache-semantics: 4.1.1
+      is-lambda: 1.0.1
+      minipass: 7.0.4
+      minipass-fetch: 3.0.4
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.3
+      promise-retry: 2.0.1
+      ssri: 10.0.5
+    transitivePeerDependencies:
       - supports-color
     dev: false
 
@@ -10345,11 +10421,29 @@ packages:
       minipass: 3.3.5
     dev: false
 
+  /minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      minipass: 7.0.4
+    dev: false
+
   /minipass-fetch@2.1.2:
     resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       minipass: 3.3.5
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+    dev: false
+
+  /minipass-fetch@3.0.4:
+    resolution: {integrity: sha512-jHAqnA728uUpIaFm7NWsCnqKT6UqZz7GcI/bDpPATuwYyKwJwW0remxSCxUlKiEty+eopHGa3oc8WxgQ1FFJqg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      minipass: 7.0.4
       minipass-sized: 1.0.3
       minizlib: 2.1.2
     optionalDependencies:
@@ -10390,12 +10484,10 @@ packages:
   /minipass@7.0.3:
     resolution: {integrity: sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
 
   /minipass@7.0.4:
     resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
     engines: {node: '>=16 || 14 >=14.17'}
-    dev: true
 
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -10516,6 +10608,10 @@ packages:
 
   /nan@2.17.0:
     resolution: {integrity: sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==}
+    dev: false
+
+  /nan@2.19.0:
+    resolution: {integrity: sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==}
     dev: false
 
   /nanoid@3.3.3:
@@ -10649,6 +10745,25 @@ packages:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
 
+  /node-gyp@10.1.0:
+    resolution: {integrity: sha512-B4J5M1cABxPc5PwfjhbV5hoy2DP9p8lFXASnEN6hugXOa61416tnTZ29x9sSwAd0o99XNIcpvDDy1swAExsVKA==}
+    engines: {node: ^16.14.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.1
+      glob: 10.3.10
+      graceful-fs: 4.2.11
+      make-fetch-happen: 13.0.0
+      nopt: 7.2.0
+      proc-log: 3.0.0
+      semver: 7.6.0
+      tar: 6.2.0
+      which: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /node-gyp@9.3.1:
     resolution: {integrity: sha512-4Q16ZCqq3g8awk6UplT7AuxQ35XN4R/yf/+wSAwcBUAjg7l58RTactWaP8fIDTi0FzI7YcVLujwExakZlfWkXg==}
     engines: {node: ^12.13 || ^14.13 || >=16}
@@ -10683,6 +10798,14 @@ packages:
     hasBin: true
     dependencies:
       abbrev: 1.1.1
+    dev: false
+
+  /nopt@7.2.0:
+    resolution: {integrity: sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+    dependencies:
+      abbrev: 2.0.0
     dev: false
 
   /normalize-package-data@2.5.0:
@@ -11126,7 +11249,6 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -11141,8 +11263,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       lru-cache: 10.1.0
-      minipass: 7.0.3
-    dev: true
+      minipass: 7.0.4
 
   /path-temp@2.1.0:
     resolution: {integrity: sha512-cMMJTAZlion/RWRRC48UbrDymEIt+/YSD/l8NqjneyDw2rDOBQcP5yRkMB4CYGn47KMhZvbblBP7Z79OsMw72w==}
@@ -11412,7 +11533,6 @@ packages:
   /proc-log@3.0.0:
     resolution: {integrity: sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dev: true
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -11629,6 +11749,17 @@ packages:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
     dev: true
+
+  /re2@1.20.10:
+    resolution: {integrity: sha512-/5JjSPXobSDaKFL6rD5Gb4qD4CVBITQb7NAxfQ/NA7o0HER3SJAPV3lPO2kvzw0/PN1pVJNVATEUk4y9j7oIIA==}
+    requiresBuild: true
+    dependencies:
+      install-artifact-from-github: 1.3.5
+      nan: 2.19.0
+      node-gyp: 10.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
@@ -12255,12 +12386,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /shell-quote-word@1.0.1:
     resolution: {integrity: sha512-lT297f1WLAdq0A4O+AknIFRP6kkiI3s8C913eJ0XqBxJbZPGWUNkRQk2u8zk4bEAjUJ5i+fSLwB6z1HzeT+DEg==}
@@ -12293,7 +12422,6 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-    dev: true
 
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -12386,6 +12514,17 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.0
+      debug: 4.3.4(supports-color@8.1.1)
+      socks: 2.7.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /socks-proxy-agent@8.0.3:
+    resolution: {integrity: sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.1
       debug: 4.3.4(supports-color@8.1.1)
       socks: 2.7.1
     transitivePeerDependencies:
@@ -12492,7 +12631,6 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       minipass: 7.0.4
-    dev: true
 
   /ssri@9.0.1:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
@@ -12584,7 +12722,6 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-    dev: true
 
   /string.fromcodepoint@0.2.1:
     resolution: {integrity: sha512-n69H31OnxSGSZyZbgBlvYIXlrMhJQ0dQAX1js1QDhpaUH6zmU3QYlj07bCwCNlPOu3oRXIubGPl2gDGnHsiCqg==}
@@ -12611,7 +12748,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -13319,9 +13455,23 @@ packages:
       unique-slug: 3.0.0
     dev: false
 
+  /unique-filename@3.0.0:
+    resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      unique-slug: 4.0.0
+    dev: false
+
   /unique-slug@3.0.0:
     resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      imurmurhash: 0.1.4
+    dev: false
+
+  /unique-slug@4.0.0:
+    resolution: {integrity: sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       imurmurhash: 0.1.4
     dev: false
@@ -13761,7 +13911,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 3.1.1
-    dev: true
 
   /why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
@@ -13855,7 +14004,6 @@ packages:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-    dev: true
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1264,6 +1264,7 @@
     "mkdirp": "^3.0.1",
     "os-browserify": "^0.3.0",
     "parse-git-diff": "^0.0.14",
+    "re2": "^1.20.10",
     "semver": "^7.5.4",
     "socks-proxy-agent": "^8.0.1",
     "unzipper": "^0.10.14",

--- a/vscode/src/context/context-filters-provider.ts
+++ b/vscode/src/context/context-filters-provider.ts
@@ -13,7 +13,7 @@ interface ParsedContextFilters {
 
 interface ParsedContextFilterItem {
     repoNamePattern: RE2
-    filePathPattern?: RE2
+    filePathPatterns?: RE2[]
 }
 
 export class ContextFiltersProvider implements vscode.Disposable {
@@ -109,18 +109,22 @@ function checkFilter(
 ): boolean {
     const matchesRepo = Boolean(parsedFilter.repoNamePattern.match(repoName))
 
-    if (!parsedFilter.filePathPattern) {
+    if (!parsedFilter.filePathPatterns) {
         return matchesRepo
     }
 
-    const matchesPath = Boolean(parsedFilter.filePathPattern.match(relativePath))
+    const matchesPath = parsedFilter.filePathPatterns.some(pattern =>
+        Boolean(pattern.match(relativePath))
+    )
 
     return matchesRepo && matchesPath
 }
 
 function parseContextFilterItem(item: CodyContextFilterItem): ParsedContextFilterItem {
     const repoNamePattern = new RE2(item.repoNamePattern)
-    const filePathPattern = item.filePathPattern ? new RE2(item.filePathPattern) : undefined
+    const filePathPatterns = item.filePathPatterns
+        ? item.filePathPatterns.map(pattern => new RE2(pattern))
+        : undefined
 
-    return { repoNamePattern, filePathPattern }
+    return { repoNamePattern, filePathPatterns }
 }

--- a/vscode/src/context/context-filters-provider.ts
+++ b/vscode/src/context/context-filters-provider.ts
@@ -24,7 +24,6 @@ export class ContextFiltersProvider implements vscode.Disposable {
     async init() {
         await this.fetchContextFilters()
         this.startRefetchTimer()
-        return this.contextFilters
     }
 
     private async fetchContextFilters(): Promise<void> {

--- a/vscode/src/context/context-filters-provider.ts
+++ b/vscode/src/context/context-filters-provider.ts
@@ -68,7 +68,6 @@ export class ContextFiltersProvider implements vscode.Disposable {
         let isAllowed = Boolean(this.contextFilters)
 
         if (this.contextFilters?.include.length) {
-            isAllowed = false
             for (const parsedFilter of this.contextFilters.include) {
                 isAllowed = checkFilter(parsedFilter, repoName, relativePath)
 

--- a/vscode/src/context/context-filters-provider.ts
+++ b/vscode/src/context/context-filters-provider.ts
@@ -1,0 +1,125 @@
+import { LRUCache } from 'lru-cache'
+import RE2 from 're2'
+import type * as vscode from 'vscode'
+
+import { type CodyContextFilterItem, graphqlClient, logDebug } from '@sourcegraph/cody-shared'
+
+const REFETCH_INTERVAL = 60 * 60 * 1000 // 1 hour
+
+interface ParsedContextFilters {
+    include: ParsedContextFilterItem[]
+    exclude: ParsedContextFilterItem[]
+}
+
+interface ParsedContextFilterItem {
+    repoNamePattern: RE2
+    filePathPattern?: RE2
+}
+
+export class ContextFiltersProvider implements vscode.Disposable {
+    private contextFilters: ParsedContextFilters | null = null
+    private fetchIntervalId: NodeJS.Timer | undefined
+    private cache = new LRUCache<string, boolean>({ max: 128 })
+
+    async init() {
+        await this.fetchContextFilters()
+        this.startRefetchTimer()
+        return this.contextFilters
+    }
+
+    private async fetchContextFilters(): Promise<void> {
+        try {
+            const response = await graphqlClient.contextFilters()
+            if (response instanceof Error) {
+                logDebug('ContextFiltersProvider', response.toString())
+            } else {
+                this.cache.clear()
+
+                if (response) {
+                    this.contextFilters = {
+                        include: response.include.map(parseContextFilterItem),
+                        exclude: response.exclude.map(parseContextFilterItem),
+                    }
+                }
+            }
+        } catch (error) {
+            if (error instanceof Error) {
+                logDebug('ContextFiltersProvider', error.toString())
+                return
+            }
+        }
+    }
+
+    private startRefetchTimer(): void {
+        this.fetchIntervalId = setTimeout(() => {
+            this.fetchContextFilters()
+            this.startRefetchTimer()
+        }, REFETCH_INTERVAL)
+    }
+
+    public isPathAllowed(repoName: string, relativePath: string): boolean {
+        const cacheKey = `${repoName}:${relativePath}`
+        const cached = this.cache.get(cacheKey)
+        if (cached !== undefined) {
+            return cached
+        }
+
+        let isAllowed = true
+
+        if (this.contextFilters?.include.length) {
+            isAllowed = false
+            for (const parsedFilter of this.contextFilters.include) {
+                isAllowed = checkFilter(parsedFilter, repoName, relativePath)
+
+                if (isAllowed) {
+                    break
+                }
+            }
+        }
+
+        if (isAllowed && this.contextFilters?.exclude.length) {
+            for (const parsedFilter of this.contextFilters.exclude) {
+                const matchesFilter = checkFilter(parsedFilter, repoName, relativePath)
+
+                if (matchesFilter) {
+                    isAllowed = false
+                    break
+                }
+            }
+        }
+
+        this.cache.set(cacheKey, isAllowed)
+        return isAllowed
+    }
+
+    public dispose(): void {
+        this.cache.clear()
+
+        if (this.fetchIntervalId) {
+            clearTimeout(this.fetchIntervalId)
+        }
+    }
+}
+
+function checkFilter(
+    parsedFilter: ParsedContextFilterItem,
+    repoName: string,
+    relativePath: string
+): boolean {
+    const matchesRepo = Boolean(parsedFilter.repoNamePattern.match(repoName))
+
+    if (!parsedFilter.filePathPattern) {
+        return matchesRepo
+    }
+
+    const matchesPath = Boolean(parsedFilter.filePathPattern.match(relativePath))
+
+    return matchesRepo && matchesPath
+}
+
+function parseContextFilterItem(item: CodyContextFilterItem): ParsedContextFilterItem {
+    const repoNamePattern = new RE2(item.repoNamePattern)
+    const filePathPattern = item.filePathPattern ? new RE2(item.filePathPattern) : undefined
+
+    return { repoNamePattern, filePathPattern }
+}

--- a/vscode/src/context/context-filters-provider.ts
+++ b/vscode/src/context/context-filters-provider.ts
@@ -4,7 +4,7 @@ import type * as vscode from 'vscode'
 
 import { type CodyContextFilterItem, graphqlClient, logError } from '@sourcegraph/cody-shared'
 
-const REFETCH_INTERVAL = 60 * 60 * 1000 // 1 hour
+export const REFETCH_INTERVAL = 60 * 60 * 1000 // 1 hour
 
 interface ParsedContextFilters {
     include: ParsedContextFilterItem[]
@@ -34,6 +34,7 @@ export class ContextFiltersProvider implements vscode.Disposable {
                 logError('ContextFiltersProvider', 'fetchContextFilters', response)
             } else {
                 this.cache.clear()
+                this.contextFilters = null
 
                 if (response) {
                     this.contextFilters = {

--- a/vscode/src/context/context-filters.provider.test.ts
+++ b/vscode/src/context/context-filters.provider.test.ts
@@ -105,7 +105,10 @@ describe('ContextFiltersProvider', () => {
 
     it('handles invalid regular expressions gracefully', async () => {
         await initProviderWithContextFilters({
-            include: [{ repoNamePattern: '(invalid_regex' }],
+            include: [
+                { repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' },
+                { repoNamePattern: '(invalid_regex' },
+            ],
             exclude: [],
         })
 

--- a/vscode/src/context/context-filters.provider.test.ts
+++ b/vscode/src/context/context-filters.provider.test.ts
@@ -83,7 +83,7 @@ describe('ContextFiltersProvider', () => {
     it('matches file path patterns correctly', async () => {
         await initProviderWithContextFilters({
             include: [
-                { repoNamePattern: '^github\\.com\\/sourcegraph\\/.*', filePathPattern: '.*\\.ts$' },
+                { repoNamePattern: '^github\\.com\\/sourcegraph\\/.*', filePathPatterns: ['.*\\.ts$'] },
             ],
             exclude: [],
         })

--- a/vscode/src/context/context-filters.provider.test.ts
+++ b/vscode/src/context/context-filters.provider.test.ts
@@ -1,0 +1,78 @@
+import { graphqlClient } from '@sourcegraph/cody-shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ContextFiltersProvider } from './context-filters-provider'
+
+describe('ContextFiltersProvider', () => {
+    let provider: ContextFiltersProvider
+
+    beforeEach(() => {
+        provider = new ContextFiltersProvider()
+    })
+
+    afterEach(() => {
+        provider.dispose()
+        vi.restoreAllMocks()
+    })
+
+    it('should allow a path if it matches the include pattern and does not match the exclude pattern', async () => {
+        const mockContextFilters = {
+            include: [
+                { repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' },
+                { repoNamePattern: '^github\\.com\\/evilcorp\\/.*' },
+            ],
+            exclude: [{ repoNamePattern: '.*sensitive.*' }],
+        }
+        vi.spyOn(graphqlClient, 'contextFilters').mockResolvedValue(mockContextFilters)
+        await provider.init()
+
+        const isAllowed = provider.isPathAllowed('github.com/sourcegraph/cody', 'src/main.ts')
+        const isAllowed2 = provider.isPathAllowed('github.com/evilcorp/cody', 'src/main.ts')
+        expect(isAllowed).toBe(true)
+        expect(isAllowed2).toBe(true)
+    })
+
+    it('should not allow a path if it does not match the include pattern', async () => {
+        const mockContextFilters = {
+            include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' }],
+            exclude: [{ repoNamePattern: '.*sensitive.*' }],
+        }
+        vi.spyOn(graphqlClient, 'contextFilters').mockResolvedValue(mockContextFilters)
+        await provider.init()
+
+        const isAllowed = provider.isPathAllowed('github.com/other/repo', 'src/main.ts')
+        expect(isAllowed).toBe(false)
+    })
+
+    it('should not allow a path if it matches the exclude pattern', async () => {
+        const mockContextFilters = {
+            include: [
+                { repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' },
+                { repoNamePattern: '^github\\.com\\/sensitive\\/.*' },
+            ],
+            exclude: [{ repoNamePattern: '.*sensitive.*' }, { repoNamePattern: '.*not-allowed.*' }],
+        }
+        vi.spyOn(graphqlClient, 'contextFilters').mockResolvedValue(mockContextFilters)
+        await provider.init()
+
+        const isAllowed = provider.isPathAllowed('github.com/sensitive/sensitive-repo', 'src/main.ts')
+        const isAllowed2 = provider.isPathAllowed(
+            'github.com/sourcegraph/not-allowed-repo',
+            'src/main.ts'
+        )
+
+        expect(isAllowed).toBe(false)
+        expect(isAllowed2).toBe(false)
+    })
+
+    it('should allow any path if include is empty and it does not match the exclude pattern', async () => {
+        const mockContextFilters = {
+            include: [],
+            exclude: [{ repoNamePattern: '.*sensitive.*' }],
+        }
+        vi.spyOn(graphqlClient, 'contextFilters').mockResolvedValue(mockContextFilters)
+        await provider.init()
+
+        const isAllowed = provider.isPathAllowed('github.com/sourcegraph/whatever', 'src/main.ts')
+        expect(isAllowed).toBe(true)
+    })
+})


### PR DESCRIPTION
## Context

- Closes subtasks from https://github.com/sourcegraph/cody/issues/3641
    - Add node RE2 package; the RFC specifies RE2
    - Fetch the enterprise rules with GraphQL
    - Provide a stub implementation for Sourcegraph endpoints which don't support this feature, with a liberal allow policy
    - Write a function which takes (repo, relative path) -> do/don't ignore
- Builds on top of backend changes https://github.com/sourcegraph/sourcegraph/pull/61101
- Mirrors backend logic from https://github.com/sourcegraph/sourcegraph/pull/61641

## Test plan

CI and new unit tests
