### PR TITLE
remove needless escapes of `/` in regexp patterns

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -75,8 +75,8 @@ describe('ContextFiltersProvider', () => {
                 label: 'include and exclude rules',
                 filters: {
                     include: [
-                        { repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' },
-                        { repoNamePattern: '^github\\.com\\/evilcorp\\/.*' },
+                        { repoNamePattern: '^github\\.com/sourcegraph/.*' },
+                        { repoNamePattern: '^github\\.com/evilcorp/.*' },
                     ],
                     exclude: [{ repoNamePattern: '.*sensitive.*' }],
                 },
@@ -86,7 +86,7 @@ describe('ContextFiltersProvider', () => {
             {
                 label: 'does not allow a repo if it does not match the include pattern',
                 filters: {
-                    include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' }],
+                    include: [{ repoNamePattern: '^github\\.com/sourcegraph/.*' }],
                     exclude: [{ repoNamePattern: '.*sensitive.*' }],
                 },
                 ignored: ['github.com/other/repo'],
@@ -95,8 +95,8 @@ describe('ContextFiltersProvider', () => {
                 label: 'does not allow a repo if it matches the exclude pattern',
                 filters: {
                     include: [
-                        { repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' },
-                        { repoNamePattern: '^github\\.com\\/sensitive\\/.*' },
+                        { repoNamePattern: '^github\\.com/sourcegraph/.*' },
+                        { repoNamePattern: '^github\\.com/sensitive/.*' },
                     ],
                     exclude: [
                         { repoNamePattern: '.*sensitive.*' },
@@ -112,7 +112,7 @@ describe('ContextFiltersProvider', () => {
             {
                 label: 'excludes repos that match both include and exclude patterns',
                 filters: {
-                    include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' }],
+                    include: [{ repoNamePattern: '^github\\.com/sourcegraph/.*' }],
                     exclude: [{ repoNamePattern: '.*sensitive.*' }],
                 },
                 ignored: ['github.com/sourcegraph/sensitive-repo'],
@@ -120,8 +120,8 @@ describe('ContextFiltersProvider', () => {
             {
                 label: 'excludes repos with anchored exclude pattern starting with the specific term',
                 filters: {
-                    include: [{ repoNamePattern: 'github\\.com\\/sourcegraph\\/.*' }],
-                    exclude: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/sensitive.*' }],
+                    include: [{ repoNamePattern: 'github\\.com/sourcegraph/.*' }],
+                    exclude: [{ repoNamePattern: '^github\\.com/sourcegraph/sensitive.*' }],
                 },
                 ignored: ['github.com/sourcegraph/sensitive-data'],
                 allowed: [
@@ -132,8 +132,8 @@ describe('ContextFiltersProvider', () => {
             {
                 label: 'excludes repos with anchored exclude pattern ending with the specific term',
                 filters: {
-                    include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' }],
-                    exclude: [{ repoNamePattern: '.*\\/sensitive$' }],
+                    include: [{ repoNamePattern: '^github\\.com/sourcegraph/.*' }],
+                    exclude: [{ repoNamePattern: '.*/sensitive$' }],
                 },
                 allowed: ['github.com/sourcegraph/data-sensitive'],
                 ignored: ['github.com/sourcegraph/sensitive'],
@@ -141,8 +141,8 @@ describe('ContextFiltersProvider', () => {
             {
                 label: 'excludes repos using non-capturing groups',
                 filters: {
-                    include: [{ repoNamePattern: '^github\\.com\\/(sourcegraph|evilcorp)\\/.*' }],
-                    exclude: [{ repoNamePattern: '.*\\/(sensitive|classified).*' }],
+                    include: [{ repoNamePattern: '^github\\.com/(sourcegraph|evilcorp)/.*' }],
+                    exclude: [{ repoNamePattern: '.*/(sensitive|classified).*' }],
                 },
                 ignored: ['github.com/sourcegraph/sensitive-project'],
                 allowed: ['github.com/evilcorp/public'],
@@ -151,11 +151,11 @@ describe('ContextFiltersProvider', () => {
                 label: 'multiple include and exclude patterns',
                 filters: {
                     include: [
-                        { repoNamePattern: '^github\\.com\\/sourcegraph\\/.+' },
-                        { repoNamePattern: '^github\\.com\\/docker\\/compose$' },
-                        { repoNamePattern: '^github\\.com\\/.+\\/react' },
+                        { repoNamePattern: '^github\\.com/sourcegraph/.+' },
+                        { repoNamePattern: '^github\\.com/docker/compose$' },
+                        { repoNamePattern: '^github\\.com/.+/react' },
                     ],
-                    exclude: [{ repoNamePattern: '.*cody.*' }, { repoNamePattern: '.+\\/docker\\/.+' }],
+                    exclude: [{ repoNamePattern: '.*cody.*' }, { repoNamePattern: '.+/docker/.+' }],
                 },
                 allowed: [
                     'github.com/sourcegraph/about',
@@ -169,9 +169,9 @@ describe('ContextFiltersProvider', () => {
                 label: 'exclude everything',
                 filters: {
                     include: [
-                        { repoNamePattern: '^github\\.com\\/sourcegraph\\/.+' },
-                        { repoNamePattern: '^github\\.com\\/docker\\/compose$' },
-                        { repoNamePattern: '^github\\.com\\/.+\\/react' },
+                        { repoNamePattern: '^github\\.com/sourcegraph/.+' },
+                        { repoNamePattern: '^github\\.com/docker/compose$' },
+                        { repoNamePattern: '^github\\.com/.+/react' },
                     ],
                     exclude: [{ repoNamePattern: '.*cody.*' }, { repoNamePattern: '.*' }],
                 },
@@ -189,7 +189,7 @@ describe('ContextFiltersProvider', () => {
                 label: 'invalid patterns cause all repo names to be excluded',
                 filters: {
                     include: [
-                        { repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' },
+                        { repoNamePattern: '^github\\.com/sourcegraph/.*' },
                         { repoNamePattern: '(invalid_regex' },
                     ],
                 },
@@ -285,7 +285,7 @@ describe('ContextFiltersProvider', () => {
 
         it('uses cached results for repeated calls', async () => {
             const contextFilters = {
-                include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' }],
+                include: [{ repoNamePattern: '^github\\.com/sourcegraph/.*' }],
             } satisfies ContextFilters
 
             const mockedApiRequest = vi
@@ -301,11 +301,11 @@ describe('ContextFiltersProvider', () => {
 
         it('refetches context filters after the specified interval', async () => {
             const mockContextFilters1 = {
-                include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/.*' }],
+                include: [{ repoNamePattern: '^github\\.com/sourcegraph/.*' }],
             } satisfies ContextFilters
 
             const mockContextFilters2 = {
-                include: [{ repoNamePattern: '^github\\.com\\/other\\/.*' }],
+                include: [{ repoNamePattern: '^github\\.com/other/.*' }],
             } satisfies ContextFilters
 
             const mockedApiRequest = vi
@@ -341,8 +341,8 @@ describe('ContextFiltersProvider', () => {
 
         it('applies context filters correctly', async () => {
             await initProviderWithContextFilters({
-                include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/cody' }],
-                exclude: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/sourcegraph' }],
+                include: [{ repoNamePattern: '^github\\.com/sourcegraph/cody' }],
+                exclude: [{ repoNamePattern: '^github\\.com/sourcegraph/sourcegraph' }],
             })
 
             const includedURI = getTestURI({ repoName: 'cody', filePath: 'foo/bar.ts' })
@@ -364,8 +364,8 @@ describe('ContextFiltersProvider', () => {
 
         it('returns `true` if repo name is not found', async () => {
             await initProviderWithContextFilters({
-                include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/cody' }],
-                exclude: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/sourcegraph' }],
+                include: [{ repoNamePattern: '^github\\.com/sourcegraph/cody' }],
+                exclude: [{ repoNamePattern: '^github\\.com/sourcegraph/sourcegraph' }],
             })
 
             const uri = getTestURI({ repoName: 'cody', filePath: 'foo/bar.ts' })
@@ -408,8 +408,8 @@ describe('ContextFiltersProvider', () => {
 
         it('does not block remote context/http(s) URIs', async () => {
             await initProviderWithContextFilters({
-                include: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/cody' }],
-                exclude: [{ repoNamePattern: '^github\\.com\\/sourcegraph\\/sourcegraph' }],
+                include: [{ repoNamePattern: '^github\\.com/sourcegraph/cody' }],
+                exclude: [{ repoNamePattern: '^github\\.com/sourcegraph/sourcegraph' }],
             })
             expect(
                 await provider.isUriIgnored(URI.parse('https://sourcegraph.sourcegraph.com/foo/bar'))


### PR DESCRIPTION
These are only needed in RegExp literals.

## Test plan

CI