### PR TITLE
Backfill v1.16.0 entries to features.json

### DIFF
--- a/vscode/features.json5
+++ b/vscode/features.json5
@@ -98,5 +98,44 @@
         },
           tags: ['context']
       },
+      {
+        "name": "NoContextChatSubmissionHotkey",
+        "description": "Alt/Opt+Enter to submit chat without context",
+        "productLine": "all",
+        "documentation": [],
+        "editors": {
+          "vscode": {
+            "status": "stable",
+            "notes": "https://github.com/sourcegraph/cody/pull/3996"
+          }
+        },
+          tags: ['chat','context']
+      },
+      {
+        "name": "EnableOllamaByDefault",
+        "description": "Ollama models are now available by default if they are installed on the user's machine",
+        "productLine": "consumer",
+        "documentation": [],
+        "editors": {
+          "vscode": {
+            "status": "stable",
+            "notes": "https://github.com/sourcegraph/cody/pull/3914"
+          }
+        },
+          tags: ['chat']
+      },
+      {
+        "name": "Claude3DefaultModel",
+        "description": "Removed Claude 2, 2.1, and Claude Instant. Users are now updated to use Claude 3 by default.",
+        "productLine": "consumer",
+        "documentation": [],
+        "editors": {
+          "vscode": {
+            "status": "stable",
+            "notes": "https://github.com/sourcegraph/cody/pull/3914"
+          }
+        },
+          tags: ['chat', 'models']
+      },
     ],
   }


### PR DESCRIPTION
backfilling some `v1.16.0` entries

Note: The notes section contains PRs only for now, eventually each submission should be done on the PR itself.

See https://github.com/sourcegraph/cody/pull/3956 for more information on how this will _eventually_ work

## Test plan
n/a
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
