### PR TITLE
make our shim URI more like VS Code's URI

### DIFF
--- a/vscode/src/testutils/uri.ts
+++ b/vscode/src/testutils/uri.ts
@@ -49,7 +49,7 @@ export class Uri {
         return new Uri(URI.from(components))
     }
 
-    private uri: URI
+    private readonly uri: URI
 
     private constructor(componentsOrUri: UriComponents | URI) {
         if (componentsOrUri instanceof URI) {
@@ -57,26 +57,19 @@ export class Uri {
         } else {
             this.uri = URI.from(componentsOrUri)
         }
+
+        this.scheme = this.uri.scheme
+        this.authority = this.uri.authority
+        this.path = this.uri.path
+        this.query = this.uri.query
+        this.fragment = this.uri.fragment
     }
 
-    public get scheme(): string {
-        return this.uri.scheme
-    }
-
-    public get authority(): string {
-        return this.uri.authority
-    }
-    public get path(): string {
-        return this.uri.path
-    }
-
-    public get query(): string {
-        return this.uri.query
-    }
-
-    public get fragment(): string {
-        return this.uri.fragment
-    }
+    public readonly scheme: string
+    public readonly authority: string
+    public readonly path: string
+    public readonly query: string
+    public readonly fragment: string
 
     public get fsPath(): string {
         return this.uri.fsPath


### PR DESCRIPTION
The [VS Code URI class](https://sourcegraph.com/github.com/microsoft/vscode/-/blob/src/vs/base/common/uri.ts) has public properties not getters for `scheme`, `authority`, `path`, `query`, and `fragment`. This means that those properties are serialized as JSON object fields when the URI instance is passed via MessagePort. This change makes our shim behave similarly so that it can be transferred via MessagePort (such as to agent in a web worker).



## Test plan

CI