### PR TITLE
use vscode-jsonrpc library for JSON-RPC implementation

### DIFF
--- a/agent/scripts/test-agent-binary.ts
+++ b/agent/scripts/test-agent-binary.ts
@@ -30,13 +30,11 @@ async function main() {
 
     const osArch = getOSArch()
 
-    const client = new TestClient(
-        {
-            name: 'defaultClient',
-            accessToken,
-        },
-        './dist/agent-' + osArch
-    )
+    const client = TestClient.create({
+        name: 'defaultClient',
+        bin: './dist/agent-' + osArch,
+        accessToken,
+    })
 
     await client.initialize({
         serverEndpoint: serverEndpoint,

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert'
 
 import { createPatch } from 'diff'
 
-import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import fspromises from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
@@ -11,6 +11,12 @@ import dedent from 'dedent'
 import { applyPatch } from 'fast-myers-diff'
 import * as vscode from 'vscode'
 import { Uri } from 'vscode'
+import {
+    type MessageConnection,
+    StreamMessageReader,
+    StreamMessageWriter,
+    createMessageConnection,
+} from 'vscode-jsonrpc/node'
 import type { ExtensionMessage, ExtensionTranscriptMessage } from '../../vscode/src/chat/protocol'
 import { doesFileExist } from '../../vscode/src/commands/utils/workspace-files'
 import { ProtocolTextDocumentWithUri } from '../../vscode/src/jsonrpc/TextDocumentWithUri'
@@ -54,9 +60,63 @@ interface ProgressEndMessage {
     message: Record<string, never>
 }
 
+export function getAgentDir(): string {
+    const cwd = process.cwd()
+    return path.basename(cwd) === 'agent' ? cwd : path.join(cwd, 'agent')
+}
+
+interface TestClientParams {
+    readonly name: string
+    readonly accessToken?: string
+    bin?: string
+    serverEndpoint?: string
+    telemetryExporter?: 'testing' | 'graphql' // defaults to testing, which doesn't send telemetry
+    areFeatureFlagsEnabled?: boolean // do not evaluate feature flags by default
+    logEventMode?: 'connected-instance-only' | 'all' | 'dotcom-only'
+    onWindowRequest?: (params: ShowWindowMessageParams) => Promise<string>
+}
+
 export class TestClient extends MessageHandler {
+    public static create({ bin = 'node', ...params }: TestClientParams): TestClient {
+        const agentDir = getAgentDir()
+        const recordingDirectory = path.join(agentDir, 'recordings')
+        const agentScript = path.join(agentDir, 'dist', 'index.js')
+
+        const args = bin === 'node' ? ['--enable-source-maps', agentScript, 'jsonrpc'] : ['jsonrpc']
+
+        const child = spawn(bin, args, {
+            stdio: 'pipe',
+            cwd: agentDir,
+            env: {
+                CODY_SHIM_TESTING: 'true',
+                CODY_TEMPERATURE_ZERO: 'true',
+                CODY_RECORDING_MODE: 'replay', // can be overwritten with process.env.CODY_RECORDING_MODE
+                CODY_RECORDING_DIRECTORY: recordingDirectory,
+                CODY_RECORDING_NAME: params.name,
+                SRC_ACCESS_TOKEN: params.accessToken,
+                CODY_TELEMETRY_EXPORTER: params.telemetryExporter ?? 'testing',
+                DISABLE_FEATURE_FLAGS: params.areFeatureFlagsEnabled ? undefined : 'true',
+                CODY_LOG_EVENT_MODE: params.logEventMode,
+                ...process.env,
+            },
+        })
+        child.on('error', error => console.error('TestClient spawn error:', error))
+        child.on('exit', code => {
+            if (code !== 0) {
+                console.error(`TestClient spawn exit code ${code}`)
+            }
+        })
+        child.stderr.on('data', data => {
+            console.error(`----stderr----\n${data}--------------`)
+        })
+        const conn = createMessageConnection(
+            new StreamMessageReader(child.stdout),
+            new StreamMessageWriter(child.stdin)
+        )
+        return new TestClient(conn, params)
+    }
+
     public info: ClientInfo
-    public agentProcess?: ChildProcessWithoutNullStreams
     // Array of all raw `progress/*` notification. Typed as `any` because
     // start/end/report have different types.
     public progressMessages: ProgressMessage[] = []
@@ -68,19 +128,14 @@ export class TestClient extends MessageHandler {
     public workspace = new AgentWorkspaceDocuments()
     public workspaceEditParams: WorkspaceEditParams[] = []
 
-    constructor(
-        private readonly params: {
-            readonly name: string
-            readonly accessToken?: string
-            serverEndpoint?: string
-            telemetryExporter?: 'testing' | 'graphql' // defaults to testing, which doesn't send telemetry
-            areFeatureFlagsEnabled?: boolean // do not evaluate feature flags by default
-            logEventMode?: 'connected-instance-only' | 'all' | 'dotcom-only'
-            onWindowRequest?: (params: ShowWindowMessageParams) => Promise<string>
-        },
-        private bin = 'node'
+    private constructor(
+        conn: MessageConnection,
+        public readonly params: Pick<
+            TestClientParams,
+            'name' | 'serverEndpoint' | 'accessToken' | 'onWindowRequest'
+        >
     ) {
-        super()
+        super(conn)
         this.serverEndpoint = params.serverEndpoint ?? 'https://sourcegraph.com'
 
         this.name = params.name
@@ -430,11 +485,6 @@ export class TestClient extends MessageHandler {
     }
 
     public async initialize(additionalConfig?: Partial<ExtensionConfiguration>): Promise<ServerInfo> {
-        this.agentProcess = this.spawnAgentProcess()
-
-        this.connectProcess(this.agentProcess, error => {
-            console.error(error)
-        })
         this.registerNotification('editTask/didUpdate', params => {
             this.taskUpdate.fire(params)
         })
@@ -446,6 +496,8 @@ export class TestClient extends MessageHandler {
             this.webviewMessages.push(params)
             this.webviewMessagesEmitter.fire(params)
         })
+
+        this.conn.listen()
 
         try {
             const serverInfo = await this.handshake(this.info, additionalConfig)
@@ -615,13 +667,8 @@ ${patch}`
             await this.request('shutdown', null)
             this.notify('exit', null)
         } else {
-            console.log('Agent has already exited')
+            console.error('Agent has already exited')
         }
-    }
-
-    public getAgentDir(): string {
-        const cwd = process.cwd()
-        return path.basename(cwd) === 'agent' ? cwd : path.join(cwd, 'agent')
     }
 
     private async handshake(
@@ -656,32 +703,6 @@ ${patch}`
                 },
                 error => reject(error)
             )
-        })
-    }
-
-    private spawnAgentProcess() {
-        const agentDir = this.getAgentDir()
-        const recordingDirectory = path.join(agentDir, 'recordings')
-        const agentScript = path.join(agentDir, 'dist', 'index.js')
-
-        const bin = this.bin
-        const args = bin === 'node' ? ['--enable-source-maps', agentScript, 'jsonrpc'] : ['jsonrpc']
-
-        return spawn(bin, args, {
-            stdio: 'pipe',
-            cwd: agentDir,
-            env: {
-                CODY_SHIM_TESTING: 'true',
-                CODY_TEMPERATURE_ZERO: 'true',
-                CODY_RECORDING_MODE: 'replay', // can be overwritten with process.env.CODY_RECORDING_MODE
-                CODY_RECORDING_DIRECTORY: recordingDirectory,
-                CODY_RECORDING_NAME: this.name,
-                SRC_ACCESS_TOKEN: this.accessToken,
-                CODY_TELEMETRY_EXPORTER: this.params.telemetryExporter ?? 'testing',
-                DISABLE_FEATURE_FLAGS: this.params.areFeatureFlagsEnabled ? undefined : 'true',
-                CODY_LOG_EVENT_MODE: this.params.logEventMode,
-                ...process.env,
-            },
         })
     }
 

--- a/agent/src/cli/server.ts
+++ b/agent/src/cli/server.ts
@@ -30,9 +30,10 @@ export const serverCommand = new Command('server')
                         version: '0.1.0',
                         workspaceRootUri: 'file:///tmp/cody-server',
                     })
-                    agent.fallbackHandler = async msg => {
-                        ws.send(JSON.stringify(msg))
-                    }
+                    // TODO(olafurpg/sqs): reimplement with vscode-jsonrpc
+                    // agent.fallbackHandler = async msg => {
+                    //     ws.send(JSON.stringify(msg))
+                    // }
                     const initialized = await agent.request('extensionConfiguration/change', {
                         accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalidtoken',
                         serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalidendpoint',
@@ -41,7 +42,8 @@ export const serverCommand = new Command('server')
                     console.log({ initialized })
                 }
 
-                agent.messageEncoder.send(JSON.parse(String(data)))
+                // TODO(olafurpg/sqs): reimplement with vscode-jsonrpc
+                // agent.messageEncoder.send(JSON.parse(String(data)))
             })
         })
     })

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   "dependencies": {
     "ignore": "^5.3.1",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "vscode-jsonrpc": "^8.2.0"
   },
   "packageManager": "pnpm@8.6.7",
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
+      vscode-jsonrpc:
+        specifier: ^8.2.0
+        version: 8.2.0
     devDependencies:
       '@biomejs/biome':
         specifier: 1.5.2
