### PR TITLE
Remove startcoder2-hybrid from settings

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1039,7 +1039,7 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [null, "starcoder-16b", "starcoder-7b", "starcoder2-hybrid", "llama-code-13b"],
+          "enum": [null, "starcoder-16b", "starcoder-7b", "llama-code-13b"],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {


### PR DESCRIPTION
Some of the Fireworks models required for this are no longer deployed:
<img width="1466" alt="Screenshot 2024-04-19 at 09 37 14" src="https://github.com/sourcegraph/cody/assets/1022220/75642c30-6aef-4425-bc55-618d5e5ac15c">
<img width="710" alt="Screenshot 2024-04-19 at 09 37 04" src="https://github.com/sourcegraph/cody/assets/1022220/47c15d35-b165-4840-8bc7-f380da83ce26">

## Test plan

- tested locally 
<img width="995" alt="Screenshot 2024-04-19 at 09 38 37" src="https://github.com/sourcegraph/cody/assets/1022220/5e90e335-6ed0-421f-b6a6-ba68bb9a7125">
