### PR TITLE
Chat: default Cody as model icon

### DIFF
--- a/vscode/webviews/Components/ChatModelIcon.tsx
+++ b/vscode/webviews/Components/ChatModelIcon.tsx
@@ -1,4 +1,5 @@
 import type { FunctionComponent } from 'react'
+import { CodyLogoBW } from '../icons/CodyLogo'
 import {
     AnthropicLogo,
     GeminiLogo,
@@ -19,11 +20,11 @@ export function chatModelIconComponent(
     if (model.startsWith('google/')) {
         return GeminiLogo
     }
+    if (model.startsWith('ollama/')) {
+        return OllamaLogo
+    }
     if (model.includes('mixtral')) {
         return MistralLogo
     }
-    if (model.includes('ollama')) {
-        return OllamaLogo
-    }
-    return null
+    return CodyLogoBW
 }

--- a/vscode/webviews/icons/CodyLogo.tsx
+++ b/vscode/webviews/icons/CodyLogo.tsx
@@ -33,3 +33,38 @@ export const CodyLogo: React.FunctionComponent<
         />
     </svg>
 )
+
+// Black and white version of the Cody logo
+export const CodyLogoBW: React.FunctionComponent<
+    React.PropsWithChildren<React.SVGAttributes<SVGSVGElement>> & { size: number }
+> = ({ size, ...props }) => (
+    <svg
+        width={size}
+        height={size}
+        viewBox="0 0 25 25"
+        fill="currentColor"
+        xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-label="Cody logo"
+        {...props}
+    >
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M17.799 -1.0423e-07C19.1159 -4.66655e-08 20.1835 1.06758 20.1835 2.38451L20.1835 6.62365C20.1835 7.94058 19.1159 9.00816 17.799 9.00816C16.482 9.00816 15.4144 7.94058 15.4144 6.62365L15.4144 2.38451C15.4144 1.06758 16.482 -1.61795e-07 17.799 -1.0423e-07Z"
+            fill="currentColor"
+        />
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M2.6969 5.56396C2.6969 4.24703 3.76448 3.17944 5.08141 3.17944H9.32055C10.6375 3.17944 11.7051 4.24703 11.7051 5.56396C11.7051 6.88089 10.6375 7.94847 9.32055 7.94847H5.08141C3.76448 7.94847 2.6969 6.88089 2.6969 5.56396Z"
+            fill="currentColor"
+        />
+        <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M23.4979 12.5055C24.3466 13.3117 24.381 14.6533 23.5748 15.502L22.8246 16.2917C16.9538 22.4715 7.05634 22.3175 1.38065 15.9582C0.601182 15.0848 0.677291 13.745 1.55064 12.9655C2.424 12.186 3.76387 12.2621 4.54334 13.1355C8.5685 17.6455 15.5877 17.7546 19.7512 13.372L20.5014 12.5823C21.3077 11.7336 22.6493 11.6992 23.4979 12.5055Z"
+            fill="currentColor"
+        />
+    </svg>
+)


### PR DESCRIPTION
fix: use Cody logo for custom chat models

![image](https://github.com/sourcegraph/cody/assets/68532117/b6e02d09-abb5-4fe1-aae4-0819cec421c7)


This pull request addresses an issue where custom chat models were not getting an associated icon in the UI. To resolve this, the changes include:

- Added a new `CodyLogoBW` component in vscode/webviews/icons/CodyLogo.tsx that renders a black and white version of the Cody logo.
- Updated the chatModelIconComponent function in vscode/webviews/Components/ChatModelIcon.tsx to use the new CodyLogoBW component when the model is not on our supported list. Previously, the function would return null in this case, resulting in no icon being displayed.

By using the Cody logo as a fallback for custom chat models, this change ensures that all models have a consistent visual representation in the application.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Build Cody from this branch
1. In your user settings JSON file, add the following settings and replace the apiKey field if you have one
  - you can get one from https://aistudio.google.com/app/prompts/new_chat
  - for testing, you can leave it like this as it still gets rendered in the UI, but choosing the model will not work
```
  "cody.dev.models": [{
    "provider": "google",
    "model": "gemini-pro",
    "apiKey": "YOUR_GEMINI_API_KEY",
  }]
```
1. Reload Cody and open a new chat
1. In the dropdown menu, you should be able to see the models you just added via your user settings.

### Before 

![image](https://github.com/sourcegraph/cody/assets/68532117/11a4331c-f76f-4274-bc4a-45c3f93fe145)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/b6e02d09-abb5-4fe1-aae4-0819cec421c7)
