### PR TITLE
VS Code: context filters graphql API update

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -20,11 +20,17 @@ interface ParsedContextFilterItem {
 }
 
 export type GetRepoNameFromWorkspaceUri = (uri: vscode.Uri) => Promise<string | undefined>
+type RepoName = string
+type IsRepoNameAllowed = boolean
 
 export class ContextFiltersProvider implements vscode.Disposable {
+    /**
+     * `null` value means that we failed to fetch context filters.
+     * In that case, we should exclude all the URIs.
+     */
     private contextFilters: ParsedContextFilters | null = null
     private fetchIntervalId: NodeJS.Timer | undefined
-    private cache = new LRUCache<string, boolean>({ max: 128 })
+    private cache = new LRUCache<RepoName, IsRepoNameAllowed>({ max: 128 })
     private getRepoNameFromWorkspaceUri: GetRepoNameFromWorkspaceUri | undefined = undefined
 
     async init(getRepoNameFromWorkspaceUri: GetRepoNameFromWorkspaceUri) {

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -193,7 +193,7 @@ export {
     type BrowserOrNodeResponse,
     type GraphQLAPIClientConfig,
     type LogEventMode,
-    type ContextFiltersResult,
+    type ContextFilters,
     type CodyContextFilterItem,
     type RepoListResponse,
 } from './sourcegraph-api/graphql/client'

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -154,16 +154,11 @@ query GetCodyContext($repos: [ID!]!, $query: String!, $codeResultsCount: Int!, $
 
 export const CONTEXT_FILTERS_QUERY = `
 query ContextFilters {
-	site {
-        codyContextFilters {
-            exclude {
-                repoNamePattern
-            }
-            include {
-                repoNamePattern
-            }
+    site {
+        codyContextFilters(version: V1) {
+            raw
         }
-	}
+    }
 }`
 
 export const SEARCH_ATTRIBUTION_QUERY = `


### PR DESCRIPTION
## Context

- Part of https://github.com/sourcegraph/cody/pull/3771
- Rebased on top of https://github.com/sourcegraph/cody/pull/3856
- Updates the Cody Ignore context filter GraphQL query to be compatible with the latest backend changes https://github.com/sourcegraph/sourcegraph/pull/61101.
- Initializes `contextFiltersProvider` on the extension activation
- Re-initializes `contextFiltersProvider` on configuration change
- Uses the "includes everything" policy for Sourcegraph instances without specified context filters or for instances where this API is not yet supported.

## Test plan

CI and unit tests.
