### PR TITLE
Remove debug.enable flag

### DIFF
--- a/agent/src/AgentWorkspaceConfiguration.ts
+++ b/agent/src/AgentWorkspaceConfiguration.ts
@@ -79,8 +79,6 @@ export class AgentWorkspaceConfiguration implements vscode.WorkspaceConfiguratio
                 return extensionConfig?.autocompleteAdvancedModel ?? null
             case 'cody.advanced.agent.running':
                 return true
-            case 'cody.debug.enable':
-                return extensionConfig?.debug ?? false
             case 'cody.debug.verbose':
                 return extensionConfig?.verboseDebug ?? false
             case 'cody.experimental.tracing':

--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -21,7 +21,6 @@ export interface ConfigGetter<T> {
 export interface Configuration {
     proxy?: string | null
     codebase?: string
-    debugEnable: boolean
     debugFilter: RegExp | null
     debugVerbose: boolean
     telemetryLevel: 'all' | 'off' | 'agent'

--- a/lib/shared/src/sourcegraph-api/completions/client.ts
+++ b/lib/shared/src/sourcegraph-api/completions/client.ts
@@ -27,7 +27,7 @@ export interface CompletionLogger {
 
 export type CompletionsClientConfig = Pick<
     ConfigurationWithAccessToken,
-    'serverEndpoint' | 'accessToken' | 'debugEnable' | 'customHeaders'
+    'serverEndpoint' | 'accessToken' | 'customHeaders'
 >
 
 /**

--- a/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
+++ b/lib/shared/src/sourcegraph-api/completions/nodeClient.ts
@@ -101,8 +101,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                         ...getTraceparentHeaders(),
                     },
                     // So we can send requests to the Sourcegraph local development instance, which has an incompatible cert.
-                    rejectUnauthorized:
-                        process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0' && !this.config.debugEnable,
+                    rejectUnauthorized: process.env.NODE_TLS_REJECT_UNAUTHORIZED !== '0',
                 },
                 (res: http.IncomingMessage) => {
                     const { 'set-cookie': _setCookie, ...safeHeaders } = res.headers

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,9 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Debug: Removed the `cody.debug.enabled` setting. Baseline debugging is now enabled by default [pull/3873](https://github.com/sourcegraph/cody/pull/3873)
+
+
 ## [1.14.0]
 
 ### Added

--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 1. Run `pnpm install` (see [repository setup instructions](../doc/dev/index.md) if you don't have `pnpm`).
 1. Open this repository in VS Code and run the `Launch VS Code Extension (Desktop)` build/debug task (or run `cd vscode && pnpm run build && pnpm run dev`).
 
-Tip: Enable `cody.debug.enable` and `cody.debug.verbose` in VS Code settings during extension development.
+Tip: Enable `cody.debug.verbose` in VS Code settings during extension development.
 
 ## File structure
 
@@ -27,7 +27,7 @@ The best way to help us improve code completions is by contributing your example
 
 ### Accessing autocomplete logs
 
-1. Enable `cody.debug.enable` and `cody.debug.verbose` in VS Code settings
+1. Enable `cody.debug.verbose` in VS Code settings
    - Make sure to restart or reload VS Code after changing these settings
 1. Open the Cody debug panel via "View > Output" and selecting the "Cody by Sourcegraph" option in the dropdown.
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -39,6 +39,7 @@
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
   "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "ai",
     "openai",
@@ -89,6 +90,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
   "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
   "contributes": {
     "walkthroughs": [
@@ -399,7 +401,7 @@
         "command": "cody.autocomplete.openTraceView",
         "category": "Cody",
         "title": "Open Autocomplete Trace View",
-        "when": "cody.activated && config.cody.autocomplete && config.cody.debug.enable && editorHasFocus && !editorReadonly"
+        "when": "cody.activated && config.cody.autocomplete && editorHasFocus && !editorReadonly"
       },
       {
         "command": "cody.autocomplete.manual-trigger",
@@ -510,8 +512,7 @@
         "command": "cody.debug.export.logs",
         "category": "Cody Debug",
         "group": "Debug",
-        "title": "Export Logs…",
-        "when": "config.cody.debug.enable"
+        "title": "Export Logs…"
       },
       {
         "command": "cody.debug.outputChannel",
@@ -619,11 +620,13 @@
       {
         "command": "cody.supercompletion.jumpTo",
         "args": ["next"],
+        "args": ["next"],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
+        "args": ["previous"],
         "args": ["previous"],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
@@ -877,10 +880,12 @@
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
           "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
+          "enum": ["embeddings", "keyword", "blended", "none"],
           "enum": ["embeddings", "keyword", "blended", "none"],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
@@ -940,11 +945,13 @@
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
           "examples": ["Answer all my questions in Spanish."]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.edit.preInstruction": {
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
+          "examples": ["Write all unit tests with Jest instead of detected framework."]
           "examples": ["Write all unit tests with Jest instead of detected framework."]
         },
         "cody.codeActions.enabled": {
@@ -991,12 +998,6 @@
           "markdownDescription": "Enable OpenTelemetry tracing",
           "default": false
         },
-        "cody.debug.enable": {
-          "order": 99,
-          "type": "boolean",
-          "markdownDescription": "Turns on debug output (visible in the VS Code Output panel under \"Cody by Sourcegraph\")",
-          "default": true
-        },
         "cody.debug.verbose": {
           "order": 99,
           "type": "boolean",
@@ -1010,6 +1011,8 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
+          "enum": ["all", "off"],
+          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "enum": ["all", "off"],
           "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
@@ -1060,6 +1063,7 @@
         "cody.experimental.foldingRanges": {
           "type": "string",
           "enum": ["lsp", "indentation-based"],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1072,6 +1076,7 @@
           "default": true,
           "markdownDescription": "Display commands in hover tooltips for code elements.",
           "description": "%config.experimental.hoverCommands%",
+          "tags": ["experimental", "feature-flag"]
           "tags": ["experimental", "feature-flag"]
         },
         "cody.autocomplete.experimental.hotStreak": {
@@ -1087,6 +1092,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
+          "enum": [null, "bfg", "bfg-mixed"],
           "enum": [null, "bfg", "bfg-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -618,13 +618,11 @@
       {
         "command": "cody.supercompletion.jumpTo",
         "args": ["next"],
-        "args": ["next"],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["previous"],
         "args": ["previous"],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -39,7 +39,6 @@
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
   "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
-  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "ai",
     "openai",
@@ -90,7 +89,6 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
   "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
   "contributes": {
     "walkthroughs": [
@@ -880,12 +878,10 @@
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
           "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": ["embeddings", "keyword", "blended", "none"],
           "enum": ["embeddings", "keyword", "blended", "none"],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
@@ -945,13 +941,11 @@
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
           "examples": ["Answer all my questions in Spanish."]
-          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.edit.preInstruction": {
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": ["Write all unit tests with Jest instead of detected framework."]
           "examples": ["Write all unit tests with Jest instead of detected framework."]
         },
         "cody.codeActions.enabled": {
@@ -1013,8 +1007,6 @@
           "type": "string",
           "enum": ["all", "off"],
           "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
-          "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
@@ -1063,7 +1055,6 @@
         "cody.experimental.foldingRanges": {
           "type": "string",
           "enum": ["lsp", "indentation-based"],
-          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1076,7 +1067,6 @@
           "default": true,
           "markdownDescription": "Display commands in hover tooltips for code elements.",
           "description": "%config.experimental.hoverCommands%",
-          "tags": ["experimental", "feature-flag"]
           "tags": ["experimental", "feature-flag"]
         },
         "cody.autocomplete.experimental.hotStreak": {
@@ -1092,7 +1082,6 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "bfg", "bfg-mixed"],
           "enum": [null, "bfg", "bfg-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },

--- a/vscode/src/chat/ContextProvider.ts
+++ b/vscode/src/chat/ContextProvider.ts
@@ -24,7 +24,6 @@ export type Config = Pick<
     ConfigurationWithAccessToken,
     | 'codebase'
     | 'serverEndpoint'
-    | 'debugEnable'
     | 'debugFilter'
     | 'debugVerbose'
     | 'customHeaders'
@@ -191,7 +190,6 @@ export class ContextProvider implements vscode.Disposable, ContextStatusProvider
             const authStatus = this.authProvider.getAuthStatus()
             const configForWebview: ConfigurationSubsetForWebview & LocalEnv = {
                 uiKindIsWeb: vscode.env.uiKind === vscode.UIKind.Web,
-                debugEnable: this.config.debugEnable,
                 serverEndpoint: this.config.serverEndpoint,
                 experimentalGuardrails: this.config.experimentalGuardrails,
             }

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -355,7 +355,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         const authStatus = this.authProvider.getAuthStatus()
         const configForWebview: ConfigurationSubsetForWebview & LocalEnv = {
             uiKindIsWeb: vscode.env.uiKind === vscode.UIKind.Web,
-            debugEnable: config.debugEnable,
             serverEndpoint: config.serverEndpoint,
             experimentalGuardrails: config.experimentalGuardrails,
         }

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -186,10 +186,7 @@ export interface ExtensionTranscriptMessage {
  * The subset of configuration that is visible to the webview.
  */
 export interface ConfigurationSubsetForWebview
-    extends Pick<
-        ConfigurationWithAccessToken,
-        'debugEnable' | 'experimentalGuardrails' | 'serverEndpoint'
-    > {}
+    extends Pick<ConfigurationWithAccessToken, 'experimentalGuardrails' | 'serverEndpoint'> {}
 
 /**
  * URLs for the Sourcegraph instance and app.

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -55,10 +55,6 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.experimental.tracing':
                         return true
-                    case 'cody.debug.enable':
-                        return true
-                    case 'cody.debug.verbose':
-                        return true
                     case 'cody.debug.filter':
                         return /.*/
                     case 'cody.telemetry.level':
@@ -135,7 +131,6 @@ describe('getConfiguration', () => {
             isRunningInsideAgent: false,
             agentIDE: undefined,
             internalUnstable: false,
-            debugEnable: true,
             debugVerbose: true,
             debugFilter: /.*/,
             telemetryLevel: 'off',

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -55,6 +55,8 @@ describe('getConfiguration', () => {
                         return true
                     case 'cody.experimental.tracing':
                         return true
+                    case 'cody.debug.verbose':
+                        return true
                     case 'cody.debug.filter':
                         return /.*/
                     case 'cody.telemetry.level':

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -92,7 +92,6 @@ export function getConfiguration(
         codebase: sanitizeCodebase(config.get(CONFIG_KEY.codebase)),
         customHeaders: config.get<object>(CONFIG_KEY.customHeaders, {}) as Record<string, string>,
         useContext: config.get<ConfigurationUseContext>(CONFIG_KEY.useContext) || 'embeddings',
-        debugEnable: config.get<boolean>(CONFIG_KEY.debugEnable, true),
         debugVerbose: config.get<boolean>(CONFIG_KEY.debugVerbose, false),
         debugFilter: debugRegex,
         telemetryLevel: config.get<'all' | 'off'>(CONFIG_KEY.telemetryLevel, 'all'),

--- a/vscode/src/external-services.ts
+++ b/vscode/src/external-services.ts
@@ -38,7 +38,6 @@ type ExternalServicesConfiguration = Pick<
     | 'useContext'
     | 'customHeaders'
     | 'accessToken'
-    | 'debugEnable'
     | 'debugVerbose'
     | 'experimentalTracing'
 > &

--- a/vscode/src/local-context/symf.test.ts
+++ b/vscode/src/local-context/symf.test.ts
@@ -23,7 +23,6 @@ describe('symf', () => {
             'REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4',
         serverEndpoint: process.env.SRC_ENDPOINT ?? 'https://sourcegraph.com',
         customHeaders: {},
-        debugEnable: true,
     })
 
     describe('expand-query', () => {

--- a/vscode/src/log.ts
+++ b/vscode/src/log.ts
@@ -49,7 +49,6 @@ export function logError(filterLabel: string, text: string, ...args: unknown[]):
  * A window refresh may be needed if these settings are changed for the behavior change to take
  * effect.
  *
- * - cody.debug.enabled: toggles debug logging on or off
  * - cody.debug.filter: sets a regex filter that opts-in messages with labels matching the regex
  * - cody.debug.verbose: prints out the text in the `verbose` field of the last argument
  *
@@ -58,9 +57,7 @@ function log(level: 'debug' | 'error', filterLabel: string, text: string, ...arg
     const workspaceConfig = vscode.workspace.getConfiguration()
     const config = getConfiguration(workspaceConfig)
 
-    const debugEnable = process.env.CODY_DEBUG_ENABLE === 'true' || config.debugEnable
-
-    if (!outputChannel || (level === 'debug' && !debugEnable)) {
+    if (!outputChannel) {
         return
     }
 
@@ -96,13 +93,6 @@ function log(level: 'debug' | 'error', filterLabel: string, text: string, ...arg
 
 export const logger: CompletionLogger = {
     startCompletion(params: CompletionParameters | Record<string, never>, endpoint: string) {
-        const workspaceConfig = vscode.workspace.getConfiguration()
-        const config = getConfiguration(workspaceConfig)
-
-        if (!config.debugEnable) {
-            return undefined
-        }
-
         const start = Date.now()
         const type =
             'prompt' in params

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -65,7 +65,11 @@ import { setUpCodyIgnore } from './services/cody-ignore'
 import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
 import { createOrUpdateTelemetryRecorderProvider, telemetryRecorder } from './services/telemetry-v2'
 import { onTextDocumentChange } from './services/utils/codeblock-action-tracker'
-import { enableDebugMode, exportOutputLog, openCodyOutputChannel } from './services/utils/export-logs'
+import {
+    enableVerboseDebugMode,
+    exportOutputLog,
+    openCodyOutputChannel,
+} from './services/utils/export-logs'
 import { openCodyIssueReporter } from './services/utils/issue-reporter'
 import { SupercompletionProvider } from './supercompletions/supercompletion-provider'
 import { parseAllVisibleDocuments, updateParseTreeOnEdit } from './tree-sitter/parse-tree-cache'
@@ -551,7 +555,7 @@ const register = async (
         // For debugging
         vscode.commands.registerCommand('cody.debug.export.logs', () => exportOutputLog(context.logUri)),
         vscode.commands.registerCommand('cody.debug.outputChannel', () => openCodyOutputChannel()),
-        vscode.commands.registerCommand('cody.debug.enable.all', () => enableDebugMode()),
+        vscode.commands.registerCommand('cody.debug.enable.all', () => enableVerboseDebugMode()),
         vscode.commands.registerCommand('cody.debug.reportIssue', () => openCodyIssueReporter()),
         new CharactersLogger()
     )

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -9,7 +9,7 @@ import { hoverCommandsProvider, isHoverCommandsEnabled } from '../commands/Hover
 import { FeedbackOptionItems, SupportOptionItems } from './FeedbackOptions'
 import { telemetryService } from './telemetry'
 import { telemetryRecorder } from './telemetry-v2'
-import { enableDebugMode } from './utils/export-logs'
+import { enableVerboseDebugMode } from './utils/export-logs'
 
 interface StatusBarError {
     title: string
@@ -234,8 +234,8 @@ export function createStatusBar(): CodyStatusBar {
         quickPick.buttons = [
             {
                 iconPath: new vscode.ThemeIcon('bug'),
-                tooltip: config.debugEnable ? 'Check Debug Logs' : 'Turn on Debug Mode',
-                onClick: () => enableDebugMode(),
+                tooltip: config.debugVerbose ? 'Check Debug Logs' : 'Turn on Debug Mode',
+                onClick: () => enableVerboseDebugMode(),
             } as vscode.QuickInputButton,
         ]
         quickPick.onDidTriggerButton(async item => {

--- a/vscode/src/services/utils/export-logs.ts
+++ b/vscode/src/services/utils/export-logs.ts
@@ -65,12 +65,11 @@ export function openCodyOutputChannel(): void {
 
 /**
  * Enables debug mode by updating workspace configuration settings.
- * Sets 'cody.debug.enable' and 'cody.debug.verbose' to true globally.
+ * Sets 'cody.debug.verbose' to true globally.
  * Opens the Cody output channel.
  */
-export function enableDebugMode(): void {
+export function enableVerboseDebugMode(): void {
     const workspaceConfig = vscode.workspace.getConfiguration()
-    void workspaceConfig.update('cody.debug.enable', undefined, vscode.ConfigurationTarget.Global)
     void workspaceConfig.update('cody.debug.verbose', true, vscode.ConfigurationTarget.Global)
     openCodyOutputChannel()
 }

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -827,7 +827,6 @@ export const DEFAULT_VSCODE_SETTINGS = {
     commandHints: false,
     isRunningInsideAgent: false,
     agentIDE: undefined,
-    debugEnable: true,
     debugVerbose: false,
     debugFilter: null,
     telemetryLevel: 'all',

--- a/vscode/test/fixtures/.vscode/settings.json
+++ b/vscode/test/fixtures/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
   "cody.codebase": "http://localhost:49300",
-  "cody.debug.enable": true,
   "cody.debug.verbose": true,
 }

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -26,7 +26,6 @@ const dummyVSCodeAPI: VSCodeWrapper = {
         cb({
             type: 'config',
             config: {
-                debugEnable: true,
                 serverEndpoint: 'https://example.com',
                 uiKindIsWeb: false,
                 experimentalGuardrails: false,

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -35,7 +35,7 @@ import { updateDisplayPathEnvInfoForWebview } from './utils/displayPathEnvInfo'
 import { createWebviewTelemetryService } from './utils/telemetry'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
-    const [config, setConfig] = useState<(Pick<Configuration, 'debugEnable'> & LocalEnv) | null>(null)
+    const [config, setConfig] = useState<LocalEnv | null>(null)
     const [view, setView] = useState<View | undefined>()
     // If the current webview is active (vs user is working in another editor tab)
     const [isWebviewActive, setIsWebviewActive] = useState<boolean>(true)

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -5,7 +5,6 @@ import './App.css'
 import {
     type AuthStatus,
     type ChatMessage,
-    type Configuration,
     type ContextItem,
     type EnhancedContextContextT,
     GuardrailsPost,


### PR DESCRIPTION
We changed the default to `true` a while back but it's still possible to have manual overwrites. Let's remove the flag.

## Test plan

- CI