### PR TITLE
Edit: Fix respins not restarting a edit

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: Fixed an issue where Cody's responses were not visible in small windows. [pull/3859](https://github.com/sourcegraph/cody/pull/3859)
+- Edit: Fixed an issue where an Edit task would not correctly respin when an irresolvable conflict is encountered. [pull/3872](https://github.com/sourcegraph/cody/pull/3872)
 
 ### Changed
 

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -67,6 +67,7 @@ export class EditManager implements vscode.Disposable {
             'cody.command.start-edit',
             (task: FixupTask) => {
                 const provider = this.getProviderForTask(task)
+                provider.abortEdit()
                 provider.startEdit()
             }
         )

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -39,6 +39,7 @@ export class EditProvider {
     private insertionResponse: string | null = null
     private insertionInProgress = false
     private insertionPromise: Promise<void> | null = null
+    private abortController: AbortController | null = null
 
     constructor(public config: EditProviderOptions) {}
 
@@ -112,7 +113,7 @@ export class EditProvider {
                 }
             }
 
-            const abortController = new AbortController()
+            this.abortController = new AbortController()
             const stream = this.config.chat.chat(
                 messages,
                 {
@@ -120,7 +121,7 @@ export class EditProvider {
                     stopSequences,
                     maxTokensToSample: contextWindow.output,
                 },
-                abortController.signal
+                this.abortController.signal
             )
 
             let textConsumed = 0
@@ -161,6 +162,10 @@ export class EditProvider {
                 }
             }
         })
+    }
+
+    public abortEdit(): void {
+        this.abortController?.abort()
     }
 
     private async handleResponse(response: string, isMessageInProgress: boolean): Promise<void> {

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -420,7 +420,7 @@ export class FixupController
             return
         }
         void vscode.window.showInformationMessage('Cody will rewrite to include your changes')
-        this.setTaskState(task, CodyTaskState.working)
+        void vscode.commands.executeCommand('cody.command.start-edit', task)
     }
 
     private countEditInsertions(task: FixupTask): { lineCount: number; charCount: number } {


### PR DESCRIPTION
## Description

https://github.com/sourcegraph/cody/assets/9516420/3707835b-90e5-47be-9053-f3650cd038df

Bug: Edits were not correctly re-spinning, as the LLM request wasn't being restarted

Solution:
- When a respin is required:
  - Access the `EditProvider` for the task
  - Abort any existing request
  - Re-trigger `startEdit` using the same task parameters

## Test plan

1. Make an edit
2. Immediately make changes within the range of that edit, that would likely conflict with the LLM's response
3. Expect that the Edit respins and resolves the issue

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
