### PR TITLE
Edit: Disable streaming for 'Add' insertions in Agent

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -8646,6 +8646,143 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 1888737ce3ed47d709945e99fa34fad2
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2444
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - name: user-agent
+            value: defaultClient / v1
+          - name: host
+            value: sourcegraph.com
+        headersSize: 277
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in adding new
+                  code by following instructions.
+
+                  - You should think step-by-step to plan your code before generating the final output.
+
+                  - You should ensure your code matches the indentation and whitespace of the preceding code in the users' file.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - You will be provided with code that is above the users' cursor, enclosed in <PRECEDINGCODE3493></PRECEDINGCODE3493> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.
+
+                  - You will be provided with code that is below the users' cursor, enclosed in <FOLLOWINGCODE2472></FOLLOWINGCODE2472> XML tags. You must use this code to help you plan your updated code. You must not repeat this code in your output unless necessary.
+
+                  - You will be provided with instructions on what to generate, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the code you added. Only respond with the generated code.
+              - speaker: human
+                text: >
+                  Below is the code from file path src/Heading.tsx. Review the
+                  code outside the XML tags to detect the functionality,
+                  formats, style, patterns, and logics in use. Then, use what
+                  you detect and reuse methods/libraries to complete and enclose
+                  completed code only inside XML tags precisely without
+                  duplicating existing implementations. Here is the code:
+
+                  <PRECEDINGCODE3493></PRECEDINGCODE3493><CODE5711></CODE5711><FOLLOWINGCODE2472></FOLLOWINGCODE2472>
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  The user is currently in the file: src/Heading.tsx
+
+                  Provide your generated code using the following instructions:
+                  <INSTRUCTIONS7390>
+                  Generate a component for this file
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-opus-20240229
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1
+      response:
+        bodySize: 24994
+        content:
+          mimeType: text/event-stream
+          size: 24994
+          text: >+
+            event: completion
+
+            data: {"completion":"import React from 'react';\n\ninterface HeadingProps {\n  text: string;\n  level: 1 | 2 | 3 | 4 | 5 | 6;\n}\n\nconst Heading: React.FC\u003cHeadingProps\u003e = ({ text, level }) =\u003e {\n  const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;\n\n  return \u003cHeadingTag\u003e{text}\u003c/HeadingTag\u003e;\n};\n\nexport default Heading;\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 03 May 2024 07:47:14 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-03T07:47:11.958Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: e2ae0ab84c1239bc6be31f736d44652b
       _order: 0
       cache: {}

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -1020,6 +1020,34 @@ describe('Agent', () => {
                   "
                 `)
             }, 20_000)
+
+            it('editCommand/code (generate at cursor)', async () => {
+                const uri = workspace.file('src', 'Heading.tsx')
+                await client.openFile(uri)
+                const task = await client.request('editCommands/code', {
+                    instruction: 'Generate a component for this file',
+                    model: ModelProvider.getProviderByModelSubstringOrError('anthropic/claude-3-opus')
+                        .model,
+                })
+                await client.acceptEditTask(uri, task)
+                expect(client.documentText(uri)).toMatchInlineSnapshot(`
+                  "import React from 'react';
+
+                  interface HeadingProps {
+                    text: string;
+                    level: 1 | 2 | 3 | 4 | 5 | 6;
+                  }
+
+                  const Heading: React.FC<HeadingProps> = ({ text, level }) => {
+                    const HeadingTag = \`h\${level}\` as keyof JSX.IntrinsicElements;
+
+                    return <HeadingTag>{text}</HeadingTag>;
+                  };
+
+                  export default Heading;
+                  "
+                `)
+            }, 20_000)
         })
 
         describe('Document code', () => {

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -215,10 +215,7 @@ export class EditProvider {
             })
         }
 
-        const intentsForInsert = ['add', 'test']
-        const shouldInsert = intentsForInsert.includes(this.config.task.intent)
-
-        if (isRunningInsideAgent() && shouldInsert) {
+        if (isRunningInsideAgent() && this.config.task.intent === 'add') {
             // TODO: We have disabled running `handleStreamedFixupInsert` through Agent
             // as we are running into a blocking issue where this results in duplicate
             // chunks of text from the LLM being inserted into the document.
@@ -232,7 +229,8 @@ export class EditProvider {
             return this.handleFixupInsert(response, isMessageInProgress)
         }
 
-        return shouldInsert
+        const intentsForInsert = ['add', 'test']
+        return intentsForInsert.includes(this.config.task.intent)
             ? this.handleStreamedFixupInsert(response, isMessageInProgress)
             : this.handleFixupEdit(response, isMessageInProgress)
     }

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -1,340 +1,375 @@
-import { Utils } from 'vscode-uri'
+import { Utils } from "vscode-uri";
 
 import {
-    BotResponseMultiplexer,
-    ModelProvider,
-    Typewriter,
-    isAbortError,
-    isDotCom,
-    posixFilePaths,
-    telemetryRecorder,
-    uriBasename,
-    wrapInActiveSpan,
-} from '@sourcegraph/cody-shared'
+	BotResponseMultiplexer,
+	ModelProvider,
+	Typewriter,
+	isAbortError,
+	isDotCom,
+	posixFilePaths,
+	telemetryRecorder,
+	uriBasename,
+	wrapInActiveSpan,
+} from "@sourcegraph/cody-shared";
 
-import { logError } from '../log'
-import type { FixupController } from '../non-stop/FixupController'
-import type { FixupTask } from '../non-stop/FixupTask'
-import { isNetworkError } from '../services/AuthProvider'
+import { logError } from "../log";
+import type { FixupController } from "../non-stop/FixupController";
+import type { FixupTask } from "../non-stop/FixupTask";
+import { isNetworkError } from "../services/AuthProvider";
 
