### PR TITLE
Add Google Authentication for `vscode-insiders-release.yml`

### DIFF
--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -21,6 +21,14 @@ jobs:
       - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # SECURITY: pin third-party action hashes
         with:
           run_install: true
+      - id: auth
+        uses: google-github-actions/auth@v0
+          # Skip auth if PR is from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        with:
+          workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}
+          service_account: ${{ secrets.DATA_TEAM_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v0
       - run: pnpm build
       - run: pnpm run test
       - run: xvfb-run -a pnpm -C vscode run test:integration

--- a/.github/workflows/vscode-insiders-release.yml
+++ b/.github/workflows/vscode-insiders-release.yml
@@ -23,7 +23,7 @@ jobs:
           run_install: true
       - id: auth
         uses: google-github-actions/auth@v0
-          # Skip auth if PR is from a fork
+        # Skip auth if PR is from a fork
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           workload_identity_provider: ${{ secrets.DATA_TEAM_PROVIDER_NAME }}


### PR DESCRIPTION
The `vscode-insiders-release` GitHub workflow runs E2E tests which require google-auth to send pubsub messages to our testing topic. Here we are introducing Google Authentication within the github Workflow.
Resolving:
- https://github.com/sourcegraph/cody-issues/issues/93
## Test plan
Test via CI and verify auth errors are gone
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
