### PR TITLE
Remove double-bundling of some lib/shared files

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -3883,6 +3883,124 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 7399dcfe6e08a79f7b3d64aa058745f1
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 347
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: x-sourcegraph-actor-anonymous-uid
+            value: enterpriseClientabcde1234
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "347"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 391
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: |
+              
+              mutation RecordTelemetryEvents($events: [TelemetryEventInput!]!) {
+              	telemetry {
+              		recordEvents(events: $events) {
+              			alwaysNil
+              		}
+              	}
+              }
+            variables:
+              events:
+                - action: hasFile
+                  feature: cody.codyIgnore
+                  parameters:
+                    privateMetadata: {}
+                    version: 0
+                  source:
+                    client: VSCode.Cody
+                    clientVersion: 1.14.0
+        queryString:
+          - name: RecordTelemetryEvents
+            value: null
+        url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
+      response:
+        bodySize: 112
+        content:
+          encoding: base64
+          mimeType: application/json
+          size: 112
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv\
+            8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
+          textDecoded:
+            data:
+              telemetry:
+                recordEvents:
+                  alwaysNil: null
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 25 Apr 2024 15:44:05 GMT
+          - name: content-type
+            value: application/json
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1248
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-04-25T15:44:05.591Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: b38540ce2256c839f6ea9b4ee26f34fd
       _order: 0
       cache: {}

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -3845,7 +3845,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 25 Apr 2024 15:17:36 GMT
+            value: Thu, 25 Apr 2024 15:39:16 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: content-length
@@ -3873,7 +3873,7 @@ log:
         redirectURL: ""
         status: 401
         statusText: Unauthorized
-      startedDateTime: 2024-04-25T15:17:36.693Z
+      startedDateTime: 2024-04-25T15:39:16.215Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -3778,17 +3778,13 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 7399dcfe6e08a79f7b3d64aa058745f1
+    - _id: 336a451ca8952ae40422463e485b1797
       _order: 0
       cache: {}
       request:
         bodySize: 347
         cookies: []
         headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
           - _fromType: array
             name: content-type
             value: application/json; charset=utf-8
@@ -3809,7 +3805,7 @@ log:
             value: gzip,deflate
           - name: host
             value: demo.sourcegraph.com
-        headersSize: 391
+        headersSize: 318
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -3840,26 +3836,20 @@ log:
             value: null
         url: https://demo.sourcegraph.com/.api/graphql?RecordTelemetryEvents
       response:
-        bodySize: 112
+        bodySize: 38
         content:
-          encoding: base64
-          mimeType: application/json
-          size: 112
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqSc1JzU0tKaoEcYpSk/OLUlzLUvNKikH8xJzyxMpiv\
-            8wcJau80pyc2traWgAAAAD//wMAhHZ9ajoAAAA=\"]"
-          textDecoded:
-            data:
-              telemetry:
-                recordEvents:
-                  alwaysNil: null
+          mimeType: text/plain; charset=utf-8
+          size: 38
+          text: |
+            Private mode requires authentication.
         cookies: []
         headers:
           - name: date
-            value: Thu, 25 Apr 2024 09:47:45 GMT
+            value: Thu, 25 Apr 2024 15:17:36 GMT
           - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "38"
           - name: connection
             value: keep-alive
           - name: access-control-allow-credentials
@@ -3869,8 +3859,7 @@ log:
           - name: cache-control
             value: no-cache, max-age=0
           - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With
           - name: x-content-type-options
             value: nosniff
           - name: x-frame-options
@@ -3879,14 +3868,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1248
+        headersSize: 1217
         httpVersion: HTTP/1.1
         redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-04-25T09:47:44.906Z
+        status: 401
+        statusText: Unauthorized
+      startedDateTime: 2024-04-25T15:17:36.693Z
       time: 0
       timings:
         blocked: -1

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -90,15 +90,6 @@ export {
     uriParseNameAndExtension,
     type FileURI,
 } from './common/uri'