-import { workspace } from 'vscode'
-import { doesFileExist } from '../commands/utils/workspace-files'
-import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
-import { CodyTaskState } from '../non-stop/utils'
-import { telemetryService } from '../services/telemetry'
-import { splitSafeMetadata } from '../services/telemetry-v2'
-import { countCode } from '../services/utils/code-count'
-import type { EditManagerOptions } from './manager'
-import { responseTransformer } from './output/response-transformer'
-import { buildInteraction } from './prompt'
-import { PROMPT_TOPICS } from './prompt/constants'
+import { workspace } from "vscode";
+import { doesFileExist } from "../commands/utils/workspace-files";
+import { isRunningInsideAgent } from "../jsonrpc/isRunningInsideAgent";
+import { CodyTaskState } from "../non-stop/utils";
+import { telemetryService } from "../services/telemetry";
+import { splitSafeMetadata } from "../services/telemetry-v2";
+import { countCode } from "../services/utils/code-count";
+import type { EditManagerOptions } from "./manager";
+import { responseTransformer } from "./output/response-transformer";
+import { buildInteraction } from "./prompt";
+import { PROMPT_TOPICS } from "./prompt/constants";
 
 interface EditProviderOptions extends EditManagerOptions {
-    task: FixupTask
-    controller: FixupController
+	task: FixupTask;
+	controller: FixupController;
 }
 
 // Initiates a completion and responds to the result from the LLM. Implements
 // "tools" like directing the response into a specific file. Code is forwarded
 // to the FixupTask.
 export class EditProvider {
-    private insertionResponse: string | null = null
-    private insertionInProgress = false
-    private insertionPromise: Promise<void> | null = null
-    private abortController: AbortController | null = null
+	private insertionResponse: string | null = null;
+	private insertionInProgress = false;
+	private insertionPromise: Promise<void> | null = null;
+	private abortController: AbortController | null = null;
 
-    constructor(public config: EditProviderOptions) {}
+	constructor(public config: EditProviderOptions) {}
 
-    public async startEdit(): Promise<void> {
-        return wrapInActiveSpan('command.edit.start', async span => {
-            this.config.controller.startTask(this.config.task)
-            const model = this.config.task.model
-            const contextWindow = ModelProvider.getContextWindowByID(model)
-            const {
-                messages,
-                stopSequences,
-                responseTopic,
-                responsePrefix = '',
-            } = await buildInteraction({
-                model,
-                codyApiVersion: this.config.authProvider.getAuthStatus().codyApiVersion,
-                contextWindow: contextWindow.input,
-                task: this.config.task,
-                editor: this.config.editor,
-            }).catch(err => {
-                this.handleError(err)
-                throw err
-            })
+	public async startEdit(): Promise<void> {
+		return wrapInActiveSpan("command.edit.start", async (span) => {
+			this.config.controller.startTask(this.config.task);
+			const model = this.config.task.model;
+			const contextWindow = ModelProvider.getContextWindowByID(model);
+			const {
+				messages,
+				stopSequences,
+				responseTopic,
+				responsePrefix = "",
+			} = await buildInteraction({
+				model,
+				codyApiVersion: this.config.authProvider.getAuthStatus().codyApiVersion,
+				contextWindow: contextWindow.input,
+				task: this.config.task,
+				editor: this.config.editor,
+			}).catch((err) => {
+				this.handleError(err);
+				throw err;
+			});
 
-            const multiplexer = new BotResponseMultiplexer()
+			const multiplexer = new BotResponseMultiplexer();
 
-            const typewriter = new Typewriter({
-                update: content => {
-                    void this.handleResponse(content, true)
-                },
-                close: () => {},
-            })
+			const typewriter = new Typewriter({
+				update: (content) => {
+					void this.handleResponse(content, true);
+				},
+				close: () => {},
+			});
 
-            let text = ''
-            multiplexer.sub(responseTopic, {
-                onResponse: async (content: string) => {
-                    text += content
-                    typewriter.update(responsePrefix + text)
-                    return Promise.resolve()
-                },
-                onTurnComplete: async () => {
-                    typewriter.close()
-                    typewriter.stop()
-                    void this.handleResponse(text, false)
-                    return Promise.resolve()
-                },
-            })
+			let text = "";
+			multiplexer.sub(responseTopic, {
+				onResponse: async (content: string) => {
+					text += content;
+					typewriter.update(responsePrefix + text);
+					return Promise.resolve();
+				},
+				onTurnComplete: async () => {
+					typewriter.close();
+					typewriter.stop();
+					void this.handleResponse(text, false);
+					return Promise.resolve();
+				},
+			});
 
-            if (this.config.task.intent === 'test') {
-                if (this.config.task.destinationFile) {
-                    // We have already provided a destination file,
-                    // Treat this as the test file to insert to
-                    await this.config.controller.didReceiveNewFileRequest(
-                        this.config.task.id,
-                        this.config.task.destinationFile
-                    )
-                } else {
-                    // Listen to test file name suggestion from responses
-                    // Allows Cody to let us know which test file we should add the new content to
-                    let filepath = ''
-                    multiplexer.sub(PROMPT_TOPICS.FILENAME.toString(), {
-                        onResponse: async (content: string) => {
-                            filepath += content
-                            void this.handleFileCreationResponse(filepath, true)
-                            return Promise.resolve()
-                        },
-                        onTurnComplete: async () => {
-                            return Promise.resolve()
-                        },
-                    })
-                }
-            }
+			if (this.config.task.intent === "test") {
+				if (this.config.task.destinationFile) {
+					// We have already provided a destination file,
+					// Treat this as the test file to insert to
+					await this.config.controller.didReceiveNewFileRequest(
+						this.config.task.id,
+						this.config.task.destinationFile,
+					);
+				} else {
+					// Listen to test file name suggestion from responses
+					// Allows Cody to let us know which test file we should add the new content to
+					let filepath = "";
+					multiplexer.sub(PROMPT_TOPICS.FILENAME.toString(), {
+						onResponse: async (content: string) => {
+							filepath += content;
+							void this.handleFileCreationResponse(filepath, true);
+							return Promise.resolve();
+						},
+						onTurnComplete: async () => {
+							return Promise.resolve();
+						},
+					});
+				}
+			}
 
-            this.abortController = new AbortController()
-            const stream = this.config.chat.chat(
-                messages,
-                {
-                    model,
-                    stopSequences,
-                    maxTokensToSample: contextWindow.output,
-                },
-                this.abortController.signal
-            )
+			this.abortController = new AbortController();
+			const stream = this.config.chat.chat(
+				messages,
+				{
+					model,
+					stopSequences,
+					maxTokensToSample: contextWindow.output,
+				},
+				this.abortController.signal,
+			);
 
-            let textConsumed = 0
-            for await (const message of stream) {
-                switch (message.type) {
-                    case 'change': {
-                        if (textConsumed === 0 && responsePrefix) {
-                            void multiplexer.publish(responsePrefix)
-                        }
-                        const text = message.text.slice(textConsumed)
-                        textConsumed += text.length
-                        void multiplexer.publish(text)
-                        break
-                    }
-                    case 'complete': {
-                        void multiplexer.notifyTurnComplete()
-                        break
-                    }
-                    case 'error': {
-                        let err = message.error
-                        logError('EditProvider:onError', err.message)
+			let textConsumed = 0;
+			for await (const message of stream) {
+				switch (message.type) {
+					case "change": {
+						if (textConsumed === 0 && responsePrefix) {
+							void multiplexer.publish(responsePrefix);
+						}
+						const text = message.text.slice(textConsumed);
+						textConsumed += text.length;
+						void multiplexer.publish(text);
+						break;
+					}
+					case "complete": {
+						void multiplexer.notifyTurnComplete();
+						break;
+					}
+					case "error": {
+						let err = message.error;
+						logError("EditProvider:onError", err.message);
 
-                        if (isAbortError(err)) {
-                            void this.handleResponse(text, false)
-                            return
-                        }
+						if (isAbortError(err)) {
+							void this.handleResponse(text, false);
+							return;
+						}
 
-                        if (isNetworkError(err)) {
-                            err = new Error('Cody could not respond due to network error.')
-                        }
+						if (isNetworkError(err)) {
+							err = new Error("Cody could not respond due to network error.");
+						}
 
-                        // Display error message as assistant response
-                        this.handleError(err)
-                        console.error(`Completion request failed: ${err.message}`)
+						// Display error message as assistant response
+						this.handleError(err);
+						console.error(`Completion request failed: ${err.message}`);
 
-                        break
-                    }
-                }
-            }
-        })
-    }
+						break;
+					}
+				}
+			}
+		});
+	}
 
-    public abortEdit(): void {
-        this.abortController?.abort()
-    }
+	public abortEdit(): void {
+		this.abortController?.abort();
+	}
 
-    private async handleResponse(response: string, isMessageInProgress: boolean): Promise<void> {
-        // Error state: The response finished but we didn't receive any text
-        if (!response && !isMessageInProgress) {
-            this.handleError(new Error('Cody did not respond with any text'))
-        }
+	private async handleResponse(
+		response: string,
+		isMessageInProgress: boolean,
+	): Promise<void> {
+		// Error state: The response finished but we didn't receive any text
+		if (!response && !isMessageInProgress) {
+			this.handleError(new Error("Cody did not respond with any text"));
+		}
 
-        if (!response) {
-            return
-        }
+		if (!response) {
+			return;
+		}
 
-        // If the response finished and we didn't receive a test file name suggestion,
-        // we will create one manually before inserting the response to the new test file
-        if (this.config.task.intent === 'test' && !this.config.task.destinationFile) {
-            if (isMessageInProgress) {
-                return
-            }
-            await this.handleFileCreationResponse('', isMessageInProgress)
-        }
+		// If the response finished and we didn't receive a test file name suggestion,
+		// we will create one manually before inserting the response to the new test file
+		if (
+			this.config.task.intent === "test" &&
+			!this.config.task.destinationFile
+		) {
+			if (isMessageInProgress) {
+				return;
+			}
+			await this.handleFileCreationResponse("", isMessageInProgress);
+		}
 
-        if (!isMessageInProgress) {
-            const { task } = this.config
-            const legacyMetadata = {
-                intent: task.intent,
-                mode: task.mode,
-                source: task.source,
-                ...countCode(response),
-            }
-            telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', legacyMetadata, {
-                hasV2Event: true,
-            })
-            const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
-            const endpoint = this.config.authProvider?.getAuthStatus()?.endpoint
-            telemetryRecorder.recordEvent('cody.fixup.response', 'hasCode', {
-                metadata,
-                privateMetadata: {
-                    ...privateMetadata,
-                    model: task.model,
-                    // 🚨 SECURITY: edit responses are to be included only for DotCom users AND for V2 telemetry
-                    // V2 telemetry exports privateMetadata only for DotCom users
-                    // the condition below is an aditional safegaurd measure
-                    responseText: endpoint && isDotCom(endpoint) ? response : undefined,
-                },
-            })
-        }
+		if (!isMessageInProgress) {
+			const { task } = this.config;
+			const legacyMetadata = {
+				intent: task.intent,
+				mode: task.mode,
+				source: task.source,
+				...countCode(response),
+			};
+			telemetryService.log(
+				"CodyVSCodeExtension:fixupResponse:hasCode",
+				legacyMetadata,
+				{
+					hasV2Event: true,
+				},
+			);
+			const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata);
+			const endpoint = this.config.authProvider?.getAuthStatus()?.endpoint;
+			telemetryRecorder.recordEvent("cody.fixup.response", "hasCode", {
+				metadata,
+				privateMetadata: {
+					...privateMetadata,
+					model: task.model,
+					// 🚨 SECURITY: edit responses are to be included only for DotCom users AND for V2 telemetry
+					// V2 telemetry exports privateMetadata only for DotCom users
+					// the condition below is an aditional safegaurd measure
+					responseText: endpoint && isDotCom(endpoint) ? response : undefined,
+				},
+			});
+		}
 
