### PR TITLE
Chat: add chat client for Groq

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -229,3 +229,37 @@ export interface FireworksOptions {
         stop?: string[]
     }
 }
+
+/**
+ * @see https://console.groq.com/docs/text-chat
+ */
+export interface GroqCompletionOptions {
+    /**
+     *An optional name to disambiguate messages from different users with the same role.
+     */
+    name?: string
+    /**
+     *Seed used for sampling. Groq attempts to return the same response to the same request with an identical seed.
+     */
+    seed?: number
+    /**
+     *The maximum number of tokens that the model can process in a single response. This limits ensures computational efficiency and resource management.
+     */
+    max_tokens?: number
+    /**
+     *A method of text generation where a model will only consider the most probable next tokens that make up the probability p. 0.5 means half of all likelihood-weighted options are considered.
+     */
+    top_p?: number
+    /**
+     *Controls randomness of responses. A lower temperature leads to more predictable outputs while a higher temperature results in more varies and sometimes more creative outputs.
+     */
+    temperature?: number
+    /**
+     *User server-side events to send the completion in small deltas rather than in a single batch after all processing has finished. This reduces the time to first token received.
+     */
+    stream?: boolean
+    /**
+     *A stop sequence is a predefined or user-specified text string that signals an AI to stop generating content, ensuring its responses remain focused and concise.
+     */
+    stop?: string[]
+}

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -4,10 +4,8 @@ export { ModelProvider } from './models'
 export { type ChatModel, type EditModel, ModelUsage } from './models/types'
 export { DEFAULT_DOT_COM_MODELS } from './models/dotcom'
 export {
-    getCompletionsModelConfig,
     getProviderName,
     getModelInfo,
-    fetchLocalOllamaModels,
 } from './models/utils'
 export { BotResponseMultiplexer } from './chat/bot-response-multiplexer'
 export { ChatClient } from './chat/chat'
