### PR TITLE
Add missing generated Kotlin stubs for `ignore/test`

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Ignore_TestParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Ignore_TestParams.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class Ignore_TestParams(
+  val uri: String,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Ignore_TestResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Ignore_TestResult.kt
@@ -1,0 +1,15 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+import com.google.gson.annotations.SerializedName
+
+data class Ignore_TestResult(
+  val policy: PolicyEnum, // Oneof: ignore, use
+) {
+
+  enum class PolicyEnum {
+    @SerializedName("ignore") Ignore,
+    @SerializedName("use") Use,
+  }
+}
+


### PR DESCRIPTION
Follow up to 3a50f57ca0a249c05851cc19ec891f49885dff86, add the generated stubs for the renamed `ignore/test` method. Forgot to add these.

## Test plan

`./agent/scripts/generate-agent-kotlin-bindings.sh` produces an empty diff.