-        if (isRunningInsideAgent() && this.config.task.intent === 'add') {
-            // TODO: We have disabled running `handleStreamedFixupInsert` through Agent
-            // as we are running into a blocking issue where this results in duplicate
-            // chunks of text from the LLM being inserted into the document.
-            // Issue to fix: TODO
+		if (isRunningInsideAgent() && this.config.task.intent === "add") {
+			// TODO: We have disabled running `handleStreamedFixupInsert` through Agent
+			// as we are running into a blocking issue where this results in duplicate
+			// chunks of text from the LLM being inserted into the document.
+			// Issue to fix: https://github.com/sourcegraph/jetbrains/issues/1449
 
-            if (isMessageInProgress) {
-                // Response hasn't finished, disable until we have the full response
-                return
-            }
+			if (isMessageInProgress) {
+				// Response hasn't finished, disable until we have the full response
+				return;
+			}
 
-            return this.handleFixupInsert(response, isMessageInProgress)
-        }
+			return this.handleFixupInsert(response, isMessageInProgress);
+		}
 
-        const intentsForInsert = ['add', 'test']
-        return intentsForInsert.includes(this.config.task.intent)
-            ? this.handleStreamedFixupInsert(response, isMessageInProgress)
-            : this.handleFixupEdit(response, isMessageInProgress)
-    }
+		const intentsForInsert = ["add", "test"];
+		return intentsForInsert.includes(this.config.task.intent)
+			? this.handleStreamedFixupInsert(response, isMessageInProgress)
+			: this.handleFixupEdit(response, isMessageInProgress);
+	}
 
-    /**
-     * Display an erred codelens to the user on failed fixup apply.
-     * Will allow the user to view the error in more detail if needed.
-     */
-    protected handleError(error: Error): void {
-        this.config.controller.error(this.config.task.id, error)
-    }
+	/**
+	 * Display an erred codelens to the user on failed fixup apply.
+	 * Will allow the user to view the error in more detail if needed.
+	 */
+	protected handleError(error: Error): void {
+		this.config.controller.error(this.config.task.id, error);
+	}
 
