### PR TITLE
Chat: reveal hidden chat panel on @-selection

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -643,6 +643,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 isTooLarge: f.size ? f.size > contextLimit : undefined,
             })),
         })
+        // Makes sure to reveal the webview panel in case the panel is hidden.
+        this.webviewPanel?.reveal()
     }
 
     private async handleSymfIndex(): Promise<void> {


### PR DESCRIPTION
This PR fixes the issue where an exisiting chat panel will stay hidden when the user tries to send the editor selection to the chat panel as @-mentions token (@-selection) . See video below for example

Expected behavior:
The existing chat panel should be revealed on click

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->


### Before

Hidden chat panel will stay hidden on @-selection 

https://github.com/sourcegraph/cody/assets/68532117/69c8beab-42b9-41a0-89e6-14fabf687ac4


### After

Current active chat panel will show up if hidden:

https://github.com/sourcegraph/cody/assets/68532117/0fd048f1-a009-4931-82a3-478a154c44e3

