### PR TITLE
Cody PLG: increase token budget for Claude 3 models w/o feature flag

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -48,9 +48,6 @@ export enum FeatureFlag {
 
     /** Support @-mentioning URLs in chat to add context from web pages. */
     URLContext = 'cody-url-context',
-
-    /** Apply a higher context window for user context items (e.g., @-mentions). */
-    CodyChatContextBudget = 'cody-chat-context-budget',
 }
 
 const ONE_HOUR = 60 * 60 * 1000

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -226,10 +226,7 @@ export {
     type ContextMentionProvider,
 } from './mentions/api'
 export { TokenCounter } from './token/counter'
-export {
-    EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET,
-    ENHANCED_CONTEXT_ALLOCATION,
-} from './token/constants'
+export { ENHANCED_CONTEXT_ALLOCATION } from './token/constants'
 export { tokensToChars, charsToTokens } from './token/utils'
 export * from './prompt/prompt-string'
 export { getCompletionsModelConfig } from './llm-providers/utils'

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -2,8 +2,8 @@ import type { ModelProvider } from '.'
 import {
     CHAT_INPUT_TOKEN_BUDGET,
     CHAT_OUTPUT_TOKEN_BUDGET,
-    EXPERIMENTAL_CHAT_INPUT_TOKEN_BUDGET,
-    EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET,
+    CLAUDE3_CHAT_INPUT_TOKEN_BUDGET,
+    CLAUDE3_USER_CONTEXT_TOKEN_BUDGET,
 } from '../token/constants'
 
 import { ModelUsage } from './types'
@@ -18,8 +18,74 @@ const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
         default: true,
         codyProOnly: false,
         usage: [ModelUsage.Chat, ModelUsage.Edit],
+        // Has a higher context window with a seperated limit for user-context.
+        contextWindow: {
+            input: CLAUDE3_CHAT_INPUT_TOKEN_BUDGET,
+            output: CHAT_OUTPUT_TOKEN_BUDGET,
+            context: { user: CLAUDE3_USER_CONTEXT_TOKEN_BUDGET },
+        },
+    },
+    {
+        title: 'Claude 3 Opus',
+        model: 'anthropic/claude-3-opus-20240229',
+        provider: 'Anthropic',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        // Has a higher context window with a seperated limit for user-context.
+        contextWindow: {
+            input: CLAUDE3_CHAT_INPUT_TOKEN_BUDGET,
+            output: CHAT_OUTPUT_TOKEN_BUDGET,
+            context: { user: CLAUDE3_USER_CONTEXT_TOKEN_BUDGET },
+        },
+    },
+    {
+        title: 'Claude 3 Haiku',
+        model: 'anthropic/claude-3-haiku-20240307',
+        provider: 'Anthropic',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
         contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
     },
+    {
+        title: 'GPT-4 Turbo',
+        model: 'openai/gpt-4-turbo',
+        provider: 'OpenAI',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
+    },
+    {
+        title: 'GPT-3.5 Turbo',
+        model: 'openai/gpt-3.5-turbo',
+        provider: 'OpenAI',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
+    },
+    // TODO (tom) Improve prompt for Mixtral + Edit to see if we can use it there too.
+    {
+        title: 'Mixtral 8x7B',
+        model: 'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct',
+        provider: 'Mistral',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat],
+        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
+    },
+    {
+        title: 'Mixtral 8x22B',
+        model: 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct',
+        provider: 'Mistral',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat],
+        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
+    },
+    // NOTE: Models soon to be deprecated.
     {
         title: 'Claude 2.0',
         model: 'anthropic/claude-2.0',
@@ -47,95 +113,13 @@ const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
         usage: [ModelUsage.Chat, ModelUsage.Edit],
         contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
     },
