### PR TITLE
Disable noRedeclare to prevent Biome crash

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,8 @@
         "noDuplicateJsonKeys": "error"
       },
       "suspicious": {
-        "noExplicitAny": "off"
+        "noExplicitAny": "off",
+        "noRedeclare": "off"
       },
       "style": {
         "noNonNullAssertion": "off",


### PR DESCRIPTION
We found that it causes biome to crash causing issues in the VS Code extension (and likely some files won't be linted the way we expected it to because of the crash): 


```
pnpm biome

> @sourcegraph/cody@ biome /Users/philipp/dev/cody
> biome check --apply --error-on-warnings .

Biome encountered an unexpected error

This is a bug in Biome, not an error in your code, and we would appreciate it if you could report it to https://github.com/biomejs/biome/issues/ along with the following information to help us fixing the issue:

Source Location: crates/biome_js_semantic/src/semantic_model/scope.rs:115:33
Thread Name: biome::worker_9
Message: no entry found for key

Biome encountered an unexpected error

This is a bug in Biome, not an error in your code, and we would appreciate it if you could report it to https://github.com/biomejs/biome/issues/ along with the following information to help us fixing the issue:

Source Location: crates/biome_js_semantic/src/semantic_model/scope.rs:115:33
Thread Name: biome::worker_4
Message: no entry found for key

./vscode/src/configuration-keys.ts internalError/panic  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ processing panicked: no entry found for key

  ⚠ This diagnostic was derived from an internal Biome error. Potential bug, please report it if necessary.


./lib/shared/src/models/types.ts internalError/panic  INTERNAL  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ processing panicked: no entry found for key

  ⚠ This diagnostic was derived from an internal Biome error. Potential bug, please report it if necessary.


Checked 739 files in 221ms. No fixes needed.
```

You can find infos on this crash in https://github.com/biomejs/biome/issues/2659. Disabling `noRedeclare` fixes this issue.


## Test plan

```
α dev/cody 🐙(ps/biome-disable-no-redeclare)✗
pnpm biome

> @sourcegraph/cody@ biome /Users/philipp/dev/cody
> biome check --apply --error-on-warnings .

Checked 741 files in 195ms. No fixes needed.
```