### PR TITLE
Custom Command: Fix new custom command not working on sidebar click

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -18,6 +18,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Generate Unit Tests: Fixed an issue where Cody would generate tests for the wrong code in the file. [pull/3759](https://github.com/sourcegraph/cody/pull/3759)
 - Chat: Fixed an issue where changing the chat model did not update the token limit for the model. [pull/3762](https://github.com/sourcegraph/cody/pull/3762)
 - Edit: Large file warnings for @-mentions are now updated dynamically as you add or remove them. [pull/3767](https://github.com/sourcegraph/cody/pull/3767)
+- Custom Commands: Fixed an issue where newly added custom commands were not working when clicked in the sidebar tree view. [pull/3804](https://github.com/sourcegraph/cody/pull/3804)
 
 ### Changed
 

--- a/vscode/src/commands/services/custom-commands.ts
+++ b/vscode/src/commands/services/custom-commands.ts
@@ -98,6 +98,16 @@ export class CustomCommandsManager implements vscode.Disposable {
     }
 
     /**
+     * Gets the map of custom commands.
+     *
+     * The custom commands map is a collection of CodyCommand objects, where the key
+     * is the command name and the value is the command object.
+     */
+    public get commands(): Map<string, CodyCommand> {
+        return this.customCommandsMap
+    }
+
+    /**
      * Get the uri of the cody.json file for the given type
      */
     private getConfigFileByType(type: CustomCommandType): vscode.Uri | undefined {

--- a/vscode/src/commands/services/provider.ts
+++ b/vscode/src/commands/services/provider.ts
@@ -36,7 +36,9 @@ export class CommandsProvider implements vscode.Disposable {
             vscode.commands.registerCommand('cody.menu.commands', a => this?.menu('default', a)),
             vscode.commands.registerCommand('cody.menu.custom-commands', a => this?.menu('custom', a)),
             vscode.commands.registerCommand('cody.menu.commands-settings', a => this?.menu('config', a)),
-            vscode.commands.registerCommand('cody.commands.open.doc', () => openCustomCommandDocsLink())
+            vscode.commands.registerCommand('cody.commands.open.doc', () => openCustomCommandDocsLink()),
+            // Update the custom commands when the tree view is refreshed
+            this.treeViewProvider.onDidChangeTreeData(() => this.getCustomCommands())
         )
 
         this.customCommandsStore.init()
@@ -61,7 +63,7 @@ export class CommandsProvider implements vscode.Disposable {
     }
 
     protected async getCustomCommands(): Promise<Map<string, CodyCommand>> {
-        const { commands } = await this.customCommandsStore.refresh()
+        const commands = this.customCommandsStore.commands
         this.groupCommands(commands)
         return commands
     }

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -88,9 +88,18 @@ test.extend<ExpectedEvents>({
     await expect(page.getByText('Workspace Settings.vscode/cody.json')).toBeVisible()
     await page.getByText('Workspace Settings.vscode/cody.json').click()
 
+    // The new command shows up in the sidebar and works on clicks
+    await expect(page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a')).toBeVisible()
+    await page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a').click()
+    // Confirm the command prompt is displayed in the chat panel on execution
+    const chatPanel = page.frameLocator('iframe.webview').last().frameLocator('iframe')
+    await expect(chatPanel.getByText(prompt)).toBeVisible()
+    // Close the index.html file
+    await page.getByRole('tab', { name: 'index.html' }).hover()
+    await page.getByLabel('index.html', { exact: true }).getByLabel(/Close/).click()
+
     // Check if cody.json in the workspace has the new command added
     await sidebarExplorer(page).click()
-    await page.getByText('index.html').first().click()
     await page.getByLabel('.vscode', { exact: true }).hover()
     await page.getByLabel('.vscode', { exact: true }).click()
     await page.getByRole('treeitem', { name: 'cody.json' }).locator('a').hover()
@@ -100,7 +109,6 @@ test.extend<ExpectedEvents>({
     await page.locator('canvas').nth(2).click()
     await page.getByText(commandName).hover()
     await expect(page.getByText(commandName)).toBeVisible()
-    await page.getByText('index.html').first().click()
 
     // Show the new command in the menu and execute it
     await page.click('.badge[aria-label="Cody"]')
@@ -109,16 +117,8 @@ test.extend<ExpectedEvents>({
     await expect(page.getByText('Cody: Custom Commands (Beta)')).toBeVisible()
     await page.getByPlaceholder('Search command to run...').click()
     await page.getByPlaceholder('Search command to run...').fill(commandName)
-
     // The new command should show up in sidebar and on the menu
     expect((await page.getByText(commandName).all()).length).toBeGreaterThan(1)
-    // The new command shows up in the sidebar
-    await expect(page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a')).toBeVisible()
-    // Click the new command on the menu to execute it
-    await page.getByLabel('tools  ATestCommand, The test command has been created').click()
-    // Confirm the command prompt is displayed in the chat panel on execution
-    const chatPanel = page.frameLocator('iframe.webview').last().frameLocator('iframe')
-    await expect(chatPanel.getByText(prompt)).toBeVisible()
 })
 
 // NOTE: If no custom commands are showing up in the command menu, it might


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/3805

This pull request addresses an issue where newly added custom commands were not working when clicked in the sidebar tree view. 

The root cause of the problem was that the commands map was not being refreshed when new commands were added or existing ones were modified.

To fix this issue, the following changes were made:

vscode/src/commands/services/custom-commands.ts:

- Added a new getter method commands that returns the customCommandsMap.
- This getter provides a convenient way to access the up-to-date custom commands map from outside the CustomCommandsManager class.

vscode/src/commands/services/provider.ts:

- Replaced the getCustomCommands method to use the new commands getter from CustomCommandsManager.
- Added an event listener to the treeViewProvider to refresh the custom commands when the tree view data changes.

With these changes, the CommandsProvider now listens for changes in the tree view data and refreshes the custom commands map accordingly. 

This ensures that any newly added or modified custom commands are immediately available and functional when clicked in the sidebar tree view.

Updated E2E test to cover executing command from sidebar click

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Run this branch in debug mode
2. Add a new Custom Command by editing the .vscode/cody.json file
3. Click on the newly created custom command to verify it's working as intended.

### Before


https://github.com/sourcegraph/cody/assets/68532117/2f6014b2-fc3d-44de-8a66-55f91959e1da


### After

https://github.com/sourcegraph/cody/assets/68532117/d277dd94-4358-4ee6-b2a1-b5563e984d2c

