### PR TITLE
Cody Ignore: support multiple remote URLs

### DIFF
--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -21,7 +21,7 @@ import {
     createLocalEmbeddingsController,
 } from './local-context/local-embeddings'
 import { SymfRunner } from './local-context/symf'
-import { gitRemoteUrlFromGitCli } from './repository/repo-name-getter.node'
+import { gitRemoteUrlsFromGitCli } from './repository/repo-name-getter.node'
 import { OpenTelemetryService } from './services/open-telemetry/OpenTelemetryService.node'
 
 /**
@@ -58,7 +58,7 @@ export function activate(
         createBfgRetriever: () => new BfgRetriever(context),
         createSentryService: (...args) => new NodeSentryService(...args),
         createOpenTelemetryService: (...args) => new OpenTelemetryService(...args),
-        getRemoteUrlGetters: () => [gitRemoteUrlFromGitCli],
+        getRemoteUrlGetters: () => [gitRemoteUrlsFromGitCli],
         startTokenReceiver: (...args) => startTokenReceiver(...args),
 
         onConfigurationChange: setCustomAgent,

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -200,8 +200,8 @@ const register = async (
     )
     disposables.push(contextFiltersProvider)
     disposables.push(contextProvider)
-    const bindedRepoNameResolver = repoNameResolver.getRepoNameFromWorkspaceUri.bind(repoNameResolver)
-    await contextFiltersProvider.init(bindedRepoNameResolver).then(() => contextProvider.init())
+    const bindedRepoNamesResolver = repoNameResolver.getRepoNamesFromWorkspaceUri.bind(repoNameResolver)
+    await contextFiltersProvider.init(bindedRepoNamesResolver).then(() => contextProvider.init())
 
     // Shared configuration that is required for chat views to send and receive messages
     const messageProviderOptions: MessageProviderOptions = {
@@ -252,10 +252,10 @@ const register = async (
         graphqlClient.onConfigurationChange(newConfig)
         promises.push(
             contextFiltersProvider
-                .init(bindedRepoNameResolver)
+                .init(bindedRepoNamesResolver)
                 .then(() => contextProvider.onConfigurationChange(newConfig))
         )
-        promises.push(contextFiltersProvider.init(bindedRepoNameResolver))
+        promises.push(contextFiltersProvider.init(bindedRepoNamesResolver))
         externalServicesOnDidConfigurationChange(newConfig)
         promises.push(configureEventsInfra(newConfig, isExtensionModeDevOrTest, authProvider))
         platform.onConfigurationChange?.(newConfig)

--- a/vscode/src/repository/repo-name-getter.node.test.ts
+++ b/vscode/src/repository/repo-name-getter.node.test.ts
@@ -2,10 +2,10 @@ import child_process from 'node:child_process'
 import { describe, expect, it, vi } from 'vitest'
 import { URI } from 'vscode-uri'
 
-import { gitRemoteUrlFromGitCli } from './repo-name-getter.node'
+import { gitRemoteUrlsFromGitCli } from './repo-name-getter.node'
 
 describe('gitRemoteUrlFromGitCli', () => {
-    it('returns the first remote push URL when available', async () => {
+    it('returns all remote URL when available', async () => {
         vi.spyOn(child_process, 'exec').mockImplementation(((
             _cmd: string,
             _config: unknown,
@@ -25,10 +25,13 @@ describe('gitRemoteUrlFromGitCli', () => {
         }) as any)
 
         const uri = URI.file('path/to/file/foo.ts')
-        expect(await gitRemoteUrlFromGitCli(uri)).toBe('https://github.com/sourcegraph/cody')
+        expect(await gitRemoteUrlsFromGitCli(uri)).toEqual([
+            'https://github.com/sourcegraph/cody',
+            'https://github.com/foo/bar',
+        ])
     })
 
-    it('returns the first remote fetch URL if no push URL is available', async () => {
+    it('returns all fetch URLs if no push URL is available', async () => {
         vi.spyOn(child_process, 'exec').mockImplementation(((
             _cmd: string,
             _config: unknown,
@@ -44,7 +47,10 @@ describe('gitRemoteUrlFromGitCli', () => {
         }) as any)
 
         const uri = URI.file('path/to/file/foo.ts')
-        expect(await gitRemoteUrlFromGitCli(uri)).toBe('https://github.com/sourcegraph/cody')
+        expect(await gitRemoteUrlsFromGitCli(uri)).toEqual([
+            'https://github.com/sourcegraph/cody',
+            'https://github.com/foo/bar',
+        ])
     })
 
     it('returns `undefined` when the remote list is empty', async () => {
@@ -60,6 +66,6 @@ describe('gitRemoteUrlFromGitCli', () => {
         }) as any)
 
         const uri = URI.file('path/to/file/foo.ts')
-        expect(await gitRemoteUrlFromGitCli(uri)).toBe(undefined)
+        expect(await gitRemoteUrlsFromGitCli(uri)).toBe(undefined)
     })
 })


### PR DESCRIPTION
## Context

- Uses all remote URLs available to resolve repo names for Cody Ignore checks
- Built on top of https://github.com/sourcegraph/cody/pull/3870
- Part of https://github.com/sourcegraph/cody/issues/3641

## Test plan

CI and updated unit tests.
