### PR TITLE
Interactive Tutorial: Add telemetry and improve unhappy paths

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -22,6 +22,7 @@ import { lines } from '../completions/text-processing'
 import { getInput } from '../edit/input/get-input'
 import type { ExtensionClient } from '../extension-client'
 import type { AuthProvider } from '../services/AuthProvider'
+import { isInTutorial } from '../tutorial/helpers'
 import { FixupDecorator } from './FixupDecorator'
 import { FixupDocumentEditObserver } from './FixupDocumentEditObserver'
 import type { FixupFile } from './FixupFile'
@@ -846,6 +847,13 @@ export class FixupController
         task: FixupTask,
         options?: { undoStopBefore: boolean; undoStopAfter: boolean }
     ): Promise<boolean> {
+        if (isInTutorial(document)) {
+            // Skip formatting in tutorial files,
+            // This is an additional enhancement that doesn't add much value to the tutorial
+            // and makes the tutorial UX more error-prone
+            return false
+        }
+
         // Expand the range to include full lines to reduce the likelihood of formatting issues
         const rangeToFormat = new vscode.Range(
             task.selectionRange.start.line,

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -362,7 +362,7 @@ export class AuthProvider {
         if (isExtensionStartup && isLoggedIn) {
             await this.setHasAuthenticatedBefore()
         } else if (isLoggedIn) {
-            this.logFirstEverAuthentication()
+            this.handleFirstEverAuthentication()
         }
 
         await this.storeAuthInfo(url, token)
@@ -492,12 +492,16 @@ export class AuthProvider {
     }
 
     // Logs a telemetry event if the user has never authenticated to Sourcegraph.
-    private logFirstEverAuthentication(): void {
-        if (!localStorage.get(HAS_AUTHENTICATED_BEFORE_KEY)) {
-            telemetryRecorder.recordEvent('cody.auth.login', 'firstEver')
-            this.setHasAuthenticatedBefore()
+    private handleFirstEverAuthentication(): void {
+        if (localStorage.get(HAS_AUTHENTICATED_BEFORE_KEY)) {
+            // User has authenticated before, noop
+            return
         }
+        telemetryRecorder.recordEvent('cody.auth.login', 'firstEver')
+        void vscode.commands.executeCommand('cody.tutorial.start')
+        this.setHasAuthenticatedBefore()
     }
+
     private setHasAuthenticatedBefore() {
         return localStorage.set(HAS_AUTHENTICATED_BEFORE_KEY, 'true')
     }

--- a/vscode/src/services/SidebarCommands.ts
+++ b/vscode/src/services/SidebarCommands.ts
@@ -14,14 +14,14 @@ import { releaseNotesURL } from '../release'
 import { telemetryService } from '../services/telemetry'
 import { version } from '../version'
 
-export function registerSidebarCommands(): vscode.Disposable[] {
-    function logSidebarClick(feature: string) {
-        telemetryService.log(`CodyVSCodeExtension:sidebar:${feature}:clicked`, undefined, {
-            hasV2Event: true,
-        })
-        telemetryRecorder.recordEvent(`cody.sidebar.${feature}`, 'clicked')
-    }
+export function logSidebarClick(feature: string) {
+    telemetryService.log(`CodyVSCodeExtension:sidebar:${feature}:clicked`, undefined, {
+        hasV2Event: true,
+    })
+    telemetryRecorder.recordEvent(`cody.sidebar.${feature}`, 'clicked')
+}
 
+export function registerSidebarCommands(): vscode.Disposable[] {
     return [
         vscode.commands.registerCommand('cody.sidebar.commands', (feature: string, command: string) => {
             // For Custom Commands

--- a/vscode/src/services/tree-views/support-items.ts
+++ b/vscode/src/services/tree-views/support-items.ts
@@ -45,7 +45,7 @@ export const SupportSidebarItems: CodySidebarTreeItem[] = [
     {
         title: 'Tutorial',
         icon: 'tasklist',
-        command: { command: 'cody.tutorial.start' },
+        command: { command: 'cody.sidebar.tutorial' },
         requireFeature: FeatureFlag.CodyInteractiveTutorial,
     },
     {

--- a/vscode/src/services/utils/enrollment-event.ts
+++ b/vscode/src/services/utils/enrollment-event.ts
@@ -1,4 +1,4 @@
-import type { FeatureFlag } from '@sourcegraph/cody-shared'
+import { FeatureFlag } from '@sourcegraph/cody-shared'
 import { telemetryRecorder } from '@sourcegraph/cody-shared'
 import { localStorage } from '../LocalStorageProvider'
 import { telemetryService } from '../telemetry'
@@ -15,7 +15,7 @@ import { telemetryService } from '../telemetry'
 export function logFirstEnrollmentEvent(key: FeatureFlag, isEnabled: boolean): boolean {
     // Check if the user is enrolled in the experiment or not
     const isEnrolled = localStorage.getEnrollmentHistory(key)
-    const eventName = getFeatureFlagEventName(key as FeatureFlag)
+    const eventName = getFeatureFlagEventName(key)
 
     // If the user is already enrolled or the event name is not found, return early,
     // as we only want to log the enrollment event once in the user's lifetime.
@@ -40,6 +40,8 @@ export function logFirstEnrollmentEvent(key: FeatureFlag, isEnabled: boolean): b
  */
 function getFeatureFlagEventName(key: FeatureFlag): string | undefined {
     switch (key) {
+        case FeatureFlag.CodyInteractiveTutorial:
+            return 'interactiveTutorial'
         default:
             return undefined
     }

--- a/vscode/src/tutorial/commands.ts
+++ b/vscode/src/tutorial/commands.ts
@@ -25,6 +25,13 @@ export const setFixDiagnostic = (
     ])
 }
 
+/**
+ * States at which we consider an Edit to be "terminated" for the purposes of the tutorial.
+ * Considers both "Applied" and "Error" to be terminal, so that we can encourage the user along
+ * into the next steps, even when they don't necessarily hit a happy-path
+ */
+const TERMINAL_EDIT_STATES = [CodyTaskState.Applied, CodyTaskState.Finished, CodyTaskState.Error]
+
 export const registerEditTutorialCommand = (
     editor: vscode.TextEditor,
     onComplete: () => void
@@ -47,7 +54,7 @@ export const registerEditTutorialCommand = (
 
         // Poll for task.state being applied
         const interval = setInterval(async () => {
-            if (task.state === CodyTaskState.Applied) {
+            if (TERMINAL_EDIT_STATES.includes(task.state)) {
                 clearInterval(interval)
                 onComplete()
             }

--- a/vscode/src/tutorial/content.ts
+++ b/vscode/src/tutorial/content.ts
@@ -181,6 +181,6 @@ const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(r
  */
 export const resetDocument = async (uri: vscode.Uri): Promise<vscode.TextDocument> => {
     await vscode.commands.executeCommand('workbench.action.closeActiveEditor', uri)
-    await sleep(100)
+    await sleep(250)
     return initTutorialDocument(uri)
 }

--- a/vscode/src/tutorial/content.ts
+++ b/vscode/src/tutorial/content.ts
@@ -167,3 +167,20 @@ export const initTutorialDocument = async (uri: vscode.Uri): Promise<vscode.Text
     await vscode.workspace.fs.writeFile(uri, Buffer.from(firstStep))
     return vscode.workspace.openTextDocument(uri)
 }
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * We need to provide users with an option to reset the document, if incorrectly modified,
+ * but VS Code doesn't provide an easy way to do this, as it doesn't allow an extension to purge
+ * the document from the VS Code internal cache.
+ *
+ * Due to this, it means we can encounter a race condition where VS Code APIs still reference an old
+ * document, whilst we are presenting a new one to the user. This causes issues especially when seeking and
+ * tracking specific ranges in the document.
+ */
+export const resetDocument = async (uri: vscode.Uri): Promise<vscode.TextDocument> => {
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor', uri)
+    await sleep(100)
+    return initTutorialDocument(uri)
+}

--- a/vscode/src/tutorial/index.ts
+++ b/vscode/src/tutorial/index.ts
@@ -16,6 +16,7 @@ import {
     getStepContent,
     getStepData,
     initTutorialDocument,
+    resetDocument,
 } from './content'
 import { setTutorialUri } from './helpers'
 import { ChatLinkProvider, ResetLensProvider } from './providers'
@@ -195,7 +196,7 @@ export const registerInteractiveTutorial = async (
 ): Promise<vscode.Disposable[]> => {
     const disposables: vscode.Disposable[] = []
     const documentUri = setTutorialUri(context)
-    const document = await initTutorialDocument(documentUri)
+    let document = await initTutorialDocument(documentUri)
 
     let status: 'stopped' | 'started' | 'starting' = 'stopped'
 
@@ -255,8 +256,7 @@ export const registerInteractiveTutorial = async (
         }),
         vscode.commands.registerCommand('cody.tutorial.reset', async () => {
             stop()
-            // We need to close the tutorial to ensure we get a full reset of the editor
-            await vscode.commands.executeCommand('workbench.action.closeActiveEditor', documentUri)
+            document = await resetDocument(documentUri)
             return start()
         })
     )

--- a/vscode/src/tutorial/index.ts
+++ b/vscode/src/tutorial/index.ts
@@ -1,6 +1,7 @@
 import { FeatureFlag, featureFlagProvider, telemetryRecorder } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { type TextChange, updateRangeMultipleChanges } from '../../src/non-stop/tracked-range'
+import { logSidebarClick } from '../services/SidebarCommands'
 import { logFirstEnrollmentEvent } from '../services/utils/enrollment-event'
 import {
     registerAutocompleteListener,
@@ -20,7 +21,6 @@ import {
 } from './content'
 import { setTutorialUri } from './helpers'
 import { ChatLinkProvider, ResetLensProvider } from './providers'
-import { logSidebarClick } from '../services/SidebarCommands'
 
 export const startTutorial = async (document: vscode.TextDocument): Promise<vscode.Disposable> => {
     const disposables: vscode.Disposable[] = []
@@ -270,7 +270,7 @@ export const registerInteractiveTutorial = async (
         vscode.commands.registerCommand('cody.sidebar.tutorial', () => {
             logSidebarClick('tutorial')
             void vscode.commands.executeCommand('cody.tutorial.start')
-        }),
+        })
     )
 
     const tutorialVisible = vscode.window.visibleTextEditors.some(

--- a/vscode/src/tutorial/index.ts
+++ b/vscode/src/tutorial/index.ts
@@ -20,6 +20,7 @@ import {
 } from './content'
 import { setTutorialUri } from './helpers'
 import { ChatLinkProvider, ResetLensProvider } from './providers'
+import { logSidebarClick } from '../services/SidebarCommands'
 
 export const startTutorial = async (document: vscode.TextDocument): Promise<vscode.Disposable> => {
     const disposables: vscode.Disposable[] = []
@@ -265,7 +266,11 @@ export const registerInteractiveTutorial = async (
             stop()
             document = await resetDocument(documentUri)
             return start()
-        })
+        }),
+        vscode.commands.registerCommand('cody.sidebar.tutorial', () => {
+            logSidebarClick('tutorial')
+            void vscode.commands.executeCommand('cody.tutorial.start')
+        }),
     )
 
     const tutorialVisible = vscode.window.visibleTextEditors.some(

--- a/vscode/src/tutorial/index.ts
+++ b/vscode/src/tutorial/index.ts
@@ -265,7 +265,7 @@ export const registerInteractiveTutorial = async (
         editor => editor.document.uri.toString() === documentUri.toString()
     )
     if (tutorialVisible) {
-        start()
+        await start()
     }
 
     return disposables

--- a/vscode/src/tutorial/index.ts
+++ b/vscode/src/tutorial/index.ts
@@ -1,6 +1,7 @@
-import { FeatureFlag, featureFlagProvider } from '@sourcegraph/cody-shared'
+import { FeatureFlag, featureFlagProvider, telemetryRecorder } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { type TextChange, updateRangeMultipleChanges } from '../../src/non-stop/tracked-range'
+import { logFirstEnrollmentEvent } from '../services/utils/enrollment-event'
 import {
     registerAutocompleteListener,
     registerChatTutorialCommand,
@@ -24,6 +25,7 @@ export const startTutorial = async (document: vscode.TextDocument): Promise<vsco
     const editor = await vscode.window.showTextDocument(document)
     const diagnosticCollection = vscode.languages.createDiagnosticCollection('codyTutorial')
     disposables.push(diagnosticCollection)
+    telemetryRecorder.recordEvent('cody.interactiveTutorial', 'started')
 
     let activeStep: TutorialStep | null = null
 
@@ -63,8 +65,13 @@ export const startTutorial = async (document: vscode.TextDocument): Promise<vsco
     const progressToNextStep = async () => {
         const nextStep = activeStep?.key ? getNextStep(activeStep.key) : 'autocomplete'
 
+        if (activeStep?.key) {
+            telemetryRecorder.recordEvent('cody.interactiveTutorial.stepComplete', activeStep.key)
+        }
+
         if (nextStep === null) {
             editor.setDecorations(TODO_DECORATION, [])
+            telemetryRecorder.recordEvent('cody.interactiveTutorial', 'finished')
             return
         }
 
@@ -186,11 +193,6 @@ export const startTutorial = async (document: vscode.TextDocument): Promise<vsco
 export const registerInteractiveTutorial = async (
     context: vscode.ExtensionContext
 ): Promise<vscode.Disposable[]> => {
-    const enabled = await featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyInteractiveTutorial)
-    if (!enabled) {
-        return []
-    }
-
     const disposables: vscode.Disposable[] = []
     const documentUri = setTutorialUri(context)
     const document = await initTutorialDocument(documentUri)
@@ -199,6 +201,14 @@ export const registerInteractiveTutorial = async (
 
     let cleanup: vscode.Disposable | undefined
     const start = async () => {
+        const enabled = await featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyInteractiveTutorial
+        )
+        logFirstEnrollmentEvent(FeatureFlag.CodyInteractiveTutorial, enabled)
+        if (!enabled) {
+            return
+        }
+
         status = 'starting'
         cleanup = await startTutorial(document)
         disposables.push(cleanup)
@@ -232,10 +242,15 @@ export const registerInteractiveTutorial = async (
             const tutorialIsActive = editor && editor.document.uri.toString() === documentUri.toString()
             return vscode.commands.executeCommand('setContext', 'cody.tutorialActive', tutorialIsActive)
         }),
-        vscode.commands.registerCommand('cody.tutorial.start', () => {
+        vscode.commands.registerCommand('cody.tutorial.start', async () => {
             if (status === 'started') {
                 return vscode.window.showTextDocument(documentUri)
             }
+            // Refresh any flags when a manual start is triggered
+            // This is primarily so, when a user authenticates for the first time,
+            // We ensure we use the correct feature flag value before determining if they should
+            // see the tutorial.
+            await featureFlagProvider.refreshFeatureFlags()
             return start()
         }),
         vscode.commands.registerCommand('cody.tutorial.reset', async () => {

--- a/vscode/src/tutorial/index.ts
+++ b/vscode/src/tutorial/index.ts
@@ -243,6 +243,12 @@ export const registerInteractiveTutorial = async (
             const tutorialIsActive = editor && editor.document.uri.toString() === documentUri.toString()
             return vscode.commands.executeCommand('setContext', 'cody.tutorialActive', tutorialIsActive)
         }),
+        vscode.workspace.onDidCloseTextDocument(document => {
+            if (document.uri !== documentUri) {
+                return
+            }
+            telemetryRecorder.recordEvent('cody.interactiveTutorial', 'closed')
+        }),
         vscode.commands.registerCommand('cody.tutorial.start', async () => {
             if (status === 'started') {
                 return vscode.window.showTextDocument(documentUri)
@@ -255,6 +261,7 @@ export const registerInteractiveTutorial = async (
             return start()
         }),
         vscode.commands.registerCommand('cody.tutorial.reset', async () => {
+            telemetryRecorder.recordEvent('cody.interactiveTutorial', 'reset')
             stop()
             document = await resetDocument(documentUri)
             return start()


### PR DESCRIPTION
## Description

This PR:
- Improves unhappy path handling for the tutorial
  - Fixes an issue where "Reset Tutorial" did not reset
  - Skips formatting for Edits
  - Continues tutorial even if an edit hits an error state
- Adds logic to open the tutorial automatically on the users first auth
  - Gated behind a feature flag, so we can incrementally enable this for new users
- Adds telemetry
  - For A/B test: enrollment events
  - For tutorial progress
    - On tutorial start
    - On tutorial finish
    - On each step finished (autocomplete, edit, fix, chat)   

Demo:

https://github.com/sourcegraph/cody/assets/9516420/fa8444d6-0a1b-40bb-9ef2-71b1db8cfaaf



## Test plan

**Enrolled**:

1. Force user into A/B test
2. Repeat demo from above video, on a clean instance of VS Code
3. Check correct telemetry is sent, and tutorial functions as expected.
4. Sign out and sign back in. Check tutorial doesn't open automatically for the repeated time

**Control**:

1. Force user out of A/B test
2. Repeat demo from above video, on a clean instance of VS Code
3. Confirm that the tutorial does not show, and the CTA doesn't appear in the sidebar


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