-    private async handleFixupEdit(response: string, isMessageInProgress: boolean): Promise<void> {
-        return this.config.controller.didReceiveFixupText(
-            this.config.task.id,
-            responseTransformer(response, this.config.task, isMessageInProgress),
-            isMessageInProgress ? 'streaming' : 'complete'
-        )
-    }
+	private async handleFixupEdit(
+		response: string,
+		isMessageInProgress: boolean,
+	): Promise<void> {
+		return this.config.controller.didReceiveFixupText(
+			this.config.task.id,
+			responseTransformer(response, this.config.task, isMessageInProgress),
+			isMessageInProgress ? "streaming" : "complete",
+		);
+	}
 
-    private async handleFixupInsert(response: string, isMessageInProgress: boolean): Promise<void> {
-        return this.config.controller.didReceiveFixupInsertion(
-            this.config.task.id,
-            responseTransformer(response, this.config.task, this.insertionInProgress),
-            this.insertionInProgress ? 'streaming' : 'complete'
-        )
-    }
+	private async handleFixupInsert(
+		response: string,
+		isMessageInProgress: boolean,
+	): Promise<void> {
+		return this.config.controller.didReceiveFixupInsertion(
+			this.config.task.id,
+			responseTransformer(response, this.config.task, this.insertionInProgress),
+			this.insertionInProgress ? "streaming" : "complete",
+		);
+	}
 
-    private async handleStreamedFixupInsert(
-        response: string,
-        isMessageInProgress: boolean
-    ): Promise<void> {
-        this.insertionResponse = response
-        this.insertionInProgress = isMessageInProgress
+	private async handleStreamedFixupInsert(
+		response: string,
+		isMessageInProgress: boolean,
+	): Promise<void> {
+		this.insertionResponse = response;
+		this.insertionInProgress = isMessageInProgress;
 
-        if (this.insertionPromise) {
-            // Already processing an insertion, wait for it to finish
-            return
-        }
+		if (this.insertionPromise) {
+			// Already processing an insertion, wait for it to finish
+			return;
+		}
 
-        while (this.insertionResponse !== null) {
-            const responseToSend = this.insertionResponse
-            this.insertionResponse = null
+		while (this.insertionResponse !== null) {
+			const responseToSend = this.insertionResponse;
+			this.insertionResponse = null;
 
-            this.insertionPromise = this.handleFixupInsert(responseToSend, this.insertionInProgress)
+			this.insertionPromise = this.handleFixupInsert(
+				responseToSend,
+				this.insertionInProgress,
+			);
 
-            try {
-                await this.insertionPromise
-            } finally {
-                this.insertionPromise = null
-            }
-        }
-    }
+			try {
+				await this.insertionPromise;
+			} finally {
+				this.insertionPromise = null;
+			}
+		}
+	}
 
-    private async handleFileCreationResponse(text: string, isMessageInProgress: boolean): Promise<void> {
-        const task = this.config.task
-        if (task.state !== CodyTaskState.Pending) {
-            return
-        }
+	private async handleFileCreationResponse(
+		text: string,
+		isMessageInProgress: boolean,
+	): Promise<void> {
+		const task = this.config.task;
+		if (task.state !== CodyTaskState.Pending) {
+			return;
+		}
 
-        // Has already been created when set
-        if (task.destinationFile) {
-            return
-        }
+		// Has already been created when set
+		if (task.destinationFile) {
+			return;
+		}
 
-        // Manually create the file if no name was suggested
-        if (!text.length && !isMessageInProgress) {
-            // Create a new untitled file if the suggested file does not exist
-            const currentFile = task.fixupFile.uri
-            const currentDoc = await workspace.openTextDocument(currentFile)
-            const newDoc = await workspace.openTextDocument({ language: currentDoc?.languageId })
-            await this.config.controller.didReceiveNewFileRequest(this.config.task.id, newDoc.uri)
-            return
-        }
+		// Manually create the file if no name was suggested
+		if (!text.length && !isMessageInProgress) {
+			// Create a new untitled file if the suggested file does not exist
+			const currentFile = task.fixupFile.uri;
+			const currentDoc = await workspace.openTextDocument(currentFile);
+			const newDoc = await workspace.openTextDocument({
+				language: currentDoc?.languageId,
+			});
+			await this.config.controller.didReceiveNewFileRequest(
+				this.config.task.id,
+				newDoc.uri,
+			);
+			return;
+		}
 
-        const opentag = `<${PROMPT_TOPICS.FILENAME}>`
-        const closetag = `</${PROMPT_TOPICS.FILENAME}>`
+		const opentag = `<${PROMPT_TOPICS.FILENAME}>`;
+		const closetag = `</${PROMPT_TOPICS.FILENAME}>`;
 
-        const currentFileUri = task.fixupFile.uri
-        const currentFileName = uriBasename(currentFileUri)
-        // remove open and close tags from text
-        const newFilePath = text.trim().replaceAll(new RegExp(`${opentag}(.*)${closetag}`, 'g'), '$1')
-        const haveSameExtensions =
-            posixFilePaths.extname(currentFileName) === posixFilePaths.extname(newFilePath)
+		const currentFileUri = task.fixupFile.uri;
+		const currentFileName = uriBasename(currentFileUri);
+		// remove open and close tags from text
+		const newFilePath = text
+			.trim()
+			.replaceAll(new RegExp(`${opentag}(.*)${closetag}`, "g"), "$1");
+		const haveSameExtensions =
+			posixFilePaths.extname(currentFileName) ===
+			posixFilePaths.extname(newFilePath);
 
-        // Get workspace uri using the current file uri
-        const workspaceUri = workspace.getWorkspaceFolder(currentFileUri)?.uri
-        const currentDirUri = Utils.joinPath(currentFileUri, '..')
+		// Get workspace uri using the current file uri
+		const workspaceUri = workspace.getWorkspaceFolder(currentFileUri)?.uri;
+		const currentDirUri = Utils.joinPath(currentFileUri, "..");
 
-        // Create a new file uri by replacing the file name of the currentFileUri with fileName
-        let newFileUri = Utils.joinPath(workspaceUri ?? currentDirUri, newFilePath)
-        if (haveSameExtensions && !task.destinationFile) {
-            const fileIsFound = await doesFileExist(newFileUri)
-            if (!fileIsFound) {
-                newFileUri = newFileUri.with({ scheme: 'untitled' })
-            }
-            this.insertionPromise = this.config.controller.didReceiveNewFileRequest(task.id, newFileUri)
-            try {
-                await this.insertionPromise
-            } catch (error) {
-                this.handleError(new Error('Cody failed to generate unit tests', { cause: error }))
-            } finally {
-                this.insertionPromise = null
-            }
-        }
-    }
+		// Create a new file uri by replacing the file name of the currentFileUri with fileName
+		let newFileUri = Utils.joinPath(workspaceUri ?? currentDirUri, newFilePath);
+		if (haveSameExtensions && !task.destinationFile) {
+			const fileIsFound = await doesFileExist(newFileUri);
+			if (!fileIsFound) {
+				newFileUri = newFileUri.with({ scheme: "untitled" });
+			}
+			this.insertionPromise = this.config.controller.didReceiveNewFileRequest(
+				task.id,
+				newFileUri,
+			);
+			try {
+				await this.insertionPromise;
+			} catch (error) {
+				this.handleError(
+					new Error("Cody failed to generate unit tests", { cause: error }),
+				);
+			} finally {
+				this.insertionPromise = null;
+			}
+		}
+	}
 }

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -1,375 +1,342 @@
-import { Utils } from "vscode-uri";
+import { Utils } from 'vscode-uri'
 
 import {
-	BotResponseMultiplexer,
-	ModelProvider,
-	Typewriter,
-	isAbortError,
-	isDotCom,
-	posixFilePaths,
-	telemetryRecorder,
-	uriBasename,
-	wrapInActiveSpan,
-} from "@sourcegraph/cody-shared";
+    BotResponseMultiplexer,
+    ModelProvider,
+    Typewriter,
+    isAbortError,
+    isDotCom,
+    posixFilePaths,
+    telemetryRecorder,
+    uriBasename,
+    wrapInActiveSpan,
+} from '@sourcegraph/cody-shared'
 
