### PR TITLE
E2E: add click interaction for index.html in command-custom test

### DIFF
--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -90,6 +90,7 @@ test.extend<ExpectedEvents>({
 
     // Check if cody.json in the workspace has the new command added
     await sidebarExplorer(page).click()
+    await page.getByText('index.html').first().click()
     await page.getByLabel('.vscode', { exact: true }).hover()
     await page.getByLabel('.vscode', { exact: true }).click()
     await page.getByRole('treeitem', { name: 'cody.json' }).locator('a').hover()


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1713194760682759

Attempt to fix the flaky custom-commands e2e test. This commit adds a new interaction step to the command-custom.test.ts file in the vscode/test/e2e directory. The added line of code clicks on the index.html file in the sidebar explorer before proceeding with the existing test steps.

In current recordings for the failed test, we can see the test failed because it was clicking on the mini-map for the index.html instead of .vscody/cody.json:
![image](https://github.com/sourcegraph/cody/assets/68532117/dca5c4a6-be4a-48eb-8cee-a208908d90ad)

By explicitly clicking on the index.html file, the test ensures that the file explorer is focused on the correct file or directory before interacting with the .vscode folder and cody.json file, so that the file will always opened in the same tab as index.html.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

The e2e test for windows passes on first time