### PR TITLE
Edit: display warning for large @-mentions

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Generate Unit Tests: Fixed an issue where Cody would generate tests for the wrong code in the file. [pull/3759](https://github.com/sourcegraph/cody/pull/3759)
 - Chat: Fixed an issue where changing the chat model did not update the token limit for the model. [pull/3762](https://github.com/sourcegraph/cody/pull/3762)
+- Edit: Large file warnings for @-mentions are now updated dynamically as you add or remove them. [pull/3767](https://github.com/sourcegraph/cody/pull/3767)
 
 ### Changed
 

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -417,7 +417,7 @@ export const getInput = async (
                 const isOverLimit = (size?: number): boolean => {
                     const currentInput = input.value
                     const max = ModelProvider.getMaxCharsByModel(activeModel)
-                    let used = 0
+                    let used = currentInput.length
                     for (const [k, v] of selectedContextItems) {
                         if (currentInput.includes(`@${k}`)) {
                             used += v.size ?? 0

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -171,6 +171,7 @@ describe('filterLargeFiles', () => {
             type: 'file',
             uri: largeTextFile.uri,
             isTooLarge: true,
+            size: oneByteOverTokenLimit,
         })
     })
 })

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -267,6 +267,7 @@ export async function filterLargeFiles(
         // Check if file contains more characters than the token limit based on fileStat.size
         // and set {@link ContextItemFile.isTooLarge} for webview to display file size
         // warning.
+        cf.size = fileStat.size
         if (fileStat.size > charsLimit) {
             cf.isTooLarge = true
         }


### PR DESCRIPTION
The changes in this pull request address an issue where the total size of selected context items could exceed the character budget for the active model when importing through @-mentions.

The Edit Command Menu has been updated to:

1. Track the total size of the selected context items and compare it against the maximum character limit for the active model.
2. Display a "Large File Warning" label in the quick pick items if the size of a selected context item would cause the total to exceed the character budget.
3. Automatically remove any selected context items that are no longer included in the current user input.

Additionally, the `filterLargeFiles` function in `editor-context.ts` has been updated to store the file size in the `ContextItemFile` object, which is used in the `getInput` function to determine if a file is too large.

These changes help ensure that the user is not presented with context items that would cause the input to exceed the character limit, providing a better user experience and preventing potential issues with the editor's functionality.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

![image](https://github.com/sourcegraph/cody/assets/68532117/e7392c6d-e4a8-465b-9369-ae61b233cebf)

![image](https://github.com/sourcegraph/cody/assets/68532117/5360c55f-85de-439b-b466-498b34e3c922)

## Follow-up

- [ ] Support @-mentions with range for Edit
