### PR TITLE
Chat: update token limit on model changes

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: Fixed an issue where changing the chat model did not update the token limit for the model. [pull/3762](https://github.com/sourcegraph/cody/pull/3762)
+
 ### Changed
 
 ## [1.12.0]

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -17,7 +17,7 @@ import { getChatPanelTitle } from './chat-helpers'
 
 export class SimpleChatModel {
     // The maximum number of characters available in the model's context window.
-    public readonly maxChars: number
+    public maxChars: number
     constructor(
         public modelID: string,
         private messages: ChatMessage[] = [],
@@ -26,6 +26,11 @@ export class SimpleChatModel {
         private selectedRepos?: Repo[]
     ) {
         this.maxChars = ModelProvider.getMaxCharsByModel(this.modelID)
+    }
+
+    public updateModel(newModelID: string): void {
+        this.modelID = newModelID
+        this.maxChars = ModelProvider.getMaxCharsByModel(newModelID)
     }
 
     public isEmpty(): boolean {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -568,7 +568,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     private async handleSetChatModel(modelID: string): Promise<void> {
-        this.chatModel.modelID = modelID
+        this.chatModel.updateModel(modelID)
         await chatModel.set(modelID)
     }
 


### PR DESCRIPTION
This pull request introduces a new method to the SimpleChatModel class that allows it to dynamically update the underlying model ID and the associated maximum character limit.

The key changes are:

- The maxChars property in SimpleChatModel has been changed from readonly to a regular property, enabling it to be updated.
- A new updateModel method has been added to SimpleChatModel, which allows updating the modelID and recalculating the maxChars based on the new model ID.
- In the SimpleChatPanelProvider, the handleSetChatModel method has been updated to use the new updateModel method, instead of directly modifying the modelID property.

Before this change, the handleSetChatModel method in SimpleChatPanelProvider only updated the modelID property of the SimpleChatModel instance, but did not update the maxChars property. This meant that the chat model's maximum character limit would not be updated when the model ID was changed, leading to potential issues or unexpected behavior in the application.

The introduction of the updateModel method in SimpleChatModel and the corresponding update in SimpleChatPanelProvider now ensures that both the modelID and the maxChars properties are properly updated when the chat model is changed. This provides more flexibility in the chat application, allowing the chat model to be easily switched without the need to create a new instance of the SimpleChatModel class. This can be useful in scenarios where the chat model needs to be dynamically updated based on user preferences or other application requirements.

> PR generated by Cody

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Green CI
- Check token limit is updated when switching to a new model