### PR TITLE
Autocomplete: Implement context filter

### DIFF
--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -59,7 +59,7 @@ const defaultOptions = {
 
 describe('ContextMixer', () => {
     beforeEach(() => {
-        vi.spyOn(contextFiltersProvider, 'isUriAllowed').mockImplementation(() => Promise.resolve(true))
+        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
     })
 
     describe('with no retriever', () => {
@@ -98,7 +98,6 @@ describe('ContextMixer', () => {
                 ])
             )
             const { context, logSummary } = await mixer.getContext(defaultOptions)
-
             expect(normalize(context)).toEqual([
                 {
                     fileName: 'foo.ts',
@@ -297,12 +296,12 @@ describe('ContextMixer', () => {
 
         describe('retrieved context is filtered by context filters', () => {
             beforeAll(() => {
-                vi.spyOn(contextFiltersProvider, 'isUriAllowed').mockImplementation(
+                vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockImplementation(
                     async (uri: vscode.Uri) => {
                         if (uri.path.includes('foo.ts')) {
-                            return false
+                            return true
                         }
-                        return true
+                        return false
                     }
                 )
             })

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -1,8 +1,9 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
     type AutocompleteContextSnippet,
     CODY_IGNORE_URI_PATH,
+    contextFiltersProvider,
     ignores,
     isCodyIgnoredFile,
     testFileUri,
@@ -16,6 +17,8 @@ import type { ContextRetriever } from '../types'
 import { Utils } from 'vscode-uri'
 import { ContextMixer } from './context-mixer'
 import type { ContextStrategyFactory } from './context-strategy'
+
+import type * as vscode from 'vscode'
 
 function createMockStrategy(resultSets: AutocompleteContextSnippet[][]): ContextStrategyFactory {
     const retrievers = []
@@ -55,6 +58,10 @@ const defaultOptions = {
 }
 
 describe('ContextMixer', () => {
+    beforeEach(() => {
+        vi.spyOn(contextFiltersProvider, 'isUriAllowed').mockImplementation(() => Promise.resolve(true))
+    })
+
     describe('with no retriever', () => {
         it('returns empty result if no retrievers', async () => {
             const mixer = new ContextMixer(createMockStrategy([]))
@@ -225,7 +232,7 @@ describe('ContextMixer', () => {
             })
         })
 
-        describe('retrived context is filtered by .cody/ignore', () => {
+        describe('retrieved context is filtered by .cody/ignore', () => {
             const workspaceRoot = testFileUri('')
             beforeAll(() => {
                 ignores.setActiveState(true)
@@ -285,6 +292,62 @@ describe('ContextMixer', () => {
                         isCodyIgnoredFile(Utils.joinPath(workspaceRoot, context.fileName))
                     ).toBeFalsy()
                 }
+            })
+        })
+
+        describe('retrieved context is filtered by context filters', () => {
+            beforeAll(() => {
+                vi.spyOn(contextFiltersProvider, 'isUriAllowed').mockImplementation(
+                    async (uri: vscode.Uri) => {
+                        if (uri.path.includes('foo.ts')) {
+                            return false
+                        }
+                        return true
+                    }
+                )
+            })
+            it('mixes results are filtered', async () => {
+                const mixer = new ContextMixer(
+                    createMockStrategy([
+                        [
+                            {
+                                uri: testFileUri('foo.ts'),
+                                content: 'function foo1() {}',
+                                startLine: 0,
+                                endLine: 0,
+                            },
+                            {
+                                uri: testFileUri('foo/bar.ts'),
+                                content: 'function bar1() {}',
+                                startLine: 0,
+                                endLine: 0,
+                            },
+                        ],
+                        [
+                            {
+                                uri: testFileUri('test/foo.ts'),
+                                content: 'function foo3() {}',
+                                startLine: 10,
+                                endLine: 10,
+                            },
+                            {
+                                uri: testFileUri('foo.ts'),
+                                content: 'function foo1() {}\nfunction foo2() {}',
+                                startLine: 0,
+                                endLine: 1,
+                            },
+                            {
+                                uri: testFileUri('example/bar.ts'),
+                                content: 'function bar1() {}\nfunction bar2() {}',
+                                startLine: 0,
+                                endLine: 1,
+                            },
+                        ],
+                    ])
+                )
+                const { context } = await mixer.getContext(defaultOptions)
+                const contextFiles = normalize(context)
+                expect(contextFiles.map(c => c.fileName)).toEqual(['bar.ts', 'bar.ts'])
             })
         })
     })

--- a/vscode/src/completions/context/context-mixer.ts
+++ b/vscode/src/completions/context/context-mixer.ts
@@ -187,7 +187,7 @@ async function filter(snippets: AutocompleteContextSnippet[]): Promise<Autocompl
                 if (isCodyIgnoredFile(snippet.uri)) {
                     return null
                 }
-                if (!(await contextFiltersProvider.isUriAllowed(snippet.uri))) {
+                if (await contextFiltersProvider.isUriIgnored(snippet.uri)) {
                     return null
                 }
                 return snippet

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -6,6 +6,7 @@ import {
     type AuthStatus,
     type GraphQLAPIClientConfig,
     RateLimitError,
+    contextFiltersProvider,
     graphqlClient,
 } from '@sourcegraph/cody-shared'
 
@@ -89,6 +90,9 @@ class MockableInlineCompletionItemProvider extends InlineCompletionItemProvider 
 describe('InlineCompletionItemProvider', () => {
     beforeAll(async () => {
         await initCompletionProviderConfig({})
+    })
+    beforeEach(() => {
+        vi.spyOn(contextFiltersProvider, 'isUriAllowed').mockImplementation(() => Promise.resolve(true))
     })
 
     it('returns results that span the whole line', async () => {
@@ -223,6 +227,22 @@ describe('InlineCompletionItemProvider', () => {
         // On the 2nd call, lastInlineCompletionResult is provided.
         await provider.provideInlineCompletionItems(document, position, DUMMY_CONTEXT)
         expect(fn.mock.calls.map(call => call[0].lastCandidate?.result.items)).toEqual([[item]])
+    })
+
+    it('no-ops on files that are ignored by the context filter policy', async () => {
+        vi.spyOn(contextFiltersProvider, 'isUriAllowed').mockImplementationOnce(() =>
+            Promise.resolve(false)
+        )
+        const { document, position } = documentAndPosition('const foo = █', 'typescript')
+        const fn = vi.fn()
+        const provider = new MockableInlineCompletionItemProvider(fn)
+        const completions = await provider.provideInlineCompletionItems(
+            document,
+            position,
+            DUMMY_CONTEXT
+        )
+        expect(completions).toBe(null)
+        expect(fn).not.toHaveBeenCalled()
     })
 
     describe('onboarding', () => {

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -92,7 +92,7 @@ describe('InlineCompletionItemProvider', () => {
         await initCompletionProviderConfig({})
     })
     beforeEach(() => {
-        vi.spyOn(contextFiltersProvider, 'isUriAllowed').mockImplementation(() => Promise.resolve(true))
+        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValue(false)
     })
 
     it('returns results that span the whole line', async () => {
@@ -230,9 +230,7 @@ describe('InlineCompletionItemProvider', () => {
     })
 
     it('no-ops on files that are ignored by the context filter policy', async () => {
-        vi.spyOn(contextFiltersProvider, 'isUriAllowed').mockImplementationOnce(() =>
-            Promise.resolve(false)
-        )
+        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValueOnce(true)
         const { document, position } = documentAndPosition('const foo = █', 'typescript')
         const fn = vi.fn()
         const provider = new MockableInlineCompletionItemProvider(fn)

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -208,7 +208,7 @@ export class InlineCompletionItemProvider
         }
 
         return wrapInActiveSpan('autocomplete.provideInlineCompletionItems', async span => {
-            if (!(await contextFiltersProvider.isUriAllowed(document.uri))) {
+            if (await contextFiltersProvider.isUriIgnored(document.uri)) {
                 logIgnored(document.uri, 'context-filter')
                 return null
             }

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -203,11 +203,13 @@ export class InlineCompletionItemProvider
     ): Promise<AutocompleteResult | null> {
         // Do not create item for files that are on the cody ignore list
         if (isCodyIgnoredFile(document.uri)) {
+            logIgnored(document.uri, 'cody-ignore')
             return null
         }
 
         return wrapInActiveSpan('autocomplete.provideInlineCompletionItems', async span => {
             if (!(await contextFiltersProvider.isUriAllowed(document.uri))) {
+                logIgnored(document.uri, 'context-filter')
                 return null
             }
 
@@ -798,4 +800,17 @@ function onlyCompletionWidgetSelectionChanged(
     }
 
     return prevSelectedCompletionInfo.text !== nextSelectedCompletionInfo.text
+}
+
+let lasIgnoredUriLogged: string | undefined = undefined
+function logIgnored(uri: vscode.Uri, reason: 'cody-ignore' | 'context-filter') {
+    const string = uri.toString()
+    if (lasIgnoredUriLogged === string) {
+        return
+    }
+    lasIgnoredUriLogged = string
+    logDebug(
+        'CodyCompletionProvider:ignored',
+        'Cody is disabled in file ' + uri.toString() + '(' + reason + ')'
+    )
 }

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -811,6 +811,6 @@ function logIgnored(uri: vscode.Uri, reason: 'cody-ignore' | 'context-filter') {
     lasIgnoredUriLogged = string
     logDebug(
         'CodyCompletionProvider:ignored',
-        'Cody is disabled in file ' + uri.toString() + '(' + reason + ')'
+        'Cody is disabled in file ' + uri.toString() + ' (' + reason + ')'
     )
 }

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -5,6 +5,7 @@ import {
     ConfigFeaturesSingleton,
     FeatureFlag,
     RateLimitError,
+    contextFiltersProvider,
     isCodyIgnoredFile,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
@@ -206,6 +207,10 @@ export class InlineCompletionItemProvider
         }
 
         return wrapInActiveSpan('autocomplete.provideInlineCompletionItems', async span => {
+            if (!(await contextFiltersProvider.isUriAllowed(document.uri))) {
+                return null
+            }
+
             // Update the last request
             const lastCompletionRequest = this.lastCompletionRequest
             const completionRequest: CompletionRequest = {


### PR DESCRIPTION
Part of https://github.com/sourcegraph/cody/issues/3642
Part of https://github.com/sourcegraph/cody/issues/3604

This PR implements context filter honoring for Autocomplete. There are two types of sources we filter:

- The current file context (appended as prefix/suffix) to the prompt: In files that are ignored, autocomplete will now no-op. **Question:** should this print a log somewhere that a user can see it so it's clear why Autocomplete does not work? I am worried that anything we add might be annoying, though.
- Retrieved file context: we now filter all retrieved context before ranking. We can move some of the checks closer into the retrievers but since all of the retrievers are local and fast, this is not a high prioroity

## Test plan

- Added tests