-export type {
-    AutocompleteTimeouts,
-    Configuration,
-    ConfigurationUseContext,
-    ConfigurationWithAccessToken,
-    OllamaGenerateParameters,
-    OllamaOptions,
-    ConfigGetter,
-} from './configuration'
 export { NoopEditor } from './editor'
 export type {
     ActiveTextEditor,
@@ -249,3 +240,6 @@ export * from './completions/types'
 export * from './sourcegraph-api/completions/parse'
 export * from './cody-ignore/context-filters-provider'
 export * from './sourcegraph-api/utils'
+export * from './token'
+export * from './token/constants'
+export * from './configuration'

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -71,6 +71,7 @@ export { CustomCommandType } from './commands/types'
 export { type DefaultCodyCommands, DefaultChatCommands, DefaultEditCommands } from './commands/types'
 export { dedupeWith, isDefined, isErrorLike, pluralize } from './common'
 export { type RangeData, toRangeData, displayLineRange, displayRange } from './common/range'
+export * from './common/abortController'
 export {
     ProgrammingLanguage,
     languageFromFilename,
@@ -169,11 +170,7 @@ export type { Message } from './sourcegraph-api'
 export { SourcegraphBrowserCompletionsClient } from './sourcegraph-api/completions/browserClient'
 export { SourcegraphCompletionsClient } from './sourcegraph-api/completions/client'
 export type { CompletionLogger, CompletionsClientConfig } from './sourcegraph-api/completions/client'
-export type {
-    CompletionParameters,
-    CompletionResponse,
-    Event,
-} from './sourcegraph-api/completions/types'
+export * from './sourcegraph-api/completions/types'
 export { DOTCOM_URL, LOCAL_APP_URL, isDotCom } from './sourcegraph-api/environments'
 export {
     AbortError,
@@ -222,14 +219,7 @@ export * from './telemetry-v2/singleton'
 export { EventLogger } from './telemetry/EventLogger'
 export type { ExtensionDetails } from './telemetry/EventLogger'
 export { testFileUri } from './test/path-helpers'
-export {
-    addTraceparent,
-    getActiveTraceAndSpanId,
-    wrapInActiveSpan,
-    recordErrorToSpan,
-    tracer,
-    logResponseHeadersToSpan,
-} from './tracing'
+export * from './tracing'
 export { convertGitCloneURLToCodebaseName, isError, createSubscriber } from './utils'
 export type { CurrentUserCodySubscription } from './sourcegraph-api/graphql/client'
 export * from './auth/types'
@@ -252,7 +242,10 @@ export {
 export { tokensToChars, charsToTokens } from './token/utils'
 export * from './prompt/prompt-string'
 export { getCompletionsModelConfig } from './llm-providers/utils'
-export type { SourcegraphNodeCompletionsClient } from './sourcegraph-api/completions/nodeClient'
+export * from './llm-providers/google/chat-client'
+export * from './llm-providers/groq/chat-client'
 export * from './fetch'
 export * from './completions/types'
+export * from './sourcegraph-api/completions/parse'
 export * from './cody-ignore/context-filters-provider'
+export * from './sourcegraph-api/utils'

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -2,17 +2,22 @@ import * as uuid from 'uuid'
 import * as vscode from 'vscode'
 
 import {
+    CHAT_INPUT_TOKEN_BUDGET,
+    CHAT_OUTPUT_TOKEN_BUDGET,
     type ChatClient,
     type ChatMessage,
     ConfigFeaturesSingleton,
     type ContextItem,
+    type ContextItemFile,
     ContextItemSource,
+    type ContextItemWithContent,
     type DefaultChatCommands,
     type EventSource,
     type FeatureFlagProvider,
     type Guardrails,
     type Message,
     ModelProvider,
+    ModelUsage,
     PromptString,
     type RangeData,
     type SerializedChatInteraction,
@@ -23,8 +28,10 @@ import {
     isError,
     isFileURI,
     isRateLimitError,
+    recordErrorToSpan,
     reformatBotMessageForChat,
     serializeChatMessage,
+    tracer,
     truncatePromptString,
 } from '@sourcegraph/cody-shared'
 
@@ -52,16 +59,6 @@ import { countGeneratedCode } from '../utils'
 
 import type { Span } from '@opentelemetry/api'
 import { captureException } from '@sentry/core'
-import type {
-    ContextItemFile,
-    ContextItemWithContent,
-} from '@sourcegraph/cody-shared/src/codebase-context/messages'
-import { ModelUsage } from '@sourcegraph/cody-shared/src/models/types'
-import {
-    CHAT_INPUT_TOKEN_BUDGET,
-    CHAT_OUTPUT_TOKEN_BUDGET,
-} from '@sourcegraph/cody-shared/src/token/constants'
-import { recordErrorToSpan, tracer } from '@sourcegraph/cody-shared/src/tracing'
 import { getContextFileFromCursor } from '../../commands/context/selection'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import type { Repo } from '../../context/repo-fetcher'

--- a/vscode/src/completions/nodeClient.ts
+++ b/vscode/src/completions/nodeClient.ts
@@ -1,21 +1,31 @@
+// The node client can not live in lib/shared (with its browserClient
+// counterpart) since it requires node-only APIs. These can't be part of
+// the main `lib/shared` bundle since it would otherwise not work in the
+// web build.
+
 import http from 'node:http'
 import https from 'node:https'
 
-import { onAbort } from '../../common/abortController'
-import { logError } from '../../logger'
-import { isError } from '../../utils'
-import { RateLimitError } from '../errors'
-import { customUserAgent } from '../graphql/client'
-import { toPartialUtf8String } from '../utils'
-
-import { contextFiltersProvider } from '../../cody-ignore/context-filters-provider'
-import { googleChatClient } from '../../llm-providers/google/chat-client'
-import { groqChatClient } from '../../llm-providers/groq/chat-client'
-import { ollamaChatClient } from '../../llm-providers/ollama/chat-client'
-import { getTraceparentHeaders, recordErrorToSpan, tracer } from '../../tracing'
-import { SourcegraphCompletionsClient } from './client'
-import { parseEvents } from './parse'
-import type { CompletionCallbacks, CompletionParameters, SerializedCompletionParameters } from './types'
+import {
+    type CompletionCallbacks,
+    type CompletionParameters,
+    RateLimitError,
+    type SerializedCompletionParameters,
+    SourcegraphCompletionsClient,
+    contextFiltersProvider,
+    customUserAgent,
+    getTraceparentHeaders,
+    googleChatClient,
+    groqChatClient,
+    isError,
+    logError,
+    ollamaChatClient,
+    onAbort,
+    parseEvents,
+    recordErrorToSpan,
+    toPartialUtf8String,
+    tracer,
+} from '@sourcegraph/cody-shared'
 
 const isTemperatureZero = process.env.CODY_TEMPERATURE_ZERO === 'true'
 

--- a/vscode/src/extension.node.ts
+++ b/vscode/src/extension.node.ts
@@ -1,12 +1,12 @@
 // Sentry should be imported first
 import { NodeSentryService } from './services/sentry/sentry.node'
 
-import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 import * as vscode from 'vscode'
 
 import { startTokenReceiver } from './auth/token-receiver'
 import { CommandsProvider } from './commands/services/provider'
 import { BfgRetriever } from './completions/context/retrievers/bfg/bfg-retriever'
+import { SourcegraphNodeCompletionsClient } from './completions/nodeClient'
 import type { ExtensionApi } from './extension-api'
 import { type ExtensionClient, defaultVSCodeExtensionClient } from './extension-client'
 import { activate as activateCommon } from './extension.common'

--- a/vscode/src/fetch.node.ts
+++ b/vscode/src/fetch.node.ts
@@ -3,9 +3,8 @@ import https from 'node:https'
 
 import { SocksProxyAgent } from 'socks-proxy-agent'
 
-import type { Configuration } from '@sourcegraph/cody-shared'
+import { type Configuration, agent } from '@sourcegraph/cody-shared'
 
-import { agent } from '@sourcegraph/cody-shared/src/fetch'
 import { getConfiguration } from './configuration'
 
 // The path to the exported class can be found in the npm contents

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -6,6 +6,7 @@ import {
     type ConfigurationWithAccessToken,
     type ContextGroup,
     type ContextStatusProvider,
+    type EmbeddingsModelConfig,
     type EmbeddingsSearchResult,
     FeatureFlag,
     type FileURI,
@@ -20,7 +21,6 @@ import {
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 
-import type { EmbeddingsModelConfig } from '@sourcegraph/cody-shared/src/configuration'
 import type { IndexHealthResultFound, IndexRequest } from '../jsonrpc/embeddings-protocol'
 import type { MessageHandler } from '../jsonrpc/jsonrpc'
 import { logDebug } from '../log'

--- a/vscode/src/local-context/symf.test.ts
+++ b/vscode/src/local-context/symf.test.ts
@@ -1,5 +1,4 @@
 import type { Polly } from '@pollyjs/core'
-import { SourcegraphNodeCompletionsClient } from '@sourcegraph/cody-shared/src/sourcegraph-api/completions/nodeClient'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { startPollyRecording } from '../testutils/polly'
@@ -11,6 +10,7 @@ import { mkdtemp, open, rmdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { type PromptString, ps } from '@sourcegraph/cody-shared'
+import { SourcegraphNodeCompletionsClient } from '../completions/nodeClient'
 
 describe('symf', () => {
     const client = new SourcegraphNodeCompletionsClient({

--- a/vscode/src/models/utils.ts
+++ b/vscode/src/models/utils.ts
@@ -1,13 +1,13 @@
 import {
     ANSWER_TOKENS,
     type AuthStatus,
+    CHAT_INPUT_TOKEN_BUDGET,
     FeatureFlag,
     ModelProvider,
     ModelUsage,
     featureFlagProvider,
+    getDotComDefaultModels,
 } from '@sourcegraph/cody-shared'
-import { getDotComDefaultModels } from '@sourcegraph/cody-shared/src/models/dotcom'
-import { CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
 import * as vscode from 'vscode'
 import { logFirstEnrollmentEvent } from '../services/utils/enrollment-event'
 

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -2,6 +2,7 @@ import {
     type ChatMessage,
     type ContextItem,
     type ContextMessage,
+    type ContextTokenUsageType,
     type Message,
     type ModelContextWindow,
     TokenCounter,
@@ -9,7 +10,6 @@ import {
     ps,
     toRangeData,
 } from '@sourcegraph/cody-shared'
-import type { ContextTokenUsageType } from '@sourcegraph/cody-shared/src/token'
 import { SHA256 } from 'crypto-js'
 import { renderContextItem } from './utils'
 

--- a/vscode/src/repository/repo-name-getter.node.ts
+++ b/vscode/src/repository/repo-name-getter.node.ts
@@ -2,11 +2,9 @@ import cp from 'node:child_process'
 import util from 'node:util'
 import type * as vscode from 'vscode'
 
-import { isFileURI } from '@sourcegraph/cody-shared'
+import { isFileURI, pathFunctionsForURI } from '@sourcegraph/cody-shared'
 
 import { logDebug } from '../log'
-
-import { pathFunctionsForURI } from '@sourcegraph/cody-shared/src/common/path'
 
 export async function gitRemoteUrlsFromGitCli(uri: vscode.Uri): Promise<string[] | undefined> {
     if (!isFileURI(uri)) {

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -14,11 +14,11 @@ import styles from './atMentions.module.css'
 import {
     type ContextItem,
     ContextItemSource,
+    FAST_CHAT_INPUT_TOKEN_BUDGET,
     type RangeData,
     displayPath,
     scanForMentionTriggerInUserTextInput,
 } from '@sourcegraph/cody-shared'
-import { FAST_CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
 import classNames from 'classnames'
 import { useCurrentChatModel } from '../../../chat/models/chatModelContext'
 import { toSerializedPromptEditorValue } from '../../PromptEditor'


### PR DESCRIPTION
We noticed that the `ContextFilterProvider` was bundled twice in the VS Code production builds. To fix this, we now move all `@sourcegraph/cody-shared` requires to use the main bundle instead of requiring files directly.

## Todo

- [ ] Can we change the package.json to not expose the individual files in the lib/shared package but only the barrel import?

## Test plan

<img width="497" alt="Screenshot 2024-04-25 at 17 11 07" src="https://github.com/sourcegraph/cody/assets/458591/a41c47b3-ab82-46f3-8b83-292553f61d88">


Add a console log to the context provider and see that it's only bundled once:

```
α cody/vscode 🐙(ps/remove-double-bundling-of-some-lib-shared-files)✗
cat dist/extension.node.js | grep "THIS SHOULD ONLY EVER BE LOGGED ONCE"
console.log("THIS SHOULD ONLY EVER BE LOGGED ONCE");
```