-import { logError } from "../log";
-import type { FixupController } from "../non-stop/FixupController";
-import type { FixupTask } from "../non-stop/FixupTask";
-import { isNetworkError } from "../services/AuthProvider";
+import { logError } from '../log'
+import type { FixupController } from '../non-stop/FixupController'
+import type { FixupTask } from '../non-stop/FixupTask'
+import { isNetworkError } from '../services/AuthProvider'
 
-import { workspace } from "vscode";
-import { doesFileExist } from "../commands/utils/workspace-files";
-import { isRunningInsideAgent } from "../jsonrpc/isRunningInsideAgent";
-import { CodyTaskState } from "../non-stop/utils";
-import { telemetryService } from "../services/telemetry";
-import { splitSafeMetadata } from "../services/telemetry-v2";
-import { countCode } from "../services/utils/code-count";
-import type { EditManagerOptions } from "./manager";
-import { responseTransformer } from "./output/response-transformer";
-import { buildInteraction } from "./prompt";
-import { PROMPT_TOPICS } from "./prompt/constants";
+import { workspace } from 'vscode'
+import { doesFileExist } from '../commands/utils/workspace-files'
+import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
+import { CodyTaskState } from '../non-stop/utils'
+import { telemetryService } from '../services/telemetry'
+import { splitSafeMetadata } from '../services/telemetry-v2'
+import { countCode } from '../services/utils/code-count'
+import type { EditManagerOptions } from './manager'
+import { responseTransformer } from './output/response-transformer'
+import { buildInteraction } from './prompt'
+import { PROMPT_TOPICS } from './prompt/constants'
 
 interface EditProviderOptions extends EditManagerOptions {
-	task: FixupTask;
-	controller: FixupController;
+    task: FixupTask
+    controller: FixupController
 }
 
 // Initiates a completion and responds to the result from the LLM. Implements
 // "tools" like directing the response into a specific file. Code is forwarded
 // to the FixupTask.
 export class EditProvider {
-	private insertionResponse: string | null = null;
-	private insertionInProgress = false;
-	private insertionPromise: Promise<void> | null = null;
-	private abortController: AbortController | null = null;
+    private insertionResponse: string | null = null
+    private insertionInProgress = false
+    private insertionPromise: Promise<void> | null = null
+    private abortController: AbortController | null = null
 
-	constructor(public config: EditProviderOptions) {}
+    constructor(public config: EditProviderOptions) {}
 
-	public async startEdit(): Promise<void> {
-		return wrapInActiveSpan("command.edit.start", async (span) => {
-			this.config.controller.startTask(this.config.task);
-			const model = this.config.task.model;
-			const contextWindow = ModelProvider.getContextWindowByID(model);
-			const {
-				messages,
-				stopSequences,
-				responseTopic,
-				responsePrefix = "",
-			} = await buildInteraction({
-				model,
-				codyApiVersion: this.config.authProvider.getAuthStatus().codyApiVersion,
-				contextWindow: contextWindow.input,
-				task: this.config.task,
-				editor: this.config.editor,
-			}).catch((err) => {
-				this.handleError(err);
-				throw err;
-			});
+    public async startEdit(): Promise<void> {
+        return wrapInActiveSpan('command.edit.start', async span => {
+            this.config.controller.startTask(this.config.task)
+            const model = this.config.task.model
+            const contextWindow = ModelProvider.getContextWindowByID(model)
+            const {
+                messages,
+                stopSequences,
+                responseTopic,
+                responsePrefix = '',
+            } = await buildInteraction({
+                model,
+                codyApiVersion: this.config.authProvider.getAuthStatus().codyApiVersion,
+                contextWindow: contextWindow.input,
+                task: this.config.task,
+                editor: this.config.editor,
+            }).catch(err => {
+                this.handleError(err)
+                throw err
+            })
 
-			const multiplexer = new BotResponseMultiplexer();
+            const multiplexer = new BotResponseMultiplexer()
 
-			const typewriter = new Typewriter({
-				update: (content) => {
-					void this.handleResponse(content, true);
-				},
-				close: () => {},
-			});
+            const typewriter = new Typewriter({
+                update: content => {
+                    void this.handleResponse(content, true)
+                },
+                close: () => {},
+            })
 
-			let text = "";
-			multiplexer.sub(responseTopic, {
-				onResponse: async (content: string) => {
-					text += content;
-					typewriter.update(responsePrefix + text);
-					return Promise.resolve();
-				},
-				onTurnComplete: async () => {
-					typewriter.close();
-					typewriter.stop();
-					void this.handleResponse(text, false);
-					return Promise.resolve();
-				},
-			});
+            let text = ''
+            multiplexer.sub(responseTopic, {
+                onResponse: async (content: string) => {
+                    text += content
+                    typewriter.update(responsePrefix + text)
+                    return Promise.resolve()
+                },
+                onTurnComplete: async () => {
+                    typewriter.close()
+                    typewriter.stop()
+                    void this.handleResponse(text, false)
+                    return Promise.resolve()
+                },
+            })
 
-			if (this.config.task.intent === "test") {
-				if (this.config.task.destinationFile) {
-					// We have already provided a destination file,
-					// Treat this as the test file to insert to
-					await this.config.controller.didReceiveNewFileRequest(
-						this.config.task.id,
-						this.config.task.destinationFile,
-					);
-				} else {
-					// Listen to test file name suggestion from responses
-					// Allows Cody to let us know which test file we should add the new content to
-					let filepath = "";
-					multiplexer.sub(PROMPT_TOPICS.FILENAME.toString(), {
-						onResponse: async (content: string) => {
-							filepath += content;
-							void this.handleFileCreationResponse(filepath, true);
-							return Promise.resolve();
-						},
-						onTurnComplete: async () => {
-							return Promise.resolve();
-						},
-					});
-				}
-			}
+            if (this.config.task.intent === 'test') {
+                if (this.config.task.destinationFile) {
+                    // We have already provided a destination file,
+                    // Treat this as the test file to insert to
+                    await this.config.controller.didReceiveNewFileRequest(
+                        this.config.task.id,
+                        this.config.task.destinationFile
+                    )
+                } else {
+                    // Listen to test file name suggestion from responses
+                    // Allows Cody to let us know which test file we should add the new content to
+                    let filepath = ''
+                    multiplexer.sub(PROMPT_TOPICS.FILENAME.toString(), {
+                        onResponse: async (content: string) => {
+                            filepath += content
+                            void this.handleFileCreationResponse(filepath, true)
+                            return Promise.resolve()
+                        },
+                        onTurnComplete: async () => {
+                            return Promise.resolve()
+                        },
+                    })
+                }
+            }
 
-			this.abortController = new AbortController();
-			const stream = this.config.chat.chat(
-				messages,
-				{
-					model,
-					stopSequences,
-					maxTokensToSample: contextWindow.output,
-				},
-				this.abortController.signal,
-			);
+            this.abortController = new AbortController()
+            const stream = this.config.chat.chat(
+                messages,
+                {
+                    model,
+                    stopSequences,
+                    maxTokensToSample: contextWindow.output,
+                },
+                this.abortController.signal
+            )
 
-			let textConsumed = 0;
-			for await (const message of stream) {
-				switch (message.type) {
-					case "change": {
-						if (textConsumed === 0 && responsePrefix) {
-							void multiplexer.publish(responsePrefix);
-						}
-						const text = message.text.slice(textConsumed);
-						textConsumed += text.length;
-						void multiplexer.publish(text);
-						break;
-					}
-					case "complete": {
-						void multiplexer.notifyTurnComplete();
-						break;
-					}
-					case "error": {
-						let err = message.error;
-						logError("EditProvider:onError", err.message);
+            let textConsumed = 0
+            for await (const message of stream) {
+                switch (message.type) {
+                    case 'change': {
+                        if (textConsumed === 0 && responsePrefix) {
+                            void multiplexer.publish(responsePrefix)
+                        }
+                        const text = message.text.slice(textConsumed)
+                        textConsumed += text.length
+                        void multiplexer.publish(text)
+                        break
+                    }
+                    case 'complete': {
+                        void multiplexer.notifyTurnComplete()
+                        break
+                    }
+                    case 'error': {
+                        let err = message.error
+                        logError('EditProvider:onError', err.message)
 
-						if (isAbortError(err)) {
-							void this.handleResponse(text, false);
-							return;
-						}
+                        if (isAbortError(err)) {
+                            void this.handleResponse(text, false)
+                            return
+                        }
 
-						if (isNetworkError(err)) {
-							err = new Error("Cody could not respond due to network error.");
-						}
+                        if (isNetworkError(err)) {
+                            err = new Error('Cody could not respond due to network error.')
+                        }
 
-						// Display error message as assistant response
-						this.handleError(err);
-						console.error(`Completion request failed: ${err.message}`);
+                        // Display error message as assistant response
+                        this.handleError(err)
+                        console.error(`Completion request failed: ${err.message}`)
 
-						break;
-					}
-				}
-			}
-		});
-	}
+                        break
+                    }
+                }
+            }
+        })
+    }
 
-	public abortEdit(): void {
-		this.abortController?.abort();
-	}
+    public abortEdit(): void {
+        this.abortController?.abort()
+    }
 
-	private async handleResponse(
-		response: string,
-		isMessageInProgress: boolean,
-	): Promise<void> {
-		// Error state: The response finished but we didn't receive any text
-		if (!response && !isMessageInProgress) {
-			this.handleError(new Error("Cody did not respond with any text"));
-		}
+    private async handleResponse(response: string, isMessageInProgress: boolean): Promise<void> {
+        // Error state: The response finished but we didn't receive any text
+        if (!response && !isMessageInProgress) {
+            this.handleError(new Error('Cody did not respond with any text'))
+        }
 
-		if (!response) {
-			return;
-		}
+        if (!response) {
+            return
+        }
 
-		// If the response finished and we didn't receive a test file name suggestion,
-		// we will create one manually before inserting the response to the new test file
-		if (
-			this.config.task.intent === "test" &&
-			!this.config.task.destinationFile
-		) {
-			if (isMessageInProgress) {
-				return;
-			}
-			await this.handleFileCreationResponse("", isMessageInProgress);
-		}
+        // If the response finished and we didn't receive a test file name suggestion,
+        // we will create one manually before inserting the response to the new test file
+        if (this.config.task.intent === 'test' && !this.config.task.destinationFile) {
+            if (isMessageInProgress) {
+                return
+            }
+            await this.handleFileCreationResponse('', isMessageInProgress)
+        }
 
-		if (!isMessageInProgress) {
-			const { task } = this.config;
-			const legacyMetadata = {
-				intent: task.intent,
-				mode: task.mode,
-				source: task.source,
-				...countCode(response),
-			};
-			telemetryService.log(
-				"CodyVSCodeExtension:fixupResponse:hasCode",
-				legacyMetadata,
-				{
-					hasV2Event: true,
-				},
-			);
-			const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata);
-			const endpoint = this.config.authProvider?.getAuthStatus()?.endpoint;
-			telemetryRecorder.recordEvent("cody.fixup.response", "hasCode", {
-				metadata,
-				privateMetadata: {
-					...privateMetadata,
-					model: task.model,
-					// 🚨 SECURITY: edit responses are to be included only for DotCom users AND for V2 telemetry
-					// V2 telemetry exports privateMetadata only for DotCom users
-					// the condition below is an aditional safegaurd measure
-					responseText: endpoint && isDotCom(endpoint) ? response : undefined,
-				},
-			});
-		}
+        if (!isMessageInProgress) {
+            const { task } = this.config
+            const legacyMetadata = {
+                intent: task.intent,
+                mode: task.mode,
+                source: task.source,
+                ...countCode(response),
+            }
+            telemetryService.log('CodyVSCodeExtension:fixupResponse:hasCode', legacyMetadata, {
+                hasV2Event: true,
+            })
+            const { metadata, privateMetadata } = splitSafeMetadata(legacyMetadata)
+            const endpoint = this.config.authProvider?.getAuthStatus()?.endpoint
+            telemetryRecorder.recordEvent('cody.fixup.response', 'hasCode', {
+                metadata,
+                privateMetadata: {
+                    ...privateMetadata,
+                    model: task.model,
+                    // 🚨 SECURITY: edit responses are to be included only for DotCom users AND for V2 telemetry
+                    // V2 telemetry exports privateMetadata only for DotCom users
+                    // the condition below is an aditional safegaurd measure
+                    responseText: endpoint && isDotCom(endpoint) ? response : undefined,
+                },
+            })
+        }
 
-		if (isRunningInsideAgent() && this.config.task.intent === "add") {
-			// TODO: We have disabled running `handleStreamedFixupInsert` through Agent
-			// as we are running into a blocking issue where this results in duplicate
-			// chunks of text from the LLM being inserted into the document.
-			// Issue to fix: https://github.com/sourcegraph/jetbrains/issues/1449
+        if (isRunningInsideAgent() && this.config.task.intent === 'add') {
+            // TODO: We have disabled running `handleStreamedFixupInsert` through Agent
+            // as we are running into a blocking issue where this results in duplicate
+            // chunks of text from the LLM being inserted into the document.
+            // Issue to fix: https://github.com/sourcegraph/jetbrains/issues/1449
 
-			if (isMessageInProgress) {
-				// Response hasn't finished, disable until we have the full response
-				return;
-			}
+            if (isMessageInProgress) {
+                // Response hasn't finished, disable until we have the full response
+                return
+            }
 
-			return this.handleFixupInsert(response, isMessageInProgress);
-		}
+            return this.handleFixupInsert(response, isMessageInProgress)
+        }
 
-		const intentsForInsert = ["add", "test"];
-		return intentsForInsert.includes(this.config.task.intent)
-			? this.handleStreamedFixupInsert(response, isMessageInProgress)
-			: this.handleFixupEdit(response, isMessageInProgress);
-	}
+        const intentsForInsert = ['add', 'test']
+        return intentsForInsert.includes(this.config.task.intent)
+            ? this.handleStreamedFixupInsert(response, isMessageInProgress)
+            : this.handleFixupEdit(response, isMessageInProgress)
+    }
 
