### PR TITLE
Cheapen CI workflow by running macOS for main commits only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   # Sets a variable that is used to determine the matrix to run e2e tests on.
-  # Only commits to main run on Windows and macOS.
+  # Everything runs on ubuntu and windows, only commits to main run on macos.
   main_commit_matrix_prep:
     runs-on: ubuntu-latest
     outputs:
@@ -21,15 +21,15 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" == "push" ] && [ "$GITHUB_REF" == "refs/heads/main" ]; then
             echo 'matrix=["ubuntu","windows","macos"]' >> $GITHUB_OUTPUT
           else
-            echo 'matrix=["ubuntu"]' >> $GITHUB_OUTPUT
+            echo 'matrix=["ubuntu","windows"]' >> $GITHUB_OUTPUT
           fi
 
   test-unit:
-    needs: build
+    needs: main_commit_matrix_prep
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu, windows, macos]
+        runner: ${{ fromJson(needs.main_commit_matrix_prep.outputs.matrix) }}
         # Run on the most recently supported version of node for all bots.
         node: [20]
         include:
@@ -62,11 +62,10 @@ jobs:
           CODY_NODE_VERSION: ${{ matrix.node }}
 
   test-integration:
-    needs: [build, main_commit_matrix_prep]
+    needs: main_commit_matrix_prep
     strategy:
       fail-fast: false
       matrix:
-        # Only run on Windows and macOS for main CI
         runner: ${{ fromJson(needs.main_commit_matrix_prep.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 15
@@ -92,7 +91,6 @@ jobs:
         if: matrix.runner == 'windows' || matrix.runner == 'macos'
 
   test-e2e:
-    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -159,6 +157,7 @@ jobs:
     needs: build
     runs-on: macos-latest-large
     name: 'test-e2e (macos)'
+    if: github.event_name == 'push' && github.ref =='refs/heads/main'
     timeout-minutes: 15
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Sets a variable that is used to determine the matrix to run e2e tests on.
+  # Only commits to main run on Windows and macOS.
+  main_commit_matrix_prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+            echo 'matrix=["ubuntu","windows","macos"]' >> $GITHUB_OUTPUT
+          else
+            echo 'matrix=["ubuntu"]' >> $GITHUB_OUTPUT
+          fi
+
   test-unit:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -46,10 +62,12 @@ jobs:
           CODY_NODE_VERSION: ${{ matrix.node }}
 
   test-integration:
+    needs: [build, main_commit_matrix_prep]
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu, windows, macos]
+        # Only run on Windows and macOS for main CI
+        runner: ${{ fromJson(needs.main_commit_matrix_prep.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}-latest
     timeout-minutes: 15
     steps:
@@ -71,9 +89,10 @@ jobs:
       - run: xvfb-run -a pnpm -C vscode run test:integration
         if: matrix.runner == 'ubuntu'
       - run: pnpm -C vscode run test:integration
-        if: github.ref == 'refs/heads/main' && (matrix.runner == 'windows' || matrix.runner == 'macos')
+        if: matrix.runner == 'windows' || matrix.runner == 'macos'
 
   test-e2e:
+    needs: build
     strategy:
       fail-fast: false
       matrix:
@@ -137,6 +156,7 @@ jobs:
   # updating the required status checks for merging PRs. Ideally it would just
   # be https://github.com/sourcegraph/cody/blob/21a40be7297da70f310350e2557a069ea06326ce/.github/workflows/ci.yml#L76
   test-e2e-macos:
+    needs: build
     runs-on: macos-latest-large
     name: 'test-e2e (macos)'
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          if [ "$GITHUB_REF" == "refs/heads/main" ]; then
+          if [ "$GITHUB_EVENT_NAME" == "push" ] && [ "$GITHUB_REF" == "refs/heads/main" ]; then
             echo 'matrix=["ubuntu","windows","macos"]' >> $GITHUB_OUTPUT
           else
             echo 'matrix=["ubuntu"]' >> $GITHUB_OUTPUT


### PR DESCRIPTION
Cheapen our GitHub actions by only running on macOS for commits to main.

No changes to branch protection rules necessary; these do not depend on macos.

## Test plan

CI