### PR TITLE
chore: upgrade to biome@1.7.2

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -34,11 +34,7 @@
     "assets": "dist/*.{wasm,map}"
   },
   "bin": "dist/index.js",
-  "files": [
-    "dist/index.js",
-    "dist/index.js.map",
-    "dist/*.wasm"
-  ],
+  "files": ["dist/index.js", "dist/index.js.map", "dist/*.wasm"],
   "dependencies": {
     "@pollyjs/core": "^6.0.6",
     "@pollyjs/persister": "^6.0.6",

--- a/agent/src/cli/jsonrpc.ts
+++ b/agent/src/cli/jsonrpc.ts
@@ -53,7 +53,7 @@ function expiryStrategyOption(value: string): EXPIRY_STRATEGY {
 
 const isDebugMode = process.env.CODY_AGENT_DEBUG_REMOTE === 'true'
 const debugPort = process.env.CODY_AGENT_DEBUG_PORT
-    ? parseInt(process.env.CODY_AGENT_DEBUG_PORT, 10)
+    ? Number.parseInt(process.env.CODY_AGENT_DEBUG_PORT, 10)
     : 3113
 
 export const jsonrpcCommand = new Command('jsonrpc')

--- a/biome.json
+++ b/biome.json
@@ -8,15 +8,7 @@
     "rules": {
       "recommended": true,
       "nursery": {
-        "useExportType": "error",
-        "useImportType": "error",
-        "useGroupedTypeImport": "error",
-        "noUnusedImports": "error",
-        "noUnusedPrivateClassMembers": "error",
-        "noInvalidUseBeforeDeclaration": "error",
-        "noUselessTernary": "error",
-        "noDuplicateJsonKeys": "error",
-        "useNodejsImportProtocol": "error"
+        "noDuplicateJsonKeys": "error"
       },
       "suspicious": {
         "noExplicitAny": "off"
@@ -24,7 +16,18 @@
       "style": {
         "noNonNullAssertion": "off",
         "noParameterAssign": "off",
-        "useTemplate": "off"
+        "useTemplate": "off",
+        "useNodejsImportProtocol": "error",
+        "useImportType": "error",
+        "useExportType": "error"
+      },
+      "complexity": {
+        "noUselessTernary": "error"
+      },
+      "correctness": {
+        "noInvalidUseBeforeDeclaration": "error",
+        "noUnusedPrivateClassMembers": "error",
+        "noUnusedImports": "error"
       }
     }
   },
@@ -60,19 +63,14 @@
       "vite.config.ts",
       "__snapshots__/",
       "__mocks__/",
-      ".vscode-test/"
+      ".vscode-test/",
+      "**/.tsconfig.json",
+      "**/tsconfig.json",
+      ".vscode/*.json",
+      "**/fixtures/**"
     ]
   },
   "overrides": [
-    {
-      "include": [".vscode/*.json"],
-      "json": {
-        "parser": {
-          "allowComments": true,
-          "allowTrailingCommas": true
-        }
-      }
-    },
     {
       "include": ["*.json"],
       "json": {

--- a/lib/shared/src/common/markdown/markdown.ts
+++ b/lib/shared/src/common/markdown/markdown.ts
@@ -97,15 +97,15 @@ export const renderMarkdown = (markdown: string, options: MarkdownOptions = {}):
             ? options.dompurifyConfig
             : options.plainText
               ? {
-                      ALLOWED_TAGS: [],
-                      ALLOWED_ATTR: [],
-                      KEEP_CONTENT: true,
-                  }
+                    ALLOWED_TAGS: [],
+                    ALLOWED_ATTR: [],
+                    KEEP_CONTENT: true,
+                }
               : {
-                      USE_PROFILES: { html: true },
-                      FORBID_TAGS: ['style', 'form', 'input', 'button'],
-                      FORBID_ATTR: ['rel', 'style', 'method', 'action'],
-                  }
+                    USE_PROFILES: { html: true },
+                    FORBID_TAGS: ['style', 'form', 'input', 'button'],
+                    FORBID_ATTR: ['rel', 'style', 'method', 'action'],
+                }
 
     if (options.addTargetBlankToAllLinks) {
         // Add a hook that adds target="_blank" and rel="noopener" to all links. DOMPurify does not

--- a/lib/shared/src/common/path.ts
+++ b/lib/shared/src/common/path.ts
@@ -1,6 +1,6 @@
 import type { URI } from 'vscode-uri'
 
-import { isMacOS, isWindows as _isWindows } from './platform'
+import { isWindows as _isWindows, isMacOS } from './platform'
 
 interface PathFunctions {
     /**

--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -38,7 +38,7 @@ export class RateLimitError extends Error {
         }.`
         this.retryAfterDate = retryAfter
             ? /^\d+$/.test(retryAfter)
-                ? new Date(Date.now() + parseInt(retryAfter, 10) * 1000)
+                ? new Date(Date.now() + Number.parseInt(retryAfter, 10) * 1000)
                 : new Date(retryAfter)
             : undefined
         this.retryMessage = this.retryAfterDate ? formatRetryAfterDate(this.retryAfterDate) : undefined

--- a/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
+++ b/lib/shared/src/telemetry-v2/TelemetryRecorderProvider.ts
@@ -1,8 +1,8 @@
 import {
+    TelemetryRecorderProvider as BaseTelemetryRecorderProvider,
     NoOpTelemetryExporter,
     type TelemetryEventInput,
     type TelemetryProcessor,
-    TelemetryRecorderProvider as BaseTelemetryRecorderProvider,
     TestTelemetryExporter,
     TimestampTelemetryProcessor,
     defaultEventRecordingOptions,

--- a/lints/git-diff-ts-ranges.ts
+++ b/lints/git-diff-ts-ranges.ts
@@ -26,8 +26,8 @@ exec('git diff --unified=0 origin/main', (error, stdout, stderr) => {
             // Extract the line numbers for additions
             const match = line.match(/\+([0-9]+),?([0-9]*)/)
             if (match) {
-                const start = parseInt(match[1], 10)
-                const count = parseInt(match[2] || '1', 10)
+                const start = Number.parseInt(match[1], 10)
+                const count = Number.parseInt(match[2] || '1', 10)
                 const end = start + count - 1
                 if (count > 0) {
                     // Ensure we only add ranges where lines were added

--- a/lints/safe-prompts.ts
+++ b/lints/safe-prompts.ts
@@ -123,7 +123,7 @@ for (const row of fileNames) {
             if (ranges === null) {
                 ranges = []
             }
-            ranges.push({ start: parseInt(start), end: parseInt(end) })
+            ranges.push({ start: Number.parseInt(start), end: Number.parseInt(end) })
         }
 
         // Parse a file

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "update-symf-recordings": "rm -rf recordings && CODY_RECORD_IF_MISSING=true vitest vscode/src/local-context/symf.test.ts"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.5.2",
+    "@biomejs/biome": "1.7.2",
     "@sourcegraph/tsconfig": "^4.0.1",
     "@storybook/addon-essentials": "^8.0.5",
     "@storybook/react": "^8.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         version: 8.2.0
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.7.2
+        version: 1.7.2
       '@sourcegraph/tsconfig':
         specifier: ^4.0.1
         version: 4.0.1
@@ -1955,88 +1955,88 @@ packages:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
     dev: true
 
-  /@biomejs/biome@1.5.2:
-    resolution: {integrity: sha512-LhycxGQBQLmfv6M3e4tMfn/XKcUWyduDYOlCEBrHXJ2mMth2qzYt1JWypkWp+XmU/7Hl2dKvrP4mZ5W44+nWZw==}
-    engines: {node: '>=14.*'}
+  /@biomejs/biome@1.7.2:
+    resolution: {integrity: sha512-6Skx9N47inLQzYi9RKgJ7PBnUnaHnMe/imqX43cOcJjZtfMnQLxEvfM2Eyo7gChkwrZlwc+VbA4huFRjw2fsYA==}
+    engines: {node: '>=14.21.3'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.5.2
-      '@biomejs/cli-darwin-x64': 1.5.2
-      '@biomejs/cli-linux-arm64': 1.5.2
-      '@biomejs/cli-linux-arm64-musl': 1.5.2
-      '@biomejs/cli-linux-x64': 1.5.2
-      '@biomejs/cli-linux-x64-musl': 1.5.2
-      '@biomejs/cli-win32-arm64': 1.5.2
-      '@biomejs/cli-win32-x64': 1.5.2
+      '@biomejs/cli-darwin-arm64': 1.7.2
+      '@biomejs/cli-darwin-x64': 1.7.2
+      '@biomejs/cli-linux-arm64': 1.7.2
+      '@biomejs/cli-linux-arm64-musl': 1.7.2
+      '@biomejs/cli-linux-x64': 1.7.2
+      '@biomejs/cli-linux-x64-musl': 1.7.2
+      '@biomejs/cli-win32-arm64': 1.7.2
+      '@biomejs/cli-win32-x64': 1.7.2
     dev: true
 
-  /@biomejs/cli-darwin-arm64@1.5.2:
-    resolution: {integrity: sha512-3JVl08aHKsPyf0XL9SEj1lssIMmzOMAn2t1zwZKBiy/mcZdb0vuyMSTM5haMQ/90wEmrkYN7zux777PHEGrGiw==}
-    engines: {node: '>=14.*'}
+  /@biomejs/cli-darwin-arm64@1.7.2:
+    resolution: {integrity: sha512-CrldIueHivWEWmeTkK8bTXajeX53F8i2Rrkkt8cPZyMtzkrwxf8Riq4a/jz3SQBHkxHFT4TqGbSTNMXe3X1ogA==}
+    engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@biomejs/cli-darwin-x64@1.5.2:
-    resolution: {integrity: sha512-QAPW9rZb/AgucUx+ogMg+9eJNipQDqvabktC5Tx4Aqb/mFzS6eDqNP7O0SbGz3DtC5Y2LATEj6o6zKIQ4ZT+3w==}
-    engines: {node: '>=14.*'}
+  /@biomejs/cli-darwin-x64@1.7.2:
+    resolution: {integrity: sha512-UELnLJuJOsTL9meArvn8BtiXDURyPil2Ej9me2uVpEvee8UQdqd/bssP5we400OWShlL1AAML4fn6d2WX5332g==}
+    engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64-musl@1.5.2:
-    resolution: {integrity: sha512-Z29SjaOyO4QfajplNXSjLx17S79oPN42D094zjE24z7C7p3NxvLhKLygtSP9emgaXkcoESe2chOzF4IrGy/rlg==}
-    engines: {node: '>=14.*'}
+  /@biomejs/cli-linux-arm64-musl@1.7.2:
+    resolution: {integrity: sha512-kKYZiem7Sj7wI0dpVxJlK7C+TFQwzO/ctufIGXGJAyEmUe9vEKSzV8CXpv+JIRiTWyqaZJ4K+eHz4SPdPCv05w==}
+    engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-arm64@1.5.2:
-    resolution: {integrity: sha512-fVLrUgIlo05rO4cNu+Py5EwwmXnXhWH+8KrNlWkr2weMYjq85SihUsuWWKpmqU+bUVR+m5gwfcIXZVWYVCJMHw==}
-    engines: {node: '>=14.*'}
+  /@biomejs/cli-linux-arm64@1.7.2:
+    resolution: {integrity: sha512-Z1CSGQE6fHz55gkiFHv9E8wEAaSUd7dHSRaxSCBa7utonHqpIeMbvj3Evm1w0WfGLFDtRXLV1fTfEdM0FMTOhA==}
+    engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64-musl@1.5.2:
-    resolution: {integrity: sha512-ZolquPEjWYUmGeERS8svHOOT7OXEeoriPnV8qptgWJmYF9EO9HUGRn1UtCvdVziDYK+u1A7PxjOdkY1B00ty5A==}
-    engines: {node: '>=14.*'}
+  /@biomejs/cli-linux-x64-musl@1.7.2:
+    resolution: {integrity: sha512-x10LpGMepDrLS+h2TZ6/T7egpHjGKtiI4GuShNylmBQJWfTotbFf9eseHggrqJ4WZf9yrGoVYrtbxXftuB95sQ==}
+    engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@biomejs/cli-linux-x64@1.5.2:
-    resolution: {integrity: sha512-ixqJtUHtF0ho1+1DTZQLAEwHGSqvmvHhAAFXZQoaSdABn+IcITYExlFVA3bGvASy/xtPjRhTx42hVwPtLwMHwg==}
-    engines: {node: '>=14.*'}
+  /@biomejs/cli-linux-x64@1.7.2:
+    resolution: {integrity: sha512-vXXyox8/CQijBxAu0+r8FfSO7JlC4tob3PbaFda8gPJFRz2uFJw39HtxVUwbTV1EcU6wSPh4SiRu5sZfP1VHrQ==}
+    engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-arm64@1.5.2:
-    resolution: {integrity: sha512-DN4cXSAoFTdjOoh7f+JITj1uQgQSXt+1pVea9bFrpbgip+ZwkONqQq+jUcmFMMehbp9LuiVtNXFz/ReHn6FY7A==}
-    engines: {node: '>=14.*'}
+  /@biomejs/cli-win32-arm64@1.7.2:
+    resolution: {integrity: sha512-kRXdlKzcU7INf6/ldu0nVmkOgt7bKqmyXRRCUqqaJfA32+9InTbkD8tGrHZEVYIWr+eTuKcg16qZVDsPSDFZ8g==}
+    engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@biomejs/cli-win32-x64@1.5.2:
-    resolution: {integrity: sha512-YvWWXZmk936FdrXqc2jcP6rfsXsNBIs9MKBQQoVXIihwNNRiAaBD9Iwa/ouU1b7Zxq2zETgeuRewVJickFuVOw==}
-    engines: {node: '>=14.*'}
+  /@biomejs/cli-win32-x64@1.7.2:
+    resolution: {integrity: sha512-qHTtpAs+CNglAAuaTy09htoqUhrQyd3nd0aGTuLNqD10h1llMVi8WFZfoa+e5MuDSfYtMK6nW2Tbf6WgzzR1Qw==}
+    engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true

--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -162,5 +162,5 @@ main().catch(console.error)
 
 function extractPreviousMinor(majorAndMinor: string): string {
     const [major, minor] = majorAndMinor.split('.')
-    return `${major}.${parseInt(minor) - 1}`
+    return `${major}.${Number.parseInt(minor) - 1}`
 }

--- a/vscode/src/chat/chat-view/InitDoer.ts
+++ b/vscode/src/chat/chat-view/InitDoer.ts
@@ -12,19 +12,17 @@ export class InitDoer<R> {
         if (this.isInitialized) {
             return
         }
-        {
-            // This block must execute synchronously, because this.isInitialized
-            // and this.onInitTodos must be updated atomically.
-            this.isInitialized = true
-            for (const { todo, onDone, onError } of this.onInitTodos) {
-                try {
-                    Promise.resolve(todo()).then(onDone, onError)
-                } catch (error) {
-                    onError(isError(error) ? error : new Error(`${error}`))
-                }
+        // This block must execute synchronously, because this.isInitialized
+        // and this.onInitTodos must be updated atomically.
+        this.isInitialized = true
+        for (const { todo, onDone, onError } of this.onInitTodos) {
+            try {
+                Promise.resolve(todo()).then(onDone, onError)
+            } catch (error) {
+                onError(isError(error) ? error : new Error(`${error}`))
             }
-            this.onInitTodos = []
         }
+        this.onInitTodos = []
     }
 
     public do(todo: () => Thenable<R> | R): Thenable<R> {

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -44,19 +44,19 @@ export type WebviewMessage =
     | { command: 'initialized' }
     | {
           /**
-             * @deprecated v1 telemetry RPC - use 'recordEvent' instead
-             */
+           * @deprecated v1 telemetry RPC - use 'recordEvent' instead
+           */
           command: 'event'
           eventName: string
           properties: TelemetryEventProperties | undefined
       }
     | {
           /**
-             * DO NOT USE DIRECTLY - ALWAYS USE a TelemetryRecorder from
-             * createWebviewTelemetryRecorder instead for webviews.
-             *
-             * V2 telemetry RPC for the webview.
-             */
+           * DO NOT USE DIRECTLY - ALWAYS USE a TelemetryRecorder from
+           * createWebviewTelemetryRecorder instead for webviews.
+           *
+           * V2 telemetry RPC for the webview.
+           */
           command: 'recordEvent'
           // 👷 HACK: WARNING: We use looser string types instead of the actual SDK at
           // '@sourcegraph/cody-shared/src/telemetry-v2' because this defines a

--- a/vscode/src/completions/client.ts
+++ b/vscode/src/completions/client.ts
@@ -243,7 +243,7 @@ export async function createRateLimitErrorFromResponse(
         'autocompletions',
         await response.text(),
         upgradeIsAvailable,
-        limit ? parseInt(limit, 10) : undefined,
+        limit ? Number.parseInt(limit, 10) : undefined,
         retryAfter
     )
 }

--- a/vscode/src/completions/context/retrievers/tsc/SymbolFormatter.ts
+++ b/vscode/src/completions/context/retrievers/tsc/SymbolFormatter.ts
@@ -56,8 +56,8 @@ export class SymbolFormatter {
                 : ts.isFunctionDeclaration(declaration)
                   ? declaration
                   : ts.isMethodDeclaration(declaration)
-                      ? declaration
-                      : undefined
+                    ? declaration
+                    : undefined
         }
         const signature = (): string | undefined => {
             const signatureDeclaration = asSignatureDeclaration(identifier, sym)

--- a/vscode/src/completions/context/retrievers/tsc/ts-internals.ts
+++ b/vscode/src/completions/context/retrievers/tsc/ts-internals.ts
@@ -48,8 +48,8 @@ export function isParameter(sym: ts.Symbol): boolean {
         ts.isParameter(node)
             ? true
             : ts.isBindingElement(node) ||
-                  ts.isObjectBindingPattern(node) ||
-                  ts.isArrayBindingPattern(node)
+                ts.isObjectBindingPattern(node) ||
+                ts.isArrayBindingPattern(node)
               ? false
               : 'quit'
     )

--- a/vscode/src/completions/get-inline-completions.ts
+++ b/vscode/src/completions/get-inline-completions.ts
@@ -327,7 +327,7 @@ async function doGetInlineCompletions(
         : triggerKind !== TriggerKind.Automatic
           ? 0
           : ((multiline ? debounceInterval?.multiLine : debounceInterval?.singleLine) ?? 0) +
-              (artificialDelay ?? 0)
+            (artificialDelay ?? 0)
 
     // We split the desired debounceTime into two chunks. One that is at most 25ms where every
     // further execution is halted...

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -293,8 +293,8 @@ export class InlineCompletionItemProvider
                     : context.triggerKind === vscode.InlineCompletionTriggerKind.Automatic
                       ? TriggerKind.Automatic
                       : takeSuggestWidgetSelectionIntoAccount
-                          ? TriggerKind.SuggestWidget
-                          : TriggerKind.Hover
+                        ? TriggerKind.SuggestWidget
+                        : TriggerKind.Hover
             this.lastManualCompletionTimestamp = null
 
             const docContext = getCurrentDocContext({

--- a/vscode/src/completions/nodeClient.ts
+++ b/vscode/src/completions/nodeClient.ts
@@ -158,7 +158,7 @@ export class SourcegraphNodeCompletionsClient extends SourcegraphCompletionsClie
                                 'chat messages and commands',
                                 e.message,
                                 upgradeIsAvailable,
-                                limit ? parseInt(limit, 10) : undefined,
+                                limit ? Number.parseInt(limit, 10) : undefined,
                                 retryAfter
                             )
                             onErrorOnce(error, res.statusCode)

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -542,8 +542,8 @@ export function createProviderConfig({
             : ['starcoder-hybrid', 'starcoder2-hybrid'].includes(model)
               ? (model as FireworksModel)
               : Object.prototype.hasOwnProperty.call(MODEL_MAP, model)
-                  ? (model as keyof typeof MODEL_MAP)
-                  : null
+                ? (model as keyof typeof MODEL_MAP)
+                : null
 
     if (resolvedModel === null) {
         throw new Error(`Unknown model: \`${model}\``)

--- a/vscode/src/completions/providers/openaicompatible.ts
+++ b/vscode/src/completions/providers/openaicompatible.ts
@@ -328,8 +328,8 @@ export function createProviderConfig({
             : model === 'starcoder-hybrid'
               ? 'starcoder-hybrid'
               : Object.prototype.hasOwnProperty.call(MODEL_MAP, model)
-                  ? (model as keyof typeof MODEL_MAP)
-                  : null
+                ? (model as keyof typeof MODEL_MAP)
+                : null
 
     if (resolvedModel === null) {
         throw new Error(`Unknown model: \`${model}\``)

--- a/vscode/src/completions/text-processing/parse-completion.ts
+++ b/vscode/src/completions/text-processing/parse-completion.ts
@@ -1,5 +1,5 @@
 import type { TextDocument } from 'vscode'
-import type { Point, Tree, default as Parser } from 'web-tree-sitter'
+import type { default as Parser, Point, Tree } from 'web-tree-sitter'
 
 import { addAutocompleteDebugEvent } from '../../services/open-telemetry/debug-utils'
 import { asPoint, getCachedParseTreeForDocument } from '../../tree-sitter/parse-tree-cache'
@@ -111,7 +111,6 @@ function pasteCompletion(params: PasteCompletionParams): PasteCompletionResult {
         docContext: {
             position,
             currentLineSuffix,
-            // biome-ignore lint/nursery/noInvalidUseBeforeDeclaration: it's actually correct
             positionWithoutInjectedCompletionText = position,
             injectedCompletionText = '',
         },

--- a/vscode/src/completions/tracer/traceView.ts
+++ b/vscode/src/completions/tracer/traceView.ts
@@ -162,12 +162,12 @@ ${
               ),
               data.completionProviderCallResult.debugMessage
                   ? codeDetailsWithSummary(
-                          'Timing',
-                          data.completionProviderCallResult.debugMessage,
-                          undefined,
-                          undefined,
-                          true
-                      )
+                        'Timing',
+                        data.completionProviderCallResult.debugMessage,
+                        undefined,
+                        undefined,
+                        true
+                    )
                   : null,
           ]
               .filter(isDefined)
@@ -195,8 +195,8 @@ ${
         : data.result.items.length === 0
           ? 'Empty completions.'
           : data.result.items
-                  .map(item => inlineCompletionItemDescription(item, data.params?.document))
-                  .join('\n\n---\n\n')
+                .map(item => inlineCompletionItemDescription(item, data.params?.document))
+                .join('\n\n---\n\n')
 }`,
 
         data?.error &&

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -414,11 +414,11 @@ export const getInput = async (
                                         : NO_PACKAGE_MATCHES_LABEL
                                     : mentionQuery.provider === 'symbol'
                                       ? mentionQuery.text.length === 0
-                                            ? SYMBOL_HELP_LABEL
-                                            : NO_SYMBOL_MATCHES_LABEL
+                                          ? SYMBOL_HELP_LABEL
+                                          : NO_SYMBOL_MATCHES_LABEL
                                       : mentionQuery.text.length === 0
-                                          ? FILE_HELP_LABEL
-                                          : NO_FILE_MATCHES_LABEL,
+                                        ? FILE_HELP_LABEL
+                                        : NO_FILE_MATCHES_LABEL,
                         },
                     ]
                     return
@@ -466,8 +466,8 @@ export const getInput = async (
                                 : mentionQuery?.provider === 'symbol'
                                   ? SYMBOL_HELP_LABEL
                                   : mentionQuery?.provider === 'file'
-                                      ? FILE_HELP_LABEL
-                                      : GENERAL_HELP_LABEL,
+                                    ? FILE_HELP_LABEL
+                                    : GENERAL_HELP_LABEL,
                     },
                 ]
             },

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -509,8 +509,8 @@ export const workspaceFs: typeof vscode_types.workspace.fs = {
             : stat.isDirectory()
               ? FileType.Directory
               : stat.isSymbolicLink()
-                  ? FileType.SymbolicLink
-                  : FileType.Unknown
+                ? FileType.SymbolicLink
+                : FileType.Unknown
 
         return {
             type,
@@ -530,8 +530,8 @@ export const workspaceFs: typeof vscode_types.workspace.fs = {
                 : entry.isDirectory()
                   ? FileType.Directory
                   : entry.isSymbolicLink()
-                      ? FileType.SymbolicLink
-                      : FileType.Unknown
+                    ? FileType.SymbolicLink
+                    : FileType.Unknown
 
             return [entry.name, type]
         })

--- a/vscode/src/testutils/textDocument.ts
+++ b/vscode/src/testutils/textDocument.ts
@@ -1,4 +1,4 @@
-import type { EndOfLine, Position, Range, TextDocument as VSCodeTextDocument, TextLine } from 'vscode'
+import type { EndOfLine, Position, Range, TextLine, TextDocument as VSCodeTextDocument } from 'vscode'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
 

--- a/vscode/src/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/tree-sitter/parse-tree-cache.ts
@@ -1,7 +1,7 @@
 import { LRUCache } from 'lru-cache'
 import * as vscode from 'vscode'
 import type { TextDocument } from 'vscode'
-import type { Tree, default as Parser } from 'web-tree-sitter'
+import type { default as Parser, Tree } from 'web-tree-sitter'
 
 import { type SupportedLanguage, isSupportedLanguage } from './grammars'
 import { type WrappedParser, createParser, getParser } from './parser'

--- a/vscode/src/tree-sitter/query-sdk.ts
+++ b/vscode/src/tree-sitter/query-sdk.ts
@@ -2,12 +2,12 @@ import { findLast } from 'lodash'
 import type { Position, TextDocument } from 'vscode'
 import type {
     Language,
+    default as Parser,
     Point,
     Query,
     QueryCapture,
     SyntaxNode,
     Tree,
-    default as Parser,
 } from 'web-tree-sitter'
 
 import { type SupportedLanguage, isSupportedLanguage } from './grammars'

--- a/vscode/src/tree-sitter/query-tests/annotate-and-match-snapshot.ts
+++ b/vscode/src/tree-sitter/query-tests/annotate-and-match-snapshot.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import dedent from 'dedent'
 import { findLast } from 'lodash'
 import { expect } from 'vitest'
-import type { Point, SyntaxNode, default as Parser } from 'web-tree-sitter'
+import type { default as Parser, Point, SyntaxNode } from 'web-tree-sitter'
 
 import type { SupportedLanguage } from '../grammars'
 import { getLanguageConfig } from '../language'

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -11,8 +11,8 @@ import {
 import {
     type DotcomUrlOverride,
     type ExpectedEvents,
-    openCustomCommandMenu,
     test as baseTest,
+    openCustomCommandMenu,
     withPlatformSlashes,
 } from './helpers'
 import { testGitWorkspace } from './utils/gitWorkspace'

--- a/vscode/test/e2e/helpers.ts
+++ b/vscode/test/e2e/helpers.ts
@@ -1,17 +1,17 @@
 import * as child_process from 'node:child_process'
 import {
+    promises as fs,
     type PathLike,
     type RmOptions,
     mkdir,
     mkdtempSync,
-    promises as fs,
     rmSync,
     writeFile,
 } from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
-import { type Frame, type FrameLocator, type Page, expect, test as base } from '@playwright/test'
+import { type Frame, type FrameLocator, type Page, test as base, expect } from '@playwright/test'
 import { _electron as electron } from 'playwright'
 import * as uuid from 'uuid'
 

--- a/vscode/test/e2e/troubleshooting-authConnection.test.ts
+++ b/vscode/test/e2e/troubleshooting-authConnection.test.ts
@@ -13,8 +13,8 @@ import {
     type DotcomUrlOverride,
     type ExpectedEvents,
     type TestConfiguration,
-    executeCommandInPalette,
     test as baseTest,
+    executeCommandInPalette,
 } from './helpers'
 
 const test = baseTest

--- a/vscode/test/e2e/tutorial.test.ts
+++ b/vscode/test/e2e/tutorial.test.ts
@@ -3,9 +3,9 @@ import * as mockServer from '../fixtures/mock-server'
 import { sidebarSignin } from './common'
 import {
     type DotcomUrlOverride,
+    test as baseTest,
     executeCommandInPalette,
     getMetaKeyByOS,
-    test as baseTest,
 } from './helpers'
 import { acceptInlineCompletion, triggerInlineCompletion } from './utils/completions'
 import { triggerFix } from './utils/edit'

--- a/vscode/webviews/Components/FileLink.tsx
+++ b/vscode/webviews/Components/FileLink.tsx
@@ -71,7 +71,6 @@ export const FileLink: React.FunctionComponent<FileLinkProps & { className?: str
     return (
         <div className={classNames(styles.linkContainer, className)}>
             {isTooLarge && <i className="codicon codicon-warning" title={WARNING} />}
-            {/* biome-ignore lint/a11y/useValidAnchor: The onClick handler is only used for logging */}
             <a
                 className={styles.linkButton}
                 title={tooltip}

--- a/vscode/webviews/OnboardingExperiment.tsx
+++ b/vscode/webviews/OnboardingExperiment.tsx
@@ -40,7 +40,6 @@ const WebLogin: React.FunctionComponent<
                 </a>
             </li>
             <li>
-                {/* biome-ignore lint/a11y/useValidAnchor: can fix with a lot of CSS but not a priority */}
                 <a
                     href="about:blank"
                     onClick={event => {

--- a/vscode/webviews/SearchPanel.tsx
+++ b/vscode/webviews/SearchPanel.tsx
@@ -269,6 +269,7 @@ export const SearchPanel: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> 
             <div className={styles.searchResultsContainer}>
                 {results.map((result, fileIndex) => (
                     <>
+                        {/* biome-ignore lint/correctness/useJsxKeyInIterable: Each of the possible divs below have an appropriate key. */}
                         {/* File result */}
                         <div
                             key={`${result.uri.toString()}`}

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -169,8 +169,8 @@ function getLineRangeInMention(query: string, range?: RangeData): string {
     const queryRange = query.match(RANGE_MATCHES_REGEXP)
     if (query && queryRange?.[1]) {
         const [_, start, end] = queryRange
-        const startLine = parseInt(start)
-        const endLine = end ? parseInt(end) : Number.POSITIVE_INFINITY
+        const startLine = Number.parseInt(start)
+        const endLine = end ? Number.parseInt(end) : Number.POSITIVE_INFINITY
         return `${startLine}-${endLine !== Number.POSITIVE_INFINITY ? endLine : '#'}`
     }
     // Passed in range string if no line number match.

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -47,8 +47,8 @@ export function parseLineRangeInMention(text: string): {
         return { textWithoutRange: text }
     }
 
-    let startLine = parseInt(match[1], 10)
-    let endLine = parseInt(match[2], 10)
+    let startLine = Number.parseInt(match[1], 10)
+    let endLine = Number.parseInt(match[2], 10)
     if (startLine > endLine) {
         // Reverse range so that startLine is always before endLine.
         ;[startLine, endLine] = [endLine, startLine]


### PR DESCRIPTION
Upgrades Biome, as Data Team wants to use https://biomejs.dev/linter/rules/no-restricted-imports/, which is not available in the version of Biome we are currently using.

It seems like quite a lot has changed within Biome - I've migrated the rules that have been promoted out of `nursery` into their modern equivalents.

## Test plan

`pnpm run biome` exits with status 0 locally, required CI passes