### PR TITLE
introduce ContextMentionProvider API for mentionable context sources

### DIFF
--- a/lib/shared/src/chat/transcript/display-text.ts
+++ b/lib/shared/src/chat/transcript/display-text.ts
@@ -2,7 +2,7 @@ import type * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 import type { ContextItem } from '../../codebase-context/messages'
 import type { RangeData } from '../../common/range'
-import { isURLContextItem } from '../../mentions/urlContextItems'
+import { isURLContextItem } from '../../mentions/providers/urlMentions'
 
 /**
  * VS Code intentionally limits what `command:vscode.open?ARGS` can have for args (see

--- a/lib/shared/src/chat/transcript/display-text.ts
+++ b/lib/shared/src/chat/transcript/display-text.ts
@@ -2,7 +2,6 @@ import type * as vscode from 'vscode'
 import type { URI } from 'vscode-uri'
 import type { ContextItem } from '../../codebase-context/messages'
 import type { RangeData } from '../../common/range'
-import { isURLContextItem } from '../../mentions/providers/urlMentions'
 
 /**
  * VS Code intentionally limits what `command:vscode.open?ARGS` can have for args (see
@@ -41,7 +40,7 @@ export function webviewOpenURIForContextItem(item: Pick<ContextItem, 'uri' | 'ra
     href: string
     target: '_blank' | undefined
 } {
-    if (isURLContextItem(item)) {
+    if (item.uri.scheme === 'http' || item.uri.scheme === 'https') {
         return {
             href: item.uri.toString(),
             target: '_blank',

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -46,6 +46,12 @@ interface ContextItemCommon {
      * Whether the content of the item is too large to be included as context.
      */
     isTooLarge?: boolean
+
+    /**
+     * The ID of the {@link ContextMentionProvider} that supplied this context item (or `undefined`
+     * if from a built-in context source such as files and symbols).
+     */
+    provider?: string
 }
 
 /**

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -240,7 +240,7 @@ export {
     getURLContextItems,
     isURLContextItem,
     resolveURLContextItem,
-} from './mentions/urlContextItems'
+} from './mentions/providers/urlMentions'
 export { TokenCounter } from './token/counter'
 export {
     EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET,

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -237,10 +237,9 @@ export {
     scanForMentionTriggerInUserTextInput,
 } from './mentions/query'
 export {
-    getURLContextItems,
-    isURLContextItem,
-    resolveURLContextItem,
-} from './mentions/providers/urlMentions'
+    CONTEXT_MENTION_PROVIDERS,
+    type ContextMentionProvider,
+} from './mentions/api'
 export { TokenCounter } from './token/counter'
 export {
     EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET,

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -239,7 +239,7 @@ export {
 export {
     getURLContextItems,
     isURLContextItem,
-    fetchContentForURLContextItem,
+    resolveURLContextItem,
 } from './mentions/urlContextItems'
 export { TokenCounter } from './token/counter'
 export {

--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -1,0 +1,54 @@
+import type { ContextItem, ContextItemWithContent } from '../codebase-context/messages'
+import { URL_CONTEXT_MENTION_PROVIDER } from './providers/urlMentions'
+
+/**
+ * A unique identifier for a {@link ContextMentionProvider}.
+ */
+export type ContextMentionProviderID = string
+
+/**
+ * Providers that supply context that the user can @-mention in chat.
+ *
+ * This API is *experimental* and subject to rapid, unannounced change.
+ *
+ * In VS Code, use {@link getEnabledContextMentionProviders} instead of this.
+ */
+export const CONTEXT_MENTION_PROVIDERS: ContextMentionProvider[] = [URL_CONTEXT_MENTION_PROVIDER]
+
+/**
+ * A provider that can supply context for users to @-mention in chat.
+ *
+ * This API is *experimental* and subject to rapid, unannounced change.
+ */
+export interface ContextMentionProvider<ID extends ContextMentionProviderID = ContextMentionProviderID> {
+    id: ID
+
+    /**
+     * Prefix strings for the user input after the `@` that trigger this provider. For example, a
+     * context mention provider with prefix `npm:` would be triggered when the user types `@npm:`.
+     */
+    triggerPrefixes: string[]
+
+    /**
+     * Get a list of possible context items to show (in a completion menu) when the user triggers
+     * this provider while typing `@` in a chat message.
+     */
+    queryContextItems(query: string, signal?: AbortSignal): Promise<ContextItemFromProvider<ID>[]>
+
+    /**
+     * Resolve a context item to one or more items that have the {@link ContextItem.content} field
+     * filled in. A provider is called to resolve only the context items that it returned in
+     * {@link queryContextItems} and that the user explicitly added.
+     */
+    resolveContextItem?(
+        item: ContextItemFromProvider<ID>,
+        signal?: AbortSignal
+    ): Promise<ContextItemWithContent[]>
+}
+
+type ContextItemFromProvider<ID extends ContextMentionProviderID> = ContextItem & {
+    /**
+     * The ID of the {@link ContextMentionProvider} that supplied this context item.
+     */
+    provider: ID
+}

