### PR TITLE
Alt/Opt+Enter submits a chat message without enhanced context

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: The context window for the `Claude 3 Sonnet` and `Claude 3 Opus` models is now increased by default for all non-Enterprise users, without requiring a feature flag. [pull/3953](https://github.com/sourcegraph/cody/pull/3953)
 - Custom Commands: Added the ability to create new custom Edit commands via the Custom Command Menu. [pull/3862](https://github.com/sourcegraph/cody/pull/3862)
 - Custom Commands: Added 'currentFile' option to include the full file content in the Custom Commands menu. [pull/3960](https://github.com/sourcegraph/cody/pull/3960)
+- Chat: Pressing <kbd>Alt+Enter</kbd> or <kbd>Opt+Enter</kbd> will submit a chat message without enhanced context (only @-mentions). [pull/3996](https://github.com/sourcegraph/cody/pull/3996)
 
 ### Fixed
 

--- a/vscode/webviews/Components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/Components/EnhancedContextSettings.tsx
@@ -3,13 +3,14 @@ import * as React from 'react'
 import { VSCodeButton, VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react'
 import classNames from 'classnames'
 
-import type {
-    ContextGroup,
-    ContextProvider,
-    EnhancedContextContextT,
-    LocalEmbeddingsProvider,
-    LocalSearchProvider,
-    RemoteSearchProvider,
+import {
+    type ContextGroup,
+    type ContextProvider,
+    type EnhancedContextContextT,
+    type LocalEmbeddingsProvider,
+    type LocalSearchProvider,
+    type RemoteSearchProvider,
+    isMacOS,
 } from '@sourcegraph/cody-shared'
 import { useEnhancedContextEnabled } from '../chat/EnhancedContext'
 
@@ -244,8 +245,8 @@ const EmbeddingsConsentComponent: React.FunctionComponent<{ provider: LocalEmbed
         <div>
             <p className={styles.providerExplanatoryText}>
                 The repository&apos;s contents will be uploaded to{' '}
-                {provider.embeddingsAPIProvider === 'sourcegraph' ? 'Sourcegraph' : 'OpenAI'}&apos;s
-                Embeddings API and then stored locally.
+                {provider.embeddingsAPIProvider === 'sourcegraph' ? 'Sourcegraph' : 'OpenAI'}
+                &apos;s Embeddings API and then stored locally.
                 {/* To exclude files, set up a <a href="about:blank#TODO">Cody ignore file.</a> */}
             </p>
             <p>
@@ -301,9 +302,9 @@ function contextProviderState(provider: ContextProvider): React.ReactNode {
     }
 }
 
-const ContextProviderComponent: React.FunctionComponent<{ provider: ContextProvider }> = ({
-    provider,
-}) => {
+const ContextProviderComponent: React.FunctionComponent<{
+    provider: ContextProvider
+}> = ({ provider }) => {
     let stateIcon: string | React.ReactElement
     switch (provider.state) {
         case 'indeterminate':
@@ -347,14 +348,14 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     const context = useEnhancedContextContext()
     const [enabled, setEnabled] = React.useState<boolean>(useEnhancedContextEnabled())
     const enabledChanged = React.useCallback(
-        (shouldEnable: boolean, source: 'btn' | 'checkbox'): void => {
+        (shouldEnable: boolean, source: 'btn' | 'checkbox' | 'altKey'): void => {
             if (enabled !== shouldEnable) {
                 events.onEnabledChange(shouldEnable)
                 setEnabled(shouldEnable)
                 // Log when a user clicks on the Enhanced Context toggle. Event names:
                 // Checkbox click: `CodyVSCodeExtension:useEnhancedContextToggler:clicked`
                 // Button click: `CodyVSCodeExtension:useEnhancedContextTogglerBtn:clicked`
-                const eventName = source === 'btn' ? 'Btn' : ''
+                const eventName = source === 'btn' ? 'Btn' : source === 'altKey' ? 'AltKey' : ''
                 getVSCodeAPI().postMessage({
                     command: 'event',
                     eventName: `CodyVSCodeExtension:useEnhancedContextToggler${eventName}:clicked`,
@@ -364,6 +365,29 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
         },
         [events, enabled]
     )
+
+    // Holding down the Alt/Opt key unchecks the box if it is checked.
+    const [disabledByAltKeyDown, setDisabledByAltKeyDown] = React.useState(false)
+    React.useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.altKey && enabled) {
+                setDisabledByAltKeyDown(true)
+                enabledChanged(false, 'altKey')
+            }
+        }
+        const onKeyUp = (event: KeyboardEvent) => {
+            if (!event.altKey && disabledByAltKeyDown) {
+                setDisabledByAltKeyDown(false)
+                enabledChanged(true, 'altKey')
+            }
+        }
+        document.addEventListener('keydown', onKeyDown)
+        document.addEventListener('keyup', onKeyUp)
+        return () => {
+            document.removeEventListener('keydown', onKeyDown)
+            document.removeEventListener('keyup', onKeyUp)
+        }
+    }, [enabled, disabledByAltKeyDown, enabledChanged])
 
     // Handles removing a manually added remote search provider.
     const handleRemoveRemoteSearchRepo = React.useCallback(
@@ -473,7 +497,9 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                 onClick={() => enabledChanged(!enabled, 'btn')}
                 appearance="icon"
                 type="button"
-                title={`${enabled ? 'Disable' : 'Enable'} Enhanced Context`}
+                title={`${enabled ? 'Disable' : 'Enable'} Enhanced Context (hold ${
+                    isMacOS() ? 'Opt' : 'Alt'
+                } to disable)`}
             >
                 {enabled ? <i className="codicon codicon-sparkle" /> : <SparkleSlash />}
             </VSCodeButton>


### PR DESCRIPTION
Holding <kbd>Alt</kbd> or <kbd>Opt</kbd> disables enhanced context, and pressing <kbd>Enter</kbd> while holding that key will submit a chat message without enhanced context (only @-mentions).

This makes it easier to use chat for tasks that do not need enhanced context, such as general code questions and things that only need context from explicitly @-mentioned files.


https://github.com/sourcegraph/cody/assets/1976/a67be857-f70a-4211-bd0f-6f6e9201877e



## Test plan

CI

Also see video: hold down <kbd>Alt</kbd> or <kbd>Opt</kbd> and ensure the checkbox is unchecked, and that it returns to being checked when you stop holding down the key. If the box was unchecked to begin with, holding down the key should not affect it.