@@ -137,7 +135,7 @@ export {
     ollamaChatClient,
     type OllamaGenerateParams,
     OLLAMA_DEFAULT_URL,
-} from './ollama'
+} from './llm-providers/ollama'
 export {
     MAX_BYTES_PER_FILE,
     MAX_CURRENT_FILE_TOKENS,
@@ -231,3 +229,4 @@ export {
     isURLContextItem,
     fetchContentForURLContextItem,
 } from './mentions/urlContextItems'
+export { getCompletionsModelConfig } from './llm-providers/utils'

--- a/lib/shared/src/llm-providers/google/chat-client.ts
+++ b/lib/shared/src/llm-providers/google/chat-client.ts
@@ -25,6 +25,7 @@ const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/
 export function googleChatClient(
     params: CompletionParameters,
     cb: CompletionCallbacks,
+    // This is used for logging as the completions request is sent to the provider's API
     completionsEndpoint: string,
     logger?: CompletionLogger,
     signal?: AbortSignal

--- a/lib/shared/src/llm-providers/google/chat-client.ts
+++ b/lib/shared/src/llm-providers/google/chat-client.ts
@@ -17,8 +17,9 @@ import { constructGeminiChatMessages } from './utils'
 const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/{model}'
 
 /**
- * Calls the Google API for chat completions with history.
+ * NOTE: Behind `chat.dev.models` configuration flag for internal dev testing purpose only!
  *
+ * Calls the Google API for chat completions with history.
  * REF: https://ai.google.dev/tutorials/rest_quickstart#multi-turn_conversations_chat
  */
 export function googleChatClient(

--- a/lib/shared/src/llm-providers/google/chat-client.ts
+++ b/lib/shared/src/llm-providers/google/chat-client.ts
@@ -1,13 +1,13 @@
 import type { GeminiCompletionResponse } from '.'
-import { getCompletionsModelConfig } from '..'
-import { onAbort } from '../common/abortController'
-import { CompletionStopReason } from '../inferenceClient/misc'
-import type { CompletionLogger } from '../sourcegraph-api/completions/client'
+import { getCompletionsModelConfig } from '../..'
+import { onAbort } from '../../common/abortController'
+import { CompletionStopReason } from '../../inferenceClient/misc'
+import type { CompletionLogger } from '../../sourcegraph-api/completions/client'
 import type {
     CompletionCallbacks,
     CompletionParameters,
     CompletionResponse,
-} from '../sourcegraph-api/completions/types'
+} from '../../sourcegraph-api/completions/types'
 import { constructGeminiChatMessages } from './utils'
 
 /**

--- a/lib/shared/src/llm-providers/google/index.ts
+++ b/lib/shared/src/llm-providers/google/index.ts
@@ -18,3 +18,8 @@ export interface GeminiCompletionResponse {
         }[]
     }[]
 }
+
+export interface GeminiChatMessage {
+    role: string
+    parts: { text: string }[]
+}

--- a/lib/shared/src/llm-providers/google/utils.test.ts
+++ b/lib/shared/src/llm-providers/google/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { Message } from '../sourcegraph-api'
+import type { Message } from '../../sourcegraph-api'
 import { constructGeminiChatMessages } from './utils'
 
 describe('constructGeminiChatMessages', () => {

--- a/lib/shared/src/llm-providers/google/utils.ts
+++ b/lib/shared/src/llm-providers/google/utils.ts
@@ -1,9 +1,5 @@
-import type { Message } from '../sourcegraph-api'
-
-interface GeminiChatMessage {
-    role: string
-    parts: { text: string }[]
-}
+import type { GeminiChatMessage } from '.'
+import type { Message } from '../../sourcegraph-api'
 
 /**
  * Constructs an array of `GeminiChatMessage` objects from an array of `Message` objects.

--- a/lib/shared/src/llm-providers/groq/chat-client.ts
+++ b/lib/shared/src/llm-providers/groq/chat-client.ts
@@ -1,4 +1,4 @@
-import { GROQ_DEFAULT_URL, type GroqCompletionsStreamResponse } from '.'
+import type { GroqCompletionsStreamResponse } from '.'
 import { getCompletionsModelConfig } from '../..'
 import { onAbort } from '../../common/abortController'
 import { CompletionStopReason } from '../../inferenceClient/misc'
@@ -8,6 +8,8 @@ import type {
     CompletionParameters,
     CompletionResponse,
 } from '../../sourcegraph-api/completions/types'
+
+const GROQ_CHAT_API_URL = new URL('https://api.groq.com/openai/v1/chat/completions')
 
 export function groqChatClient(
     params: CompletionParameters,
@@ -39,8 +41,7 @@ export function groqChatClient(
         stream: true,
     }
 
-    // Sends the completion parameters and callbacks to the Ollama API.
-    fetch(new URL(GROQ_DEFAULT_URL), {
+    fetch(config?.endpoint ?? GROQ_CHAT_API_URL, {
         method: 'POST',
         body: JSON.stringify(chatParams),
         headers: {

--- a/lib/shared/src/llm-providers/groq/chat-client.ts
+++ b/lib/shared/src/llm-providers/groq/chat-client.ts
@@ -1,0 +1,108 @@
+import { GROQ_DEFAULT_URL, type GroqCompletionsStreamResponse } from '.'
+import { getCompletionsModelConfig } from '../..'
+import { onAbort } from '../../common/abortController'
+import { CompletionStopReason } from '../../inferenceClient/misc'
+import type { CompletionLogger } from '../../sourcegraph-api/completions/client'
+import type {
+    CompletionCallbacks,
+    CompletionParameters,
+    CompletionResponse,
+} from '../../sourcegraph-api/completions/types'
+
+export function groqChatClient(
+    params: CompletionParameters,
+    cb: CompletionCallbacks,
+    completionsEndpoint: string,
+    logger?: CompletionLogger,
+    signal?: AbortSignal
+): void {
+    const log = logger?.startCompletion(params, completionsEndpoint)
+    if (!params.model || !params.messages) {
+        log?.onError('No model or messages')
+        throw new Error('No model or messages')
+    }
+
+    const config = getCompletionsModelConfig(params.model)
+    if (!config?.model) {
+        cb.onError(new Error(`Unknown model ${params.model}`))
+        return
+    }
+
+    const chatParams = {
+        model: config?.model,
+        messages: params.messages.map(msg => {
+            return {
+                role: msg.speaker === 'human' ? 'user' : 'assistant',
+                content: msg.text ?? '',
+            }
+        }),
+        stream: true,
+    }
+
+    // Sends the completion parameters and callbacks to the Ollama API.
+    fetch(new URL(GROQ_DEFAULT_URL), {
+        method: 'POST',
+        body: JSON.stringify(chatParams),
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${config.key}`,
+        },
+        signal,
+    })
+        .then(res => res.body?.getReader())
+        .then(async reader => {
+            if (!reader) {
+                log?.onError('No response body')
+                throw new Error('No response body')
+            }
+
+            onAbort(signal, () => reader.cancel())
+
+            // Handles the response stream to accumulate the full completion text.
+            let insertText = ''
+            const textDecoder = new TextDecoder()
+
+            while (true) {
+                const { done, value } = await reader.read()
+                if (done) {
+                    cb.onChange(insertText)
+                    cb.onComplete()
+                    break
+                }
+
+                const chunk = textDecoder.decode(value, { stream: true })
+                const lines = chunk.split('\n')
+
+                for (const line of lines) {
+                    if (line?.startsWith('data: ')) {
+                        const data = line.slice(6)
+                        try {
+                            const parsedData = JSON.parse(data) as GroqCompletionsStreamResponse
+                            const message = parsedData.choices?.[0]?.delta?.content
+
+                            if (message) {
+                                insertText += message
+                                cb.onChange(insertText)
+                            }
+
+                            if (parsedData.error) {
+                                cb.onError(new Error(parsedData.error.message))
+                            }
+                        } catch (error) {
+                            // Skip JSON parsing errors
+                        }
+                    }
+                }
+            }
+
+            const completionResponse: CompletionResponse = {
+                completion: insertText,
+                stopReason: CompletionStopReason.RequestFinished,
+            }
+            log?.onComplete(completionResponse)
+        })
+        .catch(error => {
+            log?.onError(error)
+            cb.onError(error)
+        })
+}

--- a/lib/shared/src/llm-providers/groq/chat-client.ts
+++ b/lib/shared/src/llm-providers/groq/chat-client.ts
@@ -82,8 +82,9 @@ export function groqChatClient(
                 const lines = chunk.split('\n')
 
                 for (const line of lines) {
-                    if (line?.startsWith('data: ')) {
-                        const data = line.slice(6)
+                    const dataMarker = 'data: '
+                    if (line?.startsWith(dataMarker)) {
+                        const data = line.slice(dataMarker.length)
                         try {
                             const parsedData = JSON.parse(data) as GroqCompletionsStreamResponse
                             const message = parsedData.choices?.[0]?.delta?.content

--- a/lib/shared/src/llm-providers/groq/chat-client.ts
+++ b/lib/shared/src/llm-providers/groq/chat-client.ts
@@ -21,6 +21,7 @@ const GROQ_CHAT_API_URL = new URL('https://api.groq.com/openai/v1/chat/completio
 export function groqChatClient(
     params: CompletionParameters,
     cb: CompletionCallbacks,
+    // This is used for logging as the completions request is sent to the provider's API
     completionsEndpoint: string,
     logger?: CompletionLogger,
     signal?: AbortSignal

--- a/lib/shared/src/llm-providers/groq/index.ts
+++ b/lib/shared/src/llm-providers/groq/index.ts
@@ -1,8 +1,6 @@
 import type { GroqCompletionOptions } from '../../configuration'
 import type { OpenAIMessage } from '../types'
 
-export const GROQ_DEFAULT_URL = 'https://api.groq.com/openai/v1/chat/completions'
-
 /**
  * Represents the parameters for a Groq chat completion request.
  *

--- a/lib/shared/src/llm-providers/groq/index.ts
+++ b/lib/shared/src/llm-providers/groq/index.ts
@@ -1,0 +1,87 @@
+import type { GroqCompletionOptions } from '../../configuration'
+import type { OpenAIMessage } from '../types'
+
+export const GROQ_DEFAULT_URL = 'https://api.groq.com/openai/v1/chat/completions'
+
+/**
+ * Represents the parameters for a Groq chat completion request.
+ *
+ * @property {string} model - The model used for the completion.
+ * @property {GroqChatMessage[]} messages - The messages in the completion request.
+ *
+ * The following parameters are not supported by Groq and will result in 400 errors:
+ * {number} [logprobs] - The number of log probabilities to return for each token.
+ * {number} [logit_bias] - The logit bias for the completion.
+ * {number} [top_logprobs] - The number of top log probabilities to return for each token.
+ */
+export interface GroqCompletionsParameters extends GroqCompletionOptions {
+    model: string
+    messages: GroqChatMessage[]
+}
+
+/**
+ * Represents a message in a Groq chat completion request.
+ *
+ * @property {string} [name] - An optional name to disambiguate messages from different users with the same role.
+ * @property {number} [seed] - Seed used for sampling. Groq attempts to return the same response to the same request with an identical seed.
+ */
+interface GroqChatMessage extends OpenAIMessage {
+    name?: string
+    seed?: number
+}
+
+/**
+ * Default context window sizes for various Groq models.
+ *
+ * @see https://console.groq.com/docs/models
+ */
+export const GROQ_DEFAULT_CONTEXT_WINDOW = {
+    mixtral: 32768,
+    llama2: 4096,
+    gemma: 8192,
+}
+
+/**
+ * Represents the response from the Groq Chat Completion API.
+ *
+ * @property {string} model - The model used for the completion.
+ * @property {GroqCompletionsError} [error] - Any error that occurred during the completion.
+ * @property {Object[]} [choices] - The completion choices returned by the API.
+ * @property {string} [choices[].finish_reason] - The reason the completion finished.
+ * @property {string|null} [choices[].logprobs] - The log probabilities of the tokens in the completion.
+ * @property {GroqChatMessage} [choices[].message] - The completion message.
+ * @property {boolean} done - Indicates whether the completion is done.
+ * @property {GroqCompletionsResponseUsage} [usage] - Usage information for the completion.
+ * @property {string} [id] - The ID of the completion.
+ * @property {number} [created] - The timestamp when the completion was created.
+ */
+export interface GroqCompletionsStreamResponse {
+    model: string
+    error?: GroqCompletionsError
+    choices?: {
+        delta?: {
+            model?: string
+            finish_reason?: string
+            logprobs?: string | null
+            content?: string
+        }
+    }[]
+    done: boolean
+    usage?: GroqCompletionsResponseUsage
+    id?: string
+    created?: number
+}
+
+interface GroqCompletionsError {
+    message: string
+    type: string
+}
+
+interface GroqCompletionsResponseUsage {
+    prompt_tokens: number
+    prompt_time: number
+    completion_tokens: number
+    completion_time: number
+    total_tokens: number
+    total_time: number
+}

--- a/lib/shared/src/llm-providers/index.ts
+++ b/lib/shared/src/llm-providers/index.ts
@@ -1,0 +1,3 @@
+import type { GeminiModelConfig } from './google'
+
+export type CompletionsModelConfig = GeminiModelConfig

--- a/lib/shared/src/llm-providers/ollama/chat-client.ts
+++ b/lib/shared/src/llm-providers/ollama/chat-client.ts
@@ -1,12 +1,12 @@
 import { OLLAMA_DEFAULT_URL, type OllamaChatParams, type OllamaGenerateResponse } from '.'
-import { onAbort } from '../common/abortController'
-import { CompletionStopReason } from '../inferenceClient/misc'
-import type { CompletionLogger } from '../sourcegraph-api/completions/client'
+import { onAbort } from '../../common/abortController'
+import { CompletionStopReason } from '../../inferenceClient/misc'
+import type { CompletionLogger } from '../../sourcegraph-api/completions/client'
 import type {
     CompletionCallbacks,
     CompletionParameters,
     CompletionResponse,
-} from '../sourcegraph-api/completions/types'
+} from '../../sourcegraph-api/completions/types'
 
 /**
  * Calls the Ollama API for chat completions with history.

--- a/lib/shared/src/llm-providers/ollama/chat-client.ts
+++ b/lib/shared/src/llm-providers/ollama/chat-client.ts
@@ -16,6 +16,7 @@ import type {
 export function ollamaChatClient(
     params: CompletionParameters,
     cb: CompletionCallbacks,
+    // This is used for logging as the completions request is sent to the provider's API
     completionsEndpoint: string,
     logger?: CompletionLogger,
     signal?: AbortSignal

--- a/lib/shared/src/llm-providers/ollama/completions-client.ts
+++ b/lib/shared/src/llm-providers/ollama/completions-client.ts
@@ -1,16 +1,16 @@
 import type { OllamaGenerateErrorResponse, OllamaGenerateParams, OllamaGenerateResponse } from '.'
-import { isDefined } from '../common'
-import type { OllamaOptions } from '../configuration'
+import { isDefined } from '../../common'
+import type { OllamaOptions } from '../../configuration'
 import {
     type CodeCompletionsClient,
     type CompletionResponseGenerator,
     CompletionStopReason,
-} from '../inferenceClient/misc'
-import type { CompletionLogger } from '../sourcegraph-api/completions/client'
-import type { CompletionResponse } from '../sourcegraph-api/completions/types'
-import { isAbortError } from '../sourcegraph-api/errors'
-import { isNodeResponse } from '../sourcegraph-api/graphql/client'
-import { isError } from '../utils'
+} from '../../inferenceClient/misc'
+import type { CompletionLogger } from '../../sourcegraph-api/completions/client'
+import type { CompletionResponse } from '../../sourcegraph-api/completions/types'
+import { isAbortError } from '../../sourcegraph-api/errors'
+import { isNodeResponse } from '../../sourcegraph-api/graphql/client'
+import { isError } from '../../utils'
 
 const RESPONSE_SEPARATOR = /\r?\n/
 

--- a/lib/shared/src/llm-providers/ollama/index.ts
+++ b/lib/shared/src/llm-providers/ollama/index.ts
@@ -1,4 +1,5 @@
-import type { OllamaGenerateParameters } from '../configuration'
+import type { OllamaGenerateParameters } from '../..'
+import type { OpenAIMessage } from '../types'
 
 export const OLLAMA_DEFAULT_URL = 'http://localhost:11434'
 
@@ -58,11 +59,7 @@ export interface OllamaGenerateResponse {
     eval_duration?: number
     sample_count?: number
     sample_duration?: number
-    message?: {
-        role: string
-        content: string
-        images?: string[] | null
-    }
+    message?: OpenAIMessage
 }
 
 export interface OllamaGenerateErrorResponse {

--- a/lib/shared/src/llm-providers/ollama/utils.ts
+++ b/lib/shared/src/llm-providers/ollama/utils.ts
@@ -1,0 +1,30 @@
+import { OLLAMA_DEFAULT_CONTEXT_WINDOW } from '.'
+import { ModelProvider, ModelUsage, OLLAMA_DEFAULT_URL, logError } from '../..'
+
+/**
+ * Fetches available Ollama models from the Ollama server.
+ */
+export async function fetchLocalOllamaModels(): Promise<ModelProvider[]> {
+    // TODO (bee) watch file change to determine if a new model is added
+    // to eliminate the needs of restarting the extension to get the new models
+    return await fetch(new URL('/api/tags', OLLAMA_DEFAULT_URL).href)
+        .then(response => response.json())
+        .then(
+            data =>
+                data?.models?.map(
+                    (m: { model: string }) =>
+                        new ModelProvider(
+                            `ollama/${m.model}`,
+                            [ModelUsage.Chat, ModelUsage.Edit],
+                            OLLAMA_DEFAULT_CONTEXT_WINDOW
+                        )
+                ),
+            error => {
+                const fetchFailedErrors = ['Failed to fetch', 'fetch failed']
+                const isFetchFailed = fetchFailedErrors.some(err => error.toString().includes(err))
+                const serverErrorMsg = 'Please make sure the Ollama server is up & running.'
+                logError('getLocalOllamaModels: failed ', isFetchFailed ? serverErrorMsg : error)
+                return []
+            }
+        )
+}

--- a/lib/shared/src/llm-providers/types.ts
+++ b/lib/shared/src/llm-providers/types.ts
@@ -1,0 +1,7 @@
+export interface OpenAIMessage {
+    role: OpenAIMessageRole
+    content: string
+    images?: string[] | null
+}
+
+type OpenAIMessageRole = 'user' | 'assistant' | 'system'

--- a/lib/shared/src/llm-providers/utils.ts
+++ b/lib/shared/src/llm-providers/utils.ts
@@ -1,0 +1,31 @@
+import type { CompletionsModelConfig } from '.'
+import { ModelProvider } from '../models'
+
+export function getCompletionsModelConfig(modelID: string): CompletionsModelConfig | undefined {
+    const provider = ModelProvider.getProviderByModel(modelID)
+    if (provider?.model.startsWith('google/') && provider?.apiKey) {
+        return {
+            model: provider.model.replace('google/', ''),
+            key: provider.apiKey,
+            endpoint: provider.apiEndpoint,
+        }
+    }
+
+    if (provider?.model.startsWith('ollama/')) {
+        return {
+            model: provider.model.replace('ollama/', ''),
+            key: provider.apiKey || '',
+            endpoint: provider.apiEndpoint,
+        }
+    }
+
+    if (provider?.model.startsWith('groq/') && provider?.apiKey) {
+        return {
+            model: provider.model.replace('groq/', ''),
+            key: provider.apiKey,
+            endpoint: 'https://api.groq.com/openai/v1/chat/completions',
+        }
+    }
+
+    return undefined
+}

--- a/lib/shared/src/llm-providers/utils.ts
+++ b/lib/shared/src/llm-providers/utils.ts
@@ -23,7 +23,7 @@ export function getCompletionsModelConfig(modelID: string): CompletionsModelConf
         return {
             model: provider.model.replace('groq/', ''),
             key: provider.apiKey,
-            endpoint: 'https://api.groq.com/openai/v1/chat/completions',
+            endpoint: provider.apiEndpoint,
         }
     }
 

