### PR TITLE
Chat: Fix chat title that starts with new line

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,6 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Edit: Fixed an issue where an Edit task would not correctly respin when an irresolvable conflict is encountered. [pull/3872](https://github.com/sourcegraph/cody/pull/3872)
 - Chat: Fixed an issue where older chats were displaying as 'N months ago' instead of the number in the Chat History sidebar. [pull/3864](https://github.com/sourcegraph/cody/pull/3864)
 - Custom Commands: Fixed an issue where the "selection" option was not being toggled correctly based on the user's selection in the Custom Command menu. [pull/3960](https://github.com/sourcegraph/cody/pull/3960)
+- Chat: Fixed an issue where the chat title showed up as "New Chat" when the question started with a new line. [pull/3977](https://github.com/sourcegraph/cody/pull/3977)
 
 ### Changed
 

--- a/vscode/src/chat/chat-view/chat-helpers.test.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.test.ts
@@ -43,4 +43,8 @@ describe('getChatPanelTitle', () => {
         const result = getChatPanelTitle(title)
         expect(result).toEqual('Explain the relationship....')
     })
+
+    test('title should be trimed', () => {
+        expect(getChatPanelTitle('\n\nExplain\n\n')).toEqual('Explain')
+    })
 })

--- a/vscode/src/chat/chat-view/chat-helpers.test.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 
 import { getChatPanelTitle } from './chat-helpers'
 
@@ -44,7 +44,11 @@ describe('getChatPanelTitle', () => {
         expect(result).toEqual('Explain the relationship....')
     })
 
-    test('title should be trimed', () => {
+    it('should trim leading and trailing whitespace from the input string', () => {
         expect(getChatPanelTitle('\n\nExplain\n\n')).toEqual('Explain')
+    })
+
+    it('should return the first non-empty line from the input string', () => {
+        expect(getChatPanelTitle('\nInclude this\nExclude this\n')).toEqual('Include this')
     })
 })

--- a/vscode/src/chat/chat-view/chat-helpers.ts
+++ b/vscode/src/chat/chat-view/chat-helpers.ts
@@ -23,11 +23,11 @@ export async function openFile(
 }
 
 export function getChatPanelTitle(lastHumanText?: string, truncateTitle = true): string {
-    if (!lastHumanText) {
+    let text = lastHumanText?.trim()?.split('\n')[0]
+    if (!text) {
         return 'New Chat'
     }
 
-    let text = lastHumanText
     // Regex to remove the markdown formatted links with this format: '[_@FILENAME_]()'
     const MARKDOWN_LINK_REGEX = /\[_(.+?)_]\((.+?)\)/g
     text = text.replaceAll(MARKDOWN_LINK_REGEX, '$1')?.trim()

--- a/vscode/src/services/HistoryChat.ts
+++ b/vscode/src/services/HistoryChat.ts
@@ -45,7 +45,7 @@ export function groupCodyChats(authStatus: AuthStatus | undefined): GroupedChats
         }
 
         if (lastHumanMessage?.text) {
-            const lastHumanText = lastHumanMessage.text?.toString().split('\n')[0]
+            const lastHumanText = lastHumanMessage.text?.toString()
             const chatTitle = chats[id].chatTitle || getChatPanelTitle(lastHumanText, false)
             const timestamp = new Date(entry.lastInteractionTimestamp)
             const timeUnit = getRelativeChatPeriod(timestamp)


### PR DESCRIPTION
Small fix: Add title trimming and handle empty text

This commit updates the getChatPanelTitle function to use the trimmed title when generating the chat panel title to address an issue where chat title is set to "New Chat" when the last chat question starts with a new line:
![image](https://github.com/sourcegraph/cody/assets/68532117/f9427744-9bac-430e-8e65-b49decc9c300)

Changes:

- Added a new test case to ensure that the getChatPanelTitle function trims the title and handles empty text.

Updated the getChatPanelTitle function to use the trimmed title when generating the chat panel title.


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- start debug mode from this branch
- start a new chat
- send a question to cody and start the question with a new line


### Before

The chat title is set to "New Chat"

![image](https://github.com/sourcegraph/cody/assets/68532117/f8d60655-fd81-4860-b763-a2ce3a792a0c)


### After

The chat title used the trimmed value:

![image](https://github.com/sourcegraph/cody/assets/68532117/6a50c9fe-f02d-4532-8837-ae6eba5c3861)

