### PR TITLE
Log first ever authentication event

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -3453,6 +3453,111 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 4541b3f392b28275270ba61bb2a43aa5
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 349
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseClientabcde1234
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "349"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 318
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: firstEver
+                  feature: cody.auth.login
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.12.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 38
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 38
+          text: |
+            Private mode requires authentication.
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 17 Apr 2024 15:29:03 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "38"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1217
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-04-17T15:29:03.132Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: b38540ce2256c839f6ea9b4ee26f34fd
       _order: 0
       cache: {}

--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -880,6 +880,111 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: d4aa243e28aa3d40360875e1fe11ebf0
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 349
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseMainBranchClientabcde1234
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "349"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 352
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: firstEver
+                  feature: cody.auth.login
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.12.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 38
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 38
+          text: |
+            Private mode requires authentication.
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 17 Apr 2024 15:29:05 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "38"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1218
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-04-17T15:29:04.732Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 3b1b5f59d45319c7ea64d97ad93384aa
       _order: 0
       cache: {}

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -32,6 +32,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Commands/Chat: Increased the maximum output limit of LLM responses. [pull/3797](https://github.com/sourcegraph/cody/pull/3797)
 - Commands: Updated the naming of various code actions to be more descriptive. [pull/3831](https://github.com/sourcegraph/cody/pull/3831)
 - Chat: Add chat model to more telemetry events. [pull/3829](https://github.com/sourcegraph/cody/pull/3829)
+- Adds a new telemetry event when users sign-in the first time. [pull/3836](https://github.com/sourcegraph/cody/pull/3836)
 
 ## [1.12.0]
 

--- a/vscode/src/chat/chat-view/SidebarViewController.ts
+++ b/vscode/src/chat/chat-view/SidebarViewController.ts
@@ -72,7 +72,7 @@ export class SidebarViewController implements vscode.WebviewViewProvider {
                         endpoint,
                         async (token, endpoint) => {
                             closeAuthProgressIndicator()
-                            const authStatus = await this.authProvider.auth(endpoint, token)
+                            const authStatus = await this.authProvider.auth({ endpoint, token })
                             telemetryService.log(
                                 'CodyVSCodeExtension:auth:fromTokenReceiver',
                                 {
@@ -138,7 +138,10 @@ export class SidebarViewController implements vscode.WebviewViewProvider {
                             if (!token) {
                                 return
                             }
-                            const authStatus = await this.authProvider.auth(DOTCOM_URL.href, token)
+                            const authStatus = await this.authProvider.auth({
+                                endpoint: DOTCOM_URL.href,
+                                token,
+                            })
                             if (!authStatus?.isLoggedIn) {
                                 void vscode.window.showErrorMessage(
                                     'Authentication failed. Please check your token and try again.'

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -374,8 +374,8 @@ const register = async (
     disposables.push(
         // Tests
         // Access token - this is only used in configuration tests
-        vscode.commands.registerCommand('cody.test.token', async (url, token) =>
-            authProvider.auth(url, token)
+        vscode.commands.registerCommand('cody.test.token', async (endpoint, token) =>
+            authProvider.auth({ endpoint, token })
         ),
         // Auth
         vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
@@ -392,7 +392,13 @@ const register = async (
                 if (typeof accessToken !== 'string') {
                     throw new TypeError('accessToken is required')
                 }
-                return (await authProvider.auth(serverEndpoint, accessToken, customHeaders)).authStatus
+                return (
+                    await authProvider.auth({
+                        endpoint: serverEndpoint,
+                        token: accessToken,
+                        customHeaders,
+                    })
+                ).authStatus
             }
         ),
         // Chat

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -14,7 +14,7 @@ import { CodyChatPanelViewType } from '../chat/chat-view/ChatManager'
 import {
     ACCOUNT_USAGE_URL,
     defaultAuthStatus,
-    isLoggedIn as isAuthed,
+    isLoggedIn as isAuthenticated,
     isSourcegraphToken,
     networkErrorAuthStatus,
     unauthenticatedStatus,
@@ -33,6 +33,8 @@ import { telemetryRecorder } from './telemetry-v2'
 
 type Listener = (authStatus: AuthStatus) => void
 type Unsubscribe = () => void
+
+const HAS_AUTHENTICATED_BEFORE_KEY = 'has-authenticated-before'
 
 export class AuthProvider {
     private endpointHistory: string[] = []
@@ -64,7 +66,8 @@ export class AuthProvider {
             token = (await secretStorage.get(lastEndpoint)) || null
         }
         logDebug('AuthProvider:init:lastEndpoint', lastEndpoint)
-        await this.auth(lastEndpoint, token || null)
+
+        await this.auth({ endpoint: lastEndpoint, token: token || null, isExtensionStartup: true })
     }
 
     public addChangeListener(listener: Listener): Unsubscribe {
@@ -116,13 +119,13 @@ export class AuthProvider {
                 // Auto log user if token for the selected instance was found in secret
                 const selectedEndpoint = item.uri
                 const token = await secretStorage.get(selectedEndpoint)
-                let authStatus = await this.auth(selectedEndpoint, token || null)
+                let authStatus = await this.auth({ endpoint: selectedEndpoint, token: token || null })
                 if (!authStatus?.isLoggedIn) {
                     const newToken = await showAccessTokenInputBox(item.uri)
                     if (!newToken) {
                         return
                     }
-                    authStatus = await this.auth(selectedEndpoint, newToken || null)
+                    authStatus = await this.auth({ endpoint: selectedEndpoint, token: newToken || null })
                 }
                 await showAuthResultMessage(selectedEndpoint, authStatus?.authStatus)
                 logDebug('AuthProvider:signinMenu', mode, selectedEndpoint)
@@ -135,7 +138,7 @@ export class AuthProvider {
         if (!accessToken) {
             return
         }
-        const authState = await this.auth(instanceUrl, accessToken)
+        const authState = await this.auth({ endpoint: instanceUrl, token: accessToken })
         telemetryService.log(
             'CodyVSCodeExtension:auth:fromToken',
             {
@@ -215,7 +218,7 @@ export class AuthProvider {
     private async signout(endpoint: string): Promise<void> {
         await secretStorage.deleteToken(endpoint)
         await localStorage.deleteEndpoint()
-        await this.auth(endpoint, null)
+        await this.auth({ endpoint, token: null })
         this.authStatus.endpoint = ''
         await vscode.commands.executeCommand('setContext', CodyChatPanelViewType, false)
         await vscode.commands.executeCommand('setContext', 'cody.activated', false)
@@ -310,21 +313,37 @@ export class AuthProvider {
     }
 
     // It processes the authentication steps and stores the login info before sharing the auth status with chatview
-    public async auth(
-        uri: string,
-        token: string | null,
+    public async auth({
+        endpoint,
+        token,
+        customHeaders,
+        isExtensionStartup = false,
+    }: {
+        endpoint: string
+        token: string | null
         customHeaders?: Record<string, string> | null
-    ): Promise<{ authStatus: AuthStatus; isLoggedIn: boolean }> {
-        const endpoint = formatURL(uri) || ''
+        isExtensionStartup?: boolean
+    }): Promise<{ authStatus: AuthStatus; isLoggedIn: boolean }> {
+        const url = formatURL(endpoint) || ''
         const config = {
-            serverEndpoint: endpoint,
+            serverEndpoint: url,
             accessToken: token,
             customHeaders: customHeaders || this.config.customHeaders,
         }
         const authStatus = await this.makeAuthStatus(config)
-        const isLoggedIn = isAuthed(authStatus)
+        const isLoggedIn = isAuthenticated(authStatus)
         authStatus.isLoggedIn = isLoggedIn
-        await this.storeAuthInfo(endpoint, token)
+
+        // If the extension is authenticated on startup, it can't be a user's first
+        // ever authentication. We store this to prevent logging first-ever events
+        // for already existing users.
+        if (isExtensionStartup && isLoggedIn) {
+            await this.setHasAuthenticatedBefore()
+        } else if (isLoggedIn) {
+            this.logFirstEverAuthentication()
+        }
+
+        await this.storeAuthInfo(url, token)
         this.syncAuthStatus(authStatus)
         await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
         return { authStatus, isLoggedIn }
@@ -333,7 +352,11 @@ export class AuthProvider {
     // Set auth status in case of reload
     public async reloadAuthStatus(): Promise<void> {
         this.config = await getFullConfig()
-        await this.auth(this.config.serverEndpoint, this.config.accessToken, this.config.customHeaders)
+        await this.auth({
+            endpoint: this.config.serverEndpoint,
+            token: this.config.accessToken,
+            customHeaders: this.config.customHeaders,
+        })
     }
 
     // Set auth status and share it with chatview
@@ -369,7 +392,7 @@ export class AuthProvider {
         if (!token || !endpoint) {
             return
         }
-        const authState = await this.auth(endpoint, token, customHeaders)
+        const authState = await this.auth({ endpoint, token, customHeaders })
         telemetryService.log(
             'CodyVSCodeExtension:auth:fromCallback',
             {
@@ -444,6 +467,17 @@ export class AuthProvider {
 
         // Simplified onboarding only supports dotcom.
         this.authStatus.endpoint = DOTCOM_URL.toString()
+    }
+
+    // Logs a telemetry event if the user has never authenticated to Sourcegraph.
+    private logFirstEverAuthentication(): void {
+        if (!localStorage.get(HAS_AUTHENTICATED_BEFORE_KEY)) {
+            telemetryRecorder.recordEvent('cody.auth.login', 'firstEver')
+            this.setHasAuthenticatedBefore()
+        }
+    }
+    private setHasAuthenticatedBefore() {
+        return localStorage.set(HAS_AUTHENTICATED_BEFORE_KEY, 'true')
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/cody-issues/issues/19

This PR adds a new analytics event that is fired the first time a user authenticates. We use local storage to make sure this is only fired ones. 

For existing users, we will check if the extension is ever authenticated when it first starts up. If someone has Cody installed and was authenticated in the past, they would be suspect to getting a first-ever event logged. However I think this is fine, we don't know wether they were authenticated before. 

## Test plan

- When loading up an instance where you're not authenticated at

```
█ logEvent (telemetry disabled): CodyVSCodeExtension:auth:simplifiedSignInGitHubClick 
█ telemetry-v2: recordEvent: cody.auth.login/firstEver      <<<<<<<<<<<<<<<<<<<<<<<
█ Cody:publishConfig: configForWebview 
█ ContextProvider:onConfigurationChange: using codebase 
█ logEvent (telemetry disabled): CodyVSCodeExtension:Auth:connected 
█ telemetry-v2: recordEvent: cody.auth/connected 
█ ContextProvider:onConfigurationChange: using codebase 
█ LocalEmbeddingsController: setAccessToken is dotcom
█ LocalEmbeddingsController: setAccessToken is dotcom
█ telemetry-v2: using no-op exports
█ logEvent (telemetry disabled): CodyVSCodeExtension:auth:fromTokenReceiver 
█ telemetry-v2: recordEvent: cody.auth.fromTokenReceiver.web/succeeded 
█ featureflag: refreshed
█ featureflag: refreshed
█ CodyCompletionProvider:initialized: fireworks/starcoder-hybrid
█ CodyCompletionProvider:initialized: fireworks/starcoder-hybrid
█ HoverCommandsProvider: registering
```

- When updating an existing instance where you're already authenticated
```
█ telemetry-v2: using no-op exports
█ telemetry-v2: recordEvent: cody.extension/savedLogin  {
  "parameters": {
    "version": 0
  },
  "timestamp": "2024-04-17T14:58:50.141Z"
}
█ AuthProvider:init:lastEndpoint: https://sourcegraph.com/
█ LocalEmbeddingsController: constructor
█ ChatManager:constructor: init has local embeddings controller
█ ChatPanelsManager:constructor: init
█ SymfRunner: unsafeEnsureIndex file:///Users/philipp/dev/postclub {
  "options": {
    "retryIfLastAttemptFailed": false,
    "ignoreExisting": false
  }
}
█ CommandsController:init: watchers created
█ HoverCommandsProvider: registering
```
