### PR TITLE
VS Code: Release 1.14.0

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -2540,7 +2540,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7474b03da6aa2191b731300eeaa4a7bf
+    - _id: 683ba00719d0e1804c3b896e0901efae
       _order: 0
       cache: {}
       request:
@@ -2592,7 +2592,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2607,7 +2607,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:52 GMT
+            value: Wed, 17 Apr 2024 21:28:03 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -2635,7 +2635,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-04-03T19:24:52.764Z
+      startedDateTime: 2024-04-17T21:28:03.263Z
       time: 0
       timings:
         blocked: -1
@@ -2645,7 +2645,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 86daaf69f07dc066572cca8728e1cda9
+    - _id: 336a451ca8952ae40422463e485b1797
       _order: 0
       cache: {}
       request:
@@ -2697,7 +2697,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2712,7 +2712,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:52 GMT
+            value: Wed, 17 Apr 2024 21:28:03 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -2740,7 +2740,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-04-03T19:24:52.807Z
+      startedDateTime: 2024-04-17T21:28:03.311Z
       time: 0
       timings:
         blocked: -1
@@ -2750,7 +2750,112 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ca2edc2c9e68428072c676d34a9727ca
+    - _id: 6ec9fe5c3b91bb455eada4819086f241
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 349
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseClientabcde1234
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "349"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 318
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: firstEver
+                  feature: cody.auth.login
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.14.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 38
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 38
+          text: |
+            Private mode requires authentication.
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 17 Apr 2024 21:28:03 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "38"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1217
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-04-17T21:28:03.354Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 9d3a2e2981afff42d86fcc6e751f44cc
       _order: 0
       cache: {}
       request:
@@ -2806,7 +2911,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2827,7 +2932,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:53 GMT
+            value: Wed, 17 Apr 2024 21:28:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2858,7 +2963,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-04-03T19:24:52.850Z
+      startedDateTime: 2024-04-17T21:28:03.376Z
       time: 0
       timings:
         blocked: -1
@@ -2868,7 +2973,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6c01dc2bc6c99e02d09ca423b234b141
+    - _id: 67ec20d8b7cedfd0772eb3a29144edf4
       _order: 0
       cache: {}
       request:
@@ -2924,7 +3029,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -2945,7 +3050,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:53 GMT
+            value: Wed, 17 Apr 2024 21:28:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -2976,7 +3081,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-04-03T19:24:52.875Z
+      startedDateTime: 2024-04-17T21:28:03.400Z
       time: 0
       timings:
         blocked: -1
@@ -2986,7 +3091,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6b70a5039ea33d1d6f157c8d94d32e83
+    - _id: a8ca8501c5dfa6c1d26ffa8c0fd27919
       _order: 0
       cache: {}
       request:
@@ -3042,7 +3147,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3063,7 +3168,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:53 GMT
+            value: Wed, 17 Apr 2024 21:28:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3094,7 +3199,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-04-03T19:24:52.894Z
+      startedDateTime: 2024-04-17T21:28:03.419Z
       time: 0
       timings:
         blocked: -1
@@ -3104,7 +3209,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: e9ef49eafb835c8e063e828bdcef50b7
+    - _id: fc3d496ba94f02ca631d7568473be62b
       _order: 0
       cache: {}
       request:
@@ -3160,7 +3265,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3181,7 +3286,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:53 GMT
+            value: Wed, 17 Apr 2024 21:28:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3212,7 +3317,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-04-03T19:24:53.064Z
+      startedDateTime: 2024-04-17T21:28:03.627Z
       time: 0
       timings:
         blocked: -1
@@ -3222,7 +3327,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: b606d29f1f30763ba3d61a505418ce96
+    - _id: 48fd48b771f3150e659db4eea226394b
       _order: 0
       cache: {}
       request:
@@ -3278,7 +3383,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3299,7 +3404,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:53 GMT
+            value: Wed, 17 Apr 2024 21:28:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3330,7 +3435,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-04-03T19:24:53.072Z
+      startedDateTime: 2024-04-17T21:28:03.642Z
       time: 0
       timings:
         blocked: -1
@@ -3340,7 +3445,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 719ae6b07479742a25a075d567707349
+    - _id: 3485b90abfa5178c57e8bde85ac57ca0
       _order: 0
       cache: {}
       request:
