### PR TITLE
Implement @-mention package context

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,4 +32,7 @@
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
 }

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -86,12 +86,40 @@ export enum ContextItemSource {
 
     /** From URI */
     Uri = 'uri',
+
+    /** From a package repository */
+    Package = 'package',
 }
 
 /**
  * An item (such as a file or symbol) that is included as context in a chat message.
  */
-export type ContextItem = ContextItemFile | ContextItemSymbol
+export type ContextItem = ContextItemFile | ContextItemSymbol | ContextItemPackage
+
+/**
+ * A file (or a subset of a file given by a range) that is included as context in a chat message.
+ */
+export interface ContextItemPackage extends ContextItemCommon {
+    type: 'package'
+
+    /**
+     * the repository id for this package.
+     */
+    repoID: string
+
+    /**
+     * the title for this package.
+     */
+    title: string
+    /**
+     * the ecosystem for this package.
+     */
+    ecosystem: string
+    /**
+     * the name for this package.
+     */
+    name: string
+}
 
 /**
  * A file (or a subset of a file given by a range) that is included as context in a chat message.

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -56,6 +56,7 @@ export {
     type ContextItemWithContent,
     type ContextItemSymbol,
     type ContextFileType,
+    type ContextItemPackage,
     type ContextMessage,
     type SymbolKind,
 } from './codebase-context/messages'

--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -1,4 +1,6 @@
 import type { ContextItem, ContextItemWithContent } from '../codebase-context/messages'
+import type { PromptString } from '../prompt/prompt-string'
+import { PACKAGE_CONTEXT_MENTION_PROVIDER } from './providers/packageMentions'
 import { URL_CONTEXT_MENTION_PROVIDER } from './providers/urlMentions'
 
 /**
@@ -13,7 +15,10 @@ export type ContextMentionProviderID = string
  *
  * In VS Code, use {@link getEnabledContextMentionProviders} instead of this.
  */
-export const CONTEXT_MENTION_PROVIDERS: ContextMentionProvider[] = [URL_CONTEXT_MENTION_PROVIDER]
+export const CONTEXT_MENTION_PROVIDERS: ContextMentionProvider[] = [
+    URL_CONTEXT_MENTION_PROVIDER,
+    PACKAGE_CONTEXT_MENTION_PROVIDER,
+]
 
 /**
  * A provider that can supply context for users to @-mention in chat.
@@ -44,11 +49,12 @@ export interface ContextMentionProvider<ID extends ContextMentionProviderID = Co
      */
     resolveContextItem?(
         item: ContextItemFromProvider<ID>,
+        input: PromptString,
         signal?: AbortSignal
     ): Promise<ContextItemWithContent[]>
 }
 
