### PR TITLE
adding finetuned model for code completions

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -17,6 +17,8 @@ export enum FeatureFlag {
     CodyAutocompleteLlamaCode13B = 'cody-autocomplete-llama-code-13b',
     // Enable StarCoder2 7b and 15b as the default model via Fireworks
     CodyAutocompleteStarCoder2Hybrid = 'cody-autocomplete-starcoder2-hybrid',
+    // Enable the FineTuned model as the default model via Fireworks
+    CodyAutocompleteFineTunedModel = 'cody-autocomplete-finetuned-model',
     // Enables Claude 3 if the user is in our holdout group
     CodyAutocompleteClaude3 = 'cody-autocomplete-claude-3',
     // Enables the bfg-mixed context retriever that will combine BFG with the default local editor

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -153,12 +153,19 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         return { provider: configuredProvider }
     }
 
-    const [starCoder2Hybrid, starCoderHybrid, llamaCode13B, claude3] = await Promise.all([
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
-        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
-    ])
+    const [starCoder2Hybrid, starCoderHybrid, llamaCode13B, claude3, finetunedModel] = await Promise.all(
+        [
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
+            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFineTunedModel),
+        ]
+    )
+
+    if (finetunedModel) {
+        return { provider: 'fireworks', model: 'fireworks-completions-fine-tuned' }
+    }
 
     if (llamaCode13B) {
         return { provider: 'fireworks', model: 'llama-code-13b' }

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -323,7 +323,7 @@ class FireworksProvider extends Provider {
                 Your goal is to perform code completion for the following code, keeping in mind the rest of the code and the file meta data.
                 Metadata details: filename: ${filename}. The code of the file until where you have to start completion:
             `
-            return ps`${intro} \n ${suffix} \n ${fixedPrompt} \n ${prefix}`
+            return ps`${intro} \n ${fixedPrompt}\n${prefix}`
         }
         console.error('Could not generate infilling prompt for', this.model)
         return ps`${intro}${prefix}`

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -80,6 +80,10 @@ const MODEL_MAP = {
 
     // Fireworks model identifiers
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
+
+    // Fine-tuned model mapping
+    'fireworks-completions-fine-tuned':
+        'fireworks/accounts/sourcegraph/models/codecompletion-m-mixtral-rb-rs-m-go-400k-25e',
 }
 
 type FireworksModel =
@@ -105,6 +109,8 @@ function getMaxContextTokens(model: FireworksModel): number {
         case 'llama-code-13b':
             // Llama 2 on Fireworks supports up to 4k tokens. We're constraining it here to better
             // compare the results
+            return 2048
+        case 'fireworks-completions-fine-tuned':
             return 2048
         default:
             return 1200
@@ -172,7 +178,7 @@ class FireworksProvider extends Provider {
         const languageConfig = getLanguageConfig(this.options.document.languageId)
 
         // In StarCoder we have a special token to announce the path of the file
-        if (!isStarCoderFamily(this.model)) {
+        if (!isStarCoderFamily(this.model) && this.model !== 'fireworks-completions-fine-tuned') {
             intro.push(ps`Path: ${PromptString.fromDisplayPath(this.options.document.uri)}`)
         }
 
@@ -312,7 +318,13 @@ class FireworksProvider extends Provider {
             // c.f. https://github.com/facebookresearch/codellama/blob/main/llama/generation.py#L402
             return ps`<PRE> ${intro}${prefix} <SUF>${suffix} <MID>`
         }
-
+        if (this.model === 'fireworks-completions-fine-tuned') {
+            const fixedPrompt = ps`You are an expert in writing code in many different languages.
+                Your goal is to perform code completion for the following code, keeping in mind the rest of the code and the file meta data.
+                Metadata details: filename: ${filename}. The code of the file until where you have to start completion:
+            `
+            return ps`${intro} \n ${suffix} \n ${fixedPrompt} \n ${prefix}`
+        }
         console.error('Could not generate infilling prompt for', this.model)
         return ps`${intro}${prefix}`
     }


### PR DESCRIPTION
## Context
1. This PR adds the fine-tuning code completions model for internal users. The offline evaluation is done on HumanEval dataset and the results are linked in the [RFC](https://docs.google.com/document/d/1myMceHu7x8gh0B9eb_kRE719AGqVHfZ3py9k_3luym8/edit#heading=h.trqab8y0kufp)
2. This PR particularly adds a fine-tuned version of the Mixtral model hosted by the fireworks.
3. Cody Gateway PR: https://github.com/sourcegraph/sourcegraph/pull/62300 

## Test plan
Manual testing
1. Added my username in the feature flag: `cody-autocomplete-finetuned-model `
2. Used debug console and cody autotrace view to check the context and completions.

<img width="1227" alt="Screenshot 2024-05-02 at 12 37 04 AM" src="https://github.com/sourcegraph/cody/assets/20701220/67d48f8f-25ed-4a94-b51d-4a4287dab541">
