### PR TITLE
Autocomplete: add file name and repeat_penalty for CodeGemma.

### DIFF
--- a/vscode/doc/ollama.md
+++ b/vscode/doc/ollama.md
@@ -7,6 +7,7 @@
 
 - `ollama pull deepseek-coder:6.7b-base-q4_K_M` for [deepseek-coder](https://ollama.ai/library/deepseek-coder)
 - `ollama pull codellama:7b-code` for [codellama](https://ollama.ai/library/codellama)
+- `ollama pull codegemma:2b` for [codegemma](https://ollama.ai/library/codegemma)
 
 1. Update Cody's VS Code settings to use the `experimental-ollama` autocomplete provider and configure the right model:
 

--- a/vscode/src/completions/providers/ollama-models.ts
+++ b/vscode/src/completions/providers/ollama-models.ts
@@ -131,10 +131,11 @@ class StarCoder2 extends DefaultOllamaModel {
 
 class CodeGemma extends DefaultOllamaModel {
     getPrompt(ollamaPrompt: OllamaPromptContext): string {
-        const { context, prefix, suffix } = ollamaPrompt
+        const { context, currentFileNameComment, prefix, suffix } = ollamaPrompt
         // c.f. https://huggingface.co/blog/codegemma
         // c.f. https://huggingface.co/google/codegemma-7b/blob/main/tokenizer.json
-        return `<|fim_prefix|>${context}${prefix}<|fim_suffix|>${suffix}<|fim_middle|>`
+        // c.f. https://storage.googleapis.com/deepmind-media/gemma/codegemma_report.pdf
+        return `${currentFileNameComment}<|fim_prefix|>${context}${prefix}<|fim_suffix|>${suffix}<|fim_middle|>`
     }
 
     getRequestOptions(isMultiline: boolean): OllamaGenerateParameters {
@@ -149,6 +150,7 @@ class CodeGemma extends DefaultOllamaModel {
         const params = {
             stop: ['\n', ...stop],
             temperature: 0.2,
+            repeat_penalty: 1.0,
             top_k: -1,
             top_p: -1,
             num_predict: 256,

--- a/vscode/src/completions/providers/ollama-models.ts
+++ b/vscode/src/completions/providers/ollama-models.ts
@@ -143,8 +143,8 @@ class CodeGemma extends DefaultOllamaModel {
             '<|fim_prefix|>',
             '<|fim_suffix|>',
             '<|fim_middle|>',
-            '<|endoftext|>',
             '<|file_separator|>',
+            '<end_of_turn>',
         ]
 
         const params = {


### PR DESCRIPTION
## Context
- Add the current file name at the beginning of the prompt.
- Explicitly set `repeat_penalty=1.0` for the best performance.

## Test plan
1. Install Ollama https://ollama.com/
2. `ollama pull codegemma:2b` or `ollama pull codegemma:7b`
3. Update user settings:
```
{
  "cody.autocomplete.experimental.ollamaOptions": {
    "url": "http://localhost:11434",
    "model": "codegemma:2b"
  },
  "cody.autocomplete.advanced.provider": "experimental-ollama",
}
```
4. Confirm Cody uses Ollama by looking at the Cody output channel or the autocomplete trace view (in the command palette).