-type ContextItemFromProvider<ID extends ContextMentionProviderID> = ContextItem & {
+export type ContextItemFromProvider<ID extends ContextMentionProviderID> = ContextItem & {
     /**
      * The ID of the {@link ContextMentionProvider} that supplied this context item.
      */

--- a/lib/shared/src/mentions/providers/packageMentions.ts
+++ b/lib/shared/src/mentions/providers/packageMentions.ts
@@ -1,0 +1,131 @@
+import { URI } from 'vscode-uri'
+import {
+    type ContextItemPackage,
+    ContextItemSource,
+    type ContextItemWithContent,
+} from '../../codebase-context/messages'
+import type { PromptString } from '../../prompt/prompt-string'
+import { graphqlClient } from '../../sourcegraph-api/graphql'
+import { isError } from '../../utils'
+import type { ContextItemFromProvider, ContextMentionProvider } from '../api'
+
+enum PackageEcosystem {
+    npm = 'npm',
+    go = 'go',
+    rust = 'rust',
+    ruby = 'ruby',
+    py = 'py',
+    java = 'java',
+}
+
+enum PackageKind {
+    npm = 'NPMPACKAGES',
+    go = 'GOMODULES',
+    rust = 'RUSTPACKAGES',
+    ruby = 'RUBYPACKAGES',
+    py = 'PYTHONPACKAGES',
+    java = 'JVMPACKAGES',
+}
+
+export function toPackageEcosystem(value: string): PackageEcosystem | null {
+    return PackageEcosystem[value as keyof typeof PackageEcosystem] || null
+}
+function toPackageKind(value: PackageEcosystem): PackageKind {
+    return PackageKind[value]
+}
+
+const MAX_PAKCAGE_LIST_CANDIDATES = 10
+export const PACKAGE_CONTEXT_MENTION_PROVIDER: ContextMentionProvider<'package'> = {
+    id: 'package',
+    triggerPrefixes: Object.values(PackageEcosystem).map(prefix => prefix + ':'),
+
+    /**
+     * Given a possibly incomplete URL from user input (that the user may be typing), return context
+     * items from fetching the URL and extracting its text content.
+     */
+    async queryContextItems(query, signal) {
+        const [ecosystemName = '', name = ''] = query.split(':')
+        const ecosystem = toPackageEcosystem(ecosystemName)
+        if (!ecosystem || name.length < 3) {
+            return []
+        }
+
+        try {
+            const dataOrError = await graphqlClient.getPackageList(
+                toPackageKind(ecosystem),
+                name,
+                MAX_PAKCAGE_LIST_CANDIDATES
+            )
+
+            if (signal) {
+                signal.throwIfAborted()
+            }
+
+            if (isError(dataOrError)) {
+                return []
+            }
+
+            const packages = dataOrError.packageRepoReferences.nodes
+
+            return packages
+                .map(node =>
+                    node.repository
+                        ? ({
+                              type: 'package',
+                              uri: URI.parse(`${graphqlClient.endpoint}${node.repository.name}`),
+                              title: node.name,
+                              content: undefined,
+                              source: ContextItemSource.Package,
+                              repoID: node.repository.id,
+                              provider: 'package',
+                              name: node.name,
+                              ecosystem,
+                          } as ContextItemPackage)
+                        : null
+                )
+                .filter(item => item !== null) as ContextItemFromProvider<'package'>[]
+        } catch (error) {
+            // Suppress errors because the user might be typing a URL that is not yet valid.
+            return []
+        }
+    },
+
+    async resolveContextItem(item, query, signal) {
+        if (item.content !== undefined) {
+            return [item as ContextItemWithContent]
+        }
+
+        if (item.type !== ContextItemSource.Package) {
+            return []
+        }
+
+        return findContextItemsWithContentForPackage(item as ContextItemPackage, query)
+    },
+}
+
+export async function findContextItemsWithContentForPackage(
+    packageContextItem: ContextItemPackage,
+    query: PromptString
+): Promise<ContextItemWithContent[]> {
+    // Sending prompt strings to the Sourcegraph search backend is fine.
+    const result = await graphqlClient.contextSearch(
+        new Set([packageContextItem.repoID]),
+        query.toString()
+    )
+    if (isError(result) || result === null) {
+        return []
+    }
+
+    return result.map(node => ({
+        type: 'file',
+        uri: node.uri,
+        title: node.path,
+        repoName: node.repoName,
+        content: node.content,
+        range: {
+            start: { line: node.startLine, character: 0 },
+            end: { line: node.endLine, character: 0 },
+        },
+        source: ContextItemSource.Package,
+    }))
+}

--- a/lib/shared/src/mentions/providers/packageMentions.ts
+++ b/lib/shared/src/mentions/providers/packageMentions.ts
@@ -39,10 +39,6 @@ export const PACKAGE_CONTEXT_MENTION_PROVIDER: ContextMentionProvider<'package'>
     id: 'package',
     triggerPrefixes: Object.values(PackageEcosystem).map(prefix => prefix + ':'),
 
-    /**
-     * Given a possibly incomplete URL from user input (that the user may be typing), return context
-     * items from fetching the URL and extracting its text content.
-     */
     async queryContextItems(query, signal) {
         const [ecosystemName = '', name = ''] = query.split(':')
         const ecosystem = toPackageEcosystem(ecosystemName)
@@ -85,7 +81,6 @@ export const PACKAGE_CONTEXT_MENTION_PROVIDER: ContextMentionProvider<'package'>
                 )
                 .filter(item => item !== null) as ContextItemFromProvider<'package'>[]
         } catch (error) {
-            // Suppress errors because the user might be typing a URL that is not yet valid.
             return []
         }
     },

