### PR TITLE
Feature-tracking: Add a script to merge features across repos

### DIFF
--- a/feature-tracking/.gitignore
+++ b/feature-tracking/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/feature-tracking/README.md
+++ b/feature-tracking/README.md
@@ -1,0 +1,21 @@
+# features.json5
+
+The goal of this system is to track the status of fine-grained features across the Cody product line, in all editors, with minimal toil. Product features are described in a [JSON5](https://json5.org/) file. The file is checked in making it easy to relate feature status to commit history.
+
+A tool semantically merges feature files across repositories. This allows common data, such as links to documentation, to be stored in one place. But by splitting editor-specific status into their respective repositories, engineers don't have to deal with multi-repo PRs. They can land status updates and code in one repository in a single commit.
+
+By semantically diffing the feature files it is possible to view what features have changed from release to release, or show the feature gap that exists between editors.
+
+## Command Line Tool
+
+**Set up the tool:**
+
+```
+$ pnpm install  # Set up dependencies
+```
+
+**Merge feature files.** The merged result is printed to the console. For example, for a complete description of JetBrains features it is necessary to merge the features.json5 file in the sourcegraph/cody repo, which has documentation links, etc. with the features.json5 file in the sourcegraph/jetbrains repo, which has the overlay feature data for JetBrains specifically.
+
+```
+$ pnpm features merge featuresA.json5 featuresB.json5 ...
+```

--- a/feature-tracking/index.ts
+++ b/feature-tracking/index.ts
@@ -1,0 +1,140 @@
+import { promises as fs } from 'fs'
+
+import { ArgumentParser } from 'argparse'
+import JSON5 from 'json5'
+
+// Types describing features.json5
+
+interface Database {
+    editors?: string[],
+    features: Feature[]
+}
+
+interface Feature {
+    name: string,
+    description?: string | undefined,
+    productLine?: 'free' | 'pro' | 'consumer' | 'enterprise' | 'all',
+    documentation?: string[],
+    editors?: {[key: string]: EditorFeature},
+    tags?: string[],
+}
+
+interface EditorFeature {
+    status?: 'will-not-do' | 'planned' | 'experimental' | 'stable' | 'deprecated' | 'removed',
+    notes?: string[],
+}
+
+const emptyDatabase: Database = Object.seal({
+    features: [],
+})
+
+// Functions to take two Database and merge them, by overlaying the second on top of the
+// first.
+
+// Merges two feature databases. The JetBrains database is layered on top of the 'master'
+// database (which happens to contain VSCode) so we can store databases with the code
+// while avoiding duplication.
+function mergeDb(a: Database, b: Database): Database {
+    return {
+        editors: mergeOptionalSet(a.editors, b.editors),
+        features: mergeFeatures(a.features, b.features)
+    }
+}
+
+// Merges two optional arrays, de-duping them like they were sets.
+function mergeOptionalSet<T>(x: T[] | undefined, y: T[] | undefined): T[] | undefined {
+    if (!x) {
+        return y
+    } else if (!y) {
+        return x
+    } else {
+        return [...new Set([...x, ...y])]
+    }
+}
+
+// Merges two features arrays. The features are joined by name, then recursively merged.
+function mergeFeatures(xs: Feature[], ys: Feature[]): Feature[] {
+    const byName = (a: Feature): [string, Feature] => [a.name, a]
+    const xsByName = Object.fromEntries(xs.map(byName))
+    const ysByName = Object.fromEntries(ys.map(byName))
+    return Object.values(mergeMap(xsByName, ysByName, mergeFeature))
+}
+
+function mergeFeature(x: Feature, y: Feature): Feature {
+    console.assert(x.name === y.name)
+    // For some simple properties, we overwrite the first value with the second value, if
+    // any. The second database acts as an "overlay" atop the first.
+    return {
+        name: x.name,
+        description: y.description || x.description,
+        productLine: y.productLine || x.productLine,
+        documentation: mergeOptionalSet(x.documentation, y.documentation),
+        editors: mergeMap(x.editors || {}, y.editors || {}, mergeEditorFeature),
+        tags: mergeOptionalSet(x.tags, y.tags)
+    }
+}
+
+function mergeEditorFeature(x: EditorFeature, y: EditorFeature): EditorFeature {
+    return {
+        status: y.status || x.status,
+        notes: mergeOptionalSet(x.notes, y.notes),
+    }
+}
+
+// Merges two objects used as hashes with a specific value combiner, `merge`, if the keys
+// overlap.
+function mergeMap<T, U extends {[key: string]: T}>(x: U, y: U, merge: (a: T, b: T) => T): {[key: string]: T} {
+    const result: {[key: string]: T} = {}
+    const allKeys = new Set([...Object.keys(x), ...Object.keys(y)])
+    for (const key of allKeys) {
+        const a = x[key]
+        const b = y[key]
+        if (!a) {
+            result[key] = b
+        } else if (!b) {
+            result[key] = a
+        } else {
+            result[key] = merge(a, b)
+        }
+    }
+    return result
+}
+
+// Interrogates gradle.properties to learn the upstream cody extension commit.
+// async function getUpstreamCommit(): Promise<string | undefined> {
+//     return (await fs.readFile(path.resolve(__dirname, '..', 'gradle.properties')))
+//         .toString()
+//         .split('\n')
+//         .map(line => line.match(/cody.commit=([0-9a-fA-F]+)/))
+//         .filter(match => match)[0]?.[1]
+// }
+
+// Merges the features in the specified files and prints the result.
+async function mergeFiles(filenames: string[]) {
+    const dbs = await Promise.all(filenames.map(async filename =>
+        JSON5.parse((await fs.readFile(filename)).toString()) as Database
+    ))
+    const merged = dbs.reduce(mergeDb, emptyDatabase)
+    console.log(JSON.stringify(merged, undefined, 2))
+}
+
+async function main() {
+    const parser = new ArgumentParser()
+    const commandParser = parser.add_subparsers({
+        dest: 'command'
+    })
+    const mergeParser = commandParser.add_parser('merge')
+    mergeParser.add_argument('file', {help: 'features.json5 file(s) to merge', nargs: '+'})
+    mergeParser.add_argument('--upstream', {help: 'Include upstream features file', action: 'store_true'})
+    const args = parser.parse_args()
+
+    switch (args.command) {
+        case 'merge':
+            await mergeFiles(args.file)
+            break
+        default:
+            throw new Error(`unknown command ${args.command}`)
+    }
+}
+
+main()

--- a/feature-tracking/package.json
+++ b/feature-tracking/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "features",
+  "description": "Queries features.json5 to summarize features in Cody",
+  "version": "0.0.1",
+  "scripts": {
+    "features": "tsc --build . && node -r ts-node/register dist/index.js"
+  },
+  "dependencies": {
+    "@types/argparse": "^2.0.16",
+    "argparse": "^2.0.1",
+    "json5": "^2.2.3"
+  }
+}