@@ -13668,6 +13671,11 @@ packages:
   /vlq@0.2.3:
     resolution: {integrity: sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==}
     dev: true
+
+  /vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+    dev: false
 
   /vscode-languageserver-textdocument@1.0.8:
     resolution: {integrity: sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==}

--- a/vscode/src/graph/bfg/spawn-bfg.ts
+++ b/vscode/src/graph/bfg/spawn-bfg.ts
@@ -2,16 +2,15 @@ import * as child_process from 'node:child_process'
 
 import * as vscode from 'vscode'
 
+import { StreamMessageReader, StreamMessageWriter, createMessageConnection } from 'vscode-jsonrpc/node'
 import { MessageHandler } from '../../jsonrpc/jsonrpc'
 import { logDebug } from '../../log'
-
 import { downloadBfg } from './download-bfg'
 
 export async function spawnBfg(
     context: vscode.ExtensionContext,
     reject: (reason?: any) => void
 ): Promise<MessageHandler> {
-    const bfg = new MessageHandler()
     const codyrpc = await downloadBfg(context)
     if (!codyrpc) {
         throw new Error(
@@ -39,7 +38,12 @@ export async function spawnBfg(
         reject(code)
     })
     child.stderr.pipe(process.stderr)
-    child.stdout.pipe(bfg.messageDecoder)
-    bfg.messageEncoder.pipe(child.stdin)
+
+    const conn = createMessageConnection(
+        new StreamMessageReader(child.stdout),
+        new StreamMessageWriter(child.stdin)
+    )
+    const bfg = new MessageHandler(conn)
+    conn.listen()
     return bfg
 }

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -1,13 +1,8 @@
-import assert from 'node:assert'
-import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { appendFileSync, existsSync, mkdirSync, rmSync } from 'node:fs'
 import { dirname } from 'node:path'
-import { Readable, Writable } from 'node:stream'
 
 import * as vscode from 'vscode'
-
-import { isRateLimitError, logError } from '@sourcegraph/cody-shared'
-
+import { type MessageConnection, Trace } from 'vscode-jsonrpc'
 import type * as agent from './agent-protocol'
 import type * as bfg from './bfg-protocol'
 import type * as contextRanking from './context-ranking-protocol'
@@ -18,14 +13,6 @@ type Notifications = bfg.Notifications &
     agent.Notifications &
     embeddings.Notifications &
     contextRanking.Notifications
-
-// This file is a standalone implementation of JSON-RPC for Node.js
-// ReadStream/WriteStream, which conventionally map to stdin/stdout.
-// The code assumes familiarity with the JSON-RPC specification as documented
-// here https://www.jsonrpc.org/specification
-// To learn more about how JSON-RPC protocols work, the LSP specification is
-// also a good read
-// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
 
 // String literal types for the names of the Cody Agent protocol methods.
 export type RequestMethodName = keyof Requests
@@ -39,212 +26,11 @@ type ParamsOf<K extends MethodName> = (Requests & Notifications)[K][0]
 // Request result types. Note: notifications don't return values.
 type ResultOf<K extends RequestMethodName> = Requests[K][1]
 
-type Id = string | number
-
-// Error codes as defined by the JSON-RPC spec.
-enum ErrorCode {
-    ParseError = -32700,
-    InvalidRequest = -32600,
-    MethodNotFound = -32601,
-    InvalidParams = -32602,
-    InternalError = -32603,
-    RequestCanceled = -32604,
-    RateLimitError = -32000,
-}
-
-// Result of an erroneous request, which populates the `error` property instead
-// of `result` for successful results.
-interface ErrorInfo<T> {
-    code: ErrorCode
-    message: string
-    data: T
-}
-
-class JsonrpcError extends Error {
-    constructor(public readonly info: ErrorInfo<any>) {
-        super()
-    }
-    public toString(): string {
-        return `${this.name}: ${this.message}`
-    }
-    public get name(): string {
-        return ErrorCode[this.info.code]
-    }
-    public get message(): string {
-        if (typeof this.info?.data === 'string') {
-            try {
-                const data = JSON.parse(this.info.data)
-                return `${this.info.message}: ${JSON.stringify(data, null, 2)}`
-            } catch {
-                // ignore
-            }
-            return `${this.info.message}: ${this.info.data}`
-        }
-        return this.info.message
-    }
-}
-
-// The three different kinds of toplevel JSON objects that get written to the
-// wire: requests, request responses, and notifications.
-interface RequestMessage<M extends RequestMethodName> {
-    jsonrpc: '2.0'
-    id: Id
-    method: M
-    params?: ParamsOf<M>
-}
-interface ResponseMessage<M extends RequestMethodName> {
-    jsonrpc: '2.0'
-    id: Id
-    result?: ResultOf<M>
-    error?: ErrorInfo<any>
-}
-interface NotificationMessage<M extends NotificationMethodName> {
-    jsonrpc: '2.0'
-    method: M
-    params?: ParamsOf<M>
-}
-type Message = RequestMessage<any> & ResponseMessage<any> & NotificationMessage<any>
-
-type MessageHandlerCallback = (err: Error | null, msg: Message | null) => void
-
 /**
  * Absolute path to a file where the agent can write low-level debugging logs to
  * trace all incoming/outgoing JSON messages.
  */
 const tracePath = process.env.CODY_AGENT_TRACE_PATH ?? ''
-
-class MessageDecoder extends Writable {
-    private buffer: Buffer = Buffer.alloc(0)
-    private contentLengthRemaining: number | null = null
-    private contentBuffer: Buffer = Buffer.alloc(0)
-
-    constructor(public callback: MessageHandlerCallback) {
-        super()
-        if (tracePath) {
-            if (existsSync(tracePath)) {
-                rmSync(tracePath)
-            }
-            mkdirSync(dirname(tracePath), { recursive: true })
-        }
-    }
-
-    public _write(chunk: Buffer, encoding: string, callback: (error?: Error | null) => void): void {
-        this.buffer = Buffer.concat([this.buffer, chunk])
-
-        // We loop through as we could have a double message that requires processing twice
-        read: while (true) {
-            if (this.contentLengthRemaining === null) {
-                const headerString = this.buffer.toString()
-
-                let startIndex = 0
-                let endIndex: number
-
-                // We create this as we might get partial messages
-                // so we only want to set the content length
-                // once we get the whole thing
-                let newContentLength = 0
-
-                const LINE_TERMINATOR = '\r\n'
-
-                // biome-ignore lint/suspicious/noAssignInExpressions: useful
-                while ((endIndex = headerString.indexOf(LINE_TERMINATOR, startIndex)) !== -1) {
-                    const entry = headerString.slice(startIndex, endIndex)
-                    const [headerName, headerValue] = entry.split(':').map(_ => _.trim())
-
-                    if (headerValue === undefined) {
-                        this.buffer = this.buffer.slice(endIndex + LINE_TERMINATOR.length)
-
-                        // Asserts we actually have a valid header with a Content-Length
-                        // This state is irrecoverable because the stream is polluted
-                        // Also what is the client doing 😭
-                        this.contentLengthRemaining = newContentLength
-                        assert(
-                            Number.isFinite(this.contentLengthRemaining),
-                            `parsed Content-Length ${this.contentLengthRemaining} is not a finite number`
-                        )
-                        continue read
-                    }
-
-                    switch (headerName) {
-                        case 'Content-Length':
-                            newContentLength = parseInt(headerValue, 10)
-                            break
-
-                        default:
-                            console.error(`Unknown header '${headerName}': ignoring!`)
-                            break
-                    }
-
-                    startIndex = endIndex + LINE_TERMINATOR.length
-                }
-
-                break
-            }
-            if (this.contentLengthRemaining === 0) {
-                try {
-                    const data = JSON.parse(this.contentBuffer.toString())
-                    this.contentBuffer = Buffer.alloc(0)
-                    this.contentLengthRemaining = null
-                    if (tracePath) {
-                        appendFileSync(tracePath, `<- ${JSON.stringify(data, null, 4)}\n`)
-                    }
-                    this.callback(null, data)
-                } catch (error: any) {
-                    if (tracePath) {
-                        appendFileSync(tracePath, `<- ${JSON.stringify({ error }, null, 4)}\n`)
-                    }
-                    process.stderr.write(
-                        `jsonrpc.ts: JSON parse error against input '${this.contentBuffer}', contentLengthRemaining=${this.contentLengthRemaining}. Error:\n${error}\n`
-                    )
-                    // Kill the process to surface the error as early as
-                    // possible. Before, we did `this.callback(error, null)`
-                    // and it regularly got the agent into an infinite loop
-                    // that was difficult to debug.
-                    process.exit(1)
-                }
-
-                continue
-            }
-
-            const data = this.buffer.slice(0, this.contentLengthRemaining)
-
-            // If there isn't anymore data, break out of the loop to wait
-            // for more chunks to be written to the stream.
-            if (data.length === 0) {
-                break
-            }
-
-            this.contentBuffer = Buffer.concat([this.contentBuffer, data])
-            this.buffer = this.buffer.slice(this.contentLengthRemaining)
-
-            this.contentLengthRemaining -= data.byteLength
-        }
-
-        callback()
-    }
-}
-
-class MessageEncoder extends Readable {
-    private buffer: Buffer = Buffer.alloc(0)
-
-    public send(data: any): void {
-        if (tracePath) {
-            appendFileSync(tracePath, `-> ${JSON.stringify(data, null, 4)}\n`)
-        }
-        this.pause()
-
-        const content = Buffer.from(JSON.stringify(data), 'utf-8')
-        const header = Buffer.from(`Content-Length: ${content.byteLength}\r\n\r\n`, 'utf-8')
-        this.buffer = Buffer.concat([this.buffer, header, content])
-
-        this.resume()
-    }
-
-    public _read(size: number): void {
-        this.push(this.buffer.slice(0, size))
-        this.buffer = this.buffer.slice(size)
-    }
-}
 
 export type RequestCallback<M extends RequestMethodName> = (
     params: ParamsOf<M>,
@@ -254,187 +40,40 @@ type NotificationCallback<M extends NotificationMethodName> = (
     params: ParamsOf<M>
 ) => void | Promise<void>
 
-/**
- * Only exported API in this file. MessageHandler exposes a public `messageDecoder` property
- * that can be piped with ReadStream/WriteStream.
- */
 export class MessageHandler {
-    public id = 0
-    public requestHandlers: Map<RequestMethodName, RequestCallback<any>> = new Map()
-    private cancelTokens: Map<Id, vscode.CancellationTokenSource> = new Map()
-    private notificationHandlers: Map<NotificationMethodName, NotificationCallback<any>> = new Map()
-    private alive = true
-    private processExitedError: () => Error = () => new Error('Process has exited')
-    private responseHandlers: Map<
-        Id,
-        {
-            resolve: (params: any) => void
-            reject: (params: Error) => void
+    // Tracked for `clientForThisInstance` only.
+    private readonly requestHandlers = new Map<RequestMethodName, RequestCallback<any>>()
+    private readonly notificationHandlers = new Map<NotificationMethodName, NotificationCallback<any>>()
+
+    private disposables: vscode.Disposable[] = []
+
+    constructor(public readonly conn: MessageConnection) {
+        this.disposables.push(
+            conn.onClose(() => {
+                this.alive = false
+            })
+        )
+        if (tracePath) {
+            if (existsSync(tracePath)) {
+                rmSync(tracePath)
+            }
+            mkdirSync(dirname(tracePath), { recursive: true })
+            conn.trace(Trace.Verbose, {
+                log: (messageOrDataObject: string, data?: string) => {
+                    appendFileSync(tracePath, `${messageOrDataObject} ${data}\n`)
+                },
+            })
         }
-    > = new Map()
-    public fallbackHandler?: (msg: any) => void = msg => {}
-    public isAlive(): boolean {
-        return this.alive
     }
-    public exit(): void {
-        this.alive = false
-        const error = this.processExitedError()
-        for (const { reject } of this.responseHandlers.values()) {
-            reject(error)
-        }
-    }
-
-    public connectProcess(child: ChildProcessWithoutNullStreams, reject?: (error: Error) => void): void {
-        child.on('disconnect', () => {
-            reject?.(new Error('disconnect'))
-            this.exit()
-        })
-        child.on('close', () => {
-            if (this.isAlive()) {
-                reject?.(new Error('close'))
-            }
-            this.exit()
-        })
-        child.on('error', error => {
-            reject?.(error)
-            this.exit()
-        })
-        child.on('exit', code => {
-            if (code !== 0) {
-                reject?.(new Error(`exit: ${code}`))
-            }
-            this.exit()
-        })
-        child.stderr.on('data', data => {
-            console.error(`----stderr----\n${data}--------------`)
-        })
-        child.stdout.pipe(this.messageDecoder)
-        this.messageEncoder.pipe(child.stdin)
-    }
-
-    // TODO: RPC error handling
-    public messageDecoder: MessageDecoder = new MessageDecoder(
-        (err: Error | null, msg: Message | null) => {
-            if (err) {
-                console.error(`Error: ${err}`)
-            }
-            if (!msg) {
-                return
-            }
-
-            if (msg.id !== undefined && msg.method) {
-                if (typeof msg.id === 'number' && msg.id > this.id) {
-                    this.id = msg.id + 1
-                }
-
-                // Requests have ids and methods
-                const handler = this.requestHandlers.get(msg.method)
-                if (handler) {
-                    const cancelToken: vscode.CancellationTokenSource =
-                        new vscode.CancellationTokenSource()
-                    this.cancelTokens.set(msg.id, cancelToken)
-                    handler(msg.params, cancelToken.token)
-                        .then(
-                            result => {
-                                const data: ResponseMessage<any> = {
-                                    jsonrpc: '2.0',
-                                    id: msg.id,
-
-                                    result,
-                                }
-                                this.messageEncoder.send(data)
-                            },
-                            error => {
-                                const message = error instanceof Error ? error.message : `${error}`
-                                const stack = error instanceof Error ? `\n${error.stack}` : ''
-                                const code = cancelToken.token.isCancellationRequested
-                                    ? ErrorCode.RequestCanceled
-                                    : isRateLimitError(error)
-                                      ? ErrorCode.RateLimitError
-                                      : ErrorCode.InternalError
-                                const data: ResponseMessage<any> = {
-                                    jsonrpc: '2.0',
-                                    id: msg.id,
-                                    error: {
-                                        code,
-                                        // Include the stack in the message because
-                                        // some JSON-RPC bindings like lsp4j don't
-                                        // expose access to the `data` property,
-                                        // only `message`. The stack is super
-                                        // helpful to track down unexpected
-                                        // exceptions.
-                                        message: `${message}\n${stack}`,
-                                        data: JSON.stringify({ error, stack }),
-                                    },
-                                }
-                                this.messageEncoder.send(data)
-                            }
-                        )
-                        .finally(() => {
-                            this.cancelTokens.get(msg.id)?.dispose()
-                            this.cancelTokens.delete(msg.id)
-                        })
-                } else {
-                    if (this.fallbackHandler) {
-                        this.fallbackHandler(msg)
-                    } else {
-                        console.error(`No handler for request with method ${msg.method}`)
-                    }
-                }
-            } else if (msg.id !== undefined) {
-                // Responses have ids
-                const handler = this.responseHandlers.get(msg.id)
-                if (handler) {
-                    if (msg?.error) {
-                        handler.reject(new JsonrpcError(msg.error))
-                    } else {
-                        handler.resolve(msg.result)
-                    }
-                    this.responseHandlers.delete(msg.id)
-                } else {
-                    if (this.fallbackHandler) {
-                        this.fallbackHandler(msg)
-                    } else {
-                        console.error(`No handler for response with id ${msg.id}`)
-                    }
-                }
-            } else if (msg.method) {
-                // Notifications have methods
-                if (
-                    msg.method === '$/cancelRequest' &&
-                    msg.params &&
-                    (typeof msg.params.id === 'string' || typeof msg.params.id === 'number')
-                ) {
-                    this.cancelTokens.get(msg.params.id)?.cancel()
-                    this.cancelTokens.delete(msg.params.id)
-                } else {
-                    const notificationHandler = this.notificationHandlers.get(msg.method)
-                    if (notificationHandler) {
-                        try {
-                            void notificationHandler(msg.params)
-                        } catch (error) {
-                            logError(
-                                'JSON-RPC',
-                                `Uncaught error in notification handler for method '${msg.method}'`,
-                                error + (error instanceof Error ? '\n\n' + error.stack : '')
-                            )
-                        }
-                    } else {
-                        if (this.fallbackHandler) {
-                            this.fallbackHandler(msg)
-                        } else {
-                            console.error(`No handler for message with method ${msg.method}`)
-                        }
-                    }
-                }
-            }
-        }
-    )
-
-    public messageEncoder: MessageEncoder = new MessageEncoder()
 
     public registerRequest<M extends RequestMethodName>(method: M, callback: RequestCallback<M>): void {
         this.requestHandlers.set(method, callback)
+        this.disposables.push(
+            this.conn.onRequest(
+                method,
+                async (params, cancelToken) => await callback(params, cancelToken)
+            )
+        )
     }
 
     public registerNotification<M extends NotificationMethodName>(
@@ -442,78 +81,62 @@ export class MessageHandler {
         callback: NotificationCallback<M>
     ): void {
         this.notificationHandlers.set(method, callback)
+        this.disposables.push(this.conn.onNotification(method, params => callback(params)))
     }
 
-    public request<M extends RequestMethodName>(method: M, params: ParamsOf<M>): Promise<ResultOf<M>> {
-        if (!this.isAlive()) {
-            throw this.processExitedError()
-        }
-        const id = this.id++
-
-        const data: RequestMessage<M> = {
-            jsonrpc: '2.0',
-            id,
-            method,
-            params,
-        }
-        this.messageEncoder.send(data)
-
-        return new Promise((resolve, reject) => {
-            this.responseHandlers.set(id, { resolve, reject })
-        })
+    public async request<M extends RequestMethodName>(
+        method: M,
+        params: ParamsOf<M>
+    ): Promise<ResultOf<M>> {
+        return await this.conn.sendRequest(method, params)
     }
 
     public notify<M extends NotificationMethodName>(method: M, params: ParamsOf<M>): void {
-        if (!this.isAlive()) {
-            throw this.processExitedError()
-        }
-        const data: NotificationMessage<M> = {
-            jsonrpc: '2.0',
-            method,
-            params,
-        }
-        this.messageEncoder.send(data)
+        this.conn.sendNotification(method, params)
+    }
+
+    private alive = true
+    public isAlive(): boolean {
+        return this.alive
     }
 
     /**
      * @returns A JSON-RPC client to interact directly with this agent instance. Useful when we want
      * to use the agent in-process without stdout/stdin transport mechanism.
      */
-    public clientForThisInstance(): InProcessClient {
-        if (!this.isAlive()) {
-            throw this.processExitedError()
+    public clientForThisInstance(): Pick<MessageHandler, 'request' | 'notify'> {
+        return {
+            request: async <M extends RequestMethodName>(
+                method: M,
+                params: ParamsOf<M>,
+                cancelToken: vscode.CancellationToken = new vscode.CancellationTokenSource().token
+            ) => {
+                const handler = this.requestHandlers.get(method)
+                if (handler) {
+                    return await handler(params, cancelToken)
+                }
+                throw new Error(`No such request handler: ${method}`)
+            },
+            notify: <M extends NotificationMethodName>(method: M, params: ParamsOf<M>) => {
+                const handler = this.notificationHandlers.get(method)
+                if (handler) {
+                    handler(params)
+                }
+                throw new Error(`No such notification handler: ${method}`)
+            },
         }
-        return new InProcessClient(this.requestHandlers, this.notificationHandlers)
-    }
-}
-
-/**
- * A client for a JSON-RPC {@link MessageHandler} running in the same process.
- */
-class InProcessClient {
-    constructor(
-        private readonly requestHandlers: Map<RequestMethodName, RequestCallback<any>>,
-        private readonly notificationHandlers: Map<NotificationMethodName, NotificationCallback<any>>
-    ) {}
-
-    public request<M extends RequestMethodName>(
-        method: M,
-        params: ParamsOf<M>,
-        cancelToken: vscode.CancellationToken = new vscode.CancellationTokenSource().token
-    ): Promise<ResultOf<M>> {
-        const handler = this.requestHandlers.get(method)
-        if (handler) {
-            return handler(params, cancelToken)
-        }
-        throw new Error(`No such request handler: ${method}`)
     }
 
-    public notify<M extends NotificationMethodName>(method: M, params: ParamsOf<M>): void {
-        const handler = this.notificationHandlers.get(method)
-        if (handler) {
-            void handler(params)
-            return
+    public exit(): void {
+        this.conn.end()
+        this.dispose()
+    }
+
+    public dispose(): void {
+        this.alive = false
+        for (const disposable of this.disposables) {
+            disposable.dispose()
         }
-        throw new Error(`No such notification handler: ${method}`)
+        this.disposables = []
     }
 }


### PR DESCRIPTION
The [vscode-jsonrpc](https://www.npmjs.com/package/vscode-jsonrpc) library is from the VS Code team and is used by many VS Code extensions and language servers to implement the JSON-RPC 2.0 protocol. It is well tested, heavily used, actively maintained, and supports both Node and Web platforms.

Using this library means we can remove our own implementation of the protocol, which is (a) less code to maintain, (b) does not support the browser, and (c) is not spec-compliant (for example, it supports string values as request parameters, which are disallowed by the [JSON-RPC 2.0 spec](https://www.jsonrpc.org/specification#request_object)).

## Test plan

1. CI
2. Manually ran BFG (cody-engine) tests and confirm that `embeddings/set-token` works in the output channel
3. Manually tested with the CLI
4. Test with JetBrains
5. Compare protocol traffic by `diff -u`'ing the `build/sourcegraph/cody-agent-trace.json` files between runs of `./gradlew -PforceAgentBuild=true :runIDE` and `CODY_DIR=$PWD/../cody ./gradlew -PforceAgentBuild=true :runIDE`: the traces are identical (except for timing, timestamps, and non-important ordering) for a session with autocomplete and chat interactions.
6. QA test on JetBrains: https://github.com/sourcegraph/jetbrains/pull/1356 - [Slack thread](https://sourcegraph.slack.com/archives/C06GFD8GFCN/p1713601212183189)