### PR TITLE
test and support node 18 (no longer node 16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           # need to run this on all platforms as we're only verifying we don't
           # call any APIs not available in this version.
           - runner: ubuntu
-            node: 16 # Supported by VS Code 1.81 (July 2023).
+            node: 18 # VS Code started using Node 18 in Aug 2023 in v1.82: https://code.visualstudio.com/updates/v1_82#_engineering
     runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 10
     steps:

--- a/agent/src/cli/evaluate-autocomplete/AutocompleteMatcher.test.ts
+++ b/agent/src/cli/evaluate-autocomplete/AutocompleteMatcher.test.ts
@@ -4,7 +4,6 @@ import dedent from 'dedent'
 import { describe, expect, it } from 'vitest'
 import * as vscode from 'vscode'
 
-import { isNode16 } from '../../isNode16'
 import { getLanguageForFileName } from '../../language'
 
 import { AutocompleteMatcher } from './AutocompleteMatcher'
@@ -12,7 +11,7 @@ import { EvaluationDocument } from './EvaluationDocument'
 import { Queries } from './Queries'
 import { isWindows } from './isWindows'
 
-describe.skipIf(isWindows() || isNode16())('AutocompleteMatcher', () => {
+describe.skipIf(isWindows())('AutocompleteMatcher', () => {
     const queriesDirectory = path.join(__dirname, 'queries')
     const queries = new Queries(queriesDirectory)
     function checkInput(filename: string, text: string, assertion: (obtained: string) => void): void {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -13,7 +13,6 @@ import { URI } from 'vscode-uri'
 import type { RequestMethodName } from '../../vscode/src/jsonrpc/jsonrpc'
 import { TestClient, asTranscriptMessage, getAgentDir } from './TestClient'
 import { decodeURIs } from './decodeURIs'
-import { isNode16 } from './isNode16'
 import type {
     CustomChatCommandResult,
     CustomEditCommandResult,
@@ -468,8 +467,7 @@ describe('Agent', () => {
             }
         })
 
-        // Tests for edits would fail on Node 16 (ubuntu16) possibly due to an API that is not supported
-        describe.skipIf(isNode16())('chat/editMessage', () => {
+        describe('chat/editMessage', () => {
             it(
                 'edits the last human chat message',
                 async () => {
@@ -805,7 +803,7 @@ describe('Agent', () => {
         }, 30_000)
 
         // This test seems extra sensitive on Node v16 for some reason.
-        it.skipIf(isNode16() || isWindows())(
+        it.skipIf(isWindows())(
             'commands/test',
             async () => {
                 await client.request('command/execute', {

--- a/agent/src/isNode16.ts
+++ b/agent/src/isNode16.ts
@@ -1,4 +1,0 @@
-export function isNode16(): boolean {
-    const [major] = process.versions.node.split('.')
-    return Number.parseInt(major, 10) <= 16
-}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/sourcegraph/cody"
   },
   "engines": {
-    "node": "^v20.4.0",
+    "node": ">=18",
     "pnpm": "^8.6.7"
   },
   "browser": {
@@ -72,9 +72,6 @@
         }
       }
     },
-    "neverBuiltDependencies": [
-      "deasync",
-      "playwright"
-    ]
+    "neverBuiltDependencies": ["deasync", "playwright"]
   }
 }


### PR DESCRIPTION
My recommendation is that we should stop testing and supporting Node 16, and instead bump this to Node 18.

We had been supporting Node 16 because the July 2023 VS Code release shipped with a version of Electron that used Node 16. That is now well in the past, and:

- VS Code's Aug 2023 release shipped with Node 18 (up from Node 16): https://code.visualstudio.com/updates/v1_82#_engineering
- Node 16 was end-of-life'd on 2023-09-11: https://nodejs.org/en/blog/announcements/nodejs16-eol
- For JetBrains, we use the agent binary that bundles Node (20), so we don't depend on Node 16 even if that's what is installed on the system.

An alternative is to start testing Node 16, 18, AND 20 (ie add tests for Node 18 since it's the version in use by VS Code). This would be safer in case any customers are still using an older version of VS Code that requires Node 16. I'll confirm this before merging: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1713845081115149.



## Test plan

CI