### PR TITLE
clearer notice when typing a line range b/c file too large

### DIFF
--- a/vscode/src/chat/context/constants.ts
+++ b/vscode/src/chat/context/constants.ts
@@ -4,7 +4,7 @@ export const SYMBOL_HELP_LABEL = 'Search for a symbol to include...'
 export const NO_SYMBOL_MATCHES_LABEL = 'No symbols found'
 export const NO_FILE_MATCHES_LABEL = 'No files found'
 export const NO_SYMBOL_MATCHES_HELP_LABEL = ' (language extensions may be loading)'
-export const FILE_RANGE_TOOLTIP_LABEL = 'Type a line range to include, e.g. 5-10...'
+export const FILE_RANGE_TOOLTIP_LABEL = 'File too large. Type a line range like 5-10...'
 export const LARGE_FILE_WARNING_LABEL =
     'File too large. Add line range with : or use @# to choose a symbol'
 


### PR DESCRIPTION
Clears up user confusion "Why do I need to enter a line range?"

Changes the notice for when the user Tab-completes an @-mentioned file in chat. It is /possible/ that they intentionally entered line range selection mode on a not-too-large file, and in which case this notice is technically incorrect, but that's an edge case and arguably it means /they/ considered the file too large.

Not sure if I missed any considerations here. Open to feedback!

Before:

![image](https://github.com/sourcegraph/cody/assets/1976/c2d1d46d-83a5-4de8-9d19-a71651c45919)


After (excuse the different theme :):

![image](https://github.com/sourcegraph/cody/assets/1976/f1a7510e-86c0-4ed4-b3b2-b26bd261e407)



## Test plan

CI