### PR TITLE
Command: Generate CodeLenses using Tree-Sitter query

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Commands: Fixed an issue where Code Lenses were displaying on incorrect lines in the file. [pull/3861](https://github.com/sourcegraph/cody/pull/3861)
+
 ### Changed
 
 ## [1.14.0]

--- a/vscode/src/commands/services/code-lenses.ts
+++ b/vscode/src/commands/services/code-lenses.ts
@@ -69,6 +69,10 @@ export class CommandCodeLenses implements vscode.CodeLensProvider {
         this.fire()
     }
 
+    private isTestFile(uri: vscode.Uri): boolean {
+        return this.addTestEnabled && isValidTestFile(uri)
+    }
+
     /**
      * Gets the code lenses for the specified document.
      */
@@ -86,12 +90,8 @@ export class CommandCodeLenses implements vscode.CodeLensProvider {
             return []
         }
 
-        let lens = commandLenses.cody
-
         // TODO (bee) For test files, adds code lenses for each symbol
-        if (this.addTestEnabled && isValidTestFile(document.uri)) {
-            lens = commandLenses.test
-        }
+        const lens = commandLenses[this.isTestFile(document.uri) ? 'test' : 'cody']
 
         // Get a list of symbols from the document, filter out symbols that are not functions / classes / methods
         const allSymbols = await fetchDocumentSymbols(document)

--- a/vscode/test/e2e/command-edit.test.ts
+++ b/vscode/test/e2e/command-edit.test.ts
@@ -91,8 +91,9 @@ test.extend<ExpectedEvents>({
     await expect(page.getByText('>Goodbye Cody</')).toBeVisible()
 
     // Retry: show the command palette with the previous instruction
+    await expect(acceptLens).toBeVisible()
     await expect(retryLens).toBeVisible()
-    await retryLens.click()
+    await retryLens.click({ delay: 1000 })
     await expect(page.getByText(inputTitle)).toBeVisible()
     await expect(inputBox).toHaveValue(instruction)
     await inputBox.press('Escape')


### PR DESCRIPTION
Refactor code lens generation for Cody Commands.

Updated to use tree-sitter for documentable nodes to display code lenses more accurately, instead of counting on folding ranges. This helps with the issues where code lenses are showing up in non-documentable nodes

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Enable Code Lenses in Cody to check if the lenses are showing up.

### Before

Code Lenses are showing up randomly due to folding ranges positions in large functions or classes:

![image](https://github.com/sourcegraph/cody/assets/68532117/2657759b-5cfb-44fc-9c0c-23cdf0db5ad0)

### After

Code Lenses will not show up in non-top-level-documentable nodes:

![image](https://github.com/sourcegraph/cody/assets/68532117/0d15d0e1-669d-4274-82b0-1a81b72ab3e1)

Known limitation: documentable nodes do not work with arrow functions