### PR TITLE
Autocomplete: Add Codegemma prompt to Ollama provider

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Chat: You can add highlighted code to the chat context by right-clicking on the code and selecting `Cody Chat: Add context`. The selected code will appear in the input box as `@-mentions`, allowing you to complete your question. [pull/3713](https://github.com/sourcegraph/cody/pull/3713)
+- Autocomplete: Add the proper infilling prompt for codegemma when using ollama. []()
 
 ### Fixed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,7 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Chat: You can add highlighted code to the chat context by right-clicking on the code and selecting `Cody Chat: Add context`. The selected code will appear in the input box as `@-mentions`, allowing you to complete your question. [pull/3713](https://github.com/sourcegraph/cody/pull/3713)
-- Autocomplete: Add the proper infilling prompt for codegemma when using ollama. []()
+- Autocomplete: Add the proper infilling prompt for Codegemma when using Ollama. [pull/3754](https://github.com/sourcegraph/cody/pull/3754)
 
 ### Fixed
 

--- a/vscode/src/completions/providers/ollama-models.ts
+++ b/vscode/src/completions/providers/ollama-models.ts
@@ -132,12 +132,9 @@ class StarCoder2 extends DefaultOllamaModel {
 class CodeGemma extends DefaultOllamaModel {
     getPrompt(ollamaPrompt: OllamaPromptContext): string {
         const { context, prefix, suffix } = ollamaPrompt
-
-        // `currentFileNameComment` is not included because it causes StarCoder2 to output
-        // invalid suggestions.
-        const infillPrefix = context + prefix
-
-        return `<|fim_prefix|>${infillPrefix}<|fim_suffix|>${suffix}<|fim_middle|>`
+        // c.f. https://huggingface.co/blog/codegemma
+        // c.f. https://huggingface.co/google/codegemma-7b/blob/main/tokenizer.json
+        return `<|fim_prefix|>${context}${prefix}<|fim_suffix|>${suffix}<|fim_middle|>`
     }
 
     getRequestOptions(isMultiline: boolean): OllamaGenerateParameters {


### PR DESCRIPTION
## Test plan

<img width="1621" alt="Screenshot 2024-04-09 at 18 39 02" src="https://github.com/sourcegraph/cody/assets/458591/94f35674-33a5-472f-99b6-b4a1ef287442">

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