-	/**
-	 * Display an erred codelens to the user on failed fixup apply.
-	 * Will allow the user to view the error in more detail if needed.
-	 */
-	protected handleError(error: Error): void {
-		this.config.controller.error(this.config.task.id, error);
-	}
+    /**
+     * Display an erred codelens to the user on failed fixup apply.
+     * Will allow the user to view the error in more detail if needed.
+     */
+    protected handleError(error: Error): void {
+        this.config.controller.error(this.config.task.id, error)
+    }
 
-	private async handleFixupEdit(
-		response: string,
-		isMessageInProgress: boolean,
-	): Promise<void> {
-		return this.config.controller.didReceiveFixupText(
-			this.config.task.id,
-			responseTransformer(response, this.config.task, isMessageInProgress),
-			isMessageInProgress ? "streaming" : "complete",
-		);
-	}
+    private async handleFixupEdit(response: string, isMessageInProgress: boolean): Promise<void> {
+        return this.config.controller.didReceiveFixupText(
+            this.config.task.id,
+            responseTransformer(response, this.config.task, isMessageInProgress),
+            isMessageInProgress ? 'streaming' : 'complete'
+        )
+    }
 
-	private async handleFixupInsert(
-		response: string,
-		isMessageInProgress: boolean,
-	): Promise<void> {
-		return this.config.controller.didReceiveFixupInsertion(
-			this.config.task.id,
-			responseTransformer(response, this.config.task, this.insertionInProgress),
-			this.insertionInProgress ? "streaming" : "complete",
-		);
-	}
+    private async handleFixupInsert(response: string, isMessageInProgress: boolean): Promise<void> {
+        return this.config.controller.didReceiveFixupInsertion(
+            this.config.task.id,
+            responseTransformer(response, this.config.task, this.insertionInProgress),
+            this.insertionInProgress ? 'streaming' : 'complete'
+        )
+    }
 
