### PR TITLE
noodle: introduce sourcegraph literal search mentions provider

### DIFF
--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -1,6 +1,7 @@
 import type { ContextItem, ContextItemWithContent } from '../codebase-context/messages'
 import type { PromptString } from '../prompt/prompt-string'
 import { PACKAGE_CONTEXT_MENTION_PROVIDER } from './providers/packageMentions'
+import { SOURCEGRAPH_SEARCH_CONTEXT_MENTION_PROVIDER } from './providers/sourcegraphSearch'
 import { URL_CONTEXT_MENTION_PROVIDER } from './providers/urlMentions'
 
 /**
@@ -18,6 +19,7 @@ export type ContextMentionProviderID = string
 export const CONTEXT_MENTION_PROVIDERS: ContextMentionProvider[] = [
     URL_CONTEXT_MENTION_PROVIDER,
     PACKAGE_CONTEXT_MENTION_PROVIDER,
+    SOURCEGRAPH_SEARCH_CONTEXT_MENTION_PROVIDER,
 ]
 
 /**

--- a/lib/shared/src/mentions/providers/sourcegraphSearch.ts
+++ b/lib/shared/src/mentions/providers/sourcegraphSearch.ts
@@ -1,0 +1,176 @@
+import { URI } from 'vscode-uri'
+import { ContextItemSource, type ContextItemWithContent } from '../../codebase-context/messages'
+import { isErrorLike } from '../../common'
+import type { RangeData } from '../../common/range'
+import { graphqlClient } from '../../sourcegraph-api/graphql'
+import { isError } from '../../utils'
+import type { ContextMentionProvider } from '../api'
+
+export const SOURCEGRAPH_SEARCH_CONTEXT_MENTION_PROVIDER: ContextMentionProvider<'src-search'> = {
+    id: 'src-search',
+    // TODO the prefix '!' seems to not trigger the @ mention code path. I am
+    // assuming there is parsing logic somewhere which only calls the @
+    // mentions if they look like a path or start with # (for symbols)
+    triggerPrefixes: ['src:'],
+
+    async queryContextItems(query, signal) {
+        const searchQuery = query.startsWith('src:') ? query.slice(4) : query
+        const uri = URI.parse(graphqlClient.endpoint).with({
+            query: 'q=' + encodeURIComponent(searchQuery),
+        })
+        return [
+            {
+                type: 'file',
+                uri: uri,
+                title: searchQuery,
+                source: ContextItemSource.Uri,
+                provider: 'src-search',
+            },
+        ]
+    },
+
+    async resolveContextItem(item, input, signal): Promise<ContextItemWithContent[]> {
+        if (item.content !== undefined) {
+            return [item as ContextItemWithContent]
+        }
+
+        // Sneaking in the search query via the title
+        const rawQuery = item.title
+        if (!rawQuery) {
+            return []
+        }
+
+        // Adjust query to limit results to filematches
+        const query = 'type:file count:10 ' + rawQuery
+
+        const chunks = await searchForFileChunks(query, signal)
+
+        if (isErrorLike(chunks)) {
+            throw chunks
+        }
+
+        return chunks.map(chunk => {
+            return {
+                ...item,
+                ...chunk,
+            }
+        })
+    },
+}
+
+type Chunk = Pick<ContextItemWithContent, 'uri' | 'range' | 'content' | 'repoName' | 'revision'>
+
+async function searchForFileChunks(
+    query: string,
+    signal: AbortSignal | undefined
+): Promise<Chunk[] | Error> {
+    const results = await graphqlClient
+        .fetchSourcegraphAPI<APIResponse<SearchResponse>>(SEARCH_QUERY, {
+            query,
+        })
+        .then(response =>
+            extractDataOrError(response, data => {
+                return data.search.results.results.flatMap(result => {
+                    if (result.__typename !== 'FileMatch') {
+                        return []
+                    }
+                    const fileContext = {
+                        uri: URI.parse(result.file.url),
+                        repoName: result.repository.name,
+                        revision: result.file.commit.oid,
+                    }
+                    return result.chunkMatches.map(chunkMatch => {
+                        return {
+                            ...fileContext,
+                            content: chunkMatch.content,
+                            range: chunkMatchContentToRange(
+                                chunkMatch.content,
+                                chunkMatch.contentStart.line
+                            ),
+                        }
+                    })
+                })
+            })
+        )
+    return results
+}
+
+function chunkMatchContentToRange(content: string, startLine: number): RangeData {
+    const lines = content.split('\n')
+    const endLine = startLine + lines.length - 1
+    return {
+        start: { line: startLine, character: 0 },
+        end: { line: endLine, character: lines[lines.length - 1].length },
+    }
+}
+
+const SEARCH_QUERY = `
+query CodyMentionProviderSearch($query: String!) {
+  search(query: $query, version: V3, patternType: literal) {
+    results {
+      results {
+        __typename
+        ... on FileMatch {
+          repository {
+            name
+          }
+          file {
+            url
+            commit {
+              oid
+            }
+          }
+          chunkMatches {
+            content
+            contentStart {
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+interface SearchResponse {
+    search: {
+        results: {
+            results: {
+                __typename: string
+                repository: {
+                    name: string
+                }
+                file: {
+                    url: string
+                    commit: {
+                        oid: string
+                    }
+                }
+                chunkMatches: {
+                    content: string
+                    contentStart: {
+                        line: number
+                    }
+                }[]
+            }[]
+        }
+    }
+}
+
+interface APIResponse<T> {
+    data?: T
+    errors?: { message: string; path?: string[] }[]
+}
+
+function extractDataOrError<T, R>(response: APIResponse<T> | Error, extract: (data: T) => R): R | Error {
+    if (isError(response)) {
+        return response
+    }
+    if (response.errors && response.errors.length > 0) {
+        return new Error(response.errors.map(({ message }) => message).join(', '))
+    }
+    if (!response.data) {
+        return new Error('response is missing data')
+    }
+    return extract(response.data)
+}


### PR DESCRIPTION
Note: this logic is currently hidden behind the noodle feature flag. Additionally instead of implementing client logic in our graphql backend, it keeps all related logic inside one file to contain the blast radius. Please give feedback if this is a reasonable idea, or if I should just implement things inside of client.ts. Because I didn't do the latter I had to copy paste some utility types/functions.

When typing the prefix "@src:" we will provide a context item which says it will search against your sourcegraph endpoint. This is presented as a URL to the search. When clicking resolving the item it will convert each search result chunk into a context item.

This is currently not working due to some recent restrictions introduced on context sources. Note that the URL mention provider also seems to be broken due to it:

  Request Failed: The prompt string contains a reference to a file that
  is not allowed by the context filters.

Other known issues:
- We can't use the triggerPrefix ! or ? due to how mentions are parsed
- Mentions also stop completing once you enter non file path looking items. EG entering a ( stops the autocomplete.
- The generated link to the search results is not clickable due to vscode incorrectly escaping the query parameters.

Test Plan: manually tested, but not yet ready for merging