### PR TITLE
Cody Ignore: Do not block context with http/s URIs

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -1,7 +1,11 @@
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
-import { type ContextFilters, graphqlClient } from '../sourcegraph-api/graphql/client'
+import {
+    type ContextFilters,
+    EXCLUDE_EVERYTHING_CONTEXT_FILTERS,
+    graphqlClient,
+} from '../sourcegraph-api/graphql/client'
 import { ContextFiltersProvider } from './context-filters-provider'
 
 describe('ContextFiltersProvider', () => {
@@ -410,7 +414,15 @@ describe('ContextFiltersProvider', () => {
             expect(
                 await provider.isUriIgnored(URI.parse('https://sourcegraph.sourcegraph.com/foo/bar'))
             ).toBe(false)
-            expect(await provider.isUriIgnored(URI.parse('http://[::1]/goodies]'))).toBe(false)
+            expect(await provider.isUriIgnored(URI.parse('http://[::1]/goodies'))).toBe(false)
+        })
+
+        it('deny all filters should not block http/s URIs', async () => {
+            await initProviderWithContextFilters(EXCLUDE_EVERYTHING_CONTEXT_FILTERS)
+            expect(
+                await provider.isUriIgnored(URI.parse('https://sourcegraph.sourcegraph.com/foo/bar'))
+            ).toBe(false)
+            expect(await provider.isUriIgnored(URI.parse('http://[::1]/goodies'))).toBe(false)
         })
     })
 })

--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -401,5 +401,16 @@ describe('ContextFiltersProvider', () => {
             const uri = getTestURI({ repoName: 'cody', filePath: 'foo/bar.ts' })
             expect(await provider.isUriIgnored(uri)).toBe(false)
         })
+
+        it('does not block remote context/http(s) URIs', async () => {
+            await initProviderWithContextFilters({
+                include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/cody' }],
+                exclude: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/sourcegraph' }],
+            })
+            expect(
+                await provider.isUriIgnored(URI.parse('https://sourcegraph.sourcegraph.com/foo/bar'))
+            ).toBe(false)
+            expect(await provider.isUriIgnored(URI.parse('http://[::1]/goodies]'))).toBe(false)
+        })
     })
 })

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -104,16 +104,12 @@ export class ContextFiltersProvider implements vscode.Disposable {
     }
 
     public async isUriIgnored(uri: vscode.Uri): Promise<boolean> {
-        if (this.hasAllowEverythingFilters()) {
+        if (allowedSchemes.has(uri.scheme) || this.hasAllowEverythingFilters()) {
             return false
         }
 
         if (this.hasIgnoreEverythingFilters()) {
             return true
-        }
-
-        if (allowedSchemes.has(uri.scheme)) {
-            return false
         }
 
         // TODO: process non-file URIs https://github.com/sourcegraph/cody/issues/3893

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -23,6 +23,10 @@ export type GetRepoNamesFromWorkspaceUri = (uri: vscode.Uri) => Promise<string[]
 type RepoName = string
 type IsRepoNameIgnored = boolean
 
+// These schemes are always deemed safe. Remote context has https URIs, but
+// the remote applies Cody ignore rules.
+const allowedSchemes = new Set(['http', 'https'])
+
 export class ContextFiltersProvider implements vscode.Disposable {
     /**
      * `null` value means that we failed to fetch context filters.
@@ -106,6 +110,10 @@ export class ContextFiltersProvider implements vscode.Disposable {
 
         if (this.hasIgnoreEverythingFilters()) {
             return true
+        }
+
+        if (allowedSchemes.has(uri.scheme)) {
+            return false
         }
 
         // TODO: process non-file URIs https://github.com/sourcegraph/cody/issues/3893


### PR DESCRIPTION
Remote context has http/s URIs, and we were conservatively blocking these because they don't pass the *file* filter. But remote context is filtered by the getCodyContext backend.

For now, unblocking all context items with http/s URIs.

## Test plan

Added a unit test; CI

Fixes #3928