### PR TITLE
remove drop shadow on model selector experimental label

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Fixed a bug where old Sourcegraph instances' error messages caused Cody to ignore all context files [pull/4024](https://github.com/sourcegraph/cody/pull/4024)
+- Fixed a visually distracting drop shadow on some text labels in the model selection dropdown menu. [pull/4026](https://github.com/sourcegraph/cody/pull/4026)
 
 ### Changed
 

--- a/vscode/webviews/Components/modelSelectField/ModelSelectField.module.css
+++ b/vscode/webviews/Components/modelSelectField/ModelSelectField.module.css
@@ -30,14 +30,9 @@
 }
 
 .badge  {
-    position: relative;
     margin-left: auto;
-    font-size: 12px;
-    font-weight: 500;
     line-height: 1;
     letter-spacing: -0.025rem;
-    text-shadow: 0px 0px 1px #280065, 0px 1px 1px rgba(36, 0, 81, 1);
-    transition: box-shadow 150ms;
 }
 
 .cody-pro-badge {


### PR DESCRIPTION
This was impeding readability on many color themes (esp. Monokai Pro).

Before:

![image](https://github.com/sourcegraph/cody/assets/1976/4d52b11e-71c8-4d1d-8e82-10e6149563b1)


After:

![image](https://github.com/sourcegraph/cody/assets/1976/7ca79b54-1726-4894-81e9-3e31e5943a2e)


## Test plan

Test on various themes.