### PR TITLE
PromptString linter: Only error when the reported violation is within one of the changed range

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -33,8 +33,7 @@ jobs:
           restore-keys: ${{ runner.os }}-20-pnpm-store-
       - run: pnpm install
       - name: Run lints
-        # We might want to use parallel here to batch if we run into command lengths issues
-        run: pnpm ts-node lints/safe-prompts.ts `git diff --name-only origin/main | grep -E "\.(ts|tsx)$"`
+        run: pnpm ts-node lints/safe-prompts.ts `pnpm ts-node lints/git-diff-ts-ranges.ts`
       - uses: actions/github-script@v6
         if: ${{ failure() }}
         with:

--- a/lints/git-diff-ts-ranges.ts
+++ b/lints/git-diff-ts-ranges.ts
@@ -1,0 +1,51 @@
+import { exec } from 'node:child_process'
+
+const EXTENSIONS = ['ts', 'tsx']
+
+exec('git diff --unified=0 origin/main', (error, stdout, stderr) => {
+    if (error) {
+        console.error(`exec error: ${error}`)
+        return
+    }
+    if (stderr) {
+        console.error(`stderr: ${stderr}`)
+        return
+    }
+
+    // Process the output
+    const lines = stdout.split('\n')
+    let currentFile = ''
+    const fileRanges: { [key: string]: string[] } = {}
+
+    for (const line of lines) {
+        if (line.startsWith('diff --git')) {
+            // Extract the filename correctly after the b/ prefix
+            const parts = line.split(' ')
+            currentFile = parts[2].substring(2) // Remove the 'b/' prefix
+        } else if (line.startsWith('@@')) {
+            // Extract the line numbers for additions
+            const match = line.match(/\+([0-9]+),?([0-9]*)/)
+            if (match) {
+                const start = parseInt(match[1], 10)
+                const count = parseInt(match[2] || '1', 10)
+                const end = start + count - 1
+                if (count > 0) {
+                    // Ensure we only add ranges where lines were added
+                    if (!fileRanges[currentFile]) {
+                        fileRanges[currentFile] = []
+                    }
+                    fileRanges[currentFile].push(`${start}-${end}`)
+                }
+            }
+        }
+    }
+
+    // Output the results
+    for (const [file, ranges] of Object.entries(fileRanges)) {
+        if (!EXTENSIONS.includes(file.split('.').pop() || '')) {
+            continue
+        }
+
+        console.log(`${file}:${ranges.join(',')}`)
+    }
+})

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1255,3 +1255,6 @@ function newChatModelFromSerializedChatTranscript(
 function isAbortError(error: Error): boolean {
     return error.message === 'aborted' || error.message === 'socket hang up'
 }
+
+// Only this unsafe usage should be report
+PromptString.unsafe_fromUserQuery('EVIL!')

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1255,6 +1255,3 @@ function newChatModelFromSerializedChatTranscript(
 function isAbortError(error: Error): boolean {
     return error.message === 'aborted' || error.message === 'socket hang up'
 }
-
-// Only this unsafe usage should be report
-PromptString.unsafe_fromUserQuery('EVIL!')


### PR DESCRIPTION
As the title suggest, we only want to emit linter errors when new call sites were added. The previous rule would fire too often.

## Test plan

- Add a change to the bottom of `vscode/src/chat/chat-view/SimpleChatPanelProvider.ts` that adds an `unsafe_` API call
- Run `pnpm ts-node lints/safe-prompts.ts `pnpm ts-node lints/git-diff-ts-ranges.ts`
- Observe that only an error for this change is emitted.