### PR TITLE
ContextFilters: Return block reason and expose current state for logging purposes

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -284,10 +284,12 @@ describe('ContextFiltersProvider', () => {
                 'github.com/sourcegraph/sourcegraph',
             ])
 
-            expect(await provider.isUriIgnored(excludedURI)).toBe(true)
+            expect(await provider.isUriIgnored(excludedURI)).toBe(
+                'repo:github.com/sourcegraph/sourcegraph'
+            )
         })
 
-        it('returns `true` if repo name is not found', async () => {
+        it('returns the `no-repo-found` if repo name is not found', async () => {
             await initProviderWithContextFilters({
                 include: [{ repoNamePattern: '^github\\.com/sourcegraph/cody' }],
                 exclude: [{ repoNamePattern: '^github\\.com/sourcegraph/sourcegraph' }],
@@ -295,7 +297,7 @@ describe('ContextFiltersProvider', () => {
 
             const uri = getTestURI({ repoName: 'cody', filePath: 'foo/bar.ts' })
             getRepoNamesFromWorkspaceUri.mockResolvedValue(undefined)
-            expect(await provider.isUriIgnored(uri)).toBe(true)
+            expect(await provider.isUriIgnored(uri)).toBe('no-repo-found')
         })
 
         it('excludes everything on network errors', async () => {
@@ -303,7 +305,7 @@ describe('ContextFiltersProvider', () => {
             await provider.init(getRepoNamesFromWorkspaceUri)
 
             const uri = getTestURI({ repoName: 'whatever', filePath: 'foo/bar.ts' })
-            expect(await provider.isUriIgnored(uri)).toBe(true)
+            expect(await provider.isUriIgnored(uri)).toBe('repo:github.com/sourcegraph/whatever')
         })
 
         it('excludes everything on unknown API errors', async () => {
@@ -313,7 +315,7 @@ describe('ContextFiltersProvider', () => {
             await provider.init(getRepoNamesFromWorkspaceUri)
 
             const uri = getTestURI({ repoName: 'whatever', filePath: 'foo/bar.ts' })
-            expect(await provider.isUriIgnored(uri)).toBe(true)
+            expect(await provider.isUriIgnored(uri)).toBe('has-ignore-everything-filters')
         })
 
         it('excludes everything on invalid response structure', async () => {
@@ -326,7 +328,7 @@ describe('ContextFiltersProvider', () => {
             await provider.init(getRepoNamesFromWorkspaceUri)
 
             const uri = getTestURI({ repoName: 'cody', filePath: 'foo/bar.ts' })
-            expect(await provider.isUriIgnored(uri)).toBe(true)
+            expect(await provider.isUriIgnored(uri)).toBe('has-ignore-everything-filters')
         })
 
         it('includes everything on empty responses', async () => {

--- a/lib/shared/src/cody-ignore/context-filters-provider.test.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.test.ts
@@ -289,7 +289,7 @@ describe('ContextFiltersProvider', () => {
             )
         })
 
-        it('returns the `no-repo-found` if repo name is not found', async () => {
+        it('returns `no-repo-found` if repo name is not found', async () => {
             await initProviderWithContextFilters({
                 include: [{ repoNamePattern: '^github\\.com/sourcegraph/cody' }],
                 exclude: [{ repoNamePattern: '^github\\.com/sourcegraph/sourcegraph' }],

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -26,7 +26,7 @@ interface ParsedContextFilterItem {
     filePathPatterns?: RE2[]
 }
 
-type IsIgnored =
+export type IsIgnored =
     | false
     | 'has-ignore-everything-filters'
     | 'non-file-uri'

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -26,6 +26,7 @@ interface ParsedContextFilterItem {
     filePathPatterns?: RE2[]
 }
 
+// Note: This can not be an empty string to make all non `false` values truthy.
 export type IsIgnored =
     | false
     | 'has-ignore-everything-filters'

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -26,6 +26,13 @@ interface ParsedContextFilterItem {
     filePathPatterns?: RE2[]
 }
 
+type IsIgnored =
+    | false
+    | 'has-ignore-everything-filters'
+    | 'non-file-uri'
+    | 'no-repo-found'
+    | `repo:${string}`
+
 export type GetRepoNamesFromWorkspaceUri = (uri: vscode.Uri) => Promise<string[] | null>
 type RepoName = string
 type IsRepoNameIgnored = boolean
@@ -135,26 +142,34 @@ export class ContextFiltersProvider implements vscode.Disposable {
         return isIgnored
     }
 
-    public async isUriIgnored(uri: vscode.Uri): Promise<boolean> {
+    public async isUriIgnored(uri: vscode.Uri): Promise<IsIgnored> {
         if (allowedSchemes.has(uri.scheme) || this.hasAllowEverythingFilters()) {
             return false
         }
-
         if (this.hasIgnoreEverythingFilters()) {
-            return true
+            return 'has-ignore-everything-filters'
         }
 
         // TODO: process non-file URIs https://github.com/sourcegraph/cody/issues/3893
         if (!isFileURI(uri)) {
             logDebug('ContextFiltersProvider', 'isUriIgnored', `non-file URI ${uri.scheme}`)
-            return true
+            return 'non-file-uri'
         }
 
         const repoNames = await wrapInActiveSpan('repoNameResolver.getRepoNamesFromWorkspaceUri', () =>
             this.getRepoNamesFromWorkspaceUri?.(uri)
         )
 
-        return repoNames ? repoNames.some(repoName => this.isRepoNameIgnored(repoName)) : true
+        if (!repoNames) {
+            return 'no-repo-found'
+        }
+
+        const ignoredRepo = repoNames.find(repoName => this.isRepoNameIgnored(repoName))
+        if (ignoredRepo) {
+            return `repo:${ignoredRepo}`
+        }
+
+        return false
     }
 
     public dispose(): void {
@@ -171,6 +186,12 @@ export class ContextFiltersProvider implements vscode.Disposable {
 
     private hasIgnoreEverythingFilters() {
         return this.lastContextFiltersResponse === EXCLUDE_EVERYTHING_CONTEXT_FILTERS
+    }
+
+    public toDebugObject() {
+        return {
+            lastContextFiltersResponse: this.lastContextFiltersResponse,
+        }
     }
 }
 

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -191,7 +191,7 @@ export class ContextFiltersProvider implements vscode.Disposable {
 
     public toDebugObject() {
         return {
-            lastContextFiltersResponse: this.lastContextFiltersResponse,
+            lastContextFiltersResponse: JSON.parse(JSON.stringify(this.lastContextFiltersResponse)),
         }
     }
 }

--- a/lib/shared/src/prompt/prompt-string.test.ts
+++ b/lib/shared/src/prompt/prompt-string.test.ts
@@ -62,10 +62,12 @@ describe('PromptString', () => {
         const promptString = PromptString.fromDocumentText(document)
 
         const allowPolicy = {
-            isUriIgnored: () => Promise.resolve(false),
+            isUriIgnored: () => Promise.resolve(false as const),
+            toDebugObject: () => ({ lastContextFiltersResponse: null }),
         }
         const denyPolicy = {
-            isUriIgnored: () => Promise.resolve(true),
+            isUriIgnored: () => Promise.resolve('repo:foo' as const),
+            toDebugObject: () => ({ lastContextFiltersResponse: null }),
         }
 
         expect(await promptString.toFilteredString(allowPolicy)).toEqual('i am from a file')

--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -57,7 +57,7 @@ export class PromptString {
      * Returns a string that is safe to use in a prompt that is sent to an LLM.
      */
     public async toFilteredString(
-        contextFilter: Pick<ContextFiltersProvider, 'isUriIgnored'>
+        contextFilter: Pick<ContextFiltersProvider, 'isUriIgnored' | 'toDebugObject'>
     ): Promise<string> {
         const references = internal_toReferences(this)
         const checks = references.map(
@@ -66,13 +66,14 @@ export class PromptString {
         const resolved = await Promise.all(checks)
 
         let shouldThrow = false
-        for (const [reference, isIgnored] of resolved) {
-            if (isIgnored) {
+        for (const [reference, reason] of resolved) {
+            if (reason) {
                 shouldThrow = true
                 logDebug(
                     'PromptString',
                     'toFilteredString',
-                    `${reference} is ignored by the current context filters ${contextFilter}`
+                    `${reference} is ignored by the current context filters. Reason: ${reason}`,
+                    { verbose: contextFilter.toDebugObject() }
                 )
                 telemetryRecorder.recordEvent('contextFilters.promptString', 'illegalReference', {
                     privateMetadata: {

--- a/lib/shared/src/prompt/prompt-string.ts
+++ b/lib/shared/src/prompt/prompt-string.ts
@@ -78,6 +78,7 @@ export class PromptString {
                 telemetryRecorder.recordEvent('contextFilters.promptString', 'illegalReference', {
                     privateMetadata: {
                         scheme: reference.scheme,
+                        reason,
                     },
                 })
             }

--- a/vscode/src/completions/context/context-mixer.test.ts
+++ b/vscode/src/completions/context/context-mixer.test.ts
@@ -299,9 +299,9 @@ describe('ContextMixer', () => {
                 vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockImplementation(
                     async (uri: vscode.Uri) => {
                         if (uri.path.includes('foo.ts')) {
-                            return true
+                            return 'repo:foo'
                         }
-                        return false
+                        return false as const
                     }
                 )
             })

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -230,7 +230,7 @@ describe('InlineCompletionItemProvider', () => {
     })
 
     it('no-ops on files that are ignored by the context filter policy', async () => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValueOnce(true)
+        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValueOnce('repo:foo')
         const { document, position } = documentAndPosition('const foo = █', 'typescript')
         const fn = vi.fn()
         const provider = new MockableInlineCompletionItemProvider(fn)

--- a/vscode/src/supercompletions/recent-edits/recent-edits-retriever.test.ts
+++ b/vscode/src/supercompletions/recent-edits/recent-edits-retriever.test.ts
@@ -115,7 +115,7 @@ describe('RecentEditsRetriever', () => {
     })
 
     it('no-ops for blocked files due to the context filter', async () => {
-        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValueOnce(true)
+        vi.spyOn(contextFiltersProvider, 'isUriIgnored').mockResolvedValueOnce('repo:foo')
 
         replaceFooLogWithNumber()
 


### PR DESCRIPTION
- Changes the return type for blocked references to a string giving a reason. We type it so that the string is always non-empty so we can still keep using `if(..)` checks easily.
- Add an API to expose the current filters as a debug object that can be used in our last-line-of-defence logging

## Test plan

<img width="1628" alt="Screenshot 2024-04-25 at 12 32 29" src="https://github.com/sourcegraph/cody/assets/458591/3f29e419-fa70-4822-8a39-bc5a2a12b442">
