### PR TITLE
Add support for using Sourcegraph Embeddings API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,12 +16,12 @@
       "env": {
         "NODE_ENV": "development",
         "CODY_DEBUG_ENABLE": "true",
-        "CODY_TESTING": "true",
+        //"CODY_TESTING": "true",
 
         // Enable the Node debug protocol for the TypeScript server:
         // "TSS_DEBUG": "5859"
         // Let extension behave like you're on dotcom when connected locally:
-        "TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
+        //"TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
         // Enable Sentry in local development mode:
         // "ENABLE_SENTRY": "true"
       }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,12 +16,10 @@
       "env": {
         "NODE_ENV": "development",
         "CODY_DEBUG_ENABLE": "true",
-        //"CODY_TESTING": "true",
-
         // Enable the Node debug protocol for the TypeScript server:
         // "TSS_DEBUG": "5859"
         // Let extension behave like you're on dotcom when connected locally:
-        //"TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
+        // "TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
         // Enable Sentry in local development mode:
         // "ENABLE_SENTRY": "true"
       }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,10 +16,12 @@
       "env": {
         "NODE_ENV": "development",
         "CODY_DEBUG_ENABLE": "true",
+        "CODY_TESTING": "true",
+
         // Enable the Node debug protocol for the TypeScript server:
         // "TSS_DEBUG": "5859"
         // Let extension behave like you're on dotcom when connected locally:
-        // "TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
+        "TESTING_DOTCOM_URL": "https://sourcegraph.test:3443"
         // Enable Sentry in local development mode:
         // "ENABLE_SENTRY": "true"
       }

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
@@ -30,6 +30,8 @@ object Constants {
   const val ready = "ready"
   const val `not-a-git-repo` = "not-a-git-repo"
   const val `git-repo-has-no-remote` = "git-repo-has-no-remote"
+  const val sourcegraph = "sourcegraph"
+  const val openai = "openai"
   const val search = "search"
   const val local = "local"
   const val unindexed = "unindexed"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextProvider.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextProvider.kt
@@ -26,6 +26,7 @@ data class LocalEmbeddingsProvider(
   val kind: KindEnum? = null, // Oneof: embeddings
   val state: StateEnum? = null, // Oneof: indeterminate, no-match, unconsented, indexing, ready
   val errorReason: ErrorReasonEnum? = null, // Oneof: not-a-git-repo, git-repo-has-no-remote
+  val embeddingsAPIProvider: EmbeddingsProvider? = null, // Oneof: sourcegraph, openai
 ) : ContextProvider() {
 
   enum class KindEnum {

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EmbeddingsProvider.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EmbeddingsProvider.kt
@@ -1,0 +1,5 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+typealias EmbeddingsProvider = String // One of: sourcegraph, openai
+

--- a/lib/shared/src/codebase-context/context-status.ts
+++ b/lib/shared/src/codebase-context/context-status.ts
@@ -31,6 +31,7 @@ export interface LocalEmbeddingsProvider {
     kind: 'embeddings'
     state: 'indeterminate' | 'no-match' | 'unconsented' | 'indexing' | 'ready'
     errorReason?: 'not-a-git-repo' | 'git-repo-has-no-remote'
+    useSourcegraphEmbeddings: boolean
 }
 
 export type SearchProvider = LocalSearchProvider | RemoteSearchProvider

--- a/lib/shared/src/codebase-context/context-status.ts
+++ b/lib/shared/src/codebase-context/context-status.ts
@@ -27,11 +27,13 @@ export interface RemoteSearchProvider {
     inclusion: 'auto' | 'manual'
 }
 
+export type EmbeddingsProvider = 'sourcegraph' | 'openai'
+
 export interface LocalEmbeddingsProvider {
     kind: 'embeddings'
     state: 'indeterminate' | 'no-match' | 'unconsented' | 'indexing' | 'ready'
     errorReason?: 'not-a-git-repo' | 'git-repo-has-no-remote'
-    useSourcegraphEmbeddings: boolean
+    embeddingsAPIProvider: EmbeddingsProvider
 }
 
 export type SearchProvider = LocalSearchProvider | RemoteSearchProvider

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -1,3 +1,6 @@
+import type { EmbeddingsProvider } from './codebase-context/context-status'
+import type { FileURI } from './common/uri'
+
 export type ConfigurationUseContext = 'embeddings' | 'keyword' | 'none' | 'blended' | 'unified'
 
 /**
@@ -74,10 +77,7 @@ export interface Configuration {
     agentIDE?: 'VSCode' | 'JetBrains' | 'Neovim' | 'Emacs'
     autocompleteTimeouts: AutocompleteTimeouts
 
-    testingLocalEmbeddingsModel: string | undefined
-    testingLocalEmbeddingsDimension: number | undefined
-    testingLocalEmbeddingsEndpoint: string | undefined
-    testingLocalEmbeddingsIndexLibraryPath: string | undefined
+    testingModelConfig: EmbeddingsModelConfig | undefined
 }
 
 export interface AutocompleteTimeouts {
@@ -227,4 +227,12 @@ export interface FireworksOptions {
         top_p?: number
         stop?: string[]
     }
+}
+
+export interface EmbeddingsModelConfig {
+    model: string
+    dimension: number
+    provider: EmbeddingsProvider
+    endpoint: string
+    indexPath: FileURI
 }

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -110,9 +110,6 @@ export class FeatureFlagProvider {
                 return false
             }
 
-            // if (flagName === FeatureFlag.CodyUseSourcegraphEmbeddings) {
-            //     return true
-            // }
             const cachedValue = this.getFromCache(flagName, endpoint)
             if (cachedValue !== undefined) {
                 return cachedValue

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -49,6 +49,9 @@ export enum FeatureFlag {
 
     // Show document hints above a symbol if the users' cursor is there. "Opt+D to Document"
     CodyDocumentHints = 'cody-document-hints',
+
+    /** Use Sourcegraph embeddings instead of OpenAI. */
+    CodyUseSourcegraphEmbeddings = 'cody-use-sourcegraph-embeddings',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -109,6 +109,9 @@ export class FeatureFlagProvider {
             if (process.env.DISABLE_FEATURE_FLAGS) {
                 return false
             }
+            if(flagName===FeatureFlag.CodyUseSourcegraphEmbeddings){
+                return true;
+            }
 
             const cachedValue = this.getFromCache(flagName, endpoint)
             if (cachedValue !== undefined) {

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -109,9 +109,6 @@ export class FeatureFlagProvider {
             if (process.env.DISABLE_FEATURE_FLAGS) {
                 return false
             }
-            if(flagName===FeatureFlag.CodyUseSourcegraphEmbeddings){
-                return true;
-            }
 
             const cachedValue = this.getFromCache(flagName, endpoint)
             if (cachedValue !== undefined) {

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -110,6 +110,9 @@ export class FeatureFlagProvider {
                 return false
             }
 
+            // if (flagName === FeatureFlag.CodyUseSourcegraphEmbeddings) {
+            //     return true
+            // }
             const cachedValue = this.getFromCache(flagName, endpoint)
             if (cachedValue !== undefined) {
                 return cachedValue

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -152,10 +152,7 @@ describe('getConfiguration', () => {
                 multiline: undefined,
                 singleline: undefined,
             },
-            testingLocalEmbeddingsEndpoint: undefined,
-            testingLocalEmbeddingsDimension: undefined,
-            testingLocalEmbeddingsIndexLibraryPath: undefined,
-            testingLocalEmbeddingsModel: undefined,
+            testingModelConfig: undefined,
             experimentalChatContextRanker: false,
         } satisfies Configuration)
     })

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -8,6 +8,7 @@ import {
     OLLAMA_DEFAULT_URL,
 } from '@sourcegraph/cody-shared'
 
+import { URI } from 'vscode-uri'
 import {
     CONFIG_KEY,
     type ConfigKeys,
@@ -81,6 +82,17 @@ export function getConfiguration(
         'autocomplete.experimental.graphContext',
         null
     )
+
+    function hasValidLocalEmbeddingsConfig(): boolean {
+        return (
+            [
+                'testing.localEmbeddings.model',
+                'testing.localEmbeddings.endpoint',
+                'testing.localEmbeddings.indexLibraryPath',
+            ].every(key => !!getHiddenSetting<string | undefined>(key, undefined)) &&
+            !!getHiddenSetting<number | undefined>('testing.localEmbeddings.dimension', undefined)
+        )
+    }
 
     return {
         proxy: config.get<string | null>(CONFIG_KEY.proxy, null),
@@ -165,19 +177,18 @@ export function getConfiguration(
                 undefined
             ),
         },
-
-        testingLocalEmbeddingsModel: isTesting
-            ? getHiddenSetting<string | undefined>('testing.localEmbeddings.model', undefined)
-            : undefined,
-        testingLocalEmbeddingsDimension: isTesting
-            ? getHiddenSetting<number | undefined>('testing.localEmbeddings.dimension', undefined)
-            : undefined,
-        testingLocalEmbeddingsEndpoint: isTesting
-            ? getHiddenSetting<string | undefined>('testing.localEmbeddings.endpoint', undefined)
-            : undefined,
-        testingLocalEmbeddingsIndexLibraryPath: isTesting
-            ? getHiddenSetting<string | undefined>('testing.localEmbeddings.indexLibraryPath', undefined)
-            : undefined,
+        testingModelConfig:
+            isTesting && hasValidLocalEmbeddingsConfig()
+                ? {
+                      model: getHiddenSetting<string>('testing.localEmbeddings.model'),
+                      dimension: getHiddenSetting<number>('testing.localEmbeddings.dimension'),
+                      endpoint: getHiddenSetting<string>('testing.localEmbeddings.endpoint'),
+                      indexPath: URI.file(
+                          getHiddenSetting<string>('testing.localEmbeddings.indexLibraryPath')
+                      ),
+                      provider: 'openai',
+                  }
+                : undefined,
     }
 }
 

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -33,7 +33,7 @@ type Constructor<T extends new (...args: any) => any> = T extends new (
 
 export interface PlatformContext {
     createCommandsProvider?: Constructor<typeof CommandsProvider>
-    createLocalEmbeddingsController?: (config: LocalEmbeddingsConfig) => LocalEmbeddingsController
+    createLocalEmbeddingsController?: (config: LocalEmbeddingsConfig) => Promise<LocalEmbeddingsController>
     createContextRankingController?: (config: ContextRankerConfig) => ContextRankingController
     createSymfRunner?: Constructor<typeof SymfRunner>
     createBfgRetriever?: () => BfgRetriever

--- a/vscode/src/extension.common.ts
+++ b/vscode/src/extension.common.ts
@@ -33,7 +33,9 @@ type Constructor<T extends new (...args: any) => any> = T extends new (
 
 export interface PlatformContext {
     createCommandsProvider?: Constructor<typeof CommandsProvider>
-    createLocalEmbeddingsController?: (config: LocalEmbeddingsConfig) => Promise<LocalEmbeddingsController>
+    createLocalEmbeddingsController?: (
+        config: LocalEmbeddingsConfig
+    ) => Promise<LocalEmbeddingsController>
     createContextRankingController?: (config: ContextRankerConfig) => ContextRankingController
     createSymfRunner?: Constructor<typeof SymfRunner>
     createBfgRetriever?: () => BfgRetriever

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -36,7 +36,7 @@ export function activate(context: vscode.ExtensionContext): Promise<ExtensionApi
     return activateCommon(context, {
         createLocalEmbeddingsController: isLocalEmbeddingsDisabled
             ? undefined
-            : (config: LocalEmbeddingsConfig): LocalEmbeddingsController =>
+            : (config: LocalEmbeddingsConfig): Promise<LocalEmbeddingsController> =>
                   createLocalEmbeddingsController(context, config),
         createContextRankingController: (config: ContextRankerConfig) =>
             createContextRankingController(context, config),

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -85,7 +85,7 @@ export async function configureExternalServices(
         ? platform.createContextRankingController?.(initialConfig)
         : undefined
 
-    const localEmbeddings = platform.createLocalEmbeddingsController?.(initialConfig)
+    const localEmbeddings = await platform.createLocalEmbeddingsController?.(initialConfig)
 
     const chatClient = new ChatClient(
         completionsClient,

--- a/vscode/src/local-context/enhanced-context-status.test.ts
+++ b/vscode/src/local-context/enhanced-context-status.test.ts
@@ -25,7 +25,7 @@ class TestProvider implements status.ContextStatusProvider {
                         {
                             kind: 'embeddings',
                             state: 'unconsented',
-                            useSourcegraphEmbeddings:false
+                            embeddingsAPIProvider: 'openai',
                         },
                     ],
                 },
@@ -51,7 +51,7 @@ describe('ContextStatusAggregator', () => {
                     {
                         kind: 'embeddings',
                         state: 'unconsented',
-                        useSourcegraphEmbeddings:false,
+                        embeddingsAPIProvider: 'openai',
                     },
                 ],
             },
@@ -95,7 +95,7 @@ describe('ContextStatusAggregator', () => {
                     {
                         kind: 'embeddings',
                         state: 'unconsented',
-                        useSourcegraphEmbeddings:false,
+                        embeddingsAPIProvider: 'openai',
                     },
                     {
                         kind: 'search',

--- a/vscode/src/local-context/enhanced-context-status.test.ts
+++ b/vscode/src/local-context/enhanced-context-status.test.ts
@@ -25,6 +25,7 @@ class TestProvider implements status.ContextStatusProvider {
                         {
                             kind: 'embeddings',
                             state: 'unconsented',
+                            useSourcegraphEmbeddings:false
                         },
                     ],
                 },
@@ -50,6 +51,7 @@ describe('ContextStatusAggregator', () => {
                     {
                         kind: 'embeddings',
                         state: 'unconsented',
+                        useSourcegraphEmbeddings:false,
                     },
                 ],
             },
@@ -93,6 +95,7 @@ describe('ContextStatusAggregator', () => {
                     {
                         kind: 'embeddings',
                         state: 'unconsented',
+                        useSourcegraphEmbeddings:false,
                     },
                     {
                         kind: 'search',

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -233,8 +233,6 @@ export class LocalEmbeddingsController
         logDebug('LocalEmbeddingsController', 'spawnAndBindService', 'service started, initializing')
         const indexPath = getIndexLibraryPath(this.modelConfig.indexSuffix)
 
-        // Tests may override the index library path
-
         const initResult = await service.request('embeddings/initialize', {
             codyGatewayEndpoint: this.endpoint,
             indexPath: indexPath.fsPath,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -843,9 +843,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
         multiline: undefined,
         singleline: undefined,
     },
-    testingLocalEmbeddingsEndpoint: undefined,
-    testingLocalEmbeddingsDimension: undefined,
-    testingLocalEmbeddingsIndexLibraryPath: undefined,
-    testingLocalEmbeddingsModel: undefined,
+    testingModelConfig: undefined,
     experimentalChatContextRanker: false,
 } satisfies Configuration

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -64,6 +64,8 @@ const test = helpers.test
                 use({
                     'cody.testing.localEmbeddings.model': 'stub/stub',
                     'cody.testing.localEmbeddings.indexLibraryPath': dir,
+                    'cody.testing.localEmbeddings.endpoint': SERVER_URL + '/v1/embeddings',
+                    'cody.testing.localEmbeddings.dimension': 1536,
                 })
             )
         },

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -153,7 +153,11 @@ export const ConsumerMultipleProviders: StoryObj<typeof EnhancedContextSettings>
                         {
                             displayName: '~/projects/foo',
                             providers: [
-                                { kind: 'embeddings', state: 'unconsented', useSourcegraphEmbeddings:false },
+                                {
+                                    kind: 'embeddings',
+                                    state: 'unconsented',
+                                    embeddingsAPIProvider: 'openai',
+                                },
                                 { kind: 'search', type: 'local', state: 'indexing' },
                             ],
                         },

--- a/vscode/webviews/Components/EnhancedContextSettings.story.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.story.tsx
@@ -153,7 +153,7 @@ export const ConsumerMultipleProviders: StoryObj<typeof EnhancedContextSettings>
                         {
                             displayName: '~/projects/foo',
                             providers: [
-                                { kind: 'embeddings', state: 'unconsented' },
+                                { kind: 'embeddings', state: 'unconsented', useSourcegraphEmbeddings:false },
                                 { kind: 'search', type: 'local', state: 'indexing' },
                             ],
                         },

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -241,7 +241,7 @@ const EmbeddingsConsentComponent: React.FunctionComponent<{ provider: LocalEmbed
     return (
         <div>
             <p className={styles.providerExplanatoryText}>
-                The repository&apos;s contents will be uploaded to OpenAI&apos;s Embeddings API and then
+                The repository&apos;s contents will be uploaded to {provider.useSourcegraphEmbeddings ? "Sourcegraph" : "OpenAI"}&apos;s Embeddings API and then
                 stored locally.
                 {/* To exclude files, set up a <a href="about:blank#TODO">Cody ignore file.</a> */}
             </p>

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -241,8 +241,9 @@ const EmbeddingsConsentComponent: React.FunctionComponent<{ provider: LocalEmbed
     return (
         <div>
             <p className={styles.providerExplanatoryText}>
-                The repository&apos;s contents will be uploaded to {provider.useSourcegraphEmbeddings ? "Sourcegraph" : "OpenAI"}&apos;s Embeddings API and then
-                stored locally.
+                The repository&apos;s contents will be uploaded to{' '}
+                {provider.embeddingsAPIProvider === 'sourcegraph' ? 'Sourcegraph' : 'OpenAI'}&apos;s
+                Embeddings API and then stored locally.
                 {/* To exclude files, set up a <a href="about:blank#TODO">Cody ignore file.</a> */}
             </p>
             <p>


### PR DESCRIPTION
Add's support for Sourcegraph Embeddings API, changing:

- model identifier and vector dimension (passed to BFG aka Cody Engine)
- storage location for indices (to allow switching from OpenAI to Sourcegraph API without data loss / conflicts)
- test used to communicate how we process user code

[Loom](https://www.loom.com/share/38a46f95a2414726816de62740c90760)

Potentially TODO (separate PR):

- can we "assume consent" and re-embed automatically if user has used OpenAI (without accepting again)?

## Test plan

- build BFG from main (`cd $BFG_REPO && cd crated/bfg && cargo build --release`)
- configure your VSCode to use locally-built BFG (add `  "cody.experimental.cody-engine.path": "$BFG_REPO/target/release/bfg"` to settings.json)
- enable the Feature [flag](https://sourcegraph.com/site-admin/feature-flags/configuration/cody-use-sourcegraph-embeddings) for yourself 
