### PR TITLE
Trace local embedding search error

### DIFF
--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -580,7 +580,7 @@ export class LocalEmbeddingsController
         if (!lastRepo || !lastRepo.repoName) {
             return []
         }
-        // without this, assingment to repoName below complains about | boolean
+        // without this, assignment to repoName below complains about | boolean
         const lastRepoName = lastRepo.repoName
         return wrapInActiveSpan('LocalEmbeddingsController.query', async span => {
             try {

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -578,13 +578,14 @@ export class LocalEmbeddingsController
         }
         return wrapInActiveSpan('LocalEmbeddingsController.query', async span => {
             try {
-                if (!this.lastRepo || !this.lastRepo.repoName) {
+                const lastRepo = this.lastRepo
+                if (!lastRepo || !lastRepo.repoName) {
                     span.setAttribute('noResultReason', 'last-repo-not-set')
                     return []
                 }
                 const service = await this.getService()
                 const resp = await service.request('embeddings/query', {
-                    repoName: this.lastRepo.repoName,
+                    repoName: lastRepo.repoName,
                     query: query.toString(),
                     numResults,
                 })

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -579,7 +579,7 @@ export class LocalEmbeddingsController
         return wrapInActiveSpan('LocalEmbeddingsController.query', async span => {
             try {
                 const lastRepo = this.lastRepo
-                if (!lastRepo || !lastRepo.repoName) {
+                if (!lastRepo?.repoName) {
                     span.setAttribute('noResultReason', 'last-repo-not-set')
                     return []
                 }

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -576,17 +576,15 @@ export class LocalEmbeddingsController
         if (!this.endpointIsDotcom) {
             return []
         }
-        const lastRepo = this.lastRepo
-        if (!lastRepo || !lastRepo.repoName) {
-            return []
-        }
-        // without this, assignment to repoName below complains about | boolean
-        const lastRepoName = lastRepo.repoName
         return wrapInActiveSpan('LocalEmbeddingsController.query', async span => {
             try {
+                if (!this.lastRepo || !this.lastRepo.repoName) {
+                    span.setAttribute('noResultReason', 'last-repo-not-set')
+                    return []
+                }
                 const service = await this.getService()
                 const resp = await service.request('embeddings/query', {
-                    repoName: lastRepoName,
+                    repoName: this.lastRepo.repoName,
                     query: query.toString(),
                     numResults,
                 })


### PR DESCRIPTION
Trace embedding search errors - currently, we only capture the number of results.

## Test plan

- local testing