### PR TITLE
Sidebar: add copy extension version command

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Add the proper infilling prompt for Codegemma when using Ollama. [pull/3754](https://github.com/sourcegraph/cody/pull/3754)
 - Chat: The new `Mixtral 8x22B Preview` chat model is available for Cody Pro users for preview. [pull/3768](https://github.com/sourcegraph/cody/pull/3768)
 - Chat: Add a "Pop out" button to the chat title bar that allows you to move Cody chat into a floating window. [pull/3773](https://github.com/sourcegraph/cody/pull/3773)
+  feat(vscode): add copy extension version command
+- Sidebar: A new button to copy the current Cody extension version to the clipboard shows up next to the Release Notes item in the SETTINGS & SUPPORT sidebar on hover. This is useful for reporting issues or getting information about the installed version. [pull/3802](https://github.com/sourcegraph/cody/pull/3802)
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -540,6 +540,13 @@
         "category": "Cody Debug",
         "group": "Debug",
         "title": "Report Issue"
+      },
+      {
+        "command": "cody.copy.version",
+        "category": "Cody Debug",
+        "group": "Debug",
+        "icon": "$(copy)",
+        "title": "Copy Cody Extension Version"
       }
     ],
     "keybindings": [
@@ -847,6 +854,11 @@
           "command": "cody.chat.history.delete",
           "when": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory && viewItem == cody.chats",
           "group": "inline@2"
+        },
+        {
+          "command": "cody.copy.version",
+          "when": "view == cody.support.tree.view && viewItem == cody.version",
+          "group": "inline@1"
         }
       ],
       "terminal/context": [

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -15,7 +15,6 @@ import {
     setLogger,
 } from '@sourcegraph/cody-shared'
 
-import { openCodyIssueReporter } from '../webviews/utils/reportIssue'
 import { ContextProvider } from './chat/ContextProvider'
 import type { MessageProviderOptions } from './chat/MessageProvider'
 import { ChatManager, CodyChatPanelViewType } from './chat/chat-view/ChatManager'
@@ -65,8 +64,10 @@ import { createOrUpdateEventLogger, telemetryService } from './services/telemetr
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
 import { onTextDocumentChange } from './services/utils/codeblock-action-tracker'
 import { enableDebugMode, exportOutputLog, openCodyOutputChannel } from './services/utils/export-logs'
+import { openCodyIssueReporter } from './services/utils/issue-reporter'
 import { SupercompletionProvider } from './supercompletions/supercompletion-provider'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
+import { version } from './version'
 
 /**
  * Start the extension, watching all relevant configuration and secrets for changes.
@@ -407,6 +408,9 @@ const register = async (
             vscode.commands.executeCommand('workbench.action.openSettings', {
                 query: '@ext:sourcegraph.cody-ai chat',
             })
+        ),
+        vscode.commands.registerCommand('cody.copy.version', () =>
+            vscode.env.clipboard.writeText(version)
         ),
 
         // Account links

--- a/vscode/src/services/tree-views/TreeViewProvider.ts
+++ b/vscode/src/services/tree-views/TreeViewProvider.ts
@@ -93,6 +93,7 @@ export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem
                 title: item.title,
                 arguments: item.command.args,
             }
+            treeItem.contextValue = item.contextValue
 
             updatedTree.push(treeItem)
         }

--- a/vscode/src/services/tree-views/support-items.ts
+++ b/vscode/src/services/tree-views/support-items.ts
@@ -1,0 +1,63 @@
+import { releaseType } from '../../release'
+import { version } from '../../version'
+import type { CodySidebarTreeItem } from './treeViewItems'
+
+export const SupportSidebarItems: CodySidebarTreeItem[] = [
+    {
+        title: 'Upgrade',
+        description: 'Upgrade to Pro',
+        icon: 'zap',
+        command: { command: 'cody.show-page', args: ['upgrade'] },
+        requireDotCom: true,
+        requireUpgradeAvailable: true,
+    },
+    {
+        title: 'Usage',
+        icon: 'pulse',
+        command: { command: 'cody.show-page', args: ['usage'] },
+        requireDotCom: true,
+    },
+    {
+        title: 'Settings',
+        icon: 'settings-gear',
+        command: { command: 'cody.sidebar.settings' },
+    },
+    {
+        title: 'Keyboard Shortcuts',
+        icon: 'keyboard',
+        command: { command: 'cody.sidebar.keyboardShortcuts' },
+    },
+    {
+        title: `${releaseType(version) === 'stable' ? 'Release' : 'Pre-Release'} Notes`,
+        description: `v${version}`,
+        icon: 'github',
+        command: { command: 'cody.sidebar.releaseNotes' },
+        contextValue: 'cody.version',
+    },
+    {
+        title: 'Documentation',
+        icon: 'book',
+        command: { command: 'cody.sidebar.documentation' },
+    },
+    {
+        title: 'Support',
+        icon: 'question',
+        command: { command: 'cody.sidebar.support' },
+        requirePaid: true,
+    },
+    {
+        title: 'Feedback',
+        icon: 'feedback',
+        command: { command: 'cody.sidebar.feedback' },
+    },
+    {
+        title: 'Discord',
+        icon: 'organization',
+        command: { command: 'cody.sidebar.discord' },
+    },
+    {
+        title: 'Account',
+        icon: 'account',
+        command: { command: 'cody.sidebar.account' },
+    },
+]

--- a/vscode/src/services/tree-views/treeViewItems.ts
+++ b/vscode/src/services/tree-views/treeViewItems.ts
@@ -1,7 +1,5 @@
 import type { FeatureFlag } from '@sourcegraph/cody-shared'
-
-import { releaseType } from '../../release'
-import { version } from '../../version'
+import { SupportSidebarItems } from './support-items'
 
 export type CodyTreeItemType = 'command' | 'support' | 'search' | 'chat'
 
@@ -14,6 +12,7 @@ export interface CodySidebarTreeItem {
         command: string
         args?: string[] | { [key: string]: string }[]
     }
+    contextValue?: string
     isNestedItem?: boolean
     requireFeature?: FeatureFlag
     requireUpgradeAvailable?: boolean
@@ -27,67 +26,8 @@ export interface CodySidebarTreeItem {
 export function getCodyTreeItems(type: CodyTreeItemType): CodySidebarTreeItem[] {
     switch (type) {
         case 'support':
-            return supportItems
+            return SupportSidebarItems
         default:
             return []
     }
 }
-
-const supportItems: CodySidebarTreeItem[] = [
-    {
-        title: 'Upgrade',
-        description: 'Upgrade to Pro',
-        icon: 'zap',
-        command: { command: 'cody.show-page', args: ['upgrade'] },
-        requireDotCom: true,
-        requireUpgradeAvailable: true,
-    },
-    {
-        title: 'Usage',
-        icon: 'pulse',
-        command: { command: 'cody.show-page', args: ['usage'] },
-        requireDotCom: true,
-    },
-    {
-        title: 'Settings',
-        icon: 'settings-gear',
-        command: { command: 'cody.sidebar.settings' },
-    },
-    {
-        title: 'Keyboard Shortcuts',
-        icon: 'keyboard',
-        command: { command: 'cody.sidebar.keyboardShortcuts' },
-    },
-    {
-        title: `${releaseType(version) === 'stable' ? 'Release' : 'Pre-Release'} Notes`,
-        description: `v${version}`,
-        icon: 'github',
-        command: { command: 'cody.sidebar.releaseNotes' },
-    },
-    {
-        title: 'Documentation',
-        icon: 'book',
-        command: { command: 'cody.sidebar.documentation' },
-    },
-    {
-        title: 'Support',
-        icon: 'question',
-        command: { command: 'cody.sidebar.support' },
-        requirePaid: true,
-    },
-    {
-        title: 'Feedback',
-        icon: 'feedback',
-        command: { command: 'cody.sidebar.feedback' },
-    },
-    {
-        title: 'Discord',
-        icon: 'organization',
-        command: { command: 'cody.sidebar.discord' },
-    },
-    {
-        title: 'Account',
-        icon: 'account',
-        command: { command: 'cody.sidebar.account' },
-    },
-]

--- a/vscode/src/services/utils/issue-reporter.ts
+++ b/vscode/src/services/utils/issue-reporter.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 
-import packageJson from '../../package.json'
+import packageJson from '../../../package.json'
+import { version } from '../../version'
 
 export function openCodyIssueReporter() {
     void vscode.commands.executeCommand('workbench.action.openIssueReporter', {
@@ -12,7 +13,7 @@ export function openCodyIssueReporter() {
 
 const issueBody = `## Extension Information
 <!-- Do not remove the pre-filled information below -->
-- Cody Version: ${packageJson.version}
+- Cody Version: ${version}
 - VS Code Version: ${vscode.version}
 - Extension Host: ${vscode.env.appHost}
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/3658

![image](https://github.com/sourcegraph/cody/assets/68532117/1d08d30b-5d82-49ec-afd5-ff15eb577fad)

This pull request introduces a new command `cody.copy.version` that allows users to copy the current version of the Cody extension to their clipboard. This can be helpful when reporting issues or seeking support, as providing the extension version is often necessary for troubleshooting purposes.

## Changes summary

Update package.json:

- Add a new command entry for cody.copy.version under the "Cody Debug" category with an appropriate icon and title.
- Add a new keybinding for the cody.copy.version command in the "cody.support.tree.view" context.

Modify main.ts:

- Import the version constant from the ./version module.
- Register the cody.copy.version command, which uses vscode.env.clipboard.writeText to copy the extension version to the clipboard.

Update TreeViewProvider.ts:

- Set the contextValue property on the tree item based on the provided item.contextValue value.

Modify treeViewItems.ts:

- Moved SupportSidebarItems into its own file `./support-items`.
- Added contextValue as an optional field for SupportSidebarItems

Updated issue-reporter.ts

- Moved it from its current location into src/utils.ts
- Use the `version` number from the function that gets the current extension version number instead of package.json

These changes add a convenient way for users to access and copy the Cody extension version, which can aid in troubleshooting and support scenarios. The new command is accessible through the command palette and the Cody support sidebar view.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

![copy-version](https://github.com/sourcegraph/cody/assets/68532117/f4e56209-4b24-4d82-be96-b480698eb3b4)

1. Build from this branch and start it in debug mode
2. Hover over the release note item in the support sidebar to verify:
  - A copy button shows up on hover
  - Clicking on the copy button will copy the version number listed on the sidebar

## Demo

https://github.com/sourcegraph/cody/assets/68532117/051e0867-9a41-4735-902c-625d54656d7a

