### PR TITLE
do not show the context file line count in chat context

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -1,7 +1,7 @@
 // Add anything else here that needs to be used outside of this library.
 
 export { ModelProvider } from './models'
-export { type ChatModel, type EditModel, ModelUsage, ModelContextWindow } from './models/types'
+export { type ChatModel, type EditModel, ModelUsage, type ModelContextWindow } from './models/types'
 export { getDotComDefaultModels } from './models/dotcom'
 export {
     getProviderName,

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -202,16 +202,6 @@ describe('fillInContextItemContent', () => {
                 uri: URI.parse('file:///a.txt'),
                 content: 'a',
                 size: 1,
-                range: {
-                    end: {
-                        character: 0,
-                        line: 1,
-                    },
-                    start: {
-                        character: 0,
-                        line: 0,
-                    },
-                },
             },
         ])
     })

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -290,7 +290,6 @@ export async function fillInContextItemContent(
                             content = await editor.getTextEditorContentForFile(uri, toVSCodeRange(range))
                         }
                         size = size ?? TokenCounter.countTokens(content)
-                        range = range ?? getRangeByContentLineCount(content)
                     } catch (error) {
                         void vscode.window.showErrorMessage(
                             `Cody could not include context from ${item.uri}. (Reason: ${error})`
@@ -298,21 +297,8 @@ export async function fillInContextItemContent(
                         return null
                     }
                 }
-                return { ...item, content: content!, size, range }
+                return { ...item, content: content!, size }
             })
         )
     ).filter(isDefined)
-}
-
-/**
- * Gets a `vscode.Range` representing the full content of the given string.
- *
- * @param content The string content to get the range for.
- * @returns A `vscode.Range` representing the full content of the given string, or `undefined` if the input is empty.
- */
-function getRangeByContentLineCount(content: string): vscode.Range | undefined {
-    if (!content.trim()) {
-        return undefined
-    }
-    return new vscode.Range(0, 0, content?.split('\n')?.length, 0)
 }

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -221,13 +221,13 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java')).toBeVisible()
     const contextCell = getContextCell(chatPanelFrame)
-    await expectContextCellCounts(contextCell, { files: 1, lines: 10 })
+    await expectContextCellCounts(contextCell, { files: 1 })
 
     // Edit the just-sent message and resend it. Confirm it is sent with the right context items.
     await chatInput.press('ArrowUp')
     await expect(chatInput).toHaveText('Explain @Main.java ')
     await chatInput.press('Meta+Enter')
-    await expectContextCellCounts(contextCell, { files: 1, lines: 10 })
+    await expectContextCellCounts(contextCell, { files: 1 })
 
     // Edit it again, add a new @-mention, and resend.
     await chatInput.press('ArrowUp')
