### PR TITLE
Custom Command: update context options

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,12 +8,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: The context window for the `Claude 3 Sonnet` and `Claude 3 Opus` models is now increased by default for all non-Enterprise users, without requiring a feature flag. [pull/3953](https://github.com/sourcegraph/cody/pull/3953)
 - Custom Commands: Added the ability to create new custom Edit commands via the Custom Command Menu. [pull/3862](https://github.com/sourcegraph/cody/pull/3862)
+- Custom Commands: Added 'currentFile' option to include the full file content in the Custom Commands menu. [pull/3960](https://github.com/sourcegraph/cody/pull/3960)
 
 ### Fixed
 
 - Chat: Fixed an issue where Cody's responses were not visible in small windows. [pull/3859](https://github.com/sourcegraph/cody/pull/3859)
 - Edit: Fixed an issue where an Edit task would not correctly respin when an irresolvable conflict is encountered. [pull/3872](https://github.com/sourcegraph/cody/pull/3872)
 - Chat: Fixed an issue where older chats were displaying as 'N months ago' instead of the number in the Chat History sidebar. [pull/3864](https://github.com/sourcegraph/cody/pull/3864)
+- Custom Commands: Fixed an issue where the "selection" option was not being toggled correctly based on the user's selection in the Custom Command menu. [pull/3960](https://github.com/sourcegraph/cody/pull/3960)
 
 ### Changed
 

--- a/vscode/src/commands/menus/command-builder.ts
+++ b/vscode/src/commands/menus/command-builder.ts
@@ -146,10 +146,10 @@ export class CustomCommandsBuilderMenu {
                     case 'openTabs':
                     case 'none':
                         newPrompt.context[context.id] = context.picked
-                        continue
+                        break
                     case 'command': {
                         newPrompt.context.command = (await showPromptCreationInputBox()) ?? undefined
-                        continue
+                        break
                     }
                 }
             }

--- a/vscode/src/commands/menus/command-builder.ts
+++ b/vscode/src/commands/menus/command-builder.ts
@@ -126,7 +126,6 @@ export class CustomCommandsBuilderMenu {
      * @returns The new Cody command with the selected context options, or null if no prompt was provided.
      */
     private async addContext(newPrompt: Partial<CodyCommand>): Promise<CodyCommand | null> {
-        newPrompt.context = {}
         const promptContext = await window.showQuickPick(customPromptsContextOptions, {
             title: 'New Custom Cody Command: Context Options',
             placeHolder: 'For accurate responses, choose only the necessary options.',
@@ -138,17 +137,19 @@ export class CustomCommandsBuilderMenu {
         })
 
         if (promptContext !== undefined) {
+            newPrompt.context = { selection: false }
             for (const context of promptContext) {
                 switch (context.id) {
                     case 'selection':
+                    case 'currentFile':
                     case 'currentDir':
                     case 'openTabs':
                     case 'none':
                         newPrompt.context[context.id] = context.picked
-                        break
+                        continue
                     case 'command': {
                         newPrompt.context.command = (await showPromptCreationInputBox()) ?? undefined
-                        break
+                        continue
                     }
                 }
             }

--- a/vscode/src/commands/menus/items/menu.ts
+++ b/vscode/src/commands/menus/items/menu.ts
@@ -78,14 +78,20 @@ export const customPromptsContextOptions: ContextOption[] = [
         picked: true,
     },
     {
+        id: 'currentFile',
+        label: 'Current File',
+        detail: 'Content of the text file in your active editor.',
+        picked: false,
+    },
+    {
         id: 'currentDir',
         label: 'Current Directory',
-        detail: 'First 10 text files in the current directory. If the prompt includes the words "test" or "tests", only test files will be included.',
+        detail: 'First 10 text files in the current directory.',
         picked: false,
     },
     {
         id: 'openTabs',
-        label: 'Current Open Tabs',
+        label: 'Open Tabs',
         detail: 'First 10 text files in current open tabs',
         picked: false,
     },

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -100,8 +100,13 @@ test.extend<ExpectedEvents>({
     await page.getByText('Workspace Settings.vscode/cody.json').click()
 
     // The new command shows up in the sidebar and works on clicks
-    await expect(page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a')).toBeVisible()
-    await page.getByRole('treeitem', { name: 'ATestCommand' }).locator('a').click()
+    await expect(page.getByText('New Custom Cody Command: Save To…')).not.toBeVisible()
+    await page.getByText('Custom Commands', { exact: true }).hover()
+    const treeItem = page.getByRole('treeitem', { name: 'ATestCommand' }).getByLabel('ATestCommand')
+    await treeItem.scrollIntoViewIfNeeded()
+    await expect(treeItem).toBeVisible()
+    await treeItem.click()
+
     // Confirm the command prompt is displayed in the chat panel on execution
     const chatPanel = page.frameLocator('iframe.webview').last().frameLocator('iframe')
     await expect(chatPanel.getByText(prompt)).toBeVisible()


### PR DESCRIPTION
This pull request updates the context options available when creating custom commands using the quick pick menu and fixes an issue with the "selection" option. 

The changes include:

- Fix "selection" Option Behavior: Previously, when creating a custom command, the "selection" option was not being toggled correctly. If an option was selected in the quick pick menu, it would not set the "selection" property to false but rather leave it as undefined. This pull request addresses this issue by explicitly setting `newPrompt.context.selection` to false when initializing the context object.
- Add 'currentFile' Option: A new option 'currentFile' has been added to the context options. This option allows users to include the full content of the currently open file in the active editor when creating a custom command. This is something we currently support but left out of the menu intentionally.
  - This is already covered by our [agent integration test ](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/index.test.ts?L1269-1295)in using this [cody.json file](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/__tests__/example-ts/.cody/commands.json?L16-23)
- Update description for 'currentDir' option: The 'currentDir' option previously filtered out non-test files if the prompt included the words "test" or "tests" when the default commands are created using the same format. Since then, this filtering has been removed, and now all text files in the current directory will be included. Updated the description to reflect the latest behavior. 
- Rename 'Current Open Tabs' Option: The 'Current Open Tabs' option has been renamed to 'Open Tabs' for better clarity and consistency.

The fix for the "selection" option ensures that the context object is correctly initialized with the selection set to false when creating a new custom command. This resolves the issue where the "selection" option was not toggled correctly based on the user's selection in the quick-pick menu.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

The new `currentFile` option is already covered by the [agent integration test](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/index.test.ts?L1269-1295) using this [cody.json file](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/__tests__/example-ts/.cody/commands.json?L16-23)

For manual testing: 
- Create a custom command via the quick pick menu to confirm `selection` is toggled correctly
-Verify the newly created command in your cody.json file has selection set to false when you have unchecked the option:
![image](https://github.com/sourcegraph/cody/assets/68532117/582b9f50-d469-428b-b88b-3b6c78db2917)


https://github.com/sourcegraph/cody/assets/68532117/f518ce6a-b755-40a8-b91e-4a0518d66cd0