--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -32,6 +32,8 @@ export interface ContextMentionProvider<ID extends ContextMentionProviderID = Co
     /**
      * Get a list of possible context items to show (in a completion menu) when the user triggers
      * this provider while typing `@` in a chat message.
+     *
+     * {@link query} omits the `@` but includes the trigger prefix from {@link triggerPrefixes}.
      */
     queryContextItems(query: string, signal?: AbortSignal): Promise<ContextItemFromProvider<ID>[]>
 

--- a/lib/shared/src/mentions/providers/urlMentions.ts
+++ b/lib/shared/src/mentions/providers/urlMentions.ts
@@ -3,7 +3,7 @@ import {
     type ContextItem,
     ContextItemSource,
     type ContextItemWithContent,
-} from '../codebase-context/messages'
+} from '../../codebase-context/messages'
 
 /**
  * Given a possibly incomplete URL from user input (that the user may be typing), return context

--- a/lib/shared/src/mentions/providers/urlMentions.ts
+++ b/lib/shared/src/mentions/providers/urlMentions.ts
@@ -17,7 +17,7 @@ export const URL_CONTEXT_MENTION_PROVIDER: ContextMentionProvider<'url'> = {
         }
 
         try {
-            const content = await fetchContentForURLContextItem(url.toString(), false, signal)
+            const content = await fetchContentForURLContextItem(url.toString(), signal)
             if (content === null) {
                 return []
             }
@@ -41,31 +41,22 @@ export const URL_CONTEXT_MENTION_PROVIDER: ContextMentionProvider<'url'> = {
         if (item.content !== undefined) {
             return [item as ContextItemWithContent]
         }
-        const content = await fetchContentForURLContextItem(item.uri.toString(), true, signal)
-        return [{ ...item, content }]
+        const content = await fetchContentForURLContextItem(item.uri.toString(), signal)
+        return content ? [{ ...item, content }] : []
     },
 }
 
 async function fetchContentForURLContextItem(
-    url: string,
-    throwIfNotOK: true,
-    signal?: AbortSignal
-): Promise<string>
-async function fetchContentForURLContextItem(
-    url: string,
-    throwIfNotOK: false,
-    signal?: AbortSignal
-): Promise<string | null>
-async function fetchContentForURLContextItem(
-    url: string,
-    throwIfNotOK: boolean,
+    urlStr: string,
     signal?: AbortSignal
 ): Promise<string | null> {
-    const resp = await fetch(url.toString(), { signal })
+    const url = new URL(urlStr)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new Error('unsupported protocol for URL mention')
+    }
+
+    const resp = await fetch(urlStr, { signal })
     if (!resp.ok) {
-        if (throwIfNotOK) {
-            throw new Error(`HTTP ${resp.status} ${resp.statusText}`)
-        }
         return null
     }
     const body = await resp.text()

--- a/lib/shared/src/mentions/query.test.ts
+++ b/lib/shared/src/mentions/query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
+import type { ContextMentionProvider } from './api'
 import {
     type MentionQuery,
     type MentionTrigger,
@@ -9,21 +10,21 @@ import {
 
 describe('parseMentionQuery', () => {
     test('empty query for empty string', () => {
-        expect(parseMentionQuery('')).toEqual<MentionQuery>({
+        expect(parseMentionQuery('', [])).toEqual<MentionQuery>({
             provider: 'default',
             text: '',
         })
     })
 
     test('file query without prefix', () => {
-        expect(parseMentionQuery('foo')).toEqual<MentionQuery>({
+        expect(parseMentionQuery('foo', [])).toEqual<MentionQuery>({
             provider: 'file',
             text: 'foo',
         })
     })
 
     test('symbol query without prefix', () => {
-        expect(parseMentionQuery('#bar')).toEqual<MentionQuery>({
+        expect(parseMentionQuery('#bar', [])).toEqual<MentionQuery>({
             provider: 'symbol',
             text: 'bar',
         })
@@ -32,18 +33,24 @@ describe('parseMentionQuery', () => {
     test('file query with @ prefix', () => {
         // Note: This means that the user is literally looking for a file whose name contains `@`.
         // This is a very rare case. See the docstring for `parseMentionQuery`.
-        expect(parseMentionQuery('@baz')).toEqual<MentionQuery>({
+        expect(parseMentionQuery('@baz', [])).toEqual<MentionQuery>({
             provider: 'file',
             text: '@baz',
         })
     })
 
     test('url query with http:// prefix', () => {
-        expect(parseMentionQuery('http://example.com/p')).toEqual<MentionQuery>({
+        const providers: Pick<ContextMentionProvider, 'id' | 'triggerPrefixes'>[] = [
+            {
+                id: 'url',
+                triggerPrefixes: ['http://', 'https://'],
+            },
+        ]
+        expect(parseMentionQuery('http://example.com/p', providers)).toEqual<MentionQuery>({
             provider: 'url',
             text: 'http://example.com/p',
         })
-        expect(parseMentionQuery('https://example.com/p')).toEqual<MentionQuery>({
+        expect(parseMentionQuery('https://example.com/p', providers)).toEqual<MentionQuery>({
             provider: 'url',
             text: 'https://example.com/p',
         })

--- a/lib/shared/src/mentions/query.test.ts
+++ b/lib/shared/src/mentions/query.test.ts
@@ -10,21 +10,21 @@ import {
 describe('parseMentionQuery', () => {
     test('empty query for empty string', () => {
         expect(parseMentionQuery('')).toEqual<MentionQuery>({
-            type: 'empty',
+            provider: 'default',
             text: '',
         })
     })
 
     test('file query without prefix', () => {
         expect(parseMentionQuery('foo')).toEqual<MentionQuery>({
-            type: 'file',
+            provider: 'file',
             text: 'foo',
         })
     })
 
     test('symbol query without prefix', () => {
         expect(parseMentionQuery('#bar')).toEqual<MentionQuery>({
-            type: 'symbol',
+            provider: 'symbol',
             text: 'bar',
         })
     })
@@ -33,18 +33,18 @@ describe('parseMentionQuery', () => {
         // Note: This means that the user is literally looking for a file whose name contains `@`.
         // This is a very rare case. See the docstring for `parseMentionQuery`.
         expect(parseMentionQuery('@baz')).toEqual<MentionQuery>({
-            type: 'file',
+            provider: 'file',
             text: '@baz',
         })
     })
 
     test('url query with http:// prefix', () => {
         expect(parseMentionQuery('http://example.com/p')).toEqual<MentionQuery>({
-            type: 'url',
+            provider: 'url',
             text: 'http://example.com/p',
         })
         expect(parseMentionQuery('https://example.com/p')).toEqual<MentionQuery>({
-            type: 'url',
+            provider: 'url',
             text: 'https://example.com/p',
         })
     })

--- a/lib/shared/src/mentions/query.ts
+++ b/lib/shared/src/mentions/query.ts
@@ -5,11 +5,11 @@ export interface MentionQuery {
     /**
      * The type of context item to search for.
      */
