### PR TITLE
Add command to debug context filters

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
@@ -29,7 +29,7 @@ data class ContextItemFile(
   val repoName: String? = null,
   val revision: String? = null,
   val title: String? = null,
-  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri, package
+  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri, package, history
   val size: Int? = null,
   val isTooLarge: Boolean? = null,
   val provider: String? = null,
@@ -48,7 +48,7 @@ data class ContextItemSymbol(
   val repoName: String? = null,
   val revision: String? = null,
   val title: String? = null,
-  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri, package
+  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri, package, history
   val size: Int? = null,
   val isTooLarge: Boolean? = null,
   val provider: String? = null,
@@ -69,7 +69,7 @@ data class ContextItemPackage(
   val repoName: String? = null,
   val revision: String? = null,
   val title: String? = null,
-  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri, package
+  val source: ContextItemSource? = null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri, package, history
   val size: Int? = null,
   val isTooLarge: Boolean? = null,
   val provider: String? = null,

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemSource.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItemSource.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-typealias ContextItemSource = String // One of: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri, package
+typealias ContextItemSource = String // One of: embeddings, user, keyword, editor, filename, search, unified, selection, terminal, uri, package, history
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -727,6 +727,10 @@
         {
           "command": "cody.show-rate-limit-modal",
           "when": "false"
+        },
+        {
+          "command": "cody.test.set-context-filters",
+          "when": "cody.activated && cody.devOrTest"
         }
       ],
       "editor/context": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -546,13 +546,6 @@
         "when": "!config.cody.debug.verbose"
       },
       {
-        "command": "cody.test.set-context-filters",
-        "category": "Cody Debug",
-        "group": "Debug",
-        "title": "[Debug] Set Context Filters Overwrite",
-        "when": "cody.enabled && config.cody.debug.verbose"
-      },
-      {
         "command": "cody.debug.reportIssue",
         "category": "Cody Debug",
         "group": "Debug",
@@ -572,6 +565,11 @@
         "icon": "$(search)",
         "title": "Natural Language Search Code (Beta)",
         "when": "cody.activated && workspaceFolderCount > 0"
+      },
+      {
+        "command": "cody.test.set-context-filters",
+        "title": "[Internal] Set Context Filters Overwrite",
+        "when": "!cody.devOrTest"
       }
     ],
     "keybindings": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -569,7 +569,7 @@
       {
         "command": "cody.test.set-context-filters",
         "title": "[Internal] Set Context Filters Overwrite",
-        "when": "!cody.devOrTest"
+        "when": "cody.activated && cody.devOrTest"
       }
     ],
     "keybindings": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -546,6 +546,13 @@
         "when": "!config.cody.debug.verbose"
       },
       {
+        "command": "cody.test.set-context-filters",
+        "category": "Cody Debug",
+        "group": "Debug",
+        "title": "[Debug] Set Context Filters Overwrite",
+        "when": "cody.enabled && config.cody.debug.verbose"
+      },
+      {
         "command": "cody.debug.reportIssue",
         "category": "Cody Debug",
         "group": "Debug",

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -149,9 +149,7 @@ const register = async (
     const isExtensionModeDevOrTest =
         context.extensionMode === vscode.ExtensionMode.Development ||
         context.extensionMode === vscode.ExtensionMode.Test
-    if (isExtensionModeDevOrTest) {
-        await vscode.commands.executeCommand('setContext', 'cody.devOrTest', true)
-    }
+
     await configureEventsInfra(initialConfig, isExtensionModeDevOrTest, authProvider)
 
     const editor = new VSCodeEditor()
@@ -393,27 +391,35 @@ const register = async (
         )
     )
 
+    // Internal-only test commands
+    if (!isExtensionModeDevOrTest) {
+        await vscode.commands.executeCommand('setContext', 'cody.devOrTest', true)
+        disposables.push(
+            vscode.commands.registerCommand('cody.test.set-context-filters', async () => {
+                // Prompt the user for the policy
+                const raw = await vscode.window.showInputBox({ title: 'Context Filters Overwrite' })
+                if (!raw) {
+                    return
+                }
+                try {
+                    const policy = JSON.parse(raw)
+                    contextFiltersProvider.setTestingContextFilters(policy)
+                } catch (error) {
+                    vscode.window.showErrorMessage(
+                        'Failed to parse context filters policy. Please check your JSON syntax.'
+                    )
+                }
+            })
+        )
+    }
+
     disposables.push(
         // Tests
         // Access token - this is only used in configuration tests
         vscode.commands.registerCommand('cody.test.token', async (endpoint, token) =>
             authProvider.auth({ endpoint, token })
         ),
-        vscode.commands.registerCommand('cody.test.set-context-filters', async () => {
-            // Prompt the user for the policy
-            const raw = await vscode.window.showInputBox({ title: 'Context Filters Overwrite' })
-            if (!raw) {
-                return
-            }
-            try {
-                const policy = JSON.parse(raw)
-                contextFiltersProvider.setTestingContextFilters(policy)
-            } catch (error) {
-                vscode.window.showErrorMessage(
-                    'Failed to parse context filters policy. Please check your JSON syntax.'
-                )
-            }
-        }),
+
         // Auth
         vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -392,7 +392,7 @@ const register = async (
     )
 
     // Internal-only test commands
-    if (!isExtensionModeDevOrTest) {
+    if (isExtensionModeDevOrTest) {
         await vscode.commands.executeCommand('setContext', 'cody.devOrTest', true)
         disposables.push(
             vscode.commands.registerCommand('cody.test.set-context-filters', async () => {

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -149,6 +149,9 @@ const register = async (
     const isExtensionModeDevOrTest =
         context.extensionMode === vscode.ExtensionMode.Development ||
         context.extensionMode === vscode.ExtensionMode.Test
+    if (isExtensionModeDevOrTest) {
+        await vscode.commands.executeCommand('setContext', 'cody.devOrTest', true)
+    }
     await configureEventsInfra(initialConfig, isExtensionModeDevOrTest, authProvider)
 
     const editor = new VSCodeEditor()

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -396,6 +396,21 @@ const register = async (
         vscode.commands.registerCommand('cody.test.token', async (endpoint, token) =>
             authProvider.auth({ endpoint, token })
         ),
+        vscode.commands.registerCommand('cody.test.set-context-filters', async () => {
+            // Prompt the user for the policy
+            const raw = await vscode.window.showInputBox({ title: 'Context Filters Overwrite' })
+            if (!raw) {
+                return
+            }
+            try {
+                const policy = JSON.parse(raw)
+                contextFiltersProvider.setTestingContextFilters(policy)
+            } catch (error) {
+                vscode.window.showErrorMessage(
+                    'Failed to parse context filters policy. Please check your JSON syntax.'
+                )
+            }
+        }),
         // Auth
         vscode.commands.registerCommand('cody.auth.signin', () => authProvider.signinMenu()),
         vscode.commands.registerCommand('cody.auth.signout', () => authProvider.signoutMenu()),


### PR DESCRIPTION
Closes CODY-1341

Add a command to overwrite context filters. I've for now gated it to only show up when verbose debugging is enabled however that doesn't seem to be working well 🤔 

## Test plan

```
{ "include": [], "exclude": [{ "repoNamePattern": "^github\\.com/sourcegraph/sourcegraph" }] }
```


https://github.com/sourcegraph/cody/assets/458591/4fda5932-a708-457f-9a55-072cd42d9b08