@@ -3396,7 +3501,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -3417,7 +3522,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:53 GMT
+            value: Wed, 17 Apr 2024 21:28:03 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -3448,112 +3553,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-04-03T19:24:53.076Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 4541b3f392b28275270ba61bb2a43aa5
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 349
-        cookies: []
-        headers:
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseClient / v1
-          - _fromType: array
-            name: x-sourcegraph-actor-anonymous-uid
-            value: enterpriseClientabcde1234
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "349"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 318
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
-              	telemetry {
-              		recordEvents(events: $events) {
-              			alwaysNil
-              		}
-              	}
-              }
-            variables:
-              events:
-                - action: firstEver
-                  feature: cody.auth.login
-                  parameters:
-                    privateMetadata: {}
-                    version: 0
-                  source:
-                    client: VSCode.Cody
-                    clientVersion: 1.12.0
-        queryString:
-          - name: RecordTelemetryEvents
-            value: null
-        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
-      response:
-        bodySize: 38
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 38
-          text: |
-            Private mode requires authentication.
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 17 Apr 2024 15:29:03 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1217
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-04-17T15:29:03.132Z
+      startedDateTime: 2024-04-17T21:28:03.644Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -552,7 +552,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8c52a6a76e7603a3f60be03fb18626d5
+    - _id: b26748c627667a2fae985a1356272d65
       _order: 0
       cache: {}
       request:
@@ -604,7 +604,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -619,7 +619,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:54 GMT
+            value: Wed, 17 Apr 2024 21:28:05 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -647,7 +647,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-04-03T19:24:54.164Z
+      startedDateTime: 2024-04-17T21:28:04.896Z
       time: 0
       timings:
         blocked: -1
@@ -657,7 +657,7 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: bc15313fe3ea6b6b6b2299aabb8bfed1
+    - _id: 8495b194946f1d70cc48952d2aef82fe
       _order: 0
       cache: {}
       request:
@@ -709,7 +709,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -724,7 +724,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:54 GMT
+            value: Wed, 17 Apr 2024 21:28:05 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -752,7 +752,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-04-03T19:24:54.224Z
+      startedDateTime: 2024-04-17T21:28:04.962Z
       time: 0
       timings:
         blocked: -1
@@ -762,7 +762,112 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8a830714dde530a585414235cf2f886d
+    - _id: 910dc15f1dd40a05a4fe30f46a8198da
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 349
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseMainBranchClientabcde1234
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "349"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 352
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: firstEver
+                  feature: cody.auth.login
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.14.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://sourcegraph.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 38
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 38
+          text: |
+            Private mode requires authentication.
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 17 Apr 2024 21:28:05 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "38"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1218
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-04-17T21:28:04.982Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: e30489bf094200bd2673f02365690f70
       _order: 0
       cache: {}
       request:
@@ -818,7 +923,7 @@ log:
                     version: 0
                   source:
                     client: VSCode.Cody
-                    clientVersion: 1.12.0
+                    clientVersion: 1.14.0
         queryString:
           - name: RecordTelemetryEvents
             value: null
