### PR TITLE
Agent: don't error on empty HAR log entries

### DIFF
--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -466,7 +466,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 // @ts-ignore
                 const persister = polly.persister._cache as Map<string, Har>
                 for (const [, har] of persister) {
-                    for (const entry of har.log.entries) {
+                    for (const entry of har?.log?.entries ?? []) {
                         if (entry.request.url !== url) {
                             continue
                         }


### PR DESCRIPTION
Context https://sourcegraph.slack.com/archives/C05AGQYD528/p1713499680284229

CI is failing when `har.log` is undefined. This PR changes the property access to fallback to an empty `[]` list when it's undefined.


## Test plan
Green CI
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
