### PR TITLE
Chat: display line range for @-mentions

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -19,13 +19,13 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Generate Unit Tests: Fixed an issue where Cody would generate tests for the wrong code in the file. [pull/3759](https://github.com/sourcegraph/cody/pull/3759)
 - Chat: Fixed an issue where changing the chat model did not update the token limit for the model. [pull/3762](https://github.com/sourcegraph/cody/pull/3762)
 - Troubleshoot: Don't show SignIn page if the authentication error is because of network connectivity issues [pull/3750](https://github.com/sourcegraph/cody/pull/3750)
-  
 - Edit: Large file warnings for @-mentions are now updated dynamically as you add or remove them. [pull/3767](https://github.com/sourcegraph/cody/pull/3767)
 - Generate Unit Tests: Improved quality for creating file names. [pull/3763](https://github.com/sourcegraph/cody/pull/3763)
 - Custom Commands: Fixed an issue where newly added custom commands were not working when clicked in the sidebar tree view. [pull/3804](https://github.com/sourcegraph/cody/pull/3804)
 - Chat: Fixed an issue where whitespaces in messages submitted by users were omitted. [pull/3817](https://github.com/sourcegraph/cody/pull/3817)
 - Chat: Improved token counting mechanism that allows more context to be correctly included or excluded. [pull/3742](https://github.com/sourcegraph/cody/pull/3742)
 - Chat: Fixed an issue where context files were opened with an incorrect link for Enterprise users due to double encoding. [pull/3818](https://github.com/sourcegraph/cody/pull/3818)
+- Chat: Line numbers for @-mentions are now included and counted toward the "x lines from y files" section in the UI. [pull/3842](https://github.com/sourcegraph/cody/pull/3842)
 
 ### Changed
 

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -197,7 +197,22 @@ describe('fillInContextItemContent', () => {
             },
         ])
         expect(contextItems).toEqual<ContextItem[]>([
-            { type: 'file', uri: URI.parse('file:///a.txt'), content: 'a', size: 1 },
+            {
+                type: 'file',
+                uri: URI.parse('file:///a.txt'),
+                content: 'a',
+                size: 1,
+                range: {
+                    end: {
+                        character: 0,
+                        line: 1,
+                    },
+                    start: {
+                        character: 0,
+                        line: 0,
+                    },
+                },
+            },
         ])
     })
 })

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -215,13 +215,13 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java')).toBeVisible()
     const contextCell = getContextCell(chatPanelFrame)
-    await expectContextCellCounts(contextCell, { files: 1 })
+    await expectContextCellCounts(contextCell, { files: 1, lines: 10 })
 
     // Edit the just-sent message and resend it. Confirm it is sent with the right context items.
     await chatInput.press('ArrowUp')
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await chatInput.press('Meta+Enter')
-    await expectContextCellCounts(contextCell, { files: 1 })
+    await expectContextCellCounts(contextCell, { files: 1, lines: 10 })
 
     // Edit it again, add a new @-mention, and resend.
     await chatInput.press('ArrowUp')
@@ -233,7 +233,7 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java and @index.html')).toBeVisible()
-    await expectContextCellCounts(contextCell, { files: 2 })
+    await expectContextCellCounts(contextCell, { files: 2, lines: 22 })
 })
 
 test('pressing Enter with @-mention menu open selects item, does not submit message', async ({

--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -129,7 +129,7 @@ test.extend<ExpectedEvents>({
     await chatInput.press('Enter')
     // both main.java and var.go should be used
     const contextCell = getContextCell(chatFrame)
-    await expectContextCellCounts(contextCell, { files: 2 })
+    await expectContextCellCounts(contextCell, { files: 2, lines: 12 })
     await contextCell.click()
     const chatContext = chatFrame.locator('details').last()
     await expect(chatContext.getByRole('link', { name: 'Main.java' })).toBeVisible()


### PR DESCRIPTION
## Issue

When @-mentioning a file without specifying the range, the file will be displayed without line numbers, and without the number, the Chat UI will not be able to display the correct number for total lines read:
![image](https://github.com/sourcegraph/cody/assets/68532117/56b32480-7647-4de4-accb-40076a9b1a79)

"5 lines from 2 files" is not correct here, because the line count from the ignore file is not included here:
![image](https://github.com/sourcegraph/cody/assets/68532117/0461bb5a-3d76-4c93-9220-3c18069bbf43)

## Summary

This PR fixed the aforementioned issue with the following changes:

- Destructure commonly used properties like `content` and `size` upfront
- Remove separate `content` and `size` assignments in favor of single conditional block
- Introduce `getRangeByContentLineCount` to infer range based on content lines

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Updated all unit tests and e2e tests.

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/42126442-bf29-4231-8f34-454a2790ba63)

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/d6d1a088-4db9-49c0-96f6-c0410e76dcb7)
