### PR TITLE
Agent: add `server` subcommand to expose agent protocol via websockets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,4 +29,7 @@
     "Supercompletion",
     "Supercompletions"
   ],
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
 }

--- a/agent/package.json
+++ b/agent/package.json
@@ -57,7 +57,8 @@
     "pretty-ms": "^8.0.0",
     "uuid": "^9.0.0",
     "vscode-uri": "^3.0.7",
-    "win-ca": "^3.5.1"
+    "win-ca": "^3.5.1",
+    "ws": "^8.16.0"
   },
   "devDependencies": {
     "@types/dedent": "^0.7.0",
@@ -66,6 +67,7 @@
     "@types/minimatch": "^5.1.2",
     "@types/uuid": "^9.0.2",
     "@types/vscode": "^1.80.0",
+    "@types/ws": "^8.5.10",
     "diff": "^5.2.0",
     "esbuild": "^0.18.19",
     "google-protobuf": "^3.21.2",

--- a/agent/src/cli/root.ts
+++ b/agent/src/cli/root.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander'
 import { cliCommand } from '../../../cli/src/command'
 import { evaluateAutocompleteCommand } from './evaluate-autocomplete/evaluate-autocomplete'
 import { jsonrpcCommand } from './jsonrpc'
+import { serverCommand } from './server'
 
 export const rootCommand = new Command()
     .name('cody-agent')
@@ -11,6 +12,7 @@ export const rootCommand = new Command()
         'Cody Agent supports running the Cody VS Code extension in headless mode and interact with it via JSON-RPC. ' +
             'The Agent is used by editor clients like JetBrains and Neovim.'
     )
+    .addCommand(serverCommand)
     .addCommand(jsonrpcCommand)
     .addCommand(evaluateAutocompleteCommand)
     .addCommand(cliCommand)

--- a/agent/src/cli/server.ts
+++ b/agent/src/cli/server.ts
@@ -1,0 +1,47 @@
+import { logDebug, logError } from '@sourcegraph/cody-shared'
+import { Command } from 'commander'
+import { WebSocketServer } from 'ws'
+import { newAgentClient } from '../agent'
+import type { MessageHandler } from '../jsonrpc-alias'
+import { intOption } from './evaluate-autocomplete/cli-parsers'
+
+interface ServerOptions {
+    port: number
+}
+
+export const serverCommand = new Command('server')
+    .option('--port <number>', 'Which port to listen to', intOption, 7000)
+    .action(async (options: ServerOptions) => {
+        const wss = new WebSocketServer({
+            port: options.port,
+        })
+        logDebug('cody-server', `Listening... http://localhost:${options.port}`)
+        wss.on('connection', async ws => {
+            logDebug('cody-server', 'New client')
+            let agent: MessageHandler | undefined
+
+            ws.on('error', error => logError('cody-server', String(error)))
+            ws.on('message', async data => {
+                const json = String(data)
+                logDebug('cody-server', 'Received message', json)
+                if (agent === undefined) {
+                    agent = await newAgentClient({
+                        name: 'cody-server',
+                        version: '0.1.0',
+                        workspaceRootUri: 'file:///tmp/cody-server',
+                    })
+                    agent.fallbackHandler = async msg => {
+                        ws.send(JSON.stringify(msg))
+                    }
+                    const initialized = await agent.request('extensionConfiguration/change', {
+                        accessToken: process.env.SRC_ACCESS_TOKEN ?? 'invalidtoken',
+                        serverEndpoint: process.env.SRC_ENDPOINT ?? 'invalidendpoint',
+                        customHeaders: {},
+                    })
+                    console.log({ initialized })
+                }
+
+                agent.messageEncoder.send(JSON.parse(String(data)))
+            })
+        })
+    })

