### PR TITLE
noodle: add ContextItemHistory type

### DIFF
--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -97,7 +97,7 @@ export enum ContextItemSource {
 /**
  * An item (such as a file or symbol) that is included as context in a chat message.
  */
-export type ContextItem = ContextItemFile | ContextItemSymbol | ContextItemPackage
+export type ContextItem = ContextItemFile | ContextItemSymbol | ContextItemPackage | ContextItemHistory
 
 /**
  * A file (or a subset of a file given by a range) that is included as context in a chat message.
@@ -146,6 +146,19 @@ export interface ContextItemSymbol extends ContextItemCommon {
 
 /** The valid kinds of a symbol. */
 export type SymbolKind = 'class' | 'function' | 'method'
+
+/**
+ * The output of source control history for a file.
+ *
+ * Note: Currently this is only used for the "Explain History" action which runs
+ * on a symbol.
+ */
+export interface ContextItemHistory extends ContextItemCommon {
+    type: 'history'
+
+    /** The symbol name we asked history for, used for presentation only (not semantically meaningful). */
+    symbolName: string
+}
 
 /** {@link ContextItem} with the `content` field set to the content. */
 export type ContextItemWithContent = ContextItem & Required<Pick<ContextItem, 'content'>>

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -52,6 +52,7 @@ export type {
 export {
     type ContextItem,
     type ContextItemFile,
+    type ContextItemHistory,
     ContextItemSource,
     type ContextItemWithContent,
     type ContextItemSymbol,

--- a/vscode/src/commands/context/git-log.ts
+++ b/vscode/src/commands/context/git-log.ts
@@ -2,11 +2,11 @@ import { type SpawnOptionsWithoutStdio, spawn } from 'node:child_process'
 import path from 'node:path'
 import {
     type ContextItem,
+    type ContextItemHistory,
     ContextItemSource,
     type FileURI,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-import * as vscode from 'vscode'
 
 export async function getContextFileFromGitLog(
     file: FileURI,
@@ -45,15 +45,15 @@ export async function getContextFileFromGitLog(
             throw new Error(`git log failed with exit code ${result.code}: ${result.stderr}`)
         }
 
-        return [
-            {
-                type: 'file',
-                content: result.stdout,
-                title: 'Terminal Output',
-                uri: vscode.Uri.file('terminal-output'),
-                source: ContextItemSource.History,
-            },
-        ]
+        const contextItem: ContextItemHistory = {
+            type: 'history',
+            content: result.stdout,
+            title: `history for ${options.funcname}`,
+            uri: file,
+            symbolName: options.funcname,
+            source: ContextItemSource.History,
+        }
+        return [contextItem]
     })
 }
 

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -105,7 +105,7 @@ const Item: FunctionComponent<{
     const isFileType = item.type === 'file'
     const isPackageType = item.type === 'package'
     const icon =
-        isFileType || isPackageType ? null : item.kind === 'class' ? 'symbol-structure' : 'symbol-method'
+        item.type === 'symbol' ? (item.kind === 'class' ? 'symbol-structure' : 'symbol-method') : null
     const title =
         item.title ?? (isFileType || isPackageType ? displayPathBasename(item.uri) : item.symbolName)
 


### PR DESCRIPTION
This is built on top of the explain history PR to introduce a type for history. Right now it is hacked in as pretend terminal output and doesn't work that well. This is the start of presenting the context more clearly.

This is still early, so is a draft.

Test Plan: CI