### PR TITLE
Add ldid as part of release action

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         with:
           run_install: true
+      - uses: MOZGIII/install-ldid-action@d5ab465f3a66a4d60a59882b935eb30e18e8d043 # SECURITY: pin third-party action hashes
+        with:
+          tag: v2.1.5-procursus7
       - name: get release version
         id: release_version
         run: |


### PR DESCRIPTION
The current 0.0.5 release has broken MacOS binaries. From the [release action](https://github.com/sourcegraph/cody/actions/runs/8568196553/job/23481553267):

```
> Warning Unable to sign the macOS executable
  Due to the mandatory code signing requirement, before the
  executable is distributed to end users, it must be signed.
  Otherwise, it will be immediately killed by kernel on launch.
  An ad-hoc signature is sufficient.
  To do that, run pkg on a Mac, or transfer the executable to a Mac
  and run "codesign --sign - <executable>", or (if you use Linux)
  install "ldid" utility to PATH and then run pkg again
```

This PR adds this [Install ldid action](https://github.com/MOZGIII/install-ldid-action) to the release in an attempt to fix it

## Test plan

Not yet sure

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
