### PR TITLE
Fix compilation error

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -439,9 +439,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
             let closestDistance = Number.MAX_VALUE
             let closest = ''
             if (polly) {
-                const persister = polly.persister._cache as Map<string, Promise<Har>>
+                // @ts-ignore
+                const persister = polly.persister._cache as Map<string, Har>
                 for (const [, har] of persister) {
-                    for (const entry of (await har).log.entries) {
+                    for (const entry of har.log.entries) {
                         if (entry.request.url !== url) {
                             continue
                         }


### PR DESCRIPTION
## Changes

I'm not sure why tsc is failing only for me locally, but that is legitimate error.
@valerybugakov looked at it also and confirmed.

```
agent/src/agent.ts:442:35 - error TS18047: 'polly.persister' is possibly 'null'.

442                 const persister = polly.persister._cache as Map<string, Promise<Har>>
                                      ~~~~~~~~~~~~~~~

agent/src/agent.ts:442:35 - error TS2352: Conversion of type 'Map<string, Har>' to type 'Map<string, Promise<Har>>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
  Type 'Har' is missing the following properties from type 'Promise<Har>': then, catch, finally, [Symbol.toStringTag]

442                 const persister = polly.persister._cache as Map<string, Promise<Har>>
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

agent/src/agent.ts:442:51 - error TS2341: Property '_cache' is private and only accessible within class 'Persister<TOptions>'.

442                 const persister = polly.persister._cache as Map<string, Promise<Har>>
```

## Test plan

None needed
