### PR TITLE
fix: Handle HTTP URIs and decode URI components in URL context mentions

### DIFF
--- a/lib/shared/src/cody-ignore/ignore-helper.ts
+++ b/lib/shared/src/cody-ignore/ignore-helper.ts
@@ -116,6 +116,10 @@ export class IgnoreHelper {
             return false
         }
 
+        if (uri.scheme === 'http') {
+            return false
+        }
+
         // Ignore all other non-file URIs
         if (uri.scheme !== 'file') {
             return true

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -181,7 +181,7 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
     // display ranges are 1-indexed.
     const rangeText = contextItem.range ? `:${displayLineRange(contextItem.range)}` : ''
     if (contextItem.type === 'file') {
-        return `@${displayPath(URI.parse(contextItem.uri))}${rangeText}`
+        return `@${decodeURIComponent(displayPath(URI.parse(contextItem.uri)))}${rangeText}`
     }
     if (contextItem.type === 'symbol') {
         return `@${displayPath(URI.parse(contextItem.uri))}${rangeText}#${contextItem.symbolName}`

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -110,7 +110,7 @@ const Item: FunctionComponent<{
         item.title ?? (isFileType || isPackageType ? displayPathBasename(item.uri) : item.symbolName)
 
     const range = getLineRangeInMention(query, item.range)
-    const dir = displayPathDirname(item.uri)
+    const dir = decodeURIComponent(displayPathDirname(item.uri))
     const description = isPackageType
         ? ''
         : isFileType


### PR DESCRIPTION
This PR introduces three changes:

1. **Decode URI components for display in URL context mentions**
   - URLs mentioned using the '@' syntax were displaying encoded characters like '%3D' instead of '='.
   - This commit fixes the issue by decoding the URI components when displaying file paths and directories for URL context mention items in `ContextItemMentionNode.ts` and `OptionsList.tsx`.
   - This ensures that users see properly decoded URLs when using the '@' mention feature to reference URLs in their prompts.

2. **Skip ignoring HTTP URIs**
   - The `IgnoreHelper` class now checks if the URI scheme is 'http' and returns false (i.e., does not ignore the URI) in that case.
   - This change allows the code to process HTTP URIs, which were previously being ignored along with other non-file URIs.
   - The updated logic in the `shouldIgnore` method ensures that HTTP URIs are handled correctly by the application, potentially enabling new functionality or fixing an issue related to HTTP resource handling.

These changes improve the handling of HTTP URIs and enhance the user experience when working with URL context mentions in the application.

Before:
![Screenshot 2024-04-22 182828](https://github.com/sourcegraph/cody/assets/31413214/e9c149ac-fecb-4613-98da-4d2b7488a798)

After:
![Screenshot 2024-04-22 183519](https://github.com/sourcegraph/cody/assets/31413214/97c3a670-ac13-4d7a-8ea9-228a820114e1)


## Test plan

Manually tested