-	private async handleStreamedFixupInsert(
-		response: string,
-		isMessageInProgress: boolean,
-	): Promise<void> {
-		this.insertionResponse = response;
-		this.insertionInProgress = isMessageInProgress;
+    private async handleStreamedFixupInsert(
+        response: string,
+        isMessageInProgress: boolean
+    ): Promise<void> {
+        this.insertionResponse = response
+        this.insertionInProgress = isMessageInProgress
 
-		if (this.insertionPromise) {
-			// Already processing an insertion, wait for it to finish
-			return;
-		}
+        if (this.insertionPromise) {
+            // Already processing an insertion, wait for it to finish
+            return
+        }
 
-		while (this.insertionResponse !== null) {
-			const responseToSend = this.insertionResponse;
-			this.insertionResponse = null;
+        while (this.insertionResponse !== null) {
+            const responseToSend = this.insertionResponse
+            this.insertionResponse = null
 
-			this.insertionPromise = this.handleFixupInsert(
-				responseToSend,
-				this.insertionInProgress,
-			);
+            this.insertionPromise = this.handleFixupInsert(responseToSend, this.insertionInProgress)
 
-			try {
-				await this.insertionPromise;
-			} finally {
-				this.insertionPromise = null;
-			}
-		}
-	}
+            try {
+                await this.insertionPromise
+            } finally {
+                this.insertionPromise = null
+            }
+        }
+    }
 
