### PR TITLE
Use new version of symf with expanded query param

### DIFF
--- a/vscode/src/local-context/download-symf.ts
+++ b/vscode/src/local-context/download-symf.ts
@@ -12,7 +12,7 @@ import { logDebug } from '../log'
 import { getOSArch } from '../os'
 import { captureException } from '../services/sentry/sentry'
 
-const symfVersion = 'v0.0.9'
+const symfVersion = 'v0.0.10'
 
 /**
  * Get the path to `symf`. If the symf binary is not found, download it.

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -259,7 +259,11 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         return lock
     }
 
-    private async unsafeRunQuery(userQuery: PromptString, keywordQuery: string, scopeDir: FileURI): Promise<string> {
+    private async unsafeRunQuery(
+        userQuery: PromptString,
+        keywordQuery: string,
+        scopeDir: FileURI
+    ): Promise<string> {
         const { indexDir } = this.getIndexDir(scopeDir)
         const { accessToken, symfPath, serverEndpoint } = await this.getSymfInfo()
         try {

--- a/vscode/src/local-context/symf.ts
+++ b/vscode/src/local-context/symf.ts
@@ -114,7 +114,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         return Promise.resolve(
             scopeDirs
                 .filter(isFileURI)
-                .map(scopeDir => this.getResultsForScopeDir(expandedQuery, scopeDir))
+                .map(scopeDir => this.getResultsForScopeDir(userQuery, expandedQuery, scopeDir))
         )
     }
 
@@ -124,6 +124,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
      * operation that is best done concurrently with querying and (re)building the index.
      */
     private async getResultsForScopeDir(
+        userQuery: PromptString,
         keywordQuery: Promise<string>,
         scopeDir: FileURI
     ): Promise<Result[]> {
@@ -145,7 +146,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
                     indexNotFound = true
                     return ''
                 }
-                return this.unsafeRunQuery(await keywordQuery, scopeDir)
+                return this.unsafeRunQuery(userQuery, await keywordQuery, scopeDir)
             })
             if (indexNotFound) {
                 continue
@@ -258,7 +259,7 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
         return lock
     }
 
-    private async unsafeRunQuery(keywordQuery: string, scopeDir: FileURI): Promise<string> {
+    private async unsafeRunQuery(userQuery: PromptString, keywordQuery: string, scopeDir: FileURI): Promise<string> {
         const { indexDir } = this.getIndexDir(scopeDir)
         const { accessToken, symfPath, serverEndpoint } = await this.getSymfInfo()
         try {
@@ -272,7 +273,9 @@ export class SymfRunner implements IndexedKeywordContextFetcher, vscode.Disposab
                     scopeDir.fsPath,
                     '--fmt',
                     'json',
-                    keywordQuery,
+                    '--expanded-query',
+                    `"${keywordQuery}"`,
+                    `${userQuery}`,
                 ],
                 {
                     env: {


### PR DESCRIPTION
We want to upgrade symf to a [new version](https://github.com/sourcegraph/symf-private/pull/13) which improves reranking. 

## Test plan

Ran this locally and logged the expanded and original user queries, these matched the inputs to Cody and search using symf worked as expected.
