### PR TITLE
Add a hover title to the LLM chat avatars

### DIFF
--- a/vscode/webviews/Components/ChatModelIcon.tsx
+++ b/vscode/webviews/Components/ChatModelIcon.tsx
@@ -10,7 +10,7 @@ import {
 
 export function chatModelIconComponent(
     model: string
-): FunctionComponent<{ size: number; className?: string }> | null {
+): FunctionComponent<{ size: number; className?: string }> {
     if (model.startsWith('openai/')) {
         return OpenAILogo
     }

--- a/vscode/webviews/chat/cells/messageCell/SpeakerIcon.tsx
+++ b/vscode/webviews/chat/cells/messageCell/SpeakerIcon.tsx
@@ -17,7 +17,13 @@ export const SpeakerIcon: FunctionComponent<{
     if (message.speaker === 'human') {
         return <UserAvatar user={user} size={size} />
     }
-
-    const ModelIcon = chatModel ? chatModelIconComponent(chatModel.model) : null
-    return ModelIcon ? <ModelIcon size={size * 0.75} /> : null
+    if (!chatModel) {
+        return null
+    }
+    const ModelIcon = chatModelIconComponent(chatModel.model)
+    return ModelIcon ? (
+        <span title={`${chatModel.title} by ${chatModel.provider}`}>
+            <ModelIcon size={size * 0.75} />
+        </span>
+    ) : null
 }

--- a/vscode/webviews/chat/cells/messageCell/SpeakerIcon.tsx
+++ b/vscode/webviews/chat/cells/messageCell/SpeakerIcon.tsx
@@ -21,9 +21,9 @@ export const SpeakerIcon: FunctionComponent<{
         return null
     }
     const ModelIcon = chatModelIconComponent(chatModel.model)
-    return ModelIcon ? (
+    return (
         <span title={`${chatModel.title} by ${chatModel.provider}`}>
             <ModelIcon size={size * 0.75} />
         </span>
-    ) : null
+    )
 }


### PR DESCRIPTION
Adds a hover tooltip to the LLM model avatars in the chat transcript, so you can see what the icon means. Ideally we include the model name in the cell text, not just the provider avatar, but this is a small improvement in the meantime.

![CleanShot 2024-04-17 at 21 30 52@2x](https://github.com/sourcegraph/cody/assets/153/56183685-05cb-4aca-8348-9e9246f98de3)

## Test plan

- Tested in webview