### PR TITLE
models: show default LLM first in dropdown

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -180,164 +180,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 9c03ab4648e9c752e0c33b9085c0fab7
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 570
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: My name is Lars Monsen
-              - speaker: assistant
-                text: It's nice to meet you Lars! I'm Cody, an AI assistant for helping with
-                  coding and technical tasks. How can I be of assistance to you
-                  today?
-              - speaker: human
-                text: What is my name?
-              - speaker: assistant
-            model: anthropic/claude-2.0
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 1019
-        content:
-          mimeType: text/event-stream
-          size: 1019
-          text: >+
-            event: completion
-
-            data: {"completion":"You","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your name","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your name is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your name is L","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your name is Lars","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your name is Lars Mon","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your name is Lars Monsen","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your name is Lars Monsen.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"You told me your name is Lars Monsen.","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 17 Apr 2024 15:22:10 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-04-17T15:22:08.709Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 8f6d82f270695d480a98416a4ce0b2cb
       _order: 0
       cache: {}
@@ -13470,6 +13312,7 @@ log:
 
 
 
+
                       
                   </selected>
               - speaker: assistant
@@ -24828,6 +24671,153 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-04-18T12:25:33.399Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 7bc46e529c9025dba3fd3c7d2b771b73
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 476
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 277
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: My name is Lars Monsen
+              - speaker: assistant
+                text: It's nice to meet you Lars! I'm Cody, an AI assistant for helping with
+                  coding and technical tasks. How can I be of assistance to you
+                  today?
+              - speaker: human
+                text: What is my name?
+            model: anthropic/claude-3-sonnet-20240229
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1
+      response:
+        bodySize: 840
+        content:
+          mimeType: text/event-stream
+          size: 840
+          text: >+
+            event: completion
+
+            data: {"completion":"You","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said your","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said your name","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said your name is","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said your name is Lars","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said your name is Lars Mon","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said your name is Lars Monsen","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said your name is Lars Monsen.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"You said your name is Lars Monsen.","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 18 Apr 2024 15:00:09 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-04-18T15:00:06.576Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
+++ b/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
@@ -5,11 +5,11 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 1dfb41922fe5dd97eb41ccb518d056d5
+    - _id: 03d466855b0746c7f8469dd1989fa621
       _order: 0
       cache: {}
       request:
-        bodySize: 336
+        bodySize: 242
         cookies: []
         headers:
           - name: content-type
@@ -23,7 +23,7 @@ log:
             value: rateLimitedClient / v1
           - name: host
             value: sourcegraph.com
-        headersSize: 267
+        headersSize: 281
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -32,19 +32,18 @@ log:
           textJSON:
             maxTokensToSample: 4000
             messages:
-              - speaker: human
+              - speaker: system
                 text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
                 text: sqrt(9)
-              - speaker: assistant
-            model: anthropic/claude-2.0
+            model: anthropic/claude-3-sonnet-20240229
             temperature: 0
             topK: -1
             topP: -1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
+        queryString:
+          - name: api-version
+            value: "1"
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1
       response:
         bodySize: 0
         content:
@@ -53,7 +52,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 17 Apr 2024 09:12:26 GMT
+            value: Thu, 18 Apr 2024 15:00:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -67,14 +66,14 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: retry-after
-            value: Thu, 18 Apr 2024 09:10:39 UTC
+            value: Fri, 19 Apr 2024 14:21:41 UTC
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
           - name: vary
             value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
               X-Requested-With,Cookie
           - name: x-cloud-trace-context
-            value: 39ba1bf7b12eb7eb16be2c2297a2c436
+            value: da21e48564b79ce98e33c6f77d146399
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -92,7 +91,7 @@ log:
         redirectURL: ""
         status: 429
         statusText: OK
-      startedDateTime: 2024-04-17T09:12:26.244Z
+      startedDateTime: 2024-04-18T15:00:15.492Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -299,7 +299,7 @@ describe('Agent', () => {
                 })
             )
             expect(reply2.messages.at(-1)?.text).toMatchInlineSnapshot(
-                `"You told me your name is Lars Monsen."`,
+                `"You said your name is Lars Monsen."`,
                 explainPollyError
             )
         }, 30_000)

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -10,6 +10,16 @@ import { ModelUsage } from './types'
 
 // The models must first be added to the custom chat models list in https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/completions/httpapi/chat.go?L48-51
 const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
+    // The order listed here is the order shown to users. Put the default LLM first.
+    {
+        title: 'Claude 3 Sonnet',
+        model: 'anthropic/claude-3-sonnet-20240229',
+        provider: 'Anthropic',
+        default: true,
+        codyProOnly: false,
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
+    },
     {
         title: 'Claude 2.0',
         model: 'anthropic/claude-2.0',
@@ -43,15 +53,6 @@ const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
         provider: 'Anthropic',
         default: false,
         codyProOnly: true,
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
-    },
-    {
-        title: 'Claude 3 Sonnet',
-        model: 'anthropic/claude-3-sonnet-20240229',
-        provider: 'Anthropic',
-        default: true,
-        codyProOnly: false,
         usage: [ModelUsage.Chat, ModelUsage.Edit],
         contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
     },

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -14,6 +14,7 @@ interface MockRequest {
     body: {
         messages: {
             text: string
+            speaker?: string
         }[]
     }
 }
@@ -249,7 +250,12 @@ export class MockServer {
             // Ideas from Dom - see if we could put something in the test request itself where we tell it what to respond with
             // or have a method on the server to send a set response the next time it sees a trigger word in the request.
             const request = req as MockRequest
-            const lastHumanMessageIndex = request.body.messages.length - 2
+            let lastHumanMessageIndex = request.body.messages.findLastIndex(
+                msg => msg?.speaker === 'human'
+            )
+            if (lastHumanMessageIndex < 0) {
+                lastHumanMessageIndex = request.body.messages.length - 2
+            }
             let response = responses.chat
             // Long chat response
             if (request.body.messages[lastHumanMessageIndex].text.startsWith('Lorem ipsum')) {


### PR DESCRIPTION
The order we list our models in dotcom.ts is the order it is shown in. I imagine in future we likely want to order these such that LLMs we want to guide users to use are higher up. For now I just moved the default LLM to the top.

Alternatively we should consider making the selected LLM at the top of the dropdown list?

Test Plan: CI

Fixes https://github.com/sourcegraph/cody/issues/3820