### PR TITLE
Cody Ignore: Treat unterminated JSON responses as an outdated API error message

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -1029,5 +1029,11 @@ export type LogEventMode =
     | 'all' // log to both dotcom AND the connected instance
 
 function hasOutdatedAPIErrorMessages(error: Error): boolean {
-    return error.message.includes('Cannot query field')
+    // Sourcegraph 5.2.3 returns an empty string ("") instead of an error message
+    // when querying non-existent codyContextFilters; this produces
+    // 'Unexpected end of JSON input'
+    return (
+        error.message.includes('Cannot query field') ||
+        error.message.includes('Unexpected end of JSON input')
+    )
 }

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Fixed a bug where old Sourcegraph instances' error messages caused Cody to ignore all context files [pull/4024](https://github.com/sourcegraph/cody/pull/4024)
+
 ### Changed
 
 ## [1.16.0]


### PR DESCRIPTION
This unbreaks 5.2.3 treating all files as ignored.

## Test plan

Tested manually: Log in to 5.2.3 and chat with an @-file mention. You should not get a Cody Ignore error message.