### PR TITLE
add OpenCtx context mention provider

### DIFF
--- a/lib/shared/package.json
+++ b/lib/shared/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@microsoft/fetch-event-source": "^2.0.1",
+    "@openctx/client": "^0.0.8",
     "@opentelemetry/api": "^1.7.0",
     "@sourcegraph/telemetry": "^0.16.0",
     "crypto-js": "^4.2.0",

--- a/lib/shared/src/context/openctx/api.ts
+++ b/lib/shared/src/context/openctx/api.ts
@@ -1,0 +1,39 @@
+import type { Annotation, ItemsParams, ItemsResult } from '@openctx/client'
+import type { TextDocument } from 'vscode'
+import type { RangeData } from '../../common/range'
+
+/**
+ * Copied from OpenCtx's VS Code extension sources.
+ */
+export interface OpenCtxExtensionAPI {
+    getItems(params: ItemsParams): Promise<ItemsResult | null>
+    getAnnotations(doc: Pick<TextDocument, 'uri' | 'getText'>): Promise<Annotation<RangeData>[] | null>
+}
+
+let _getAPI: (() => Promise<OpenCtxExtensionAPI | null>) | undefined
+
+/**
+ * Set the handle to the OpenCtx extension API (e.g., from
+ * `vscode.extensions.getExtension('sourcegraph.openctx')`).
+ */
+export function setOpenCtxExtensionAPI(getAPI: () => Promise<OpenCtxExtensionAPI | null>): void {
+    if (_getAPI) {
+        throw new Error('OpenCtx extension API is already set')
+    }
+    _getAPI = getAPI
+}
+
+let _api: Promise<OpenCtxExtensionAPI | null> | undefined
+
+/**
+ * Get a handle to the OpenCtx extension API, set in {@link setOpenCtxExtensionAPI}.
+ */
+export function getOpenCtxExtensionAPI(): Promise<OpenCtxExtensionAPI | null | undefined> {
+    if (!_getAPI) {
+        return Promise.resolve(undefined)
+    }
+    if (!_api) {
+        _api = _getAPI()
+    }
+    return _api
+}

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -244,3 +244,8 @@ export * from './token/constants'
 export * from './configuration'
 export * from './mentions/providers/packageMentions'
 export * from './mentions/providers/sourcegraphSearch'
+export {
+    setOpenCtxExtensionAPI,
+    getOpenCtxExtensionAPI,
+    type OpenCtxExtensionAPI,
+} from './context/openctx/api'

--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -1,5 +1,6 @@
 import type { ContextItem, ContextItemWithContent } from '../codebase-context/messages'
 import type { PromptString } from '../prompt/prompt-string'
+import { OPENCTX_CONTEXT_MENTION_PROVIDER } from './providers/openctxMentions'
 import { PACKAGE_CONTEXT_MENTION_PROVIDER } from './providers/packageMentions'
 import { SOURCEGRAPH_SEARCH_CONTEXT_MENTION_PROVIDER } from './providers/sourcegraphSearch'
 import { URL_CONTEXT_MENTION_PROVIDER } from './providers/urlMentions'