--- a/lib/shared/src/logger.ts
+++ b/lib/shared/src/logger.ts
@@ -19,10 +19,10 @@ interface CodyLogger {
 
 const consoleLogger: CodyLogger = {
     logDebug(filterLabel, text, ...args) {
-        console.log(`${filterLabel}:${text}`, ...args)
+        console.log(`${filterLabel}: ${text}`, ...args)
     },
     logError(filterLabel, text, ...args) {
-        console.log(`${filterLabel}:${text}`, ...args)
+        console.log(`${filterLabel}: ${text}`, ...args)
     },
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       win-ca:
         specifier: ^3.5.1
         version: 3.5.1
+      ws:
+        specifier: ^8.16.0
+        version: 8.16.0
     devDependencies:
       '@types/dedent':
         specifier: ^0.7.0
@@ -169,6 +172,9 @@ importers:
       '@types/vscode':
         specifier: ^1.80.0
         version: 1.80.0
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.5.10
       diff:
         specifier: ^5.2.0
         version: 5.2.0
@@ -5599,6 +5605,12 @@ packages:
 
   /@types/vscode@1.80.0:
     resolution: {integrity: sha512-qK/CmOdS2o7ry3k6YqU4zD3R2AYlJfbwBoSbKpBoP+GpXNE+0NEgJOli4n0bm0diK5kfBnchgCEj4igQz/44Hg==}
+    dev: true
+
+  /@types/ws@8.5.10:
+    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
+    dependencies:
+      '@types/node': 20.4.0
     dev: true
 
   /@types/yaml@1.9.7:
@@ -14110,7 +14122,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: true
 
   /xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}

--- a/vscode/src/jsonrpc/jsonrpc.ts
+++ b/vscode/src/jsonrpc/jsonrpc.ts
@@ -272,6 +272,7 @@ export class MessageHandler {
             reject: (params: Error) => void
         }
     > = new Map()
+    public fallbackHandler?: (msg: any) => void = msg => {}
     public isAlive(): boolean {
         return this.alive
     }
@@ -374,7 +375,11 @@ export class MessageHandler {
                             this.cancelTokens.delete(msg.id)
                         })
                 } else {
-                    console.error(`No handler for request with method ${msg.method}`)
+                    if (this.fallbackHandler) {
+                        this.fallbackHandler(msg)
+                    } else {
+                        console.error(`No handler for request with method ${msg.method}`)
+                    }
                 }
             } else if (msg.id !== undefined) {
                 // Responses have ids
@@ -387,7 +392,11 @@ export class MessageHandler {
                     }
                     this.responseHandlers.delete(msg.id)
                 } else {
-                    console.error(`No handler for response with id ${msg.id}`)
+                    if (this.fallbackHandler) {
+                        this.fallbackHandler(msg)
+                    } else {
+                        console.error(`No handler for response with id ${msg.id}`)
+                    }
                 }
             } else if (msg.method) {
                 // Notifications have methods
@@ -411,7 +420,11 @@ export class MessageHandler {
                             )
                         }
                     } else {
-                        console.error(`No handler for notification with method ${msg.method}`)
+                        if (this.fallbackHandler) {
+                            this.fallbackHandler(msg)
+                        } else {
+                            console.error(`No handler for message with method ${msg.method}`)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Previously, it was only possible to do RPC with the Cody Agent via stdin/stdout, which required the client to run on the same computer as the Cody Agent. This PR adds a new `server` subcommand that starts a server that allows clients to connect with the Cody Agent via web sockets from another computer.

One example use-case for this feature is to implement a browser client to interact with Cody Chat. By using websockets, the browser client can interact with Cody without installing any custom dependencies. To improve the ergonomics of interacting with Cody, we can extend our current Kotlin bindings generation tool to generate bindings for other languages like TypeScript and Go.

Below is a demo of a SvelteKit static page that establishes a websocket connection to expose a basic chat interface

![CleanShot 2024-04-18 at 22 15 13](https://github.com/sourcegraph/cody/assets/1408093/22640ecb-6f90-48d3-aaa6-1c7c2da464ce)


## Test plan

Manually tested with a SvelteKit client.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
