### PR TITLE
shim re2-wasm to fix storybook

### DIFF
--- a/vscode/.storybook/main.ts
+++ b/vscode/.storybook/main.ts
@@ -9,6 +9,10 @@ const config: StorybookConfig = {
         options: {},
     },
     viteFinal: async config =>
-        defineProjectWithDefaults(__dirname, { ...config, define: { 'process.env': '{}' } }),
+        defineProjectWithDefaults(__dirname, {
+            ...config,
+            define: { 'process.env': '{}' },
+            resolve: { alias: { 're2-wasm': __dirname + '/re2-wasm-shim.js' } },
+        }),
 }
 export default config

--- a/vscode/.storybook/re2-wasm-shim.js
+++ b/vscode/.storybook/re2-wasm-shim.js
@@ -1,0 +1,1 @@
+export const RE2 = {}


### PR DESCRIPTION
Fixes issue when loading all storybooks:

```
abort(sync fetching of the wasm failed: you can preload it to Module['wasmBinary'] manually, or emcc.py will do that for you when generating HTML (but not JS)) at Error
```

There's almost certainly a better way to do this, but this unblocks storybooks for now.



## Test plan

CI