### PR TITLE
Ensure Biome never crashes by checking the CI for a bad phrase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,23 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
       - run: pnpm install
+      # Run Biome and capture the output. If biome crashes, it still reports a
+      # successful CI run (exit code 0) but that will ripple down to errors in
+      # the Biome VS Code extension. This ensures that we don't accidentally
+      # break Biome.
+      - run: |
+          set +e
+          output=$(pnpm exec biome ci --error-on-warnings . 2>&1)
+          status=$?
+          echo "$output"
+          if [ $status -ne 0 ]; then
+            exit $status
+          fi
+          if echo "$output" | grep -q "Biome encountered an unexpected error"; then
+            echo "Error string 'Biome encountered an unexpected error' detected in output."
+            exit 1
+          fi
+        shell: bash
       - run: pnpm exec biome ci --error-on-warnings .
       - run: pnpm run build
       - run: pnpm -C vscode run build


### PR DESCRIPTION
We found biome can crash internally and still exit with code `0`. This will then cause issues in e.g. the Biome VS Code extension so we really want to keep this clean.

c.f. https://sourcegraph.slack.com/archives/C05AGQYD528/p1714639734553859

## Test plan

- CI Green