--- a/lib/shared/src/llm-providers/utils.ts
+++ b/lib/shared/src/llm-providers/utils.ts
@@ -3,27 +3,27 @@ import { ModelProvider } from '../models'
 
 export function getCompletionsModelConfig(modelID: string): CompletionsModelConfig | undefined {
     const provider = ModelProvider.getProviderByModel(modelID)
-    if (provider?.model.startsWith('google/') && provider?.apiKey) {
+    if (provider?.model.startsWith('google/') && provider.config?.apiKey) {
         return {
             model: provider.model.replace('google/', ''),
-            key: provider.apiKey,
-            endpoint: provider.apiEndpoint,
+            key: provider.config.apiKey,
+            endpoint: provider.config?.apiEndpoint,
         }
     }
 
     if (provider?.model.startsWith('ollama/')) {
         return {
             model: provider.model.replace('ollama/', ''),
-            key: provider.apiKey || '',
-            endpoint: provider.apiEndpoint,
+            key: provider.config?.apiKey || '',
+            endpoint: provider.config?.apiEndpoint,
         }
     }
 
-    if (provider?.model.startsWith('groq/') && provider?.apiKey) {
+    if (provider?.model.startsWith('groq/') && provider?.config?.apiKey) {
         return {
             model: provider.model.replace('groq/', ''),
-            key: provider.apiKey,
-            endpoint: provider.apiEndpoint,
+            key: provider.config.apiKey,
+            endpoint: provider.config?.apiEndpoint,
         }
     }
 

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -1,6 +1,7 @@
+import { fetchLocalOllamaModels } from '../llm-providers/ollama/utils'
 import { DEFAULT_CHAT_MODEL_TOKEN_LIMIT, tokensToChars } from '../prompt/constants'
 import type { ModelUsage } from './types'
-import { fetchLocalOllamaModels, getModelInfo } from './utils'
+import { getModelInfo } from './utils'
 
 /**
  * ModelProvider manages available chat and edit models.

--- a/lib/shared/src/models/index.ts
+++ b/lib/shared/src/models/index.ts
@@ -29,10 +29,19 @@ export class ModelProvider {
          * that can be processed by the model in a single request.
          */
         public readonly maxToken: number = DEFAULT_CHAT_MODEL_TOKEN_LIMIT,
-        // The API key for the model
-        public readonly apiKey?: string,
-        // The API endpoint for the model
-        public readonly apiEndpoint?: string
+        /**
+         * The configuration for the model.
+         */
+        public readonly config?: {
+            /**
+             * The API key for the model
+             */
+            apiKey?: string
+            /**
+             * The API endpoint for the model
+             */
+            apiEndpoint?: string
+        }
     ) {
         const { provider, title } = getModelInfo(model)
         this.provider = provider

--- a/lib/shared/src/models/types.ts
+++ b/lib/shared/src/models/types.ts
@@ -1,4 +1,3 @@
-import type { GeminiModelConfig } from '../google'
 import type { DEFAULT_DOT_COM_MODELS } from './dotcom'
 
 export enum ModelUsage {
@@ -38,5 +37,3 @@ export type ChatModel =
           [K in keyof Models]: HasUsage<Models[K], ModelUsage.Chat>
       }[keyof Models]['model']
     | (string & {})
-
-export type CompletionsModelConfig = GeminiModelConfig

--- a/lib/shared/src/models/utils.ts
+++ b/lib/shared/src/models/utils.ts
@@ -1,8 +1,3 @@
-import { ModelProvider } from '.'
-import { logError } from '../logger'
-import { OLLAMA_DEFAULT_CONTEXT_WINDOW, OLLAMA_DEFAULT_URL } from '../ollama'
-import type { CompletionsModelConfig } from './types'
-import { ModelUsage } from './types'
 export function getProviderName(name: string): string {
     const providerName = name.toLowerCase()
     switch (providerName) {
@@ -30,45 +25,4 @@ export function getModelInfo(modelID: string): {
     const provider = getProviderName(providerID)
     const title = (rest.at(-1) || '').replace(/-/g, ' ')
     return { provider, title }
-}
-
-/**
- * Fetches available Ollama models from the Ollama server.
- */
-export async function fetchLocalOllamaModels(): Promise<ModelProvider[]> {
-    // TODO (bee) watch file change to determine if a new model is added
-    // to eliminate the needs of restarting the extension to get the new models
-    return await fetch(new URL('/api/tags', OLLAMA_DEFAULT_URL).href)
-        .then(response => response.json())
-        .then(
-            data =>
-                data?.models?.map(
-                    (m: { model: string }) =>
-                        new ModelProvider(
-                            `ollama/${m.model}`,
-                            [ModelUsage.Chat, ModelUsage.Edit],
-                            OLLAMA_DEFAULT_CONTEXT_WINDOW
-                        )
-                ),
-            error => {
-                const fetchFailedErrors = ['Failed to fetch', 'fetch failed']
-                const isFetchFailed = fetchFailedErrors.some(err => error.toString().includes(err))
-                const serverErrorMsg = 'Please make sure the Ollama server is up & running.'
-                logError('getLocalOllamaModels: failed ', isFetchFailed ? serverErrorMsg : error)
-                return []
-            }
-        )
-}
-
-export function getCompletionsModelConfig(modelID: string): CompletionsModelConfig | undefined {
-    const provider = ModelProvider.getProviderByModel(modelID)
-    if (provider?.model.startsWith('google/') && provider?.apiKey) {
-        return {
-            model: provider.model.replace('google/', ''),
-            key: provider.apiKey,
-            endpoint: provider.apiEndpoint,
-        }
-    }
-
-    return undefined
 }

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -8,8 +8,9 @@ import { RateLimitError } from '../errors'
 import { customUserAgent } from '../graphql/client'
 import { toPartialUtf8String } from '../utils'
 
-import { googleChatClient } from '../../google/chat-client'
-import { ollamaChatClient } from '../../ollama/chat-client'
+import { googleChatClient } from '../../llm-providers/google/chat-client'
+import { groqChatClient } from '../../llm-providers/groq/chat-client'
+import { ollamaChatClient } from '../../llm-providers/ollama/chat-client'
 import { getTraceparentHeaders, recordErrorToSpan, tracer } from '../../tracing'
 import { SourcegraphCompletionsClient } from './client'
 import { parseEvents } from './parse'
@@ -46,11 +47,15 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                 }
             }
 
+            // TODO - Centralize this logic in a single place
             if (params.model?.startsWith('ollama')) {
                 ollamaChatClient(params, cb, this.completionsEndpoint, this.logger, signal)
                 return
             }
-
+            if (params.model?.startsWith('groq')) {
+                groqChatClient(params, cb, this.completionsEndpoint, this.logger, signal)
+                return
+            }
             if (params.model?.startsWith('google')) {
                 googleChatClient(params, cb, this.completionsEndpoint, this.logger, signal)
                 return

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -48,16 +48,17 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
             }
 
             // TODO - Centralize this logic in a single place
-            if (params.model?.startsWith('ollama')) {
+            const [provider] = params.model?.split('/') ?? []
+            if (provider === 'ollama') {
                 ollamaChatClient(params, cb, this.completionsEndpoint, this.logger, signal)
                 return
             }
-            if (params.model?.startsWith('groq')) {
-                groqChatClient(params, cb, this.completionsEndpoint, this.logger, signal)
+            if (provider === 'google') {
+                googleChatClient(params, cb, this.completionsEndpoint, this.logger, signal)
                 return
             }
-            if (params.model?.startsWith('google')) {
-                googleChatClient(params, cb, this.completionsEndpoint, this.logger, signal)
+            if (provider === 'groq') {
+                groqChatClient(params, cb, this.completionsEndpoint, this.logger, signal)
                 return
             }
 

--- a/vscode/src/models/utils.ts
+++ b/vscode/src/models/utils.ts
@@ -77,8 +77,7 @@ export function getChatModelsFromConfiguration(): ModelProvider[] {
             `${m.provider}/${m.model}`,
             [ModelUsage.Chat, ModelUsage.Edit],
             m.tokens,
-            m.apiKey,
-            m.apiEndpoint
+            { apiKey: m.apiKey, apiEndpoint: m.apiEndpoint }
         )
         provider.codyProOnly = true
         providers.push(provider)


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1712770567742159

Add internal dev support for Groq models when an API key and config are provided.

![image](https://github.com/sourcegraph/cody/assets/68532117/913a0dd6-85c2-455a-8745-b6504ee5ee03)

This PR adds a new chat client specifically for Groq models provided via the `cody.dev.models"` config option introduced in https://github.com/sourcegraph/cody/pull/3758

I also moved the existing third-party clients (ollama and Google) into a new `llm-providers` directory to centralize them.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Create an API KEY in https://console.groq.com/keys
1. Build Cody from this branch
1. In your user settings JSON file, add the following settings and fill in the apiKey field:
```json
{
  "cody.dev.models": [
    {
      "provider": "groq",
      "model": "llama2-70b-4096",
      "tokens": 4096,
      "apiKey": "$YOUR_GROQ_API_KEY"
    },
    {
      "provider": "groq",
      "model": "gemma-7b-it",
      "tokens": 8192,
      "apiKey": "$YOUR_GROQ_API_KEY"
    },
    {
      "provider": "groq",
      "model": "mixtral-8x7b-32768",
      "tokens": 32768,
      "apiKey": "$YOUR_GROQ_API_KEY"
    },
    {
      "provider": "google",
      "model": "gemini-pro",
      "apiKey": "$YOUR_GEMINI_API_KEY",
    }
  ]
}
```
1. Reload Cody and open a new chat
1. In the dropdown menu, you should be able to see the models you just added via your user settings
1. Select one of the models and submit a question or run a command. Example: gemma-7b-it:
![image](https://github.com/sourcegraph/cody/assets/68532117/d71b465c-6a52-45ae-affa-ba744dcfb9dd)
1. Verify other providers used by the configs are still working. Example: Google Gemini 1.5 Pro
![image](https://github.com/sourcegraph/cody/assets/68532117/d627a997-cd76-40b3-8441-a3fb3b19da91)

## OpenAI Compatibility

This chat client should also work with APIs compatible with  OpenAI's, as the Groq's APIs are designed to be compatible.

Here is an example of how to set up your config to test an API that is OpenAI compatible:
```json
{
  "cody.dev.models": [
    {
      "provider": "groq", // Keep the provider as groq
      "model": "$OPENAI_MODEL_NAME",
      "apiKey": "OPENAI_API_KEY",
      "apiEndpoint": "OPENAI_API_ENDPOINT",
    }
  }
```