### PR TITLE
improve contrast of context links and at-mention colors in various VS Code themes

### DIFF
--- a/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
@@ -52,6 +52,4 @@
 
 .file-link {
     padding: 2px 4px 2px 2px;
-    background-color: var(--vscode-list-activeSelectionBackground);
-    border-radius: 2px;
 }

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -1,7 +1,9 @@
 import type { ContextItem } from '@sourcegraph/cody-shared'
+import classNames from 'classnames'
 import type React from 'react'
 import { FileLink } from '../../../Components/FileLink'
 import { SourcegraphLogo } from '../../../icons/SourcegraphLogo'
+import { MENTION_CLASS_NAME } from '../../../promptEditor/nodes/ContextItemMentionNode'
 import { getVSCodeAPI } from '../../../utils/VSCodeApi'
 import { LoadingDots } from '../../components/LoadingDots'
 import { Cell } from '../Cell'
@@ -100,7 +102,7 @@ export const ContextCell: React.FunctionComponent<{
                                     isTooLarge={
                                         item.type === 'file' && item.isTooLarge && item.source === 'user'
                                     }
-                                    className={styles.fileLink}
+                                    className={classNames(styles.fileLink, MENTION_CLASS_NAME)}
                                 />
                             </li>
                         ))}

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
@@ -1,7 +1,6 @@
 .context-item-mention-node {
-    /** Match styles in ContextCell. */
     color: var(--vscode-textLink-foreground);
-    background-color: var(--vscode-list-activeSelectionBackground);
+    background-color: color-mix(in lch, var(--vscode-textLink-foreground) 10%, transparent);
     border-radius: 2px;
 }
 

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -22,6 +22,8 @@ import {
 } from 'lexical'
 import { URI } from 'vscode-uri'
 
+export const MENTION_CLASS_NAME = styles.contextItemMentionNode
+
 /**
  * The subset of {@link ContextItem} fields that we need to store to identify and display context
  * item mentions.


### PR DESCRIPTION
Some VS Code color themes made the context links and at-mentions in chat unreadable. This was because the styling assumed that the text link foreground had contrast with the list active selection background, which is an incorrect assumption in general. Now the styles are formally shared between these 2 components and use CSS theme variables that can be assumed to have appropriate contrast.

Fix https://github.com/sourcegraph/cody/issues/3816

TBH this regressed the consistency between the at-mentions in the editor and the list somewhat, but they weren't consistent before and we'll need to clean up the button styles or something else. This is unobjectionable and fixes the obvious bug, so I think it's worth merging for the release.


<img width="577" alt="image" src="https://github.com/sourcegraph/cody/assets/1976/07db5650-1f82-459e-acb1-83bcac5ce55f">
<img width="462" alt="image" src="https://github.com/sourcegraph/cody/assets/1976/3b8be6c9-7c97-40b0-8ebf-39593262c822">




## Test plan

CI. Also view chat and switch themes.