### PR TITLE
noodle: include patternType in search URL

### DIFF
--- a/lib/shared/src/mentions/providers/sourcegraphSearch.ts
+++ b/lib/shared/src/mentions/providers/sourcegraphSearch.ts
@@ -16,7 +16,7 @@ export const SOURCEGRAPH_SEARCH_CONTEXT_MENTION_PROVIDER: ContextMentionProvider
     async queryContextItems(query, signal) {
         const searchQuery = query.startsWith('src:') ? query.slice(4) : query
         const uri = URI.parse(graphqlClient.endpoint).with({
-            query: 'q=' + encodeURIComponent(searchQuery),
+            query: 'q=' + encodeURIComponent(searchQuery) + '&patternType=literal',
         })
         return [
             {
@@ -34,8 +34,7 @@ export const SOURCEGRAPH_SEARCH_CONTEXT_MENTION_PROVIDER: ContextMentionProvider
             return [item as ContextItemWithContent]
         }
 
-        // Sneaking in the search query via the title
-        const rawQuery = item.title
+        const rawQuery = new URLSearchParams(item.uri.query).get('q')
         if (!rawQuery) {
             return []
         }


### PR DESCRIPTION
This is so when you click through it uses the same interpretation of the query string we use against the backend.

Additionally instead of using the title of the item, we extract out the query from the URI. This is a small change which makes this more useful as a generic extractor of search results from URLs.

Test Plan: tested manually to ensure context was still returned. Then clicked through on the @ mentioned link. Right now there is another bug which double quotes the URL when clicking through so not fully functional.