### PR TITLE
Chat: remove capitalization from model names

### DIFF
--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -77,7 +77,6 @@ test('chat input focus', async ({ page, sidebar }) => {
     await page.getByRole('tab', { name: 'buzz.ts' }).dblclick()
 
     // Submit a new chat question from the command menu.
-    await page.getByLabel(/Commands \(/).hover()
     await page.getByLabel(/Commands \(/).click()
     await page.waitForTimeout(100)
     // HACK: The 'delay' command is used to make sure the response is streamed 400ms after
@@ -87,6 +86,7 @@ test('chat input focus', async ({ page, sidebar }) => {
     await chatInput.fill('delay')
     await chatInput.press('Enter')
     await expect(chatInput).toBeFocused()
+    await chatInput.click()
 
     // Ensure equal-width columns so we can be sure the code we're about to click is in view (and is
     // not out of the editor's scroll viewport). This became required due to new (undocumented)

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -334,7 +334,8 @@ export async function signOut(page: Page): Promise<void> {
 export async function executeCommandInPalette(page: Page, commandName: string): Promise<void> {
     // TODO(sqs): could simplify this further with a cody.auth.signoutAll command
     await page.keyboard.press('F1')
-    await page.getByRole('combobox', { name: 'input' }).fill(`>${commandName}`)
+    await page.getByPlaceholder('Type the name of a command to run.').click()
+    await page.getByPlaceholder('Type the name of a command to run.').fill(`>${commandName}`)
     await page.keyboard.press('Enter')
 }
 

--- a/vscode/webviews/Components/ChatModelDropdownMenu.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.tsx
@@ -115,7 +115,7 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
                                     : undefined
                             }
                         >
-                            <span className={styles.title}>{capitalize(option.title)}</span>
+                            <span className={styles.title}>{option.title}</span>
                             <span className={styles.provider}>{` by ${capitalize(
                                 option.provider
                             )}`}</span>
@@ -134,7 +134,7 @@ export const ChatModelDropdownMenu: React.FunctionComponent<ChatModelDropdownMen
                 <div slot="selected-value" className={styles.selectedValue}>
                     <ChatModelIcon model={currentModel.model} />
                     <span>
-                        <span className={styles.title}>{capitalize(currentModel.title)}</span>
+                        <span className={styles.title}>{currentModel.title}</span>
                     </span>
                 </div>
             </VSCodeDropdown>


### PR DESCRIPTION
Suggested by @toolmantim 

Remove the `capitalize` function call when rendering the title for chat model options and the selected model in the dropdown menu. This change  allows the original casing of the model titles to be displayed as-is.

## Changes

- Remove the `capitalize` function call when rendering `option.title` in the dropdown menu options.
- Remove the `capitalize` function call when rendering `currentModel.title` in the selected value of the dropdown.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Verify third-party modes (e.g. ollama) from the dropdown list are not capitalized

![image](https://github.com/sourcegraph/cody/assets/68532117/134fe901-4f26-40c4-9192-8a7f4aadd03c)

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/4f9b7932-c0e2-4bd1-9026-c29f6d00fcf5)
