### PR TITLE
Enable Ollama Chat by default

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Debug: Removed the `cody.debug.enabled` setting. Baseline debugging is now enabled by default [pull/3873](https://github.com/sourcegraph/cody/pull/3873)
+- Chat: The experimental Ollama Chat feature, which allows using local Ollama models for chat and commands, is now enabled by default. [pull/3914](https://github.com/sourcegraph/cody/pull/3914)
 
 ## [1.14.0]
 

--- a/vscode/doc/ollama.md
+++ b/vscode/doc/ollama.md
@@ -32,7 +32,7 @@
 3. Select a chat model (model that includes instruct or chat, e.g. [gemma:7b-instruct-q4_K_M](https://ollama.com/library/gemma:7b-instruct-q4_K_M)) from the [Ollama Library](https://ollama.com/library)
 4. Pull the chat model locally (e.g. `ollama pull gemma:7b-instruct-q4_K_M`)
 5. Once the chat model is downloaded successfully, open Cody in VS Code
-6. Enable the `cody.experimental.ollamaChat` configuration
+6. Select `Preferences: Open Settings (JSON)` from the Command Palette and add the `"cody.experimental.ollamaChat": true` configuration to enable Cody's experimental chat support for Ollama.
 7. Open a new Cody chat
 8. In the new chat panel, you should see the chat model you've pulled in the dropdown list
 9. Currently, you will need to restart VS Code to see the new models

--- a/vscode/doc/ollama.md
+++ b/vscode/doc/ollama.md
@@ -32,9 +32,8 @@
 3. Select a chat model (model that includes instruct or chat, e.g. [gemma:7b-instruct-q4_K_M](https://ollama.com/library/gemma:7b-instruct-q4_K_M)) from the [Ollama Library](https://ollama.com/library)
 4. Pull the chat model locally (e.g. `ollama pull gemma:7b-instruct-q4_K_M`)
 5. Once the chat model is downloaded successfully, open Cody in VS Code
-6. Select `Preferences: Open Settings (JSON)` from the Command Palette and add the `"cody.experimental.ollamaChat": true` configuration to enable Cody's experimental chat support for Ollama.
-7. Open a new Cody chat
-8. In the new chat panel, you should see the chat model you've pulled in the dropdown list
-9. Currently, you will need to restart VS Code to see the new models
+6. Open a new Cody chat
+7. In the new chat panel, you should see the chat model you've pulled in the dropdown list
+8. Currently, you will need to restart VS Code to see the new models
 
-Note: You can run `curl http://localhost:11434/api/tags` in your terminal to see what models are currently available on your machine
+Note: You can run `ollama list` in your terminal to see what Ollama models are currently available on your machine

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -141,7 +141,7 @@ export function getConfiguration(
         experimentalGuardrails: getHiddenSetting('experimental.guardrails', isTesting),
         experimentalTracing: getHiddenSetting('experimental.tracing', false),
 
-        experimentalOllamaChat: getHiddenSetting('experimental.ollamaChat', false),
+        experimentalOllamaChat: getHiddenSetting('experimental.ollamaChat', true),
         experimentalSupercompletions: getHiddenSetting('experimental.supercompletions', false),
 
         experimentalChatContextRanker: getHiddenSetting('experimental.chatContextRanker', false),

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -197,6 +197,14 @@ export function createStatusBar(): CodyStatusBar {
                 c => c.experimentalSymfContext,
                 false
             ),
+            await createFeatureToggle(
+                'Ollama Chat',
+                'Experimental',
+                'Enable Chat and Commands to use your local Ollama models when available',
+                'cody.experimental.ollamaChat',
+                c => c.experimentalOllamaChat,
+                false
+            ),
             { label: 'settings', kind: vscode.QuickPickItemKind.Separator },
             {
                 label: '$(gear) Cody Extension Settings',

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -200,7 +200,7 @@ export function createStatusBar(): CodyStatusBar {
             await createFeatureToggle(
                 'Ollama for Chat',
                 'Experimental',
-                'Enable using your local Ollama models for chat and commands when available',
+                'Use local Ollama models for chat and commands when available',
                 'cody.experimental.ollamaChat',
                 c => c.experimentalOllamaChat,
                 false

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -198,9 +198,9 @@ export function createStatusBar(): CodyStatusBar {
                 false
             ),
             await createFeatureToggle(
-                'Ollama Chat',
+                'Ollama for Chat',
                 'Experimental',
-                'Enable Chat and Commands to use your local Ollama models when available',
+                'Enable using your local Ollama models for chat and commands when available',
                 'cody.experimental.ollamaChat',
                 c => c.experimentalOllamaChat,
                 false

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -820,7 +820,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
     experimentalGuardrails: false,
     experimentalSimpleChatContext: true,
     experimentalSupercompletions: false,
-    experimentalOllamaChat: false,
+    experimentalOllamaChat: true,
     experimentalSymfContext: true,
     experimentalTracing: false,
     codeActions: true,

--- a/vscode/webviews/Components/ChatModelDropdownMenu.module.css
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.module.css
@@ -76,19 +76,29 @@
     width: 100%;
 }
 
-.badge {
+.badge  {
     position: relative;
     margin-left: auto;
-    padding: 3px 4px;
-    background: repeating-conic-gradient(#7048E8 50%, #00CBEC 75%, #A112FF 100%, #FF5543 125%, #7048E8 150%);
-    border-radius: 4px;
     font-size: 12px;
     font-weight: 500;
     line-height: 1;
     letter-spacing: -0.025rem;
     text-shadow: 0px 0px 1px #280065, 0px 1px 1px rgba(36, 0, 81, 1);
     transition: box-shadow 150ms;
-    color: rgba(255,255,255,0.9);
+}
+
+.cody-pro-badge {
+    background: repeating-conic-gradient(#7048E8 50%, #00CBEC 75%, #A112FF 100%, #FF5543 125%, #7048E8 150%);
+    color: rgba(255, 255, 255, 0.9);
+    border-radius: 4px;
+    padding: 3px 4px;
+}
+
+.experimental-badge {
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    border-radius: 4px;
+    padding: 3px 4px;
 }
 
 .container vscode-option:hover .badge {

--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -120,9 +120,14 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
                                 option.provider
                             )}`}</span>
                         </span>
-                        {isModelDisabled(option.codyProOnly) && (
-                            <span className={styles.badge}>Pro</span>
-                        )}
+                        <span className={styles.badge}>
+                            {isModelDisabled(option.codyProOnly) && (
+                                <span className={styles.codyProBadge}>Pro</span>
+                            )}
+                            {option.provider === 'Ollama' && (
+                                <span className={styles.experimentalBadge}>Experimental</span>
+                            )}
+                        </span>
                     </VSCodeOption>
                 ))}
 


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1713891011703859

This pull request updates the Cody extension for VS Code to enable the experimental Ollama Chat feature by default. 

The changes include:

- Configuration Update: In the configuration.ts file, the experimentalOllamaChat setting is changed from false to true by default. This setting controls whether the Ollama Chat feature is enabled or not.
- Status Bar Update: In the StatusBar.ts file, a new feature toggle is added for the "Ollama Chat" feature. This toggle appears in the Cody extension's status bar and allows users to enable or disable the Ollama Chat feature from the UI.
- Dropdown menu Update: Display Ollama models in the dropdown menu with `experimental` badge.

With these changes, users will now have the Ollama Chat feature enabled by default, allowing them to use their local Ollama models for chat and commands within VS Code. However, users can still disable this experimental feature through the extension's JSON settings or the new status bar toggle if desired.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Manual test plan:
1. Start your local ollama app
2. Start Cody from this branch in debug mode and verify the following:

Ollama models in the dropdown has an `experimental` badge next to them:

![image](https://github.com/sourcegraph/cody/assets/68532117/b30d7462-47a3-45d8-9491-894a1aae76f3)

You can toggle the experimental settings via Cody Settings Menu:

![image](https://github.com/sourcegraph/cody/assets/68532117/6392ac94-d2ad-49d0-a40b-ed70c24ef3ed)
