### PR TITLE
Chat: minor clean up

### DIFF
--- a/lib/shared/src/token/counter.ts
+++ b/lib/shared/src/token/counter.ts
@@ -122,7 +122,7 @@ export class TokenCounter {
     /**
      * The default tokenizer is cl100k_base.
      */
-    private static tokenize = getEncoding('cl100k_base')
+    private static tokenizer = getEncoding('cl100k_base')
 
     /**
      * Encode the given text using the tokenizer.
@@ -130,11 +130,11 @@ export class TokenCounter {
      * All special tokens are included in the token count.
      */
     public static encode(text: string): number[] {
-        return TokenCounter.tokenize.encode(text.normalize('NFKC'), 'all')
+        return TokenCounter.tokenizer.encode(text.normalize('NFKC'), 'all')
     }
 
     public static decode(encoded: number[]): string {
-        return TokenCounter.tokenize.decode(encoded)
+        return TokenCounter.tokenizer.decode(encoded)
     }
 
     /**

--- a/vscode/src/chat/utils.ts
+++ b/vscode/src/chat/utils.ts
@@ -1,4 +1,4 @@
-import type { AuthStatus, ChatMessage } from '@sourcegraph/cody-shared'
+import type { AuthStatus } from '@sourcegraph/cody-shared'
 import semver from 'semver'
 import { defaultAuthStatus, unauthenticatedStatus } from './protocol'
 
@@ -106,36 +106,4 @@ function inferCodyApiVersion(version: string, isDotCom: boolean): 0 | 1 {
     }
 
     return 0 // zero refers to the legacy, unversioned, Cody API
-}
-
-/**
- * Counts the total number of bytes used in a list of chat messages.
- *
- * This function is exported and can be used to calculate the byte usage
- * of chat messages for storage/bandwidth purposes.
- *
- * @param messages - The list of chat messages to count bytes for
- * @returns The total number of bytes used in the messages
- */
-export function countBytesInChatMessages(messages: ChatMessage[]): number {
-    if (messages.length === 0) {
-        return 0
-    }
-    return messages.reduce((acc, msg) => acc + msg.speaker.length + (msg.text?.length || 0) + 3, 0)
-}
-
-/**
- * Gets the context window limit in bytes for chat messages, taking into
- * account the maximum allowed character count. Returns 0 if the used bytes
- * exceeds the limit.
- * @param messages - The chat messages
- * @param maxChars - The maximum allowed character count
- * @returns The context window limit in bytes
- */
-export function getContextWindowLimitInBytes(messages: ChatMessage[], maxChars: number): number {
-    const used = countBytesInChatMessages(messages)
-    if (used > maxChars) {
-        return 0
-    }
-    return maxChars - used
 }


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1713491201142189
Follow-up on https://github.com/sourcegraph/cody/pull/3742

In https://github.com/sourcegraph/cody/pull/3742 we have replaced the old token-counting logic with js-tiktoken using `'cl100k_base'` encoding. This PR contains some minor clean-up works as a follow-up to that. 

- The `tokenize` method (which was a typo) has been renamed to `tokenizer`.
  - References to `tokenize` have been updated to use the `tokenizer` instance property instead.
- Removed unused `countBytesInChatMessages` and `getContextWindowLimitInBytes` utility functions

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Just removed unused functions and fixed a typo. Everything should work as before with green CI.