### PR TITLE
VS Code: add non-file URI logs

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -111,7 +111,9 @@ export class ContextFiltersProvider implements vscode.Disposable {
             return false
         }
 
+        // TODO: process non-file URIs https://github.com/sourcegraph/cody/issues/3893
         if (!isFileURI(uri)) {
+            logDebug('ContextFiltersProvider', 'isUriAllowed', `non-file URI ${uri.scheme}`)
             return false
         }
 


### PR DESCRIPTION
## Context

- Follow up on the comment https://github.com/sourcegraph/cody/pull/3771#discussion_r1568301215
- Logs non-file URIs via `logDebug`
- Part of https://github.com/sourcegraph/cody/issues/3641

## Test plan

CI