@@ -239,7 +239,7 @@ test('editing a chat message with @-mention', async ({ page, sidebar }) => {
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
     await expect(chatPanelFrame.getByText('Explain @Main.java and @index.html')).toBeVisible()
-    await expectContextCellCounts(contextCell, { files: 2, lines: 22 })
+    await expectContextCellCounts(contextCell, { files: 2 })
 })
 
 test('pressing Enter with @-mention menu open selects item, does not submit message', async ({
@@ -293,7 +293,7 @@ test('@-mention file range', async ({ page, sidebar }) => {
 
     // @-file range with the correct line range shows up in the chat view and it opens on click
     const contextCell = getContextCell(chatPanelFrame)
-    await expectContextCellCounts(contextCell, { files: 1, lines: 3 })
+    await expectContextCellCounts(contextCell, { files: 1 })
     await contextCell.hover()
     await contextCell.click()
     const chatContext = chatPanelFrame.locator('details').last()
@@ -353,7 +353,7 @@ test.extend<ExpectedEvents>({
 
     // @-file with the correct line range shows up in the chat view and it opens on click
     const contextCell = getContextCell(chatPanelFrame)
-    await expectContextCellCounts(contextCell, { files: 1, lines: 15 })
+    await expectContextCellCounts(contextCell, { files: 1 })
     await contextCell.hover()
     await contextCell.click()
     const chatContext = chatPanelFrame.locator('details').last()
@@ -443,7 +443,7 @@ test.extend<ExtraWorkspaceSettings>({
 
         // URL context item shows up and is clickable.
         const contextCell = getContextCell(chatPanelFrame)
-        await expectContextCellCounts(contextCell, { files: 1, lines: 1 })
+        await expectContextCellCounts(contextCell, { files: 1 })
         await contextCell.click()
         await contextCell.getByRole('link', { name: mentionURL.toString() }).click()
     } finally {

--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -129,7 +129,7 @@ test.extend<ExpectedEvents>({
     await chatInput.press('Enter')
     // both main.java and var.go should be used
     const contextCell = getContextCell(chatFrame)
-    await expectContextCellCounts(contextCell, { files: 2, lines: 12 })
+    await expectContextCellCounts(contextCell, { files: 2 })
     await contextCell.click()
     const chatContext = chatFrame.locator('details').last()
     await expect(chatContext.getByRole('link', { name: 'Main.java' })).toBeVisible()

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -47,7 +47,7 @@ test.extend<ExpectedEvents>({
     // If there is no cursor position, we will use the visible content of the editor
     // NOTE: Core commands context should not start with ✨
     const contextCell = getContextCell(chatPanel)
-    await expectContextCellCounts(contextCell, { files: 1, lines: 11 })
+    await expectContextCellCounts(contextCell, { files: 1 })
     await contextCell.click()
 
     // Check if assistant responsed
@@ -66,7 +66,7 @@ test.extend<ExpectedEvents>({
     await page.getByText('<title>Hello Cody</title>').click()
     await expect(page.getByText('Explain Code')).toBeVisible()
     await page.getByText('Explain Code').click()
-    await expectContextCellCounts(contextCell, { files: 1, lines: 20 })
+    await expectContextCellCounts(contextCell, { files: 1 })
     await contextCell.click()
     await expect(chatPanel.getByRole('link', { name: 'index.html:2-10' })).toBeVisible()
     await expect(chatPanel.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
@@ -80,7 +80,7 @@ test.extend<ExpectedEvents>({
     // Running a command again should reuse the current cursor position
     await expect(page.getByText('Find Code Smells')).toBeVisible()
     await page.getByText('Find Code Smells').click()
-    await expectContextCellCounts(contextCell, { files: 1, lines: 9 })
+    await expectContextCellCounts(contextCell, { files: 1 })
     await contextCell.click()
     await expect(chatPanel.getByRole('link', { name: 'index.html:2-10' })).toBeVisible()
     await expect(disabledEditButtons).toHaveCount(0)

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -169,7 +169,7 @@ test.extend<ExpectedEvents>({
     await expect(chatPanel.getByText('Add four context files from the current directory.')).toBeVisible()
     // Show the current file numbers used as context
     const contextCell = getContextCell(chatPanel)
-    await expectContextCellCounts(contextCell, { files: 5, lines: 56 })
+    await expectContextCellCounts(contextCell, { files: 5 })
     await contextCell.click()
     // Display the context files to confirm no hidden files are included
     await expect(chatPanel.getByRole('link', { name: '.mydotfile:1-2' })).not.toBeVisible()
@@ -185,7 +185,7 @@ test.extend<ExpectedEvents>({
     await page.getByRole('treeitem', { name: 'filePath' }).locator('a').click()
     await expect(chatPanel.getByText('Add lib/batches/env/var.go as context.')).toBeVisible()
     // Should show 2 files with current file added as context
-    await expectContextCellCounts(contextCell, { files: 2, lines: 12 })
+    await expectContextCellCounts(contextCell, { files: 2 })
 
     /* Test: context.directory with directory command */
 
@@ -195,7 +195,7 @@ test.extend<ExpectedEvents>({
     await page.getByPlaceholder('Search command to run...').fill('directory')
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Directory has one context file.')).toBeVisible()
-    await expectContextCellCounts(contextCell, { files: 2, lines: 12 })
+    await expectContextCellCounts(contextCell, { files: 2 })
     await contextCell.click()
     await expect(
         chatPanel.getByRole('link', { name: withPlatformSlashes('lib/batches/env/var.go:1') })
@@ -216,7 +216,7 @@ test.extend<ExpectedEvents>({
     await page.keyboard.press('Enter')
     await expect(chatPanel.getByText('Open tabs as context.')).toBeVisible()
     // The files from the open tabs should be added as context
-    await expectContextCellCounts(contextCell, { files: 2, lines: 12 })
+    await expectContextCellCounts(contextCell, { files: 2 })
     await contextCell.click()
     await expect(chatContext.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
     await expect(
@@ -322,7 +322,7 @@ testGitWorkspace('use terminal output as context', async ({ page, sidebar }) => 
     // Check the context list to confirm the terminal output is added as file
     const panel = getChatPanel(page)
     const contextCell = getContextCell(panel)
-    await expectContextCellCounts(contextCell, { files: 2, lines: 1 })
+    await expectContextCellCounts(contextCell, { files: 2 })
     await contextCell.click()
     const chatContext = panel.locator('details').last()
     await expect(

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -77,16 +77,12 @@ export function getContextCell(
 
 export async function expectContextCellCounts(
     contextCell: Locator,
-    counts: { files: number; lines?: number; timeout?: number }
+    counts: { files: number; timeout?: number }
 ): Promise<void> {
     const summary = contextCell.locator('summary', { hasText: 'Context' })
     await expect(summary).toHaveAttribute(
         'title',
-        `${
-            counts.lines !== undefined
-                ? `${counts.lines} line${counts.lines === 1 ? '' : 's'} from `
-                : ''
-        }${counts.files} file${counts.files === 1 ? '' : 's'}`,
+        `${counts.files} file${counts.files === 1 ? '' : 's'}`,
         { timeout: counts.timeout }
     )
 }

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -159,7 +159,6 @@ test
     const contextCell = getContextCell(chatFrame)
     await expectContextCellCounts(contextCell, {
         files: 2,
-        lines: 2,
         timeout: 10000,
     })
 })

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -32,26 +32,11 @@ export const ContextCell: React.FunctionComponent<{
         }
     }
 
-    // It checks if file.range exists first before accessing start and end.
-    // If range doesn't exist, it adds 0 lines for that file.
-    const lineCount = usedContext.reduce(
-        (total, file) =>
-            total +
-            (file.range
-                ? // Don't count a line with no characters included (character == 0).
-                  (file.range.end.character === 0 ? file.range.end.line - 1 : file.range.end.line) -
-                  file.range.start?.line +
-                  1
-                : 0),
-        0
-    )
     const fileCount = new Set(usedContext.map(file => file.uri.toString())).size
-    const lines = `${lineCount} line${lineCount > 1 ? 's' : ''}`
-    const files = `${fileCount} file${fileCount > 1 ? 's' : ''}`
-    let title = lineCount ? `${lines} from ${files}` : `${files}`
+    let fileCountLabel = `${fileCount} file${fileCount > 1 ? 's' : ''}`
     if (excludedAtContext.length) {
         const excludedAtUnit = excludedAtContext.length === 1 ? 'mention' : 'mentions'
-        title = `${title} — ${excludedAtContext.length} ${excludedAtUnit} excluded`
+        fileCountLabel = `${fileCountLabel} — ${excludedAtContext.length} ${excludedAtUnit} excluded`
     }
 
     function logContextOpening() {
@@ -59,7 +44,6 @@ export const ContextCell: React.FunctionComponent<{
             command: 'event',
             eventName: 'CodyVSCodeExtension:chat:context:opened',
             properties: {
-                lineCount,
                 fileCount,
                 excludedAtContext: excludedAtContext.length,
             },
@@ -82,10 +66,10 @@ export const ContextCell: React.FunctionComponent<{
                         className={styles.summary}
                         onClick={logContextOpening}
                         onKeyUp={logContextOpening}
-                        title={title}
+                        title={fileCountLabel}
                     >
                         <h4 className={styles.heading}>
-                            Context <span className={styles.stats}>&mdash; {title}</span>
+                            Context <span className={styles.stats}>&mdash; {fileCountLabel}</span>
                         </h4>
                     </summary>
                     <ul className={styles.list}>


### PR DESCRIPTION
Previously the chat context cell would display `Context: 93 lines from 7 files`. The number of lines is not necessary, and now it just shows the file count, as in `Context: 7 files`.
    
The total line count is an unnecessary detail even for today's context sources. It is not clear what users should do with that information. As context sources start to get less about "chunks of files", it becomes even less relevant.

## Test plan

CI