### PR TITLE
PromptString: Log blocked references

### DIFF
--- a/lib/shared/src/prompt/prompt-string.test.ts
+++ b/lib/shared/src/prompt/prompt-string.test.ts
@@ -70,7 +70,7 @@ describe('PromptString', () => {
 
         expect(await promptString.toFilteredString(allowPolicy)).toEqual('i am from a file')
         expect(async () => await promptString.toFilteredString(denyPolicy)).rejects.toThrowError(
-            'The prompt string contains a reference to a file that is not allowed by the context filters.'
+            'The prompt contains a reference to a file that is not allowed by your current Cody policy.'
         )
     })
 


### PR DESCRIPTION
Add logging around blocked references and simplify the message since it might leak to the user while we find all cases where context is pulled in from.

## Test plan

- CI