### PR TITLE
Telemetry: add sessionID to properties for Chat events

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -405,6 +405,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 source,
                 command,
                 traceId: span.spanContext().traceId,
+                sessionID: this.chatModel.sessionID,
             }
             telemetryService.log('CodyVSCodeExtension:chat-question:submitted', sharedProperties)
             telemetryRecorder.recordEvent('cody.chat-question', 'submitted', {


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/3688

The code change in this commit adds the `sessionID` property to the sharedProperties object that is logged with the `CodyVSCodeExtension:chat-question:submitted` and `CodyVSCodeExtension:chat-question:executed` telemetry event.

The `sessionID` property is obtained from the chatModel instance, which likely represents the current chat session. By including the sessionID in the telemetry data, it becomes easier to correlate and analyze chat-related events within the same session.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Submit a message and verify in Output channel that sessionID is included as event properties.

`CodyVSCodeExtension:chat-question:submitted`:

```json
█ logEvent (telemetry disabled): CodyVSCodeExtension:chat-question:submitted  {
  "details": "VSCode",
  "properties": {
    "requestID": "d9440a6f-5fa9-40d5-b4d7-2ada0249f500",
    "chatModel": "anthropic/claude-3-sonnet-20240229",
    "source": "hover",
    "command": "explain",
    "traceId": "10039136671c03d3195d1cdc55baf057",
    "sessionID": "Mon, 15 Apr 2024 15:49:17 GMT" // The new sessionID field
  }
}
█ telemetry-v2: recordEvent: cody.chat-question/submitted  {
  "parameters": {
    "version": 0,
    "metadata": [
      {
        "key": "recordsPrivateMetadataTranscript",
        "value": 1
      }
    ],
    "privateMetadata": {
      "requestID": "d9440a6f-5fa9-40d5-b4d7-2ada0249f500",
      "chatModel": "anthropic/claude-3-sonnet-20240229",
      "source": "hover",
      "command": "explain",
      "traceId": "10039136671c03d3195d1cdc55baf057",
      "sessionID": "Mon, 15 Apr 2024 15:49:17 GMT", // The new sessionID field
      "promptText": "Explain..."
    }
  },
```

`CodyVSCodeExtension:chat-question:executed`:

```json
█ logEvent (telemetry disabled): CodyVSCodeExtension:chat-question:executed  {
  "details": "VSCode",
  "properties": {
    "requestID": "d9440a6f-5fa9-40d5-b4d7-2ada0249f500",
    "chatModel": "anthropic/claude-3-sonnet-20240229",
    "source": "hover",
    "command": "explain",
    "traceId": "10039136671c03d3195d1cdc55baf057",
    "sessionID": "Mon, 15 Apr 2024 15:49:17 GMT", // The new sessionID field
    "contextSummary": {
      "selection": 1,
      "editor": 1
    }
  },
  "opts": {
    "hasV2Event": true
  }
}
█ telemetry-v2: recordEvent: cody.chat-question/executed  {
  "parameters": {
    "version": 0,
    "metadata": [
      {
        "key": "selection",
        "value": 1
      },
      {
        "key": "editor",
        "value": 1
      },
      {
        "key": "recordsPrivateMetadataTranscript",
        "value": 1
      }
    ],
    "privateMetadata": {
      "properties": {
        "requestID": "d9440a6f-5fa9-40d5-b4d7-2ada0249f500",
        "chatModel": "anthropic/claude-3-sonnet-20240229",
        "source": "hover",
        "command": "explain",
        "traceId": "10039136671c03d3195d1cdc55baf057",
        "sessionID": "Mon, 15 Apr 2024 15:49:17 GMT", // The new sessionID field
        "contextSummary": {
          "selection": 1,
          "editor": 1
        }
      },
      "promptText": "Explai..."
    }
  },
```