### PR TITLE
Fix repo name resolver

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -376,7 +376,7 @@ describe('ContextFiltersProvider', () => {
             vi.spyOn(graphqlClient, 'fetchSourcegraphAPI').mockResolvedValue(
                 new Error('API error message')
             )
-            await provider.init(getRepoNameFromWorkspaceUri)
+            await provider.init(getRepoNamesFromWorkspaceUri)
 
             const uri = getTestURI({ repoName: 'cody', filePath: 'foo/bar.ts' })
             expect(await provider.isUriIgnored(uri)).toBe(true)
@@ -386,7 +386,7 @@ describe('ContextFiltersProvider', () => {
             vi.spyOn(graphqlClient, 'fetchSourcegraphAPI').mockResolvedValue({
                 data: { site: { codyContextFilters: { raw: null } } },
             })
-            await provider.init(getRepoNameFromWorkspaceUri)
+            await provider.init(getRepoNamesFromWorkspaceUri)
 
             const uri = getTestURI({ repoName: 'cody', filePath: 'foo/bar.ts' })
             expect(await provider.isUriIgnored(uri)).toBe(false)
@@ -396,7 +396,7 @@ describe('ContextFiltersProvider', () => {
             vi.spyOn(graphqlClient, 'fetchSourcegraphAPI').mockResolvedValue(
                 new Error('Error: Cannot query field `codyContextFilters`')
             )
-            await provider.init(getRepoNameFromWorkspaceUri)
+            await provider.init(getRepoNamesFromWorkspaceUri)
 
             const uri = getTestURI({ repoName: 'cody', filePath: 'foo/bar.ts' })
             expect(await provider.isUriIgnored(uri)).toBe(false)

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -50,7 +50,7 @@ export class RepoNameResolver {
         try {
             let remoteUrls = gitRemoteUrlsFromGitExtension(uri)
 
-            if (remoteUrls?.length === 0) {
+            if (remoteUrls === undefined || remoteUrls.length === 0) {
                 remoteUrls = await gitRemoteUrlsFromTreeWalk(uri)
             }
 

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -78,6 +78,7 @@ export class RepoNameResolver {
                 return definedRepoNames
             }
         } catch (error) {
+            console.error(error)
             logDebug('RepoNameResolver:getCodebaseFromWorkspaceUri', 'error', { verbose: error })
         }
 

--- a/vscode/src/repository/repo-name-resolver.ts
+++ b/vscode/src/repository/repo-name-resolver.ts
@@ -1,7 +1,12 @@
 import ini from 'ini'
 import * as vscode from 'vscode'
 
-import { graphqlClient, isDefined, isFileURI } from '@sourcegraph/cody-shared'
+import {
+    convertGitCloneURLToCodebaseName,
+    graphqlClient,
+    isDefined,
+    isFileURI,
+} from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
 
@@ -14,7 +19,7 @@ type RemoteUrl = string
 
 export class RepoNameResolver {
     private platformSpecificGitRemoteGetters: RemoteUrlGetter[] = []
-    private fsPathToRepoNameCache = new LRUCacheWithNullValues()
+    private fsPathToRepoNameCache = new LRUCache<RepoName, string[]>({ max: 1000 })
     private remoteUrlToRepoNameCache = new LRUCache<RemoteUrl, Promise<string | null>>({ max: 1000 })
 
     /**
@@ -33,13 +38,13 @@ export class RepoNameResolver {
      * If not found, attempts to use Git CLI to get the repo names (in node.js environment only).
      * If not found, returns `undefined`.
      */
-    public async getRepoNamesFromWorkspaceUri(uri: vscode.Uri): Promise<string[] | null> {
+    public async getRepoNamesFromWorkspaceUri(uri: vscode.Uri): Promise<string[]> {
         if (!isFileURI(uri)) {
-            return null
+            return []
         }
 
         if (this.fsPathToRepoNameCache.has(uri.fsPath)) {
-            return this.fsPathToRepoNameCache.get(uri.fsPath)
+            return this.fsPathToRepoNameCache.get(uri.fsPath)!
         }
 
         try {
@@ -49,7 +54,7 @@ export class RepoNameResolver {
                 remoteUrls = await gitRemoteUrlsFromTreeWalk(uri)
             }
 
-            if (remoteUrls?.length === 0) {
+            if (remoteUrls === undefined || remoteUrls.length === 0) {
                 for (const getter of this.platformSpecificGitRemoteGetters) {
                     remoteUrls = await getter(uri)
 
@@ -76,7 +81,7 @@ export class RepoNameResolver {
             logDebug('RepoNameResolver:getCodebaseFromWorkspaceUri', 'error', { verbose: error })
         }
 
-        return null
+        return []
     }
 
     private async resolveRepoNameForRemoteUrl(remoteUrl: string): Promise<string | null> {
@@ -84,32 +89,15 @@ export class RepoNameResolver {
             return this.remoteUrlToRepoNameCache.get(remoteUrl)!
         }
 
-        const repoNameRequest = graphqlClient.getRepoName(remoteUrl)
+        const repoNameRequest = graphqlClient.getRepoName(remoteUrl).then(repoName => {
+            if (repoName === null) {
+                return convertGitCloneURLToCodebaseName(remoteUrl)
+            }
+            return repoName
+        })
         this.remoteUrlToRepoNameCache.set(remoteUrl, repoNameRequest)
 
         return repoNameRequest
-    }
-}
-
-// Required to store null values in the cache.
-// See https://github.com/isaacs/node-lru-cache#storing-undefined-values
-const nullCacheValue = Symbol('null cache value')
-type UriFsPath = string
-
-class LRUCacheWithNullValues {
-    cache = new LRUCache<UriFsPath, RepoName[] | typeof nullCacheValue>({ max: 1000 })
-
-    has(key: string): boolean {
-        return this.cache.has(key)
-    }
-
-    set(key: string, value: string[]): void {
-        this.cache.set(key, value.length === 0 ? nullCacheValue : value)
-    }
-
-    get(key: string): string[] | null {
-        const value = this.cache.get(key) || null
-        return value === nullCacheValue ? null : value
     }
 }
 


### PR DESCRIPTION
This PR fixes a few things regarding the repo name resolver:

- It will now fall back to the previous URL parsing if the repo is not known in the Sourcegraph instance (for backward compat): https://github.com/sourcegraph/cody/pull/3870/files#diff-282c58c06ab5f90a1cda9f3adae0bd0541bf9a3c4f681d0399037a568cc8c605L61-R64
- I remove the nullability since we moved this to an array (an empty array is the same as null now)
- Fixed some type issues that creeped into `main`
- Fixed an issue where the upstream request was not sent that I discovered when adding unit tests 😬 

## Test plan

Added a unit test