### PR TITLE
use pure-JS RE2 impl instead of re2-wasm

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^10.0.0",
     "marked": "^4.0.16",
-    "re2-wasm": "^1.0.2",
+    "re2js": "^0.4.1",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {

--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -1,3 +1,4 @@
+import { RE2JS as RE2 } from 're2js'
 import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
@@ -424,5 +425,18 @@ describe('ContextFiltersProvider', () => {
             ).toBe(false)
             expect(await provider.isUriIgnored(URI.parse('http://[::1]/goodies'))).toBe(false)
         })
+    })
+})
+
+describe('RE2JS', () => {
+    it('exhibits RE2 u (unicode) flag behavior without the flag being explicitly set', () => {
+        // This is the behavior of the 'u' flag as documented at
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#description:
+        //
+        // > Surrogate pairs will be interpreted as whole characters instead of two separate
+        // > characters. For example, /[😄]/u would only match "😄" but not "\ud83d".
+        const re = RE2.compile('[😄]')
+        expect(re.matches('😄')).toBe(true)
+        expect(re.matches('\ud83d')).toBe(false)
     })
 })

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -84,7 +84,6 @@ export class ContextFiltersProvider implements vscode.Disposable {
         if (this.contextFilters?.include?.length) {
             for (const parsedFilter of this.contextFilters.include) {
                 isIgnored = !matchesContextFilter(parsedFilter, repoName)
-                console.log('XX1', isIgnored, parsedFilter, repoName)
                 if (!isIgnored) {
                     break
                 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,9 +263,9 @@ importers:
       marked:
         specifier: ^4.0.16
         version: 4.0.16
-      re2-wasm:
-        specifier: ^1.0.2
-        version: 1.0.2
+      re2js:
+        specifier: ^0.4.1
+        version: 0.4.1
       vscode-uri:
         specifier: ^3.0.7
         version: 3.0.7
@@ -429,9 +429,6 @@ importers:
       proxy-agent:
         specifier: ^6.4.0
         version: 6.4.0
-      re2-wasm:
-        specifier: ^1.0.2
-        version: 1.0.2
       semver:
         specifier: ^7.5.4
         version: 7.6.0
@@ -11630,9 +11627,8 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /re2-wasm@1.0.2:
-    resolution: {integrity: sha512-VXUdgSiUrE/WZXn6gUIVVIsg0+Hp6VPZPOaHCay+OuFKy6u/8ktmeNEf+U5qSA8jzGGFsg8jrDNu1BeHpz2pJA==}
-    engines: {node: '>=10'}
+  /re2js@0.4.1:
+    resolution: {integrity: sha512-Kxb+OKXrEPowP4bXAF07NDXtgYX07S8HeVGgadx5/D/R41LzWg1kgTD2szIv2iHJM3vrAPnDKaBzfUE/7QWX9w==}
     dev: false
 
   /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):

--- a/vscode/.storybook/main.ts
+++ b/vscode/.storybook/main.ts
@@ -12,7 +12,6 @@ const config: StorybookConfig = {
         defineProjectWithDefaults(__dirname, {
             ...config,
             define: { 'process.env': '{}' },
-            resolve: { alias: { 're2-wasm': __dirname + '/re2-wasm-shim.js' } },
         }),
 }
 export default config

--- a/vscode/.storybook/re2-wasm-shim.js
+++ b/vscode/.storybook/re2-wasm-shim.js
@@ -1,1 +1,0 @@
-export const RE2 = {}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1270,7 +1270,6 @@
     "os-browserify": "^0.3.0",
     "parse-git-diff": "^0.0.14",
     "proxy-agent": "^6.4.0",
-    "re2-wasm": "^1.0.2",
     "semver": "^7.5.4",
     "socks-proxy-agent": "^8.0.1",
     "unzipper": "^0.10.14",

--- a/vscode/scripts/download-wasm-modules.ts
+++ b/vscode/scripts/download-wasm-modules.ts
@@ -15,9 +15,6 @@ const TREE_SITTER_WASM_PATH = require.resolve(`web-tree-sitter/${TREE_SITTER_WAS
 const JS_GRAMMAR_PATH = require.resolve('@sourcegraph/tree-sitter-wasms/out/tree-sitter-javascript.wasm')
 const GRAMMARS_PATH = path.dirname(JS_GRAMMAR_PATH)
 
-const RE2_WASM_FILE = 're2.wasm'
-const RE2_WASM_PATH = require.resolve(`re2-wasm/build/wasm/${RE2_WASM_FILE}`)
-
 export async function main(): Promise<void> {
     const hasStoreDir = existsSync(WASM_DIRECTORY)
 
@@ -53,5 +50,4 @@ function copyFilesToDistDir(): void {
     }
 
     copyFileSync(TREE_SITTER_WASM_PATH, path.join(DIST_DIRECTORY, TREE_SITTER_WASM_FILE))
-    copyFileSync(RE2_WASM_PATH, path.join(DIST_DIRECTORY, RE2_WASM_FILE))
 }


### PR DESCRIPTION
[RE2JS](https://github.com/le0pard/re2js) is a pure JavaScript implementation of RE2. This is more portable than [re2-wasm](https://github.com/google/re2-wasm), which [does not support usage in the browser](https://github.com/google/re2-wasm/issues/15), which breaks storybooks (although there is an easy hack workarond) and prevents Cody Web from reusing this code. It is possible to make re2-wasm usable in the browser, but it would require forking the upstream, which does not seem worth the effort unless we find the performance of RE2JS to be unacceptable.

RE2JS does not support the `u` flag for RE2, which [enables various Unicode-related features](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode), so I added a test to confirm that this is its default behavior.

(I wasn't sure if there was a reason you preferred re2-wasm. RE2JS is weird in that `.matches(input)` looks for full string matches by default, but otherwise it seems like a solid library.)

## Test plan

CI