### PR TITLE
Record embedding provider on embedding span

### DIFF
--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -578,6 +578,7 @@ export class LocalEmbeddingsController
         }
         return wrapInActiveSpan('LocalEmbeddingsController.query', async span => {
             try {
+                span.setAttribute('provider', this.modelConfig.provider)
                 const lastRepo = this.lastRepo
                 if (!lastRepo?.repoName) {
                     span.setAttribute('noResultReason', 'last-repo-not-set')


### PR DESCRIPTION
Record the embedding provider on search spans so we can correlate errors/latency with a specific provider being used.

## Test plan

- tested locally
- tracing only
