### PR TITLE
Fix: text-wrapping and code scrolling in chat views

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: Fixed an issue where Cody's responses were not visible in small windows. [pull/3859](https://github.com/sourcegraph/cody/pull/3859)
+
 ### Changed
 
 ## [1.14.0]

--- a/vscode/test/fixtures/mock-server.ts
+++ b/vscode/test/fixtures/mock-server.ts
@@ -48,6 +48,21 @@ const responses = {
      * Mocked doc string
      */
     `,
+    lorem: `\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n
+    \`\`\`
+    // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean blandit erat egestas, malesuada urna id, congue sem.
+    export interface Animal {
+            name: string
+            makeAnimalSound(): string
+            isMammal: boolean
+            printName(): void {
+                console.log(this.name);
+            }
+        }
+    }
+    \`\`\`
+    \n\n
+    `,
 }
 
 const FIXUP_PROMPT_TAG = '<SELECTEDCODE7662>'
@@ -236,6 +251,10 @@ export class MockServer {
             const request = req as MockRequest
             const lastHumanMessageIndex = request.body.messages.length - 2
             let response = responses.chat
+            // Long chat response
+            if (request.body.messages[lastHumanMessageIndex].text.startsWith('Lorem ipsum')) {
+                response = responses.lorem
+            }
             // Doc command
             if (request.body.messages[lastHumanMessageIndex].text.includes('documentation comment')) {
                 response = responses.document

--- a/vscode/webviews/chat/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent.module.css
@@ -82,6 +82,7 @@
 .content {
     word-break: break-word;
     line-height: 150%;
+    text-wrap: wrap;
 }
 
 /* Style @-file tokens to match TranscriptAction context files */
@@ -115,6 +116,7 @@
 .content pre {
     font-family: var(--vscode-editor-font-family);
     font-size: var(--vscode-editor-font-size);
+    overflow: scroll;
 }
 
 .content pre,

--- a/vscode/webviews/chat/cells/Cell.module.css
+++ b/vscode/webviews/chat/cells/Cell.module.css
@@ -20,7 +20,10 @@
 
 .content {
     flex: 1 0;
-    min-width: 0;
+
+    overflow: auto;
+    word-break: break-word;
+    text-wrap: pretty;
 }
 
 .container--disabled {

--- a/vscode/webviews/chat/cells/messageCell/MessageCell.module.css
+++ b/vscode/webviews/chat/cells/messageCell/MessageCell.module.css
@@ -1,14 +1,14 @@
-.message-content-container {
+.human-message-container {
     display: flex;
     align-items: flex-start;
     gap: var(--cell-spacing);
+    white-space: pre-wrap;
 }
+
 .message-content {
     flex: 1 0;
 }
-.human-content {
-    white-space: pre-wrap;
-}
+
 .edit-button {
     flex: 0 0 auto;
 }

--- a/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
@@ -71,17 +71,13 @@ export const MessageCell: FunctionComponent<{
                 <SpeakerIcon message={message} userInfo={userInfo} chatModel={chatModel} size={24} />
             }
             disabled={disabled}
-            containerClassName={classNames(
-                styles.cellContainer,
-                message.speaker === 'human' && styles.humanContent,
-                {
-                    [styles.focused]: isItemBeingEdited,
-                    [styles.disabled]: disabled,
-                }
-            )}
+            containerClassName={classNames(styles.cellContainer, {
+                [styles.focused]: isItemBeingEdited,
+                [styles.disabled]: disabled,
+            })}
             data-testid="message"
         >
-            <div className={styles.messageContentContainer}>
+            <div className={classNames(message.speaker === 'human' && styles.humanMessageContainer)}>
                 <div className={styles.messageContent}>
                     {message.error ? (
                         typeof message.error === 'string' ? (


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/3863

This PR improves text wrapping and scrolling behavior in the chat views:

- Enables text wrapping in chat message content by adding 'text-wrap: wrap' CSS rule. This allows long messages to wrap instead of overflowing.

- Adds 'overflow: scroll' to `<pre>` tags in message content to enable scrolling for code blocks. Previously code blocks could overflow container. 

- Sets 'overflow: auto' on chat cell content containers. This enables scrolling when content overflows cell.

- Moves 'white-space: pre-wrap' to human message containers for nicer text wrapping of human messages.
These changes improve the readability and scrolling behavior of long chat messages and code blocks. Text will wrap instead of overflowing, and scrolling will be enabled where needed.

PR generated by Cody ;)

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Manual testing:

1. Ask Cody a question that requires Cody to generate a code block
2. Shrink the chat view to see if the text are wrapped correctly, and the code blocks are scrollable

![image](https://github.com/sourcegraph/cody/assets/68532117/02bb5faa-7c31-4313-ab0b-36079dc7d830)

## Before

There is no scrolling for code block and messages, and long texts are cut off and hidden when in a small window:

![image](https://github.com/sourcegraph/cody/assets/68532117/54e29bac-2c1b-4635-ba18-5504e6456e48)
