### PR TITLE
Chat: render spacings for human messages

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,7 +10,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Autocomplete: Add the proper infilling prompt for Codegemma when using Ollama. [pull/3754](https://github.com/sourcegraph/cody/pull/3754)
 - Chat: The new `Mixtral 8x22B Preview` chat model is available for Cody Pro users for preview. [pull/3768](https://github.com/sourcegraph/cody/pull/3768)
 - Chat: Add a "Pop out" button to the chat title bar that allows you to move Cody chat into a floating window. [pull/3773](https://github.com/sourcegraph/cody/pull/3773)
-  feat(vscode): add copy extension version command
 - Sidebar: A new button to copy the current Cody extension version to the clipboard shows up next to the Release Notes item in the SETTINGS & SUPPORT sidebar on hover. This is useful for reporting issues or getting information about the installed version. [pull/3802](https://github.com/sourcegraph/cody/pull/3802)
 - Generate Unit Tests: Added a new code action "Ask Cody to Test" currently shows against functions in JS, TS, Go and Python. [pull/3763](https://github.com/sourcegraph/cody/pull/3763)
 
@@ -21,6 +20,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Edit: Large file warnings for @-mentions are now updated dynamically as you add or remove them. [pull/3767](https://github.com/sourcegraph/cody/pull/3767)
 - Generate Unit Tests: Improved quality for creating file names. [pull/3763](https://github.com/sourcegraph/cody/pull/3763)
 - Custom Commands: Fixed an issue where newly added custom commands were not working when clicked in the sidebar tree view. [pull/3804](https://github.com/sourcegraph/cody/pull/3804)
+- Chat: Fixed an issue where whitespaces in messages submitted by users were omitted. [pull/3817](https://github.com/sourcegraph/cody/pull/3817)
 
 ### Changed
 

--- a/vscode/webviews/chat/cells/messageCell/MessageCell.module.css
+++ b/vscode/webviews/chat/cells/messageCell/MessageCell.module.css
@@ -6,6 +6,9 @@
 .message-content {
     flex: 1 0;
 }
+.human-content {
+    white-space: pre-wrap;
+}
 .edit-button {
     flex: 0 0 auto;
 }

--- a/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
@@ -7,7 +7,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
-import type { ComponentProps, FunctionComponent } from 'react'
+import { type ComponentProps, type FunctionComponent, useMemo } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../Chat'
 import { serializedPromptEditorStateFromChatMessage } from '../../../promptEditor/PromptEditor'
 import { getVSCodeAPI } from '../../../utils/VSCodeApi'
@@ -62,7 +62,7 @@ export const MessageCell: FunctionComponent<{
     /** A boolean indicating whether the current transcript item is the one being edited. */
     const isItemBeingEdited = beingEdited === messageIndexInTranscript
 
-    const displayMarkdown = useDisplayMarkdown(message)
+    const displayMarkdown = useMemo(() => useDisplayMarkdown(message), [message])
 
     return (
         <Cell
@@ -71,10 +71,14 @@ export const MessageCell: FunctionComponent<{
                 <SpeakerIcon message={message} userInfo={userInfo} chatModel={chatModel} size={24} />
             }
             disabled={disabled}
-            containerClassName={classNames(styles.cellContainer, {
-                [styles.focused]: isItemBeingEdited,
-                [styles.disabled]: disabled,
-            })}
+            containerClassName={classNames(
+                styles.cellContainer,
+                message.speaker === 'human' && styles.humanContent,
+                {
+                    [styles.focused]: isItemBeingEdited,
+                    [styles.disabled]: disabled,
+                }
+            )}
             data-testid="message"
         >
             <div className={styles.messageContentContainer}>

--- a/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
@@ -7,7 +7,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
-import { type ComponentProps, type FunctionComponent, useMemo } from 'react'
+import type { ComponentProps, FunctionComponent } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../Chat'
 import { serializedPromptEditorStateFromChatMessage } from '../../../promptEditor/PromptEditor'
 import { getVSCodeAPI } from '../../../utils/VSCodeApi'
@@ -62,7 +62,7 @@ export const MessageCell: FunctionComponent<{
     /** A boolean indicating whether the current transcript item is the one being edited. */
     const isItemBeingEdited = beingEdited === messageIndexInTranscript
 
-    const displayMarkdown = useMemo(() => useDisplayMarkdown(message), [message])
+    const displayMarkdown = useDisplayMarkdown(message)
 
     return (
         <Cell


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/3815

This commit adds a new CSS class `.human-content` that applies `white-space: pre-wrap` styling specifically to human messages in the chat transcript. 

It also updates the `MessageCell` component to conditionally apply this new class to message cells if `message.speaker === 'human'`.

This enables messages submitted by users to render with correct spacing as a temporary workaround until the new design has been fully implemented.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/c07dfdcd-a194-4d10-9b1a-ee7e198760ed)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/4e98fce8-f346-43d3-aa5d-cb6280b60c90)