@@ -839,7 +944,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Apr 2024 19:24:54 GMT
+            value: Wed, 17 Apr 2024 21:28:05 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -870,112 +975,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-04-03T19:24:54.244Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: d4aa243e28aa3d40360875e1fe11ebf0
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 349
-        cookies: []
-        headers:
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: enterpriseMainBranchClient / v1
-          - _fromType: array
-            name: x-sourcegraph-actor-anonymous-uid
-            value: enterpriseMainBranchClientabcde1234
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "349"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.sourcegraph.com
-        headersSize: 352
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |
-              
-              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
-              	telemetry {
-              		recordEvents(events: $events) {
-              			alwaysNil
-              		}
-              	}
-              }
-            variables:
-              events:
-                - action: firstEver
-                  feature: cody.auth.login
-                  parameters:
-                    privateMetadata: {}
-                    version: 0
-                  source:
-                    client: VSCode.Cody
-                    clientVersion: 1.12.0
-        queryString:
-          - name: RecordTelemetryEvents
-            value: null
-        url: https://sourcegraph.sourcegraph.com/.api/graphql?RecordTelemetryEvents
-      response:
-        bodySize: 38
-        content:
-          mimeType: text/plain; charset=utf-8
-          size: 38
-          text: |
-            Private mode requires authentication.
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 17 Apr 2024 15:29:05 GMT
-          - name: content-type
-            value: text/plain; charset=utf-8
-          - name: content-length
-            value: "38"
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1218
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 401
-        statusText: Unauthorized
-      startedDateTime: 2024-04-17T15:29:04.732Z
+      startedDateTime: 2024-04-17T21:28:05.004Z
       time: 0
       timings:
         blocked: -1

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -93,8 +93,8 @@ const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
         contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
     },
     {
-        title: 'Mixtral 8x22B Preview',
-        model: 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct-preview',
+        title: 'Mixtral 8x22B',
+        model: 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct',
         provider: 'Mistral',
         default: false,
         codyProOnly: true,

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,7 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: Add highlighted code to Cody Chat as `@-mentions` context by right-clicking on the code and selecting `Cody Chat: Add context`. [pull/3713](https://github.com/sourcegraph/cody/pull/3713)
 - Autocomplete: Add the proper infilling prompt for Codegemma when using Ollama. [pull/3754](https://github.com/sourcegraph/cody/pull/3754)
-- Chat: The new `Mixtral 8x22B Preview` chat model is available for Cody Pro users for preview. [pull/3768](https://github.com/sourcegraph/cody/pull/3768)
+- Chat: The new `Mixtral 8x22B` chat model is available for Cody Pro users. [pull/3768](https://github.com/sourcegraph/cody/pull/3768)
 - Chat: Add a "Pop out" button to the chat title bar that allows you to move Cody chat into a floating window. [pull/3773](https://github.com/sourcegraph/cody/pull/3773)
 - Sidebar: A new button to copy the current Cody extension version to the clipboard shows up next to the Release Notes item in the SETTINGS & SUPPORT sidebar on hover. This is useful for reporting issues or getting information about the installed version. [pull/3802](https://github.com/sourcegraph/cody/pull/3802)
 - Generate Unit Tests: Added a new code action "Ask Cody to Test" currently shows against functions in JS, TS, Go and Python. [pull/3763](https://github.com/sourcegraph/cody/pull/3763)

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,7 +6,15 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-- Chat: You can add highlighted code to the chat context by right-clicking on the code and selecting `Cody Chat: Add context`. The selected code will appear in the input box as `@-mentions`, allowing you to complete your question. [pull/3713](https://github.com/sourcegraph/cody/pull/3713)
+### Fixed
+
+### Changed
+
+## [1.14.0]
+
+### Added
+
+- Chat: Add highlighted code to Cody Chat as `@-mentions` context by right-clicking on the code and selecting `Cody Chat: Add context`. [pull/3713](https://github.com/sourcegraph/cody/pull/3713)
 - Autocomplete: Add the proper infilling prompt for Codegemma when using Ollama. [pull/3754](https://github.com/sourcegraph/cody/pull/3754)
 - Chat: The new `Mixtral 8x22B Preview` chat model is available for Cody Pro users for preview. [pull/3768](https://github.com/sourcegraph/cody/pull/3768)
 - Chat: Add a "Pop out" button to the chat title bar that allows you to move Cody chat into a floating window. [pull/3773](https://github.com/sourcegraph/cody/pull/3773)
@@ -36,14 +44,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Support Sidebar: Update the icon for Discord to use the official Discord logo. [pull/3803](https://github.com/sourcegraph/cody/pull/3803)
 - Commands/Chat: Increased the maximum output limit of LLM responses. [pull/3797](https://github.com/sourcegraph/cody/pull/3797)
 - Commands: Updated the naming of various code actions to be more descriptive. [pull/3831](https://github.com/sourcegraph/cody/pull/3831)
-- Chat: Add chat model to more telemetry events. [pull/3829](https://github.com/sourcegraph/cody/pull/3829)
-- Adds a new telemetry event when users sign-in the first time. [pull/3836](https://github.com/sourcegraph/cody/pull/3836)
+- Chat: Adds chat model to more telemetry events. [pull/3829](https://github.com/sourcegraph/cody/pull/3829)
+- Telemetry: Adds a new telemetry event when users sign-in the first time. [pull/3836](https://github.com/sourcegraph/cody/pull/3836)
 
 ### Feature Flags
 
-> This section covers experiments that run behind feature flags.
+> This section covers experiments that run behind feature flags for non-Enterprise users.
 
-- CodyChatContextBudget: Expanded context window for user-added context in Cody chat. [pull/3742](https://github.com/sourcegraph/cody/pull/3742)
+- Chat: Increased context window size when using the `Claude 3 Sonnet` and `Claude 3 Opus` models. [pull/3742](https://github.com/sourcegraph/cody/pull/3742)
 
 ## [1.12.0]
 
@@ -81,7 +89,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Feature Flags
 
-> This section covers experiments that run behind feature flags.
+> This section covers experiments that run behind feature flags for non-Enterprise users.
 
 - Hover Commands: Cody commands are now integrated with the native hover provider, allowing you to seamlessly access essential commands on mouse hover. [pull/3585](https://github.com/sourcegraph/cody/pull/3585)
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.12.0",
+  "version": "1.14.0",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
VS Code: Release 1.14.0 - Stable Release.

Blog post: https://github.com/sourcegraph/about/pull/6882

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- [x] [vscode/CHANGELOG.md](./CHANGELOG.md)
- [x] [vscode/package.json](./package.json)
- [x] Update agent recordings
- [x] Enable Feature Flag `cody-chat-context-budget` for all DotCom users ([context](https://sourcegraph.slack.com/archives/C05AGQYD528/p1713384433580899?thread_ts=1713382141.616899&cid=C05AGQYD528))

![image](https://github.com/sourcegraph/cody/assets/68532117/1a23acbb-d903-465b-9f73-9479f74bbe05)
