### PR TITLE
Cody Ignore: Tidy up context filter overrides

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -4249,672 +4249,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: a26994c6ae9bac34976bbceb949f58a4
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 894
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 263
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            fast: true
-            maxTokensToSample: 400
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "You are helping the user search over a codebase. List some filename
-                  fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
-                  keyword</value><variants>a space separated list of synonyms
-                  and variants of the keyword, including acronyms,
-                  abbreviations, and expansions</variants><weight>a numerical
-                  weight between 0.0 and 1.0 that indicates the importance of
-                  the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>What files contain
-                  SELECTION_START?</userQuery>"
-              - speaker: assistant
-            temperature: 0
-            topK: 1
-        queryString: []
-        url: https://sourcegraph.com/.api/completions/stream
-      response:
-        bodySize: 44310
-        content:
-          mimeType: text/event-stream
-          size: 44310
-          text: >+
-            event: completion
-
-            data: {"completion":"\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECT","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECT","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGIN","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n   ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e\n  \u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e\n  \u003c/keyword","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e\n  \u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\u003ckeywords\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECT\u003c/value\u003e\n    \u003cvariants\u003eSELECTION SELECTED SELECTING\u003c/variants\u003e \n    \u003cweight\u003e0.9\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSTART\u003c/value\u003e\n    \u003cvariants\u003eBEGINNING\u003c/variants\u003e\n    \u003cweight\u003e0.8\u003c/weight\u003e\n  \u003c/keyword\u003e\n  \u003ckeyword\u003e\n    \u003cvalue\u003eSELECTION_START\u003c/value\u003e\n    \u003cvariants\u003e\u003c/variants\u003e\n    \u003cweight\u003e1.0\u003c/weight\u003e\n  \u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 17 Apr 2024 15:22:40 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-04-17T15:22:38.963Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: aab673b8d9f1a2a6a11a464b068253a2
       _order: 0
       cache: {}
@@ -11727,1419 +11061,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 00fee0987e4d5ec322f3feabbfbc6433
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1100
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 277
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/animal.ts:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/animal.ts:
-                  ```typescript
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/multiple-selections.ts:
-                  ```typescript
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-                  /* SELECTION_2_START */
-                  function anotherFunction() {}
-                  /* SELECTION_2_END */
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What files contain SELECTION_START?
-            model: anthropic/claude-3-sonnet-20240229
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1
-      response:
-        bodySize: 5795
-        content:
-          mimeType: text/event-stream
-          size: 5795
-          text: >+
-            event: completion
-
-            data: {"completion":"Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src/multiple-selections.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the provided codebase context, the files that contain `SELECTION_START` are:\n\n1. `src/animal.ts`\n2. `src/multiple-selections.ts`","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 17 Apr 2024 15:22:42 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-04-17T15:22:41.065Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 30ac2e8b25505006dd91474861b3829d
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 287
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 277
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: Which file is the isIgnoredByCody functions defined?
-            model: anthropic/claude-3-sonnet-20240229
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1
-      response:
-        bodySize: 96636
-        content:
-          mimeType: text/event-stream
-          size: 96636
-          text: >+
-            event: completion
-
-            data: {"completion":"The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgn","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgno","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredB","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByC","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourc","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourceg","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by C","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me)","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of pred","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgn","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgno","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredB","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByC","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ign","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts` file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts` file in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts` file in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts` file in the c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts` file in the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts` file in the codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts` file in the codebase.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The `isIgnoredByCody` function is defined in the `util.ts` file, which is located in the `src/util` directory of the Sourcegraph codebase.\n\nThis function is responsible for checking if a given file path should be ignored by Cody (me) during the code analysis process. It is used to exclude certain files or directories from being processed, based on a set of predefined rules and patterns.\n\nThe `isIgnoredByCody` function takes a file path as input and returns a boolean value indicating whether the file should be ignored or not. It uses regular expressions and other logic to match the file path against various patterns, such as patterns for ignoring specific file extensions, directories, or files matching certain names or patterns.\n\nIf you need more details about how this function works or want to modify the ignored file patterns, you can refer to the `util.ts` file in the codebase.","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 17 Apr 2024 15:22:43 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-04-17T15:22:42.725Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: a92f339726d309f30d396cd88af41d67
       _order: 0
       cache: {}
@@ -13308,6 +11229,7 @@ log:
                   <selected>
 
                       return function inner() {}
+
 
 
 
@@ -22187,819 +20109,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1419928337c4b11724c7fa7cda76b532
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3434
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
-          - name: user-agent
-            value: defaultClient / v1
-          - name: host
-            value: sourcegraph.com
-        headersSize: 277
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  My selected typescript code from file `src/trickyLogic.ts`:
-                  <selected>
-                  export function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-
-
-
-                  </selected>
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path .cody/ignore: # NOTE: For
-                  agent integration test only
-
-                  **/*Ignored.ts
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path src/animal.ts: /*
-                  SELECTION_START */
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-
-                  /* SELECTION_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path src/multiple-selections.ts:
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-
-                  /* SELECTION_2_START */
-
-                  function anotherFunction() {}
-
-                  /* SELECTION_2_END */
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path src/squirrel.ts: /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path src/sum.ts: export function
-                  sum(a: number, b: number): number {
-                      /* CURSOR */
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path src/TestLogger.ts: const foo =
-                  42
-
-                  export const TestLogger = {
-                      startLogging: () => {
-                          // Do some stuff
-
-                          function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }
-
-                          recordLog()
-                      },
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  Codebase context from file path src/trickyLogic.ts: export
-                  function trickyLogic(a: number, b: number): number {
-                      if (a === 0) {
-                          return 1
-                      }
-                      if (b === 2) {
-                          return 1
-                      }
-
-                      return a - b
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Give me the names of the files I have shared with you so far.
-            model: anthropic/claude-3-sonnet-20240229
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1
-      response:
-        bodySize: 25042
-        content:
-          mimeType: text/event-stream
-          size: 25042
-          text: >+
-            event: completion
-
-            data: {"completion":"Based","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the c","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the code","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/tric","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/tricky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/tric","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/tricky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLogic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLogic.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLogic.ts","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLogic.ts`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLogic.ts` (","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLogic.ts` (repeated","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLogic.ts` (repeated)","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Based on the codebase context you provided, the file names are:\n\n1. `src/trickyLogic.ts`\n2. `src/animal.ts`\n3. `src/example.test.ts`\n4. `src/multiple-selections.ts`\n5. `src/squirrel.ts`\n6. `src/sum.ts`\n7. `src/TestClass.ts`\n8. `src/TestLogger.ts`\n9. `src/trickyLogic.ts` (repeated)","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 17 Apr 2024 15:30:24 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-04-17T15:30:21.519Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 88be82ce66137d2068f5f146fa0dde12
       _order: 0
       cache: {}
@@ -24818,6 +21927,671 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-04-18T15:00:06.576Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: bfd4b3a6cf213fe655737a2f3a0980fd
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3266
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 277
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: |-
+                  My selected typescript code from file `src/trickyLogic.ts`:
+                  <selected>
+                  export function trickyLogic(a: number, b: number): number {
+                      if (a === 0) {
+                          return 1
+                      }
+                      if (b === 2) {
+                          return 1
+                      }
+
+                      return a - b
+                  }
+
+
+
+                  </selected>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file path src/animal.ts: /*
+                  SELECTION_START */
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+
+                  /* SELECTION_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file path src/example.test.ts: import {
+                  expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+                      it('does 1', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does 2', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does something else', () => {
+                          // This line will error due to incorrect usage of `performance.now`
+                          const startTime = performance.now(/* CURSOR */)
+                      })
+                  })
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file path src/multiple-selections.ts:
+                  function outer() {
+                      /* SELECTION_START */
+                      return function inner() {}
+                      /* SELECTION_END */
+                  }
+
+
+                  /* SELECTION_2_START */
+
+                  function anotherFunction() {}
+
+                  /* SELECTION_2_END */
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file path src/squirrel.ts: /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file path src/sum.ts: export function
+                  sum(a: number, b: number): number {
+                      /* CURSOR */
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file path src/TestClass.ts: const foo =
+                  42
+
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file path src/TestLogger.ts: const foo =
+                  42
+
+                  export const TestLogger = {
+                      startLogging: () => {
+                          // Do some stuff
+
+                          function recordLog() {
+                              console.log(/* CURSOR */ 'Recording the log')
+                          }
+
+                          recordLog()
+                      },
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  Codebase context from file path src/trickyLogic.ts: export
+                  function trickyLogic(a: number, b: number): number {
+                      if (a === 0) {
+                          return 1
+                      }
+                      if (b === 2) {
+                          return 1
+                      }
+
+                      return a - b
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Give me the names of the files I have shared with you so far.
+            model: anthropic/claude-3-sonnet-20240229
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1
+      response:
+        bodySize: 16967
+        content:
+          mimeType: text/event-stream
+          size: 16967
+          text: >+
+            event: completion
+
+            data: {"completion":"Base","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provide","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snipp","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets,","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have share","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `tric","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `tricky","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLog","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squir","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `Test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8. `","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8. `Test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8. `TestLogger","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8. `TestLogger.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8. `TestLogger.ts","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8. `TestLogger.ts`","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"Based on the provided code snippets, the file names you have shared so far are:\n\n1. `trickyLogic.ts`\n2. `animal.ts`\n3. `example.test.ts`\n4. `multiple-selections.ts`\n5. `squirrel.ts`\n6. `sum.ts`\n7. `TestClass.ts`\n8. `TestLogger.ts`","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 25 Apr 2024 15:22:07 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-04-25T15:22:05.111Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -122,7 +122,8 @@ describe('Agent', () => {
         const ignore = await client.request('ignore/test', {
             uri: URI.file(ignoredPath).toString(),
         })
-        expect(ignore.policy).toBe('ignore')
+        // TODO(dpc): Integrate file-based .cody/ignore with ignore/test
+        expect(ignore.policy).toBe('use')
     }, 10_000)
 
     beforeEach(async () => {
@@ -540,7 +541,8 @@ describe('Agent', () => {
         })
     })
 
-    describe('Cody Ignore', () => {
+    // TODO(dpc): Integrate file-based .cody/ignore with ignore/test
+    describe.skip('Cody Ignore', () => {
         beforeAll(async () => {
             // Make sure Cody ignore config exists and works
             const codyIgnoreConfig = vscode.Uri.file(path.join(workspaceRootPath, '.cody/ignore'))
@@ -549,7 +551,7 @@ describe('Agent', () => {
             expect(codyIgnoreConfigFile?.content).toBeDefined()
 
             const result = await client.request('ignore/test', {
-                uri: URI.file(ignoredPath).toString(),
+                uri: ignoredUri.toString(),
             })
             expect(result.policy).toBe('ignore')
         }, 10_000)
@@ -655,7 +657,7 @@ describe('Agent', () => {
             // Makes sure cody ignore is still active after tests
             // as it should stay active for each workspace session.
             const result = await client.request('ignore/test', {
-                uri: URI.file(ignoredPath).toString(),
+                uri: ignoredUri.toString(),
             })
             expect(result.policy).toBe('ignore')
 
@@ -1141,17 +1143,16 @@ describe('Agent', () => {
             const lastMessage = await client.firstNonEmptyTranscript(result?.chatResult as string)
             expect(trimEndOfLine(lastMessage.messages.at(-1)?.text ?? '')).toMatchInlineSnapshot(
                 `
-              "Based on the codebase context you provided, the file names are:
+              "Based on the provided code snippets, the file names you have shared so far are:
 
-              1. \`src/trickyLogic.ts\`
-              2. \`src/animal.ts\`
-              3. \`src/example.test.ts\`
-              4. \`src/multiple-selections.ts\`
-              5. \`src/squirrel.ts\`
-              6. \`src/sum.ts\`
-              7. \`src/TestClass.ts\`
-              8. \`src/TestLogger.ts\`
-              9. \`src/trickyLogic.ts\` (repeated)"
+              1. \`trickyLogic.ts\`
+              2. \`animal.ts\`
+              3. \`example.test.ts\`
+              4. \`multiple-selections.ts\`
+              5. \`squirrel.ts\`
+              6. \`sum.ts\`
+              7. \`TestClass.ts\`
+              8. \`TestLogger.ts\`"
             `,
                 explainPollyError
             )

--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -82,25 +82,20 @@ export class ContextFiltersProvider implements vscode.Disposable {
         this.cache.clear()
         this.parsedContextFilters = null
         this.lastContextFiltersResponse = contextFilters
-        this.contextFiltersSubscriber.notify(contextFilters)
 
         logDebug('ContextFiltersProvider', 'setContextFilters', { verbose: contextFilters })
         this.parsedContextFilters = {
             include: contextFilters.include?.map(parseContextFilterItem) || null,
             exclude: contextFilters.exclude?.map(parseContextFilterItem) || null,
         }
+
+        this.contextFiltersSubscriber.notify(contextFilters)
     }
 
     /**
      * Overrides context filters for testing.
      */
     public setTestingContextFilters(contextFilters: ContextFilters | null): void {
-        if (process.env.VITEST !== 'true') {
-            throw new Error(
-                'contextFiltersProvider.setTestingContextFilters should be only used in tests'
-            )
-        }
-
         if (contextFilters === null) {
             // Reset context filters to the value from the Sourcegraph API.
             this.init(this.getRepoNamesFromWorkspaceUri!)


### PR DESCRIPTION
- Context filters should fire the changed event *after* parsing the filters, so clients which query the filters can see updated values.
- Remove the hook for applying overrides for dotcom users at the agent level; the overrides need to be at the extension level. For now we simply won't integrate file-based Cody Ignore here.
- Remove the VITEST guard. The purpose of this hook is largely for testing IntelliJ, which is not VITEST.
- For now, disables Agent file-based Cody Ignore tests. File-based Cody Ignore should be integrated at the extension level, not the Agent "container" level. Then these tests can come back.

Part of #3641 

## Test plan

Manually tested with a sourcegraph/jetbrains#1396

CI