### PR TITLE
fix nested react hook usage and only have 1 editor mutation listener

### DIFF
--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -96,9 +96,8 @@ export default function MentionsPlugin(): JSX.Element | null {
 
     const results = useChatContextItems(query)
 
-    // biome-ignore lint/correctness/useExhaustiveDependencies: runs effect when `results` changes.
+    const model = useCurrentChatModel()
     const options = useMemo(() => {
-        const model = useCurrentChatModel()
         const limit =
             model?.contextWindow?.context?.user ||
             model?.contextWindow?.input ||
@@ -115,23 +114,26 @@ export default function MentionsPlugin(): JSX.Element | null {
                 })
                 .slice(0, SUGGESTION_LIST_LENGTH_LIMIT) ?? []
         )
-    }, [results])
+    }, [results, model, tokenAdded])
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: Intent is to update whenever `options` changes.
     useEffect(() => {
         update()
     }, [options, update])
 
-    // Listen for changes to ContextItemMentionNode to update the token count.
-    // This updates the token count when a mention is added or removed.
-    editor.registerMutationListener(ContextItemMentionNode, node => {
-        const items = toSerializedPromptEditorValue(editor)?.contextItems
-        if (!items?.length) {
-            setTokenAdded(0)
-            return
-        }
-        setTokenAdded(items?.reduce((acc, item) => acc + (item.size ? item.size : 0), 0) ?? 0)
-    })
+    useEffect(() => {
+        // Listen for changes to ContextItemMentionNode to update the token count.
+        // This updates the token count when a mention is added or removed.
+        const unregister = editor.registerMutationListener(ContextItemMentionNode, node => {
+            const items = toSerializedPromptEditorValue(editor)?.contextItems
+            if (!items?.length) {
+                setTokenAdded(0)
+                return
+            }
+            setTokenAdded(items?.reduce((acc, item) => acc + (item.size ? item.size : 0), 0) ?? 0)
+        })
+        return unregister
+    }, [editor])
 
     const onSelectOption = useCallback(
         (


### PR DESCRIPTION
- Fixes a React warning (in the devtools console) `Warning: Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks.` because `useCurrentModel()` was being called within a `useMemo()` hook. This can cause unexpected behavior in React. It is also desirable for the `isTooLarge` property of each option to be recomputed when the model changes because different models have different context window sizes.
- Avoids registering another editor mutation listener each time the component is rendered by wrapping the registration in a `useEffect` hook. I don't *know* if this causes any problems, but it could make things slow or result in weird behavior.



## Test plan

CI, and try adding mentions in the storybook