### PR TITLE
Agent: Create dir if not exists when writeFile is called

### DIFF
--- a/agent/src/vscode-shim.test.ts
+++ b/agent/src/vscode-shim.test.ts
@@ -105,6 +105,15 @@ describe.skipIf(os.platform().startsWith('win'))('vscode.workspace.fs', () => {
         expect(content).toEqual(testBuffer)
     })
 
+    it('writeFile in non-existent directory', async () => {
+        const testBuffer = Buffer.from('Hello')
+        const nonExistentDir = path.join(tmpdir.fsPath, 'non-existent')
+        const testFilePath = path.join(nonExistentDir, 'testFile')
+        await vscode.workspace.fs.writeFile(vscode.Uri.parse(testFilePath), new Uint8Array(testBuffer))
+        const content = await fspromises.readFile(testFilePath)
+        expect(content).toEqual(testBuffer)
+    })
+
     it('readFile', async () => {
         const testFilePath = path.join(tmpdir.fsPath, 'testFile')
         await fspromises.writeFile(testFilePath, 'Hello')

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -17,7 +17,9 @@ import {
     ps,
 } from '@sourcegraph/cody-shared'
 
+import path from 'node:path'
 import { AgentEventEmitter as EventEmitter } from './AgentEventEmitter'
+import { AgentWorkspaceEdit as WorkspaceEdit } from './AgentWorkspaceEdit'
 import { Uri } from './uri'
 
 export { Uri } from './uri'
@@ -25,7 +27,6 @@ export { Uri } from './uri'
 export { AgentEventEmitter as EventEmitter } from './AgentEventEmitter'
 export { AgentWorkspaceEdit as WorkspaceEdit } from './AgentWorkspaceEdit'
 export { Disposable } from './Disposable'
-import { AgentWorkspaceEdit as WorkspaceEdit } from './AgentWorkspaceEdit'
 
 /**
  * This module defines shared VSCode mocks for use in every Vitest test.
@@ -548,6 +549,7 @@ export const workspaceFs: typeof vscode_types.workspace.fs = {
         }
     },
     writeFile: async (uri, content) => {
+        await fspromises.mkdir(path.dirname(uri.fsPath), { recursive: true })
         await fspromises.writeFile(uri.fsPath, content)
     },
     delete: async (uri, options) => {

--- a/vscode/src/tutorial/index.ts
+++ b/vscode/src/tutorial/index.ts
@@ -1,6 +1,7 @@
 import { FeatureFlag, featureFlagProvider, telemetryRecorder } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
 import { type TextChange, updateRangeMultipleChanges } from '../../src/non-stop/tracked-range'
+import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import { logSidebarClick } from '../services/SidebarCommands'
 import { logFirstEnrollmentEvent } from '../services/utils/enrollment-event'
 import {
@@ -195,6 +196,14 @@ export const startTutorial = async (document: vscode.TextDocument): Promise<vsco
 export const registerInteractiveTutorial = async (
     context: vscode.ExtensionContext
 ): Promise<vscode.Disposable[]> => {
+    if (isRunningInsideAgent()) {
+        // TODO: The interactive tutorial is currently VS Code specific, both in terms of features and keyboard shortcuts.
+        // Consider opening this up to support dynamic content via Cody Agent.
+        // This would allow us the present the same tutorial but with client-specific steps.
+        // Alternatively, clients may not wish to use this tutorial and instead opt for something more suitable for their environment.
+        return []
+    }
+
     const disposables: vscode.Disposable[] = []
     const documentUri = setTutorialUri(context)
     let document = await initTutorialDocument(documentUri)


### PR DESCRIPTION
## Description

Fixes CODY-1326

closes https://linear.app/sourcegraph/issue/CODY-1326/noisy-ci-warning-cody-nodejswalkthroughscody-tutorialpy

VS Code will create a directory on `writeFile` if it doesn't already exist.

This updates the Agent to match that behavior

## Test plan

Tests pass without any errors logged in CI


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