-    {
-        title: 'Claude 3 Haiku',
-        model: 'anthropic/claude-3-haiku-20240307',
-        provider: 'Anthropic',
-        default: false,
-        codyProOnly: true,
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
-    },
-    {
-        title: 'Claude 3 Opus',
-        model: 'anthropic/claude-3-opus-20240229',
-        provider: 'Anthropic',
-        default: false,
-        codyProOnly: true,
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
-    },
-    {
-        title: 'GPT-3.5 Turbo',
-        model: 'openai/gpt-3.5-turbo',
-        provider: 'OpenAI',
-        default: false,
-        codyProOnly: true,
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
-    },
-    {
-        title: 'GPT-4 Turbo',
-        model: 'openai/gpt-4-turbo',
-        provider: 'OpenAI',
-        default: false,
-        codyProOnly: true,
-        usage: [ModelUsage.Chat, ModelUsage.Edit],
-        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
-    },
-    // TODO (tom) Improve prompt for Mixtral + Edit to see if we can use it there too.
-    {
-        title: 'Mixtral 8x7B',
-        model: 'fireworks/accounts/fireworks/models/mixtral-8x7b-instruct',
-        provider: 'Mistral',
-        default: false,
-        codyProOnly: true,
-        usage: [ModelUsage.Chat],
-        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
-    },
-    {
-        title: 'Mixtral 8x22B',
-        model: 'fireworks/accounts/fireworks/models/mixtral-8x22b-instruct',
-        provider: 'Mistral',
-        default: false,
-        codyProOnly: true,
-        usage: [ModelUsage.Chat],
-        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
-    },
 ]
-
-/**
- * NOTE: DotCom users with FeatureFlag.CodyChatContextBudget for A/B testing only.
- *
- * An array of model IDs that are used for the FeatureFlag.CodyChatContextBudget A/B testing.
- * Users with the feature flag enabled will have a seperated token limit for user-context.
- *
- * For other models, the context window remains the same and is shared between input and context.
- */
-const modelsWithHigherLimit = ['anthropic/claude-3-sonnet-20240229', 'anthropic/claude-3-opus-20240229']
 
 /**
  * Returns an array of ModelProviders representing the default models for DotCom.
  *
- * NOTE: 'experimental' is only for DotCom users with FeatureFlag.CodyChatContextBudget enabled
- *
- * @param modelType - Specifies whether to return the default or experimental models.
  * @returns An array of `ModelProvider` objects.
  */
