### PR TITLE
fix: update ContextItemSource for usage examples

### DIFF
--- a/vscode/src/commands/execute/usage-examples.ts
+++ b/vscode/src/commands/execute/usage-examples.ts
@@ -89,7 +89,7 @@ export async function executeUsageExamplesCommand(
             type: 'file',
             uri: doc.uri,
             range: snippetRange,
-            source: ContextItemSource.Editor,
+            source: ContextItemSource.Unified,
         })
 
         try {
@@ -207,7 +207,7 @@ async function symbolContextItems(
                     ...use,
                     type: 'file',
                     title: uriBasename(use.uri),
-                    source: ContextItemSource.Search,
+                    source: ContextItemSource.Unified,
                 }) satisfies ContextItem
         ),
     ]

--- a/vscode/src/commands/execute/usage-examples.ts
+++ b/vscode/src/commands/execute/usage-examples.ts
@@ -89,7 +89,7 @@ export async function executeUsageExamplesCommand(
             type: 'file',
             uri: doc.uri,
             range: snippetRange,
-            source: ContextItemSource.Unified,
+            source: ContextItemSource.Editor,
         })
 
         try {

--- a/vscode/src/commands/execute/usage-examples.ts
+++ b/vscode/src/commands/execute/usage-examples.ts
@@ -199,6 +199,7 @@ async function symbolContextItems(
                     ...item,
                     type: 'file',
                     range: item.range ? expandRangeByLines(toVSCodeRange(item.range)!, 10) : undefined,
+                    source: ContextItemSource.Unified,
                 }) satisfies ContextItem
         ),
         ...uses.map(

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames'
 import type React from 'react'
 
 import {
-    ContextItemSource,
     type RangeData,
     displayLineRange,
     displayPath,
@@ -47,15 +46,12 @@ export const FileLink: React.FunctionComponent<FileLinkProps & { className?: str
     let pathWithRange: string
     let href: string
     let target: string | undefined
-    if (source === 'unified' || source === ContextItemSource.Search) {
+    if (source === 'unified') {
         // Remote search result.
         const repoShortName = repoName?.slice(repoName.lastIndexOf('/') + 1)
         const pathToDisplay = `${repoShortName} ${title}`
         pathWithRange = range ? `${pathToDisplay}:${displayLineRange(range)}` : pathToDisplay
-        tooltip =
-            source === 'unified'
-                ? `${repoName} @${revision}\nincluded via Enhanced Context (Enterprise Search)`
-                : ''
+        tooltip = `${repoName} @${revision}\nincluded via Enhanced Context (Remote Search)`
         // We can skip encoding when the uri path already contains '@'.
         href = uri.toString(uri.path.includes('@'))
         target = '_blank'


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1714489870131939
RE: https://github.com/sourcegraph/cody/pull/3939

![image](https://github.com/sourcegraph/cody/assets/68532117/1994983d-7c3a-4563-bf3f-d394601f051d)

 This pull request addresses an issue where the context items for usage examples have the `source` property set to `ContextItemSource.Search`, which is reserved for results returned by `symf`. However, `symf` has a different interface than results returned from `Remote Search`, which is associated with `ContextItemSource.Unified`. As a result, the results returned from `symf` are displayed as `undefined` in the UI.


Changes:

- Fixes the issue of `symf` results displaying as `undefined` in the UI for usage examples
- Unifies the source for usage examples to `ContextItemSource.Unified`, ensuring correct display
  - Updates the `source` property of `ContextItem` for `usage-examples.ts` from `ContextItemSource.Editor` and `ContextItemSource.Search` to `ContextItemSource.Unified` 
- Updated tooltip from `Enterprise Search` to `Remote Search` to avoid confusion.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Verify that usage examples from `symf` are correctly displayed with the unified source, resolving the `undefined` display issue
- Ensure that the `FileLink` component renders correctly for remote search results from usage example

### After

Results from example-usage are rendering correctly:

![image](https://github.com/sourcegraph/cody/assets/68532117/b7c6fc40-5d64-4703-80e9-31c4175237d1)

Results from symf are rendering correctly:

![image](https://github.com/sourcegraph/cody/assets/68532117/49ea9890-8eb8-4c2d-b616-0d7c03030255)

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/b0806511-58bb-45ca-b462-98c2811f302e)
