### PR TITLE
example: add public GitHub repo detection

### DIFF
--- a/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
+++ b/vscode/src/chat/chat-view/CodebaseStatusProvider.ts
@@ -15,13 +15,17 @@ import { getConfiguration } from '../../configuration'
 import type { CodebaseRepoIdMapper } from '../../context/enterprise-context-factory'
 import { getEditor } from '../../editor/active-editor'
 import type { SymfRunner } from '../../local-context/symf'
-import { getCodebaseFromWorkspaceUri } from '../../repository/git-extension-api'
+import {
+    getCodebaseFromWorkspaceUri,
+    isCodebasPublicGitHubRepo,
+} from '../../repository/git-extension-api'
 
 interface CodebaseIdentifiers {
     localFolder: vscode.Uri
     remote?: string
     remoteRepoId?: string
     setting?: string
+    isPublic?: boolean
 }
 
 /**
@@ -160,6 +164,7 @@ export class CodebaseStatusProvider implements vscode.Disposable, ContextStatusP
                 newCodebase.remoteRepoId = (
                     await this.codebaseRepoIdMapper?.repoForCodebase(newCodebase.remote)
                 )?.id
+                newCodebase.isPublic = await isCodebasPublicGitHubRepo(newCodebase.remote)
             }
         }
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -497,6 +497,12 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                               })
                         : undefined
                 )
+
+                // NOTE (bee): Is there a possibility where the current codebase does not match
+                // the codebase used for fetching the enhanced context?
+                const currentCodebase = await this.codebaseStatusProvider.currentCodebase()
+                console.log(currentCodebase?.isPublic, 'is currentCodebase public?')
+
                 const sendTelemetry = (contextSummary: any, privateContextStats?: any): void => {
                     const properties = {
                         ...sharedProperties,

--- a/vscode/src/local-context/context-ranking.ts
+++ b/vscode/src/local-context/context-ranking.ts
@@ -305,6 +305,7 @@ export class ContextRankingController implements ContextRanker {
                     range,
                     content: result.content,
                     source: ContextItemSource.Embeddings,
+                    repoName: result.repoName,
                 })
             }
             return contextItems

--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -598,6 +598,7 @@ export class LocalEmbeddingsController
                 return resp.results.map(result => ({
                     ...result,
                     uri: vscode.Uri.joinPath(lastRepo.dir, result.fileName),
+                    repoName: lastRepo.repoName as string,
                 }))
             } catch (error) {
                 logDebug('LocalEmbeddingsController', 'query', captureException(error), error)

--- a/vscode/src/repository/git-extension-api.ts
+++ b/vscode/src/repository/git-extension-api.ts
@@ -106,3 +106,22 @@ export function gitRemoteUrlsFromGitExtension(uri: vscode.Uri): string[] | undef
 
     return remoteUrls.size ? Array.from(remoteUrls) : undefined
 }
+
+export async function isCodebasPublicGitHubRepo(codebase: string): Promise<boolean> {
+    // codebase format example: github.com/owner/repo or github.com/owner/repo.git
+    const match = codebase?.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/)
+    if (!match) {
+        return false
+    }
+
+    const [, owner, repo] = match
+    const repositoryUrl = `https://api.github.com/repos/${owner}/${repo}`
+
+    try {
+        const response = await fetch(repositoryUrl, { method: 'HEAD' })
+        return response.ok
+    } catch (error) {
+        console.error('Error fetching repository information:', error)
+        return false
+    }
+}


### PR DESCRIPTION
RE: https://github.com/sourcegraph/cody/pull/3882
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1714713057094709

This pull request introduces a new feature to detect if the current codebase is a public GitHub repository. 

The main changes are as follows:

- A new function isCodebasPublicGitHubRepo is added, which takes a codebase string (e.g., github.com/owner/repo) and performs a HEAD request to the GitHub API to determine if the repository is public or private.
- A new property isPublic is added to the CodebaseIdentifiers interface to store the public/private status of the codebase.
- The currentCodebase method is updated to fetch and store the public/private status using the new isCodebasPublicGitHubRepo function from the git-extension-api module.
- Updated the searchSymf and searchEmbeddingsLocal functions to pass the repository name (obtained from the codebase URI) to the generated ContextItem objects.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Perform a search and check console log to look for `is currentCodebase public?` to verify if the returned result is correct:

![image](https://github.com/sourcegraph/cody/assets/68532117/79db2c61-9389-4648-b5c2-8714479e39b8)