-	private async handleFileCreationResponse(
-		text: string,
-		isMessageInProgress: boolean,
-	): Promise<void> {
-		const task = this.config.task;
-		if (task.state !== CodyTaskState.Pending) {
-			return;
-		}
+    private async handleFileCreationResponse(text: string, isMessageInProgress: boolean): Promise<void> {
+        const task = this.config.task
+        if (task.state !== CodyTaskState.Pending) {
+            return
+        }
 
-		// Has already been created when set
-		if (task.destinationFile) {
-			return;
-		}
+        // Has already been created when set
+        if (task.destinationFile) {
+            return
+        }
 
-		// Manually create the file if no name was suggested
-		if (!text.length && !isMessageInProgress) {
-			// Create a new untitled file if the suggested file does not exist
-			const currentFile = task.fixupFile.uri;
-			const currentDoc = await workspace.openTextDocument(currentFile);
-			const newDoc = await workspace.openTextDocument({
-				language: currentDoc?.languageId,
-			});
-			await this.config.controller.didReceiveNewFileRequest(
-				this.config.task.id,
-				newDoc.uri,
-			);
-			return;
-		}
+        // Manually create the file if no name was suggested
+        if (!text.length && !isMessageInProgress) {
+            // Create a new untitled file if the suggested file does not exist
+            const currentFile = task.fixupFile.uri
+            const currentDoc = await workspace.openTextDocument(currentFile)
+            const newDoc = await workspace.openTextDocument({
+                language: currentDoc?.languageId,
+            })
+            await this.config.controller.didReceiveNewFileRequest(this.config.task.id, newDoc.uri)
+            return
+        }
 
-		const opentag = `<${PROMPT_TOPICS.FILENAME}>`;
-		const closetag = `</${PROMPT_TOPICS.FILENAME}>`;
+        const opentag = `<${PROMPT_TOPICS.FILENAME}>`
+        const closetag = `</${PROMPT_TOPICS.FILENAME}>`
 
-		const currentFileUri = task.fixupFile.uri;
-		const currentFileName = uriBasename(currentFileUri);
-		// remove open and close tags from text
-		const newFilePath = text
-			.trim()
-			.replaceAll(new RegExp(`${opentag}(.*)${closetag}`, "g"), "$1");
-		const haveSameExtensions =
-			posixFilePaths.extname(currentFileName) ===
-			posixFilePaths.extname(newFilePath);
+        const currentFileUri = task.fixupFile.uri
+        const currentFileName = uriBasename(currentFileUri)
+        // remove open and close tags from text
+        const newFilePath = text.trim().replaceAll(new RegExp(`${opentag}(.*)${closetag}`, 'g'), '$1')
+        const haveSameExtensions =
+            posixFilePaths.extname(currentFileName) === posixFilePaths.extname(newFilePath)
 
-		// Get workspace uri using the current file uri
-		const workspaceUri = workspace.getWorkspaceFolder(currentFileUri)?.uri;
-		const currentDirUri = Utils.joinPath(currentFileUri, "..");
+        // Get workspace uri using the current file uri
+        const workspaceUri = workspace.getWorkspaceFolder(currentFileUri)?.uri
+        const currentDirUri = Utils.joinPath(currentFileUri, '..')
 
-		// Create a new file uri by replacing the file name of the currentFileUri with fileName
-		let newFileUri = Utils.joinPath(workspaceUri ?? currentDirUri, newFilePath);
-		if (haveSameExtensions && !task.destinationFile) {
-			const fileIsFound = await doesFileExist(newFileUri);
-			if (!fileIsFound) {
-				newFileUri = newFileUri.with({ scheme: "untitled" });
-			}
-			this.insertionPromise = this.config.controller.didReceiveNewFileRequest(
-				task.id,
-				newFileUri,
-			);
-			try {
-				await this.insertionPromise;
-			} catch (error) {
-				this.handleError(
-					new Error("Cody failed to generate unit tests", { cause: error }),
-				);
-			} finally {
-				this.insertionPromise = null;
-			}
-		}
-	}
+        // Create a new file uri by replacing the file name of the currentFileUri with fileName
+        let newFileUri = Utils.joinPath(workspaceUri ?? currentDirUri, newFilePath)
+        if (haveSameExtensions && !task.destinationFile) {
+            const fileIsFound = await doesFileExist(newFileUri)
+            if (!fileIsFound) {
+                newFileUri = newFileUri.with({ scheme: 'untitled' })
+            }
+            this.insertionPromise = this.config.controller.didReceiveNewFileRequest(task.id, newFileUri)
+            try {
+                await this.insertionPromise
+            } catch (error) {
+                this.handleError(new Error('Cody failed to generate unit tests', { cause: error }))
+            } finally {
+                this.insertionPromise = null
+            }
+        }
+    }
 }

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -223,6 +223,12 @@ export class EditProvider {
             // as we are running into a blocking issue where this results in duplicate
             // chunks of text from the LLM being inserted into the document.
             // Issue to fix: TODO
+
+            if (isMessageInProgress) {
+                // Response hasn't finished, disable until we have the full response
+                return
+            }
+
             return this.handleFixupInsert(response, isMessageInProgress)
         }
 

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -19,6 +19,7 @@ import { isNetworkError } from '../services/AuthProvider'
 
 import { workspace } from 'vscode'
 import { doesFileExist } from '../commands/utils/workspace-files'
+import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import { CodyTaskState } from '../non-stop/utils'
 import { telemetryService } from '../services/telemetry'
 import { splitSafeMetadata } from '../services/telemetry-v2'
@@ -215,8 +216,18 @@ export class EditProvider {
         }
 
         const intentsForInsert = ['add', 'test']
-        return intentsForInsert.includes(this.config.task.intent)
-            ? this.handleFixupInsert(response, isMessageInProgress)
+        const shouldInsert = intentsForInsert.includes(this.config.task.intent)
+
+        if (isRunningInsideAgent() && shouldInsert) {
+            // TODO: We have disabled running `handleStreamedFixupInsert` through Agent
+            // as we are running into a blocking issue where this results in duplicate
+            // chunks of text from the LLM being inserted into the document.
+            // Issue to fix: TODO
+            return this.handleFixupInsert(response, isMessageInProgress)
+        }
+
+        return shouldInsert
+            ? this.handleStreamedFixupInsert(response, isMessageInProgress)
             : this.handleFixupEdit(response, isMessageInProgress)
     }
 
@@ -237,6 +248,17 @@ export class EditProvider {
     }
 
     private async handleFixupInsert(response: string, isMessageInProgress: boolean): Promise<void> {
+        return this.config.controller.didReceiveFixupInsertion(
+            this.config.task.id,
+            responseTransformer(response, this.config.task, this.insertionInProgress),
+            this.insertionInProgress ? 'streaming' : 'complete'
+        )
+    }
+
+    private async handleStreamedFixupInsert(
+        response: string,
+        isMessageInProgress: boolean
+    ): Promise<void> {
         this.insertionResponse = response
         this.insertionInProgress = isMessageInProgress
 
@@ -245,19 +267,11 @@ export class EditProvider {
             return
         }
 
-        return this.processInsertionQueue()
-    }
-
-    private async processInsertionQueue(): Promise<void> {
         while (this.insertionResponse !== null) {
             const responseToSend = this.insertionResponse
             this.insertionResponse = null
 
-            this.insertionPromise = this.config.controller.didReceiveFixupInsertion(
-                this.config.task.id,
-                responseTransformer(responseToSend, this.config.task, this.insertionInProgress),
-                this.insertionInProgress ? 'streaming' : 'complete'
-            )
+            this.insertionPromise = this.handleFixupInsert(responseToSend, this.insertionInProgress)
 
             try {
                 await this.insertionPromise


### PR DESCRIPTION
## Description

We are running into issues where streamed insertions are not reliably applied to a document in JetBrains ([issue](https://github.com/sourcegraph/jetbrains/issues/1449)). This PR temporarily disables this so we can unblock progress on JetBrains whilst we figure out why this is happening

This PR:
- Disables streaming insertions into the document when running an inline edit with the `add` intent

## Test plan

1. Check the `add` variant of inline edit (create an edit with no selection)
2. Check edits are not streamed when running via agent

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