--- a/lib/shared/src/mentions/providers/urlMentions.ts
+++ b/lib/shared/src/mentions/providers/urlMentions.ts
@@ -37,7 +37,7 @@ export const URL_CONTEXT_MENTION_PROVIDER: ContextMentionProvider<'url'> = {
         }
     },
 
-    async resolveContextItem(item, signal) {
+    async resolveContextItem(item, _, signal) {
         if (item.content !== undefined) {
             return [item as ContextItemWithContent]
         }

--- a/lib/shared/src/mentions/query.ts
+++ b/lib/shared/src/mentions/query.ts
@@ -46,7 +46,12 @@ export function parseMentionQuery(
     return { provider: 'file', text: query }
 }
 
+const PUNCTUATION = ',\\+\\*\\$\\|#{}\\(\\)\\^\\[\\]!\'"<>;'
+
 const TRIGGERS = '@'
+
+/** Chars we expect to see in a mention (non-space, non-punctuation). */
+const VALID_CHARS = '[^' + PUNCTUATION + '\\s]'
 
 const MAX_LENGTH = 250
 
@@ -57,7 +62,9 @@ const AT_MENTIONS_REGEXP = new RegExp(
         '[' +
         TRIGGERS +
         ']' +
-        '(?<matchingString>#?(?:[^\\s]){0,' +
+        '(?<matchingString>#?(?:' +
+        VALID_CHARS +
+        '){0,' +
         MAX_LENGTH +
         '}' +
         RANGE_REGEXP +

--- a/lib/shared/src/mentions/query.ts
+++ b/lib/shared/src/mentions/query.ts
@@ -46,12 +46,7 @@ export function parseMentionQuery(
     return { provider: 'file', text: query }
 }
 
-// const PUNCTUATION = ',\\+\\*\\$\\@\\|#{}\\(\\)\\^\\[\\]!\'"<>;'
-
 const TRIGGERS = '@'
-
-/** Chars we expect to see in a mention (non-space, non-punctuation). */
-const VALID_CHARS = '[^\\s]'
 
 const MAX_LENGTH = 250
 
@@ -62,9 +57,7 @@ const AT_MENTIONS_REGEXP = new RegExp(
         '[' +
         TRIGGERS +
         ']' +
-        '(?<matchingString>#?(?:' +
-        VALID_CHARS +
-        '){0,' +
+        '(?<matchingString>#?(?:[^\\s]){0,' +
         MAX_LENGTH +
         '}' +
         RANGE_REGEXP +

--- a/lib/shared/src/mentions/query.ts
+++ b/lib/shared/src/mentions/query.ts
@@ -46,12 +46,12 @@ export function parseMentionQuery(
     return { provider: 'file', text: query }
 }
 
-const PUNCTUATION = ',\\+\\*\\$\\@\\|#{}\\(\\)\\^\\[\\]!\'"<>;'
+// const PUNCTUATION = ',\\+\\*\\$\\@\\|#{}\\(\\)\\^\\[\\]!\'"<>;'
 
 const TRIGGERS = '@'
 
 /** Chars we expect to see in a mention (non-space, non-punctuation). */
-const VALID_CHARS = '[^' + TRIGGERS + PUNCTUATION + '\\s]'
+const VALID_CHARS = '[^\\s]'
 
 const MAX_LENGTH = 250
 

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -249,3 +249,23 @@ export const EVALUATE_FEATURE_FLAG_QUERY = `
         evaluateFeatureFlag(flagName: $flagName)
     }
 `
+
+export const PACKAGE_LIST_QUERY = `
+    query Packages($kind: PackageRepoReferenceKind!, $name: String!, $first: Int!, $after: String) {
+        packageRepoReferences(kind: $kind, name: $name, first: $first, after: $after) {
+            nodes {
+                id
+                name
+                kind
+                repository {
+                    id
+                    name
+                    url
+                }
+            }
+            pageInfo {
+                endCursor
+            }
+        }
+    }
+`

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -453,7 +453,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
                 const userContextItems: ContextItemWithContent[] = await resolveContextItems(
                     this.editor,
-                    userContextFiles || []
+                    userContextFiles || [],
+                    inputText
                 )
                 span.setAttribute('strategy', this.config.useContext)
                 const prompter = new DefaultPrompter(

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -80,8 +80,15 @@ export function getEnabledContextMentionProviders(): ContextMentionProvider[] {
 
     const isURLProviderEnabled =
         vscode.workspace.getConfiguration('cody').get<boolean>('experimental.urlContext') === true
-    if (isURLProviderEnabled) {
-        return CONTEXT_MENTION_PROVIDERS.filter(provider => provider.id === 'url')
+    const isPackageProviderEnabled =
+        vscode.workspace.getConfiguration('cody').get<boolean>('experimental.packageContext') === true
+
+    if (isURLProviderEnabled || isPackageProviderEnabled) {
+        return CONTEXT_MENTION_PROVIDERS.filter(
+            provider =>
+                (isURLProviderEnabled && provider.id === 'url') ||
+                (isPackageProviderEnabled && provider.id === 'package')
+        )
     }
     return []
 }

--- a/vscode/src/chat/context/constants.ts
+++ b/vscode/src/chat/context/constants.ts
@@ -4,6 +4,8 @@ export const SYMBOL_HELP_LABEL = 'Search for a symbol to include...'
 export const NO_SYMBOL_MATCHES_LABEL = 'No symbols found'
 export const NO_FILE_MATCHES_LABEL = 'No files found'
 export const NO_SYMBOL_MATCHES_HELP_LABEL = ' (language extensions may be loading)'
+export const PACKAGE_HELP_LABEL = 'Search for a package to include...'
+export const NO_PACKAGE_MATCHES_LABEL = 'No packages found'
 export const FILE_RANGE_TOOLTIP_LABEL = 'Type a line range to include, e.g. 5-10...'
 export const LARGE_FILE_WARNING_LABEL =
     'File too large. Add line range with : or use @# to choose a symbol'

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -16,7 +16,9 @@ import {
     GENERAL_HELP_LABEL,
     LARGE_FILE_WARNING_LABEL,
     NO_FILE_MATCHES_LABEL,
+    NO_PACKAGE_MATCHES_LABEL,
     NO_SYMBOL_MATCHES_LABEL,
+    PACKAGE_HELP_LABEL,
     SYMBOL_HELP_LABEL,
 } from '../../chat/context/constants'
 import { ACCOUNT_UPGRADE_URL } from '../../chat/protocol'
@@ -406,13 +408,17 @@ export const getInput = async (
                         {
                             alwaysShow: true,
                             label:
-                                mentionQuery.provider === 'symbol'
-                                    ? mentionQuery.text.length === 0
-                                        ? SYMBOL_HELP_LABEL
-                                        : NO_SYMBOL_MATCHES_LABEL
-                                    : mentionQuery.text.length === 0
-                                      ? FILE_HELP_LABEL
-                                      : NO_FILE_MATCHES_LABEL,
+                                mentionQuery.provider === 'package'
+                                    ? mentionQuery.text.length < 3
+                                        ? PACKAGE_HELP_LABEL
+                                        : NO_PACKAGE_MATCHES_LABEL
+                                    : mentionQuery.provider === 'symbol'
+                                      ? mentionQuery.text.length === 0
+                                            ? SYMBOL_HELP_LABEL
+                                            : NO_SYMBOL_MATCHES_LABEL
+                                      : mentionQuery.text.length === 0
+                                          ? FILE_HELP_LABEL
+                                          : NO_FILE_MATCHES_LABEL,
                         },
                     ]
                     return
@@ -455,11 +461,13 @@ export const getInput = async (
                     {
                         alwaysShow: true,
                         label:
-                            mentionQuery?.provider === 'symbol'
-                                ? SYMBOL_HELP_LABEL
-                                : mentionQuery?.provider === 'file'
-                                  ? FILE_HELP_LABEL
-                                  : GENERAL_HELP_LABEL,
+                            mentionQuery?.provider === 'package'
+                                ? PACKAGE_HELP_LABEL
+                                : mentionQuery?.provider === 'symbol'
+                                  ? SYMBOL_HELP_LABEL
+                                  : mentionQuery?.provider === 'file'
+                                      ? FILE_HELP_LABEL
+                                      : GENERAL_HELP_LABEL,
                     },
                 ]
             },
@@ -485,6 +493,7 @@ export const getInput = async (
                     case FILE_HELP_LABEL:
                     case LARGE_FILE_WARNING_LABEL:
                     case SYMBOL_HELP_LABEL:
+                    case PACKAGE_HELP_LABEL:
                     case NO_FILE_MATCHES_LABEL:
                     case NO_SYMBOL_MATCHES_LABEL:
                     case GENERAL_HELP_LABEL:

--- a/vscode/src/edit/input/utils.ts
+++ b/vscode/src/edit/input/utils.ts
@@ -23,6 +23,10 @@ export function removeAfterLastAt(str: string): string {
  * Includes the file path and an optional range or symbol specifier.
  */
 export function getLabelForContextItem(item: ContextItem): string {
+    if (item.type === 'package') {
+        return `${item.ecosystem}:${item.name}`
+    }
+
     const isFileType = item.type === 'file'
     if (isFileType && item.title) {
         return `Add context from: ${item.title}`

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -149,6 +149,6 @@ export const getContext = async ({
     }
 
     const derivedContext = await getContextFromIntent({ editor, ...options })
-    const userContext = await resolveContextItems(editor, userContextItems)
+    const userContext = await resolveContextItems(editor, userContextItems, options.selectedText)
     return [...derivedContext, ...userContext]
 }

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -8,6 +8,7 @@ import {
     EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET,
     type Editor,
     ignores,
+    ps,
     testFileUri,
     uriBasename,
 } from '@sourcegraph/cody-shared'
@@ -186,16 +187,20 @@ describe('resolveContextItems', () => {
                 throw new Error('error')
             },
         }
-        const contextItems = await resolveContextItems(mockEditor as Editor, [
-            {
-                type: 'file',
-                uri: URI.parse('file:///a.txt'),
-            },
-            {
-                type: 'file',
-                uri: URI.parse('file:///error.txt'),
-            },
-        ])
+        const contextItems = await resolveContextItems(
+            mockEditor as Editor,
+            [
+                {
+                    type: 'file',
+                    uri: URI.parse('file:///a.txt'),
+                },
+                {
+                    type: 'file',
+                    uri: URI.parse('file:///error.txt'),
+                },
+            ],
+            ps``
+        )
         expect(contextItems).toEqual<ContextItem[]>([
             {
                 type: 'file',

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -4,6 +4,7 @@ import styles from './ContextItemMentionNode.module.css'
 import {
     type ContextItem,
     type ContextItemFile,
+    type ContextItemPackage,
     type ContextItemSymbol,
     displayLineRange,
     displayPath,
@@ -31,6 +32,7 @@ export const MENTION_CLASS_NAME = styles.contextItemMentionNode
 export type SerializedContextItem = { uri: string; content?: undefined } & (
     | Omit<ContextItemFile, 'uri' | 'content'>
     | Omit<ContextItemSymbol, 'uri' | 'content'>
+    | Omit<ContextItemPackage, 'uri' | 'content'>
 )
 
 export function serializeContextItem(
@@ -183,6 +185,9 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
     }
     if (contextItem.type === 'symbol') {
         return `@${displayPath(URI.parse(contextItem.uri))}${rangeText}#${contextItem.symbolName}`
+    }
+    if (contextItem.type === 'package') {
+        return `@${contextItem.ecosystem}:${contextItem.name}`
     }
     // @ts-ignore
     throw new Error(`unrecognized context item type ${contextItem.type}`)

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -1,5 +1,6 @@
 import type { MenuRenderFn } from '@lexical/react/LexicalTypeaheadMenuPlugin'
 import {
+    type MentionQuery,
     type RangeData,
     displayLineRange,
     displayPath,
@@ -15,8 +16,10 @@ import {
     GENERAL_HELP_LABEL,
     LARGE_FILE_WARNING_LABEL,
     NO_FILE_MATCHES_LABEL,
+    NO_PACKAGE_MATCHES_LABEL,
     NO_SYMBOL_MATCHES_HELP_LABEL,
     NO_SYMBOL_MATCHES_LABEL,
+    PACKAGE_HELP_LABEL,
     SYMBOL_HELP_LABEL,
 } from '../../../../src/chat/context/constants'
 import styles from './OptionsList.module.css'
@@ -41,20 +44,7 @@ export const OptionsList: FunctionComponent<
     return (
         <div className={styles.container}>
             <h3 className={classNames(styles.item, styles.helpItem)}>
-                <span>
-                    {mentionQuery.provider === 'default'
-                        ? GENERAL_HELP_LABEL
-                        : mentionQuery.provider === 'symbol'
-                          ? options.length > 0 || !mentionQuery.text.length
-                                ? SYMBOL_HELP_LABEL
-                                : NO_SYMBOL_MATCHES_LABEL +
-                                  (mentionQuery.text.length < 3 ? NO_SYMBOL_MATCHES_HELP_LABEL : '')
-                          : options.length > 0
-                              ? isValidLineRangeQuery(query)
-                                    ? FILE_RANGE_TOOLTIP_LABEL
-                                    : FILE_HELP_LABEL
-                              : NO_FILE_MATCHES_LABEL}
-                </span>
+                <span>{getHelpText(mentionQuery, options)}</span>
                 <br />
             </h3>
             {options.length > 0 && (
@@ -81,6 +71,28 @@ export const OptionsList: FunctionComponent<
     )
 }
 
+function getHelpText(mentionQuery: MentionQuery, options: MentionTypeaheadOption[]): string {
+    switch (mentionQuery.provider) {
+        case 'default':
+            return GENERAL_HELP_LABEL
+        case 'package':
+            return options.length > 0 || mentionQuery.text.length < 3
+                ? PACKAGE_HELP_LABEL
+                : NO_PACKAGE_MATCHES_LABEL
+        case 'symbol':
+            return options.length > 0 || !mentionQuery.text.length
+                ? SYMBOL_HELP_LABEL
+                : NO_SYMBOL_MATCHES_LABEL +
+                      (mentionQuery.text.length < 3 ? NO_SYMBOL_MATCHES_HELP_LABEL : '')
+        default:
+            return options.length > 0
+                ? isValidLineRangeQuery(mentionQuery.text)
+                    ? FILE_RANGE_TOOLTIP_LABEL
+                    : FILE_HELP_LABEL
+                : NO_FILE_MATCHES_LABEL
+    }
+}
+
 const Item: FunctionComponent<{
     query: string
     isSelected: boolean
@@ -91,14 +103,19 @@ const Item: FunctionComponent<{
 }> = ({ query, isSelected, onClick, onMouseEnter, option, className }) => {
     const item = option.item
     const isFileType = item.type === 'file'
-    const icon = isFileType ? null : item.kind === 'class' ? 'symbol-structure' : 'symbol-method'
-    const title = item.title ?? (isFileType ? displayPathBasename(item.uri) : item.symbolName)
+    const isPackageType = item.type === 'package'
+    const icon =
+        isFileType || isPackageType ? null : item.kind === 'class' ? 'symbol-structure' : 'symbol-method'
+    const title =
+        item.title ?? (isFileType || isPackageType ? displayPathBasename(item.uri) : item.symbolName)
 
     const range = getLineRangeInMention(query, item.range)
     const dir = displayPathDirname(item.uri)
-    const description = isFileType
-        ? `${range ? `Lines ${range} · ` : ''}${dir === '.' ? '' : dir}`
-        : `${displayPath(item.uri)}:${getLineRangeInMention(query, item.range)}`
+    const description = isPackageType
+        ? ''
+        : isFileType
+          ? `${range ? `Lines ${range} · ` : ''}${dir === '.' ? '' : dir}`
+          : `${displayPath(item.uri)}:${getLineRangeInMention(query, item.range)}`
 
     const isLargeFile = isFileType && item.isTooLarge
     const warning =


### PR DESCRIPTION
Demo: https://www.loom.com/share/342e1903f93e4ff28f582c5d310ef5ff?sid=f8b66a30-b230-4403-8869-cb3e748cdbb5

We have 370K+ packages from various ecosystems (npm, go, rust, ruby, python, java) already indexed on [sourcegraph.com](http://sourcegraph.com/). It is already enterprise-ready as well.

This new feature will allow users to include specific packages into the context using the syntax `@<ecosystem>:<package_name>`, for example: `@npm:tailwindcss`.

Cody will make a Remote Search for the tailwind package repo against the user's query and include the related code snippets in the context.

## Test plan
TODO
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