-    type: 'file' | 'symbol' | 'url' | 'empty'
+    provider: 'file' | 'symbol' | 'url' | 'default'
 
     /**
      * The user's text input, to be interpreted as a fuzzy-matched query. It is stripped of any
-     * prefix characters that indicate the {@link MentionQuery.type}, such as `#` for symbols.
+     * prefix characters that indicate the {@link MentionQuery.provider}, such as `#` for symbols.
      */
     text: string
 }
@@ -25,16 +25,16 @@ export interface MentionQuery {
  */
 export function parseMentionQuery(query: string): MentionQuery {
     if (query === '') {
-        return { type: 'empty', text: '' }
+        return { provider: 'default', text: '' }
     }
 
     if (query.startsWith('#')) {
-        return { type: 'symbol', text: query.slice(1) }
+        return { provider: 'symbol', text: query.slice(1) }
     }
     if (query.startsWith('http://') || query.startsWith('https://')) {
-        return { type: 'url', text: query }
+        return { provider: 'url', text: query }
     }
-    return { type: 'file', text: query }
+    return { provider: 'file', text: query }
 }
 
 const PUNCTUATION = ',\\+\\*\\$\\@\\|#{}\\(\\)\\^\\[\\]!\'"<>;'

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -589,9 +589,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     privateMetadata: { source },
                 })
             },
-            withType: type => {
-                telemetryService.log(`CodyVSCodeExtension:at-mention:${type}:executed`, { source })
-                telemetryRecorder.recordEvent(`cody.at-mention.${type}`, 'executed', {
+            withProvider: provider => {
+                telemetryService.log(`CodyVSCodeExtension:at-mention:${provider}:executed`, { source })
+                telemetryRecorder.recordEvent(`cody.at-mention.${provider}`, 'executed', {
                     privateMetadata: { source },
                 })
             },

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -31,7 +31,7 @@ import {
 import type { View } from '../../../webviews/NavBar'
 import { getFullConfig } from '../../configuration'
 import { type RemoteSearch, RepoInclusion } from '../../context/remote-search'
-import { fillInContextItemContent } from '../../editor/utils/editor-context'
+import { resolveContextItems } from '../../editor/utils/editor-context'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import { ContextStatusAggregator } from '../../local-context/enhanced-context-status'
 import type { LocalEmbeddingsController } from '../../local-context/local-embeddings'
@@ -451,7 +451,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
                 this.postEmptyMessageInProgress()
 
-                const userContextItems: ContextItemWithContent[] = await fillInContextItemContent(
+                const userContextItems: ContextItemWithContent[] = await resolveContextItems(
                     this.editor,
                     userContextFiles || []
                 )

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -20,7 +20,7 @@ export async function getChatContextItemsForMention(
     cancellationToken: vscode.CancellationToken,
     telemetryRecorder?: {
         empty: () => void
-        withType: (type: MentionQuery['type']) => void
+        withType: (type: MentionQuery['provider']) => void
     },
     range?: RangeData
 ): Promise<ContextItem[]> {
@@ -29,15 +29,15 @@ export async function getChatContextItemsForMention(
     // Logging: log when the at-mention starts, and then log when we know the type (after the 1st
     // character is typed). Don't log otherwise because we would be logging prefixes of the same
     // query repeatedly, which is not needed.
-    if (mentionQuery.type === 'empty') {
+    if (mentionQuery.provider === 'default') {
         telemetryRecorder?.empty()
     } else if (mentionQuery.text.length === 1) {
-        telemetryRecorder?.withType(mentionQuery.type)
+        telemetryRecorder?.withType(mentionQuery.provider)
     }
 
     const MAX_RESULTS = 20
-    switch (mentionQuery.type) {
-        case 'empty':
+    switch (mentionQuery.provider) {
+        case 'default':
             return getOpenTabsContextFile()
         case 'symbol':
             // It would be nice if the VS Code symbols API supports cancellation, but it doesn't

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -19,7 +19,7 @@ export async function getChatContextItemsForMention(
     cancellationToken: vscode.CancellationToken,
     telemetryRecorder?: {
         empty: () => void
-        withType: (type: MentionQuery['provider']) => void
+        withProvider: (type: MentionQuery['provider']) => void
     },
     range?: RangeData
 ): Promise<ContextItem[]> {
@@ -31,8 +31,8 @@ export async function getChatContextItemsForMention(
     // query repeatedly, which is not needed.
     if (mentionQuery.provider === 'default') {
         telemetryRecorder?.empty()
-    } else if (mentionQuery.text.length === 1) {
-        telemetryRecorder?.withType(mentionQuery.provider)
+    } else {
+        telemetryRecorder?.withProvider(mentionQuery.provider)
     }
 
     const MAX_RESULTS = 20

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -402,7 +402,7 @@ export const getInput = async (
                         {
                             alwaysShow: true,
                             label:
-                                mentionQuery.type === 'symbol'
+                                mentionQuery.provider === 'symbol'
                                     ? mentionQuery.text.length === 0
                                         ? SYMBOL_HELP_LABEL
                                         : NO_SYMBOL_MATCHES_LABEL
@@ -451,9 +451,9 @@ export const getInput = async (
                     {
                         alwaysShow: true,
                         label:
-                            mentionQuery?.type === 'symbol'
+                            mentionQuery?.provider === 'symbol'
                                 ? SYMBOL_HELP_LABEL
-                                : mentionQuery?.type === 'file'
+                                : mentionQuery?.provider === 'file'
                                   ? FILE_HELP_LABEL
                                   : GENERAL_HELP_LABEL,
                     },

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -10,6 +10,7 @@ import {
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 
+import { getEnabledContextMentionProviders } from '../../chat/context/chatContext'
 import {
     FILE_HELP_LABEL,
     GENERAL_HELP_LABEL,
@@ -381,7 +382,10 @@ export const getInput = async (
 
                 const mentionTrigger = scanForMentionTriggerInUserTextInput(value)
                 const mentionQuery = mentionTrigger
-                    ? parseMentionQuery(mentionTrigger.matchingString)
+                    ? parseMentionQuery(
+                          mentionTrigger.matchingString,
+                          getEnabledContextMentionProviders()
+                      )
                     : undefined
 
                 if (!mentionQuery) {

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -16,7 +16,7 @@ import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { EditIntent } from '../types'
 
 import { truncatePromptString, truncatePromptStringStart } from '@sourcegraph/cody-shared'
-import { fillInContextItemContent } from '../../editor/utils/editor-context'
+import { resolveContextItems } from '../../editor/utils/editor-context'
 import { PROMPT_TOPICS } from './constants'
 
 interface GetContextFromIntentOptions {
@@ -149,6 +149,6 @@ export const getContext = async ({
     }
 
     const derivedContext = await getContextFromIntent({ editor, ...options })
-    const userContext = await fillInContextItemContent(editor, userContextItems)
+    const userContext = await resolveContextItems(editor, userContextItems)
     return [...derivedContext, ...userContext]
 }

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -12,7 +12,7 @@ import {
     uriBasename,
 } from '@sourcegraph/cody-shared'
 
-import { fillInContextItemContent, filterContextItemFiles, getFileContextFiles } from './editor-context'
+import { filterContextItemFiles, getFileContextFiles, resolveContextItems } from './editor-context'
 
 vi.mock('lodash/throttle', () => ({ default: vi.fn(fn => fn) }))
 
@@ -175,7 +175,7 @@ describe('filterContextItemFiles', () => {
     })
 })
 
-describe('fillInContextItemContent', () => {
+describe('resolveContextItems', () => {
     it('omits files that could not be read', async () => {
         // Fixes https://github.com/sourcegraph/cody/issues/2390.
         const mockEditor: Partial<Editor> = {
@@ -186,7 +186,7 @@ describe('fillInContextItemContent', () => {
                 throw new Error('error')
             },
         }
-        const contextItems = await fillInContextItemContent(mockEditor as Editor, [
+        const contextItems = await resolveContextItems(mockEditor as Editor, [
             {
                 type: 'file',
                 uri: URI.parse('file:///a.txt'),

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -15,13 +15,11 @@ import {
     displayPath,
     isCodyIgnoredFile,
     isDefined,
-    isURLContextItem,
     isWindows,
-    resolveURLContextItem,
 } from '@sourcegraph/cody-shared'
 
 import { getOpenTabsUris } from '.'
-import { isURLContextFeatureFlagEnabled } from '../../chat/context/chatContext'
+import { getEnabledContextMentionProviders } from '../../chat/context/chatContext'
 import { toVSCodeRange } from '../../common/range'
 import { findWorkspaceFiles } from './findWorkspaceFiles'
 
@@ -280,7 +278,7 @@ export async function resolveContextItems(
 ): Promise<ContextItemWithContent[]> {
     return (
         await Promise.all(
-            items.map(async (item: ContextItem): Promise<ContextItemWithContent | null> => {
+            items.map(async (item: ContextItem): Promise<ContextItemWithContent[] | null> => {
                 try {
                     return await resolveContextItem(item, editor)
                 } catch (error) {
@@ -291,18 +289,33 @@ export async function resolveContextItems(
                 }
             })
         )
-    ).filter(isDefined)
+    )
+        .filter(isDefined)
+        .flat()
 }
 
-async function resolveContextItem(item: ContextItem, editor: Editor): Promise<ContextItemWithContent> {
-    const resolvedItem =
-        isURLContextItem(item) && (await isURLContextFeatureFlagEnabled())
-            ? await resolveURLContextItem(item)
-            : await resolveFileOrSymbolContextItem(item, editor)
-    return {
+async function resolveContextItem(item: ContextItem, editor: Editor): Promise<ContextItemWithContent[]> {
+    const resolvedItems = item.provider
+        ? await resolveContextMentionProviderContextItem(item)
+        : [await resolveFileOrSymbolContextItem(item, editor)]
+    return resolvedItems.map(resolvedItem => ({
         ...resolvedItem,
         size: resolvedItem.size ?? TokenCounter.countTokens(resolvedItem.content),
+    }))
+}
+
+export async function resolveContextMentionProviderContextItem({
+    provider: itemProvider,
+    ...item
+}: ContextItem): Promise<ContextItemWithContent[]> {
+    for (const provider of getEnabledContextMentionProviders()) {
+        if (provider.id === itemProvider && provider.resolveContextItem) {
+            return provider.resolveContextItem({ ...item, provider: itemProvider })
+        }
     }
+
+    // No resolver, so return the context item as-is if it has content.
+    return item.content !== undefined ? [item as ContextItemWithContent] : []
 }
 
 async function resolveFileOrSymbolContextItem(

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -304,7 +304,7 @@ async function resolveContextItem(item: ContextItem, editor: Editor): Promise<Co
     }))
 }
 
-export async function resolveContextMentionProviderContextItem({
+async function resolveContextMentionProviderContextItem({
     provider: itemProvider,
     ...item
 }: ContextItem): Promise<ContextItemWithContent[]> {

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -36,7 +36,7 @@ export const OptionsList: FunctionComponent<
         setHighlightedIndex(0)
     }, [options])
 
-    const mentionQuery = parseMentionQuery(query)
+    const mentionQuery = parseMentionQuery(query, [])
 
     return (
         <div className={styles.container}>

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -42,9 +42,9 @@ export const OptionsList: FunctionComponent<
         <div className={styles.container}>
             <h3 className={classNames(styles.item, styles.helpItem)}>
                 <span>
-                    {mentionQuery.type === 'empty'
+                    {mentionQuery.provider === 'default'
                         ? GENERAL_HELP_LABEL
-                        : mentionQuery.type === 'symbol'
+                        : mentionQuery.provider === 'symbol'
                           ? options.length > 0 || !mentionQuery.text.length
                                 ? SYMBOL_HELP_LABEL
                                 : NO_SYMBOL_MATCHES_LABEL +

--- a/vscode/webviews/promptEditor/plugins/atMentions/fixtures.ts
+++ b/vscode/webviews/promptEditor/plugins/atMentions/fixtures.ts
@@ -16,7 +16,7 @@ export const dummyChatContextClient: ChatContextClient = {
         await new Promise<void>(resolve => setTimeout(resolve, 250))
 
         query = query.toLowerCase()
-        const mentionQuery = parseMentionQuery(query)
+        const mentionQuery = parseMentionQuery(query, [])
         return mentionQuery.provider === 'symbol'
             ? DUMMY_SYMBOLS.filter(
                   f =>

--- a/vscode/webviews/promptEditor/plugins/atMentions/fixtures.ts
+++ b/vscode/webviews/promptEditor/plugins/atMentions/fixtures.ts
@@ -17,7 +17,7 @@ export const dummyChatContextClient: ChatContextClient = {
 
         query = query.toLowerCase()
         const mentionQuery = parseMentionQuery(query)
-        return mentionQuery.type === 'symbol'
+        return mentionQuery.provider === 'symbol'
             ? DUMMY_SYMBOLS.filter(
                   f =>
                       f.symbolName.toLowerCase().includes(query.slice(1)) ||


### PR DESCRIPTION
A ContextMentionProvider can provide context items that the user can `@`-mention in chat. It exposes an API with:

- triggerPrefixes: eg `npm:` to show a list of possible npm packages to mention when the user types `@npm:`
- queryContextItems: return a list of possible npm packages when the user types in `@npm:left-p` into the chat
- resolveContextItem (optional): enrich the context item with more content, used right before the context is sent to the LLM and only run on items that the user explicitly mentioned (so it can be slower)

The experimental URL mention feature was also ported to use this new API. It was designed to support more mentionable context sources, such as https://github.com/sourcegraph/cody/pull/3866 (@-mentionable packages like `@npm:left-pad`).

**Status: experimental.** For now, this API is only enabled (and these context sources are only available) when the `cody.experimental.noodle` VS Code setting is `true`. If this setting is off, it is not possible for any new ContextMentionProviders to be triggered, which is how we can experiment with adding new ones with less risk to the overall stability of Cody.

Go to [API for context sources (Sourcegraph community forum post)](https://community.sourcegraph.com/t/api-for-context-sources-contextmentionprovider-openctx/152) to read and share feedback/ideas about how you'd want to use this API as a dev.

## Test plan

CI (which includes the revived URL mention e2e test)