### PR TITLE
fix "Updating Cody search index for" message

### DIFF
--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -10,6 +10,7 @@ import {
     hydrateAfterPostMessage,
     isDefined,
     isFileURI,
+    uriBasename,
 } from '@sourcegraph/cody-shared'
 
 import type { ExtensionMessage, WebviewMessage } from '../chat/protocol'
@@ -89,7 +90,7 @@ class IndexManager implements vscode.Disposable {
         void vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: `Updating Cody search index for ${displayPath(scopeDir)}`,
+                title: `Updating Cody search index for ${uriBasename(scopeDir)}`,
                 cancellable: true,
             },
             async (_progress, token) => {


### PR DESCRIPTION
It should show the basename of the dir. Fixes a bug where it is blank and just says "Updating Cody search index for" in VS Code workspaces with a single root. The problem is that `displayPath` truncates the workspace root folder prefix.

<img width="626" alt="image" src="https://github.com/sourcegraph/cody/assets/1976/be93084f-20dd-48ba-831b-8cdd520984c7">


## Test plan

CI