### PR TITLE
Fix undo/accept/cancel command calls

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -40,14 +40,14 @@ interface CodyAgentServer {
   fun editCommands_code(params: EditCommands_CodeParams): CompletableFuture<EditTask>
   @JsonRequest("editCommands/test")
   fun editCommands_test(params: Null): CompletableFuture<EditTask>
-  @JsonRequest("commands/document")
-  fun commands_document(params: Null): CompletableFuture<EditTask>
+  @JsonRequest("editCommands/document")
+  fun editCommands_document(params: Null): CompletableFuture<EditTask>
   @JsonRequest("editTask/accept")
-  fun editTask_accept(params: FixupTaskID): CompletableFuture<Null>
+  fun editTask_accept(params: EditTask_AcceptParams): CompletableFuture<Null>
   @JsonRequest("editTask/undo")
-  fun editTask_undo(params: FixupTaskID): CompletableFuture<Null>
+  fun editTask_undo(params: EditTask_UndoParams): CompletableFuture<Null>
   @JsonRequest("editTask/cancel")
-  fun editTask_cancel(params: FixupTaskID): CompletableFuture<Null>
+  fun editTask_cancel(params: EditTask_CancelParams): CompletableFuture<Null>
   @JsonRequest("editTask/getFoldingRanges")
   fun editTask_getFoldingRanges(params: GetFoldingRangeParams): CompletableFuture<GetFoldingRangeResult>
   @JsonRequest("command/execute")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_AcceptParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_AcceptParams.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class EditTask_AcceptParams(
+  val id: FixupTaskID? = null,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_CancelParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_CancelParams.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class EditTask_CancelParams(
+  val id: FixupTaskID? = null,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_UndoParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask_UndoParams.kt
@@ -1,5 +1,7 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-typealias FixupTaskID = String // One of: 
+data class EditTask_UndoParams(
+  val id: FixupTaskID? = null,
+)
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -743,22 +743,19 @@ export class Agent extends MessageHandler implements ExtensionClient {
             )
         })
 
-        // TODO: JetBrains is buggy and serializes 'string' as ['string'].
-        // The params[0] unpacking here only works because of the type punning
-        // params: string means params[0]: string too. Fix JetBrains client to
-        // send string values as strings; or encode these parameter values as
-        // an object holding a string.
-        this.registerAuthenticatedRequest('editTask/accept', params => {
-            this.fixups?.accept(params[0])
-            return Promise.resolve(null)
+        this.registerAuthenticatedRequest('editTask/accept', async ({ id }) => {
+            this.fixups?.accept(id)
+            return null
         })
-        this.registerAuthenticatedRequest('editTask/undo', params => {
-            this.fixups?.undo(params[0])
-            return Promise.resolve(null)
+
+        this.registerAuthenticatedRequest('editTask/undo', async ({ id }) => {
+            this.fixups?.undo(id)
+            return null
         })
-        this.registerAuthenticatedRequest('editTask/cancel', params => {
-            this.fixups?.cancel(params[0])
-            return Promise.resolve(null)
+
+        this.registerAuthenticatedRequest('editTask/cancel', async ({ id }) => {
+            this.fixups?.cancel(id)
+            return null
         })
 
         this.registerAuthenticatedRequest(
@@ -796,6 +793,12 @@ export class Agent extends MessageHandler implements ExtensionClient {
             )
         })
 
+        this.registerAuthenticatedRequest('editCommands/document', () => {
+            return this.createEditTask(
+                vscode.commands.executeCommand<CommandResult | undefined>('cody.command.document-code')
+            )
+        })
+
         this.registerAuthenticatedRequest('commands/smell', () => {
             return this.createChatPanel(
                 vscode.commands.executeCommand('cody.command.smell-code', commandArgs)
@@ -809,12 +812,6 @@ export class Agent extends MessageHandler implements ExtensionClient {
                     key,
                     commandArgs
                 )
-            )
-        })
-
-        this.registerAuthenticatedRequest('commands/document', () => {
-            return this.createEditTask(
-                vscode.commands.executeCommand<CommandResult | undefined>('cody.command.document-code')
             )
         })
 

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -616,7 +616,7 @@ describe('Agent', () => {
                 command: 'cody.search.index-update',
             })
             await client.openFile(ignoredUri, { removeCursor: false })
-            await client.request('commands/document', null).catch(err => {
+            await client.request('editCommands/document', null).catch(err => {
                 expect(err).toBeDefined()
             })
         })
@@ -708,12 +708,12 @@ describe('Agent', () => {
                 })
                 const uri = vscode.Uri.file(path.join(workspaceRootPath, 'src', filename))
                 await documentClient.openFile(uri, { removeCursor: false })
-                const task = await documentClient.request('commands/document', null)
+                const task = await documentClient.request('editCommands/document', null)
                 await documentClient.taskHasReachedAppliedPhase(task)
                 const lenses = documentClient.codeLenses.get(uri.toString()) ?? []
                 expect(lenses).toHaveLength(0) // Code lenses are now handled client side
 
-                await documentClient.request('editTask/accept', task.id)
+                await documentClient.request('editTask/accept', { id: task.id })
                 const newContent = documentClient.workspace.getDocument(uri)?.content
                 assertion(trimEndOfLine(newContent))
             },

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -80,15 +80,15 @@ export type ClientRequests = {
     // Trigger commands that edit the code.
     'editCommands/code': [{ params: { instruction: string } }, EditTask]
     'editCommands/test': [null, EditTask]
-    'commands/document': [null, EditTask] // TODO: rename to editCommands/document
+    'editCommands/document': [null, EditTask]
 
     // If the task is "applied", discards the task.
-    'editTask/accept': [FixupTaskID, null]
+    'editTask/accept': [{ id: FixupTaskID }, null]
     // If the task is "applied", attempts to revert the task's edit, then
     // discards the task.
-    'editTask/undo': [FixupTaskID, null]
+    'editTask/undo': [{ id: FixupTaskID }, null]
     // Discards the task. Applicable to tasks in any state.
-    'editTask/cancel': [FixupTaskID, null]
+    'editTask/cancel': [{ id: FixupTaskID }, null]
 
     // Utility for clients that don't have language-neutral folding-range support.
     // Provides a list of all the computed folding ranges in the specified document.


### PR DESCRIPTION
## Changes

Fixes API for calling `editTask/undo`, `editTask/accept` and `editTask/cancel`

## Test plan

Manual tests with the JB plugin