--- a/feature-tracking/pnpm-lock.yaml
+++ b/feature-tracking/pnpm-lock.yaml
@@ -1,0 +1,164 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  '@types/argparse':
+    specifier: ^2.0.16
+    version: 2.0.16
+  '@types/node':
+    specifier: ^20.12.7
+    version: 20.12.7
+  argparse:
+    specifier: ^2.0.1
+    version: 2.0.1
+  json5:
+    specifier: ^2.2.3
+    version: 2.2.3
+  ts-node:
+    specifier: ^10.9.2
+    version: 10.9.2(@types/node@20.12.7)(typescript@5.4.5)
+  typescript:
+    specifier: ^5.4.5
+    version: 5.4.5
+
+packages:
+
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: false
+
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+    dev: false
+
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: false
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: false
+
+  /@tsconfig/node10@1.0.11:
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+    dev: false
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: false
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: false
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: false
+
+  /@types/argparse@2.0.16:
+    resolution: {integrity: sha512-aMqBra2JlqpFeCWOinCtpRpiCkPIXH8hahW2+FkGzvWjfE5sAqtOcrjN5DRcMnTQqFDe6gb1CVYuGnBH0lhXwA==}
+    dev: false
+
+  /@types/node@20.12.7:
+    resolution: {integrity: sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: false
+
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
+    dev: false
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: false
+
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: false
+
+  /argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: false
+
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: false
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: false
+
+  /json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+    dev: false
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: false
+
+  /ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.5):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.12.7
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: false
+
+  /typescript@5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: false
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: false
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: false

--- a/feature-tracking/tsconfig.json
+++ b/feature-tracking/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist",
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "index.ts",
+  ],
+  "ts-node": {
+    "esm": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
   },
   "references": [
     { "path": "agent" },
+    { "path": "feature-tracking" },
     { "path": "lib/shared" },
     { "path": "vscode" },
     { "path": "vscode/test/integration" },


### PR DESCRIPTION
## Test plan

Manually tested. Patch the features files from #3846 and sourcegraph/jetbrains#1400 , then:

```
$ pnpm features merge ../features.json5 ~/projects/jetbrains/features5.json
```

Output:

```json
{
  "editors": [
    "vscode",
    "jetbrains"
  ],
  "features": [
    {
      "name": "NotebookBasedChatUI",
      "description": "new chat UI that resembles a notebook instead of a chat session",
      "productLine": "all",
      "documentation": [],
      "editors": {
        "vscode": {
          "status": "stable"
        },
        "jetbrains": {
          "status": "planned"
        }
      },
      "tags": [
        "chat"
      ]
    },
   ...
```