### PR TITLE
Convert editCommands/code to a proper PromptString

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditCommands_CodeParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditCommands_CodeParams.kt
@@ -2,6 +2,7 @@
 package com.sourcegraph.cody.protocol_generated
 
 data class EditCommands_CodeParams(
-  val params: ParamsParams? = null,
+  val instruction: String? = null,
+  val model: String? = null,
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ParamsParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ParamsParams.kt
@@ -1,7 +1,0 @@
-@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
-package com.sourcegraph.cody.protocol_generated
-
-data class ParamsParams(
-  val instruction: String? = null,
-)
-

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -36,6 +36,7 @@ import type { Har } from '@pollyjs/persister'
 import levenshtein from 'js-levenshtein'
 import { ModelUsage } from '../../lib/shared/src/models/types'
 import type { CompletionItemID } from '../../vscode/src/completions/logger'
+import { ExecuteEditArguments } from '../../vscode/src/edit/execute'
 import { getEditSmartSelection } from '../../vscode/src/edit/utils/edit-selection'
 import type { ExtensionClient, ExtensionObjects } from '../../vscode/src/extension-client'
 import { IndentationBasedFoldingRangeProvider } from '../../vscode/src/lsp/foldingRanges'
@@ -809,7 +810,8 @@ export class Agent extends MessageHandler implements ExtensionClient {
         )
 
         this.registerAuthenticatedRequest('editCommands/code', params => {
-            const args = { configuration: { ...params } }
+            const instruction = PromptString.unsafe_fromUserQuery(params.params.instruction)
+            const args: ExecuteEditArguments = { configuration: { instruction } }
             return this.createEditTask(
                 vscode.commands
                     .executeCommand<FixupTask | undefined>('cody.command.edit-code', args)

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -81,7 +81,7 @@ export type ClientRequests = {
     'commands/custom': [{ key: string }, CustomCommandResult]
 
     // Trigger commands that edit the code.
-    'editCommands/code': [{ params: { instruction: string } }, EditTask]
+    'editCommands/code': [{ instruction: string; model: string }, EditTask]
     'editCommands/test': [null, EditTask]
     'editCommands/document': [null, EditTask]
 


### PR DESCRIPTION
The introduction of PromptString did not catch this case where an Agent command was converted into the arguments for Edit. I added a cast to `ExecuteEditArguments` now so that the next time this will yell.

`command.executeCommand()` being untyped is not great 😞 

## Test plan

- CI; Will ask @sourcegraph/jetbrains-plugin folks