@@ -20,6 +21,7 @@ export const CONTEXT_MENTION_PROVIDERS: ContextMentionProvider[] = [
     URL_CONTEXT_MENTION_PROVIDER,
     PACKAGE_CONTEXT_MENTION_PROVIDER,
     SOURCEGRAPH_SEARCH_CONTEXT_MENTION_PROVIDER,
+    OPENCTX_CONTEXT_MENTION_PROVIDER,
 ]
 
 /**

--- a/lib/shared/src/mentions/providers/openctxMentions.ts
+++ b/lib/shared/src/mentions/providers/openctxMentions.ts
@@ -1,0 +1,42 @@
+import { URI } from 'vscode-uri'
+import type { ContextItemWithContent } from '../../codebase-context/messages'
+import { isDefined } from '../../common'
+import { getOpenCtxExtensionAPI } from '../../context/openctx/api'
+import type { ContextItemFromProvider, ContextMentionProvider } from '../api'
+
+const TRIGGER_PREFIX = 'octx:'
+
+export const OPENCTX_CONTEXT_MENTION_PROVIDER: ContextMentionProvider<'openctx'> = {
+    id: 'openctx',
+    triggerPrefixes: [TRIGGER_PREFIX],
+    async queryContextItems(query) {
+        const openctxAPI = await getOpenCtxExtensionAPI()
+        if (!openctxAPI) {
+            return []
+        }
+        const results = await openctxAPI.getItems({ query: query.slice(TRIGGER_PREFIX.length) })
+        const items =
+            results
+                ?.map((result, i) =>
+                    result.ai?.content
+                        ? ({
+                              type: 'file',
+                              title: result.title,
+                              uri: URI.parse(result.url ?? `openctx-item:${i}`),
+                              provider: 'openctx',
+                              content: result.ai?.content,
+                          } satisfies ContextItemWithContent & ContextItemFromProvider<'openctx'>)
+                        : null
+                )
+                .filter(isDefined) ?? []
+        HACK_LAST_RESULTS = items
+        return items
+    },
+    resolveContextItem(item) {
+        return Promise.resolve(
+            HACK_LAST_RESULTS.filter(({ uri }) => item.uri.toString() === uri.toString())
+        )
+    },
+}
+
+let HACK_LAST_RESULTS: ContextItemWithContent[] & ContextItemFromProvider<'openctx'>[] = []

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       '@microsoft/fetch-event-source':
         specifier: ^2.0.1
         version: 2.0.1
+      '@openctx/client':
+        specifier: ^0.0.8
+        version: 0.0.8
       '@opentelemetry/api':
         specifier: ^1.7.0
         version: 1.7.0
@@ -3148,6 +3151,35 @@ packages:
     dependencies:
       which: 4.0.0
     dev: true
+
+  /@openctx/client@0.0.8:
+    resolution: {integrity: sha512-CJ1jUbbNpbySfYG2fBVyaa8w56eLGjfiUIKR/OtF7BnBjK9OHneV4SzBi3UBrZ0mTHOzr92bUKbehsk86YrZmw==}
+    dependencies:
+      '@openctx/protocol': 0.0.7
+      '@openctx/provider': 0.0.7
+      '@openctx/schema': 0.0.6
+      lru-cache: 10.2.2
+      picomatch: 3.0.1
+      rxjs: 7.8.1
+    dev: false
+
+  /@openctx/protocol@0.0.7:
+    resolution: {integrity: sha512-hUgRrTJk0ixbFZitqI2VLaYh/lG7lEteTZE9u8vLJjVE/R7S9UpaLHVzcMPVRUl6vnyfgODxpMdlNRcCgEa0eg==}
+    dependencies:
+      '@openctx/schema': 0.0.6
+    dev: false
+
+  /@openctx/provider@0.0.7:
+    resolution: {integrity: sha512-3dP77AD0REW37bw2Ou+g1Nk7FmIgj7/T8dvofBKY408LVMrA4gCc/UCoXvmRb2bHDza7Zm3CNXjkUynv1tBgVg==}
+    dependencies:
+      '@openctx/protocol': 0.0.7
+      '@openctx/schema': 0.0.6
+      picomatch: 3.0.1
+    dev: false
+
+  /@openctx/schema@0.0.6:
+    resolution: {integrity: sha512-kmX6dyuKDiJwX0KASv9Yu3hPg9Vm/IYB0MLfDUFORC0IRvs9YWzMgmyVQYF0HoaJ/l8bxmMoyi/0Ks4lCpkpQw==}
+    dev: false
 
   /@opentelemetry/api-logs@0.45.1:
     resolution: {integrity: sha512-zVGq/k70l+kB/Wuv3O/zhptP2hvDhEbhDu9EtHde1iWZJf3FedeYS/nWVcMBkkyPAjS/JKNk86WN4CBQLGUuOw==}
@@ -9539,7 +9571,6 @@ packages:
   /lru-cache@10.2.2:
     resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -10788,6 +10819,11 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  /picomatch@3.0.1:
+    resolution: {integrity: sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==}
+    engines: {node: '>=10'}
+    dev: false
 
   /pify@3.0.0:
     resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
@@ -12953,6 +12989,7 @@ packages:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+    requiresBuild: true
     dev: true
 
   /underscore@1.13.6:

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -1,0 +1,21 @@
+import { type OpenCtxExtensionAPI, setOpenCtxExtensionAPI } from '@sourcegraph/cody-shared'
+import * as vscode from 'vscode'
+
+export function exposeOpenCtxExtensionAPIHandle(): void {
+    setOpenCtxExtensionAPI(async (): Promise<OpenCtxExtensionAPI | null> => {
+        const API_VERSION = 1 as const
+
+        const ext = vscode.extensions.getExtension<OpenCtxVSCodeExtensionAPI>('sourcegraph.openctx')
+        if (!ext) {
+            return null
+        }
+        return (await ext.activate()).apiVersion(API_VERSION)
+    })
+}
+
+interface OpenCtxVSCodeExtensionAPI {
+    /**
+     * If this API changes, the version number will be incremented.
+     */
+    apiVersion(version: 1): OpenCtxExtensionAPI
+}

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -45,6 +45,7 @@ import { newCodyCommandArgs } from './commands/utils/get-commands'
 import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
 import { getConfiguration, getFullConfig } from './configuration'
 import { EnterpriseContextFactory } from './context/enterprise-context-factory'
+import { exposeOpenCtxExtensionAPIHandle } from './context/openctx'
 import { EditManager } from './edit/manager'
 import { manageDisplayPathEnvInfoForExtension } from './editor/displayPathEnvInfo'
 import { VSCodeEditor } from './editor/vscode-editor'
@@ -120,6 +121,8 @@ export async function start(
             }
         })
     )
+
+    exposeOpenCtxExtensionAPIHandle()
 
     return vscode.Disposable.from(...disposables)
 }


### PR DESCRIPTION
Allows any [OpenCtx](https://openctx.org) provider to be used as a `ContextMentionProvider` to provide @-mentionable context.

For example, the [Google Docs OpenCtx provider](https://sourcegraph.com/github.com/sourcegraph/openctx@8b11111e9fccb207828b9b8ec5217a44acaa108d/-/blob/provider/google-docs/index.ts) makes it possible to @-mention Google Docs.

This lets us add more context providers without committing them to the `cody` repo. We can even add them by external HTTP URLs if there is some service that implements the HTTP OpenCtx API.

## Test plan

CI