### PR TITLE
remove misleading `| undefined` return for editor file content

### DIFF
--- a/lib/shared/src/editor/index.ts
+++ b/lib/shared/src/editor/index.ts
@@ -51,7 +51,7 @@ export interface Editor {
 
     getActiveTextEditorVisibleContent(): ActiveTextEditorVisibleContent | null
 
-    getTextEditorContentForFile(uri: URI, range?: RangeData): Promise<string | undefined>
+    getTextEditorContentForFile(uri: URI, range?: RangeData): Promise<string>
 
     showWarningMessage(message: string): Promise<void>
 }
@@ -77,8 +77,8 @@ export class NoopEditor implements Editor {
         return null
     }
 
-    public getTextEditorContentForFile(_uri: URI, _range?: RangeData): Promise<string | undefined> {
-        return Promise.resolve(undefined)
+    public getTextEditorContentForFile(_uri: URI, _range?: RangeData): Promise<string> {
+        return Promise.reject(new Error('NoopEditor: no file content available'))
     }
 
     public showWarningMessage(_message: string): Promise<void> {

--- a/lib/shared/src/test/mocks.ts
+++ b/lib/shared/src/test/mocks.ts
@@ -38,8 +38,8 @@ export class MockEditor implements Editor {
         return this.mocks.showWarningMessage?.(message) ?? Promise.resolve()
     }
 
-    public async getTextEditorContentForFile(uri: URI, range?: RangeData): Promise<string | undefined> {
-        return this.mocks.getTextEditorContentForFile?.(uri, range) ?? Promise.resolve(undefined)
+    public async getTextEditorContentForFile(uri: URI, range?: RangeData): Promise<string> {
+        return this.mocks.getTextEditorContentForFile?.(uri, range) ?? Promise.resolve('')
     }
 }
 

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -223,9 +223,6 @@ async function searchSymf(
                     let text: string | undefined
                     try {
                         text = await editor.getTextEditorContentForFile(result.file, range)
-                        if (!text) {
-                            return []
-                        }
                     } catch (error) {
                         logError(
                             'SimpleChatPanelProvider.searchSymf',

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -289,10 +289,8 @@ export async function fillInContextItemContent(
                         } else {
                             content = await editor.getTextEditorContentForFile(uri, toVSCodeRange(range))
                         }
-                        if (content) {
-                            size = size ?? TokenCounter.countTokens(content)
-                            range = range ?? getRangeByContentLineCount(content)
-                        }
+                        size = size ?? TokenCounter.countTokens(content)
+                        range = range ?? getRangeByContentLineCount(content)
                     } catch (error) {
                         void vscode.window.showErrorMessage(
                             `Cody could not include context from ${item.uri}. (Reason: ${error})`

--- a/vscode/src/editor/vscode-editor.ts
+++ b/vscode/src/editor/vscode-editor.ts
@@ -74,11 +74,7 @@ export class VSCodeEditor implements Editor {
     public async getTextEditorContentForFile(
         fileUri: vscode.Uri,
         selectionRange?: RangeData
-    ): Promise<string | undefined> {
-        if (!fileUri) {
-            return undefined
-        }
-
+    ): Promise<string> {
         let range: vscode.Range | undefined
         if (selectionRange) {
             const startLine = selectionRange?.start?.line


### PR DESCRIPTION
`Editor.getTextEditorContentForFile` now returns `Promise<string>` not `Promise<string | undefined>`. The only case where the impl returned an `undefined` content value was if the URI argument was undefined, which was impossible per the type signature anyway and does not make sense.

Now, reading a file either returns a string or throws an exception, which makes sense. It does not make sense for it to ever return `undefined`.



## Test plan

CI