### PR TITLE
Ollama: update default context window

### DIFF
--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -23,8 +23,10 @@ export class ModelProvider {
         public readonly model: string,
         // The usage of the model, e.g. chat or edit.
         public readonly usage: ModelUsage[],
-        // The maximum number of tokens that can be processed by the model in a single request.
-        // NOTE: A token is equivalent to 4 characters/bytes.
+        /**
+         * The context window of the model, which is the maximum number of tokens
+         * that can be processed by the model in a single request.
+         */
         public readonly maxToken: number = DEFAULT_CHAT_MODEL_TOKEN_LIMIT,
         // The API key for the model
         public readonly apiKey?: string,

--- a/lib/shared/src/models/utils.ts
+++ b/lib/shared/src/models/utils.ts
@@ -1,7 +1,6 @@
 import { ModelProvider } from '.'
 import { logError } from '../logger'
-import { OLLAMA_DEFAULT_URL } from '../ollama'
-import { DEFAULT_FAST_MODEL_TOKEN_LIMIT, tokensToChars } from '../prompt/constants'
+import { OLLAMA_DEFAULT_CONTEXT_WINDOW, OLLAMA_DEFAULT_URL } from '../ollama'
 import type { CompletionsModelConfig } from './types'
 import { ModelUsage } from './types'
 export function getProviderName(name: string): string {
@@ -46,7 +45,7 @@ export async function fetchLocalOllamaModels(): Promise<ModelProvider[]> {
                         new ModelProvider(
                             `ollama/${m.model}`,
                             [ModelUsage.Chat, ModelUsage.Edit],
-                            tokensToChars(DEFAULT_FAST_MODEL_TOKEN_LIMIT)
+                            OLLAMA_DEFAULT_CONTEXT_WINDOW
                         )
                 ),
             error => {

--- a/lib/shared/src/ollama/index.ts
+++ b/lib/shared/src/ollama/index.ts
@@ -6,6 +6,13 @@ export { createOllamaClient } from './completions-client'
 export { ollamaChatClient } from './chat-client'
 
 /**
+ * By default, Ollama uses a context window size of 2048 tokens.
+ *
+ * @see https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size
+ */
+export const OLLAMA_DEFAULT_CONTEXT_WINDOW = 2048
+
+/**
  * @see https://sourcegraph.com/github.com/jmorganca/ollama/-/blob/api/types.go?L35
  */
 export interface OllamaGenerateParams {


### PR DESCRIPTION
The changes in this pull request remove the tokensToChars function from the fetch ollama function in lib/shared/src/models/utils.ts file. This function was previously used to convert the maxToken property of the ModelProvider class from a token count to a character count, but this was incorrect as the ModelProvider class has always taken the context window size in tokens directly.

The OLLAMA_DEFAULT_CONTEXT_WINDOW constant has been added to the lib/shared/src/ollama/index.ts file, which represents the default context window size used by the Ollama model, which is 2048 tokens ([source](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size)).

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

simple string variable update