-export function getDotComDefaultModels(modelType: 'default' | 'experimental'): ModelProvider[] {
-    return modelType === 'default'
-        ? DEFAULT_DOT_COM_MODELS
-        : // NOTE: Required FeatureFlag.CodyChatContextBudget for A/B testing.
-          DEFAULT_DOT_COM_MODELS.map(m =>
-              modelsWithHigherLimit.includes(m.model)
-                  ? {
-                          ...m,
-                          contextWindow: {
-                              input: EXPERIMENTAL_CHAT_INPUT_TOKEN_BUDGET,
-                              context: { user: EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET },
-                              output: CHAT_OUTPUT_TOKEN_BUDGET,
-                          },
-                      }
-                  : m
-          )
+export function getDotComDefaultModels(): ModelProvider[] {
+    return DEFAULT_DOT_COM_MODELS
 }

--- a/lib/shared/src/models/index.test.ts
+++ b/lib/shared/src/models/index.test.ts
@@ -16,18 +16,19 @@ describe('Model Provider', () => {
             expect(max).toEqual({ input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET })
         })
 
-        it('returns max token limit for known chat model', () => {
-            const models = getDotComDefaultModels('default')
+        it('returns max token limit for known DotCom chat model ', () => {
+            const models = getDotComDefaultModels()
+            ModelProvider.setProviders(models)
+            expect(models[0].model).toBeDefined()
             const cw = ModelProvider.getContextWindowByID(models[0].model)
-            expect(cw.input).toEqual(models[0].contextWindow.input)
-            expect(models[0].contextWindow.context?.user).toEqual(undefined)
+            expect(cw).toStrictEqual(models[0].contextWindow)
         })
 
-        it('returns max token limit for dot com chat model with user context feature flag', () => {
-            const models = getDotComDefaultModels('experimental')
+        it('returns max token limit for known DotCom chat model with higher context window (claude 3)', () => {
+            const models = getDotComDefaultModels()
             ModelProvider.setProviders(models)
             const claude3SonnetModelID = 'anthropic/claude-3-sonnet-20240229'
-            const claude3SonnetModel = models.find(m => m.model === claude3SonnetModelID)
+            const claude3SonnetModel = ModelProvider.getProviderByModel(claude3SonnetModelID)
             expect(claude3SonnetModel?.contextWindow?.context?.user).greaterThan(0)
             expect(claude3SonnetModel).toBeDefined()
             const cw = ModelProvider.getContextWindowByID(claude3SonnetModelID)
@@ -60,7 +61,7 @@ describe('Model Provider', () => {
         })
 
         it('returns max token limit for known chat model', () => {
-            const knownModel = getDotComDefaultModels('default')[0]
+            const knownModel = getDotComDefaultModels()[0]
             const { output } = ModelProvider.getContextWindowByID(knownModel.model)
             expect(output).toEqual(knownModel.contextWindow.output)
         })

--- a/lib/shared/src/token/constants.ts
+++ b/lib/shared/src/token/constants.ts
@@ -1,5 +1,5 @@
 /**
- * The default context window for chat models.
+ * The default context window for chat models that are NOT Claude-3 Sonnet or Opus.
  */
 export const CHAT_INPUT_TOKEN_BUDGET = 7000
 
@@ -20,20 +20,15 @@ export const CHAT_OUTPUT_TOKEN_BUDGET = 4000
 export const ENHANCED_CONTEXT_ALLOCATION = 0.6
 
 /**
- * NOTE: DotCom users with FeatureFlag.CodyChatContextBudget enabled for A/B testing only.
+ * NOTE: Reserved for Claude-3 Sonnet and Opus only.
  *
  * The total context window reserved for user added context (@-mention, right-click, etc.)
- *
- * This is only being used for Claude-3 Sonnet and Opus when feature flag is enabled.
- * For those models, this is added on top of the chat context window.
- * For other models, this number is not used. Instead, they will share
- * the token budget for user-context with the chat context window.
  */
-export const EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET = 30000
+export const CLAUDE3_USER_CONTEXT_TOKEN_BUDGET = 30000
 
 /**
- * NOTE: DotCom users with FeatureFlag.CodyChatContextBudget enabled for A/B testing only.
+ * NOTE: Reserved for Claude-3 Sonnet and Opus only.
  *
  * The total context window reserved for chat input.
  */
-export const EXPERIMENTAL_CHAT_INPUT_TOKEN_BUDGET = 15000
+export const CLAUDE3_CHAT_INPUT_TOKEN_BUDGET = 15000

--- a/lib/shared/src/token/counter.test.ts
+++ b/lib/shared/src/token/counter.test.ts
@@ -3,8 +3,8 @@ import { ps } from '../prompt/prompt-string'
 import type { Message } from '../sourcegraph-api'
 import {
     CHAT_INPUT_TOKEN_BUDGET,
+    CLAUDE3_USER_CONTEXT_TOKEN_BUDGET,
     ENHANCED_CONTEXT_ALLOCATION,
-    EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET,
 } from './constants'
 import { TokenCounter } from './counter'
 
@@ -35,10 +35,10 @@ describe('TokenCounter class', () => {
         const counter = new TokenCounter({
             input: CHAT_INPUT_TOKEN_BUDGET,
             output: 0,
-            context: { user: EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET },
+            context: { user: CLAUDE3_USER_CONTEXT_TOKEN_BUDGET },
         })
         expect(counter.maxChatTokens).toBe(CHAT_INPUT_TOKEN_BUDGET)
-        expect(counter.maxContextTokens.user).toBe(EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET)
+        expect(counter.maxContextTokens.user).toBe(CLAUDE3_USER_CONTEXT_TOKEN_BUDGET)
         expect(counter.maxContextTokens.enhanced).toBe(
             CHAT_INPUT_TOKEN_BUDGET * ENHANCED_CONTEXT_ALLOCATION
         )
@@ -68,7 +68,7 @@ describe('TokenCounter class', () => {
         const counter = new TokenCounter({
             input: CHAT_INPUT_TOKEN_BUDGET,
             output: 0,
-            context: { user: EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET },
+            context: { user: CLAUDE3_USER_CONTEXT_TOKEN_BUDGET },
         })
         expect(counter.updateUsage('preamble', preamble)).toBe(true) // 3 chat tokens used
         expect(

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Chat: The context window for the `Claude 3 Sonnet` and `Claude 3 Opus` models is now increased by default for all non-Enterprise users, without requiring a feature flag. [pull/3953](https://github.com/sourcegraph/cody/pull/3953)
 - Custom Commands: Added the ability to create new custom Edit commands via the Custom Command Menu. [pull/3862](https://github.com/sourcegraph/cody/pull/3862)
 
 ### Fixed

--- a/vscode/src/editor/utils/editor-context.test.ts
+++ b/vscode/src/editor/utils/editor-context.test.ts
@@ -3,9 +3,9 @@ import * as vscode from 'vscode'
 import { URI } from 'vscode-uri'
 
 import {
+    CLAUDE3_USER_CONTEXT_TOKEN_BUDGET,
     type ContextItem,
     type ContextItemFile,
-    EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET,
     type Editor,
     ignores,
     ps,
@@ -159,7 +159,7 @@ describe('filterContextItemFiles', () => {
             uri: vscode.Uri.file('/large-text.txt'),
             type: 'file',
         }
-        const fsSizeInBytes = EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET * 4 + 100
+        const fsSizeInBytes = CLAUDE3_USER_CONTEXT_TOKEN_BUDGET * 4 + 100
         vscode.workspace.fs.stat = vi.fn().mockResolvedValueOnce({
             size: fsSizeInBytes,
             type: vscode.FileType.File,

--- a/vscode/webviews/App.story.tsx
+++ b/vscode/webviews/App.story.tsx
@@ -42,7 +42,7 @@ const dummyVSCodeAPI: VSCodeWrapper = {
             },
             workspaceFolderUris: [],
         })
-        cb({ type: 'chatModels', models: getDotComDefaultModels('default') })
+        cb({ type: 'chatModels', models: getDotComDefaultModels() })
         cb({
             type: 'history',
             localHistory: {

--- a/vscode/webviews/Components/ChatModelDropdownMenu.story.tsx
+++ b/vscode/webviews/Components/ChatModelDropdownMenu.story.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof ChatModelDropdownMenu> = {
     component: ChatModelDropdownMenu,
     decorators: [VSCodeStandaloneComponent],
     args: {
-        models: getDotComDefaultModels('default'),
+        models: getDotComDefaultModels(),
         disabled: false,
     },
 }

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
@@ -60,7 +60,7 @@ export function VSCodeDecorator(className: string | undefined, style?: CSSProper
 }
 
 function useDummyChatModelContext(): ChatModelContext {
-    const [chatModels, setChatModels] = useState(getDotComDefaultModels('default'))
+    const [chatModels, setChatModels] = useState(getDotComDefaultModels())
     const onCurrentChatModelChange = (value: ModelProvider): void => {
         setChatModels(chatModels =>
             chatModels.map(model => ({ ...model, default: model.model === value.model }))


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody-issues/issues/27

> @chillatom And for the removal that limits to Dotcom users, we could release that to stable in the next release (5/1)

As we have rolled out the expanded context window to 100% of our DotCom users, and implement a more stable tokenizer on both client and cody gateway https://github.com/sourcegraph/sourcegraph/issues/62057 , we are now expected to roll out the expanded windows to PLG users without the feature flag.

This PR aims to remove the feature flag we used for A/B testing the expanded context window for DotCom users using Claude 3 Opus and Sonnet models. Changes include:

- Update token consts:
  - EXPERIMENTAL_CHAT_INPUT_TOKEN_BUDGET to CLAUDE3_CHAT_INPUT_TOKEN_BUDGET
  - EXPERIMENTAL_USER_CONTEXT_TOKEN_BUDGET to CLAUDE3_USER_CONTEXT_TOKEN_BUDGET
- Remove the feature flag evaluation used for context budget: `FeatureFlag.CodyChatContextBudget`
- Remove the 'default' and 'experimental' mode from `getDotComDefaultModels()` as the old `experimental` mode is the `default` now
- Moved Claude 2 models to the bottom of the default model list as they will soon be depracated

The context token budget has been increased for the Claude 3 model, and the feature flag evaluation for the context budget has been removed. The default models for Sourcegraph.com users are now set without specifying a mode, and the fallback behavior for enterprise instances has been clarified.


No major change as this is removing the logic that gated the expanded context window behind the current feature flag, which will also be removed by this PR.

- The expanded context window only applies to the Claude 3 Opus and Sonnet models fo DotCom users only.
- The expanded context window does not apply to Enterprise users 
  - This is under a separated issue https://github.com/sourcegraph/cody-issues/issues/28

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Run this branch in debug mode
2. Check the output channel to verify the feature flag for `CodyChatContextBudget` was not queried / needed
3. Try to @-mention SimpleChatPanelProvider.ts using Claude 2.0 model, you are expected to see the `File too large` warning
![image](https://github.com/sourcegraph/cody/assets/68532117/df89a91f-77ad-4dfd-b119-6956e9b28e72)
4. Hit ESC to make sure the @-mentions pop-up is closed
5. Switch to Claude 3 models to repeat step 3 again
6. You should NOT see the `File too large` warning  when using Claude 3 Opus and Sonnet models
![image](https://github.com/sourcegraph/cody/assets/68532117/eb6b0d41-decf-4552-847b-c6085630e459)
![image](https://github.com/sourcegraph/cody/assets/68532117/2cc11abe-e64a-4b15-8b1c-b198e29a2922)

