### PR TITLE
add experimental vscode command to get completions from multiple models

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -77,6 +77,7 @@ export interface Configuration {
     autocompleteExperimentalOllamaOptions: OllamaOptions
     autocompleteExperimentalFireworksOptions?: FireworksOptions
     autocompleteExperimentalSmartThrottle?: boolean
+    autocompleteExperimentalMultiModelCompletions?: MultimodelSingleModelConfig[]
 
     /**
      * Hidden settings
@@ -235,6 +236,13 @@ export interface FireworksOptions {
         top_p?: number
         stop?: string[]
     }
+}
+
+export interface MultimodelSingleModelConfig {
+    provider: string
+    model: string
+    // This flag decides if to enable "cody.autocomplete.experimental.fireworksOptions" settings when creating a custom provider
+    enableExperimentalFireworksOverrides: boolean
 }
 
 export interface EmbeddingsModelConfig {

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -417,6 +417,12 @@
         "when": "cody.activated && config.cody.autocomplete && editorHasFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
+        "command": "cody.multi-model-autocomplete.manual-trigger",
+        "category": "Cody",
+        "title": "Get Completions for multiple autocomplete models",
+        "when": "cody.activated && config.cody.autocomplete && editorHasFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
+      },
+      {
         "command": "cody.chat.panel.new",
         "category": "Cody",
         "title": "New Chat",
@@ -641,6 +647,11 @@
       },
       {
         "command": "cody.autocomplete.manual-trigger",
+        "key": "alt+\\",
+        "when": "editorTextFocus && !editorHasSelection && config.cody.autocomplete.enabled && !inlineSuggestionsVisible"
+      },
+      {
+        "command": "cody.multi-model-autocomplete.manual-trigger",
         "key": "alt+\\",
         "when": "editorTextFocus && !editorHasSelection && config.cody.autocomplete.enabled && !inlineSuggestionsVisible"
       },

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -420,7 +420,7 @@
         "command": "cody.multi-model-autocomplete.manual-trigger",
         "category": "Cody",
         "title": "Get Completions for multiple autocomplete models",
-        "when": "cody.activated && config.cody.autocomplete && editorHasFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
+        "when": "cody.activated && config.cody.autocomplete.experimental.multiModelCompletions && config.cody.autocomplete && editorHasFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
         "command": "cody.chat.panel.new",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -652,7 +652,7 @@
       },
       {
         "command": "cody.multi-model-autocomplete.manual-trigger",
-        "key": "alt+\\",
+        "key": "alt+m",
         "when": "editorTextFocus && !editorHasSelection && config.cody.autocomplete.enabled && !inlineSuggestionsVisible"
       },
       {

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -144,6 +144,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
         {
             'provider': 'fireworks',
             'model': 'fireworks-completions-fine-tuned',
+            'overrideFireworks': true
         },
         {
             'provider': 'anthropic',
@@ -151,13 +152,18 @@ export async function createInlineCompletionItemFromMultipleProviders({
         }
     ]
     const allProviders: InlineCompletionItemProvider[] = []
+
     for (const curretProviderConfig of allProviderConfigs) {
+        const newConfig = JSON.parse(JSON.stringify(config))
+        newConfig.autocompleteExperimentalFireworksOptions = curretProviderConfig.overrideFireworks
+            ? config.autocompleteExperimentalFireworksOptions
+            : undefined
         const providerConfig = await createProviderConfigForModel(
             client,
             authStatus,
             curretProviderConfig['model'],
             curretProviderConfig['provider'],
-            config
+            newConfig
         )
         if(providerConfig) {
             const authStatus = authProvider.getAuthStatus()

--- a/vscode/src/completions/create-inline-completion-item-provider.ts
+++ b/vscode/src/completions/create-inline-completion-item-provider.ts
@@ -16,6 +16,7 @@ import type { BfgRetriever } from './context/retrievers/bfg/bfg-retriever'
 import { InlineCompletionItemProvider } from './inline-completion-item-provider'
 import { createProviderConfig } from './providers/create-provider'
 import { registerAutocompleteTraceView } from './tracer/traceView'
+import { createProviderConfigForModel } from './providers/create-provider'
 
 interface InlineCompletionItemProviderArgs {
     config: ConfigurationWithAccessToken
@@ -39,6 +40,106 @@ class NoopCompletionItemProvider implements vscode.InlineCompletionItemProvider 
         _token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.InlineCompletionItem[] | vscode.InlineCompletionList> {
         return { items: [] }
+    }
+}
+
+export async function triggerMultiModelAutocompletionsForComparison(allProviders: InlineCompletionItemProvider[]) {
+    const activeEditor = vscode.window.activeTextEditor
+    if (!activeEditor) {
+        return
+    }
+    const document = activeEditor.document;
+    const position = activeEditor.selection.active;
+    const context = {
+        triggerKind: vscode.InlineCompletionTriggerKind.Automatic,
+        selectedCompletionInfo: undefined
+    }
+    const allPromises: Promise<string>[] = []
+    for (const provider of allProviders) {
+        allPromises.push(provider.manuallyGetCompletionItemsForProvider(
+            document,
+            position,
+            context
+        ))
+    }
+    const results = await Promise.all(allPromises);
+    const allResults = results.join('\n');
+    logDebug('MultiModelAutoComplete:\n', allResults);
+}
+
+
+export async function createInlineCompletionItemFromMultipleProviders({
+    config,
+    client,
+    statusBar,
+    authProvider,
+    triggerNotice,
+    createBfgRetriever,
+}: InlineCompletionItemProviderArgs) {
+    // Creates multiple providers to get completions from.
+    // The primary purpose of this method is to get the completions generated from multiple providers,
+    // which helps judge the quality of code completions
+    const authStatus = authProvider.getAuthStatus()
+    if (!authStatus.isLoggedIn) {
+        return {
+            dispose: () => {},
+        }
+    }
+
+    const disposables: vscode.Disposable[] = []
+    const allProviderConfigs = [
+        {
+            'provider': 'fireworks',
+            'model': 'starcoder-hybrid',
+        },
+        {
+            'provider': 'fireworks',
+            'model': 'fireworks-completions-fine-tuned',
+        },
+        {
+            'provider': 'anthropic',
+            'model': 'claude-3-haiku-20240307',
+        }
+    ]
+    const allProviders: InlineCompletionItemProvider[] = []
+    for (const curretProviderConfig of allProviderConfigs) {
+        const providerConfig = await createProviderConfigForModel(
+            client,
+            authStatus,
+            curretProviderConfig['model'],
+            curretProviderConfig['provider'],
+            config
+        )
+        if(providerConfig) {
+            const authStatus = authProvider.getAuthStatus()
+            const completionsProvider = new InlineCompletionItemProvider({
+                authStatus,
+                providerConfig,
+                statusBar,
+                completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,
+                formatOnAccept: config.autocompleteFormatOnAccept,
+                disableInsideComments: config.autocompleteDisableInsideComments,
+                triggerNotice,
+                isRunningInsideAgent: config.isRunningInsideAgent,
+                createBfgRetriever,
+                isDotComUser: isDotCom(authStatus.endpoint || ''),
+                isRequestForMultipleModelCompletions: true,
+            })
+            allProviders.push(completionsProvider)
+        }
+    }
+    disposables.push(
+        vscode.commands.registerCommand('cody.multi-model-autocomplete.manual-trigger', () =>
+            triggerMultiModelAutocompletionsForComparison(allProviders)
+        )
+    )
+
+    return {
+        dispose: () => {
+            for (const disposable of disposables) {
+                disposable.dispose()
+            }
+        },
     }
 }
 

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -8,8 +8,8 @@ import { InlineCompletionItemProvider } from './inline-completion-item-provider'
 import { createProviderConfigFromVSCodeConfig } from './providers/create-provider'
 
 interface providerConfig {
-    providerName: string,
-    modelName: string,
+    providerName: string
+    modelName: string
     completionsProvider: InlineCompletionItemProvider
 }
 
@@ -50,7 +50,9 @@ export async function triggerMultiModelAutocompletionsForComparison(
     }
     const allPromises: Promise<MultiModelCompletionsResults>[] = []
     for (const completionsProviderConfig of allCompletionsProvidersConfig) {
-        allPromises.push(manuallyGetCompletionItemsForProvider(completionsProviderConfig, document, position, context))
+        allPromises.push(
+            manuallyGetCompletionItemsForProvider(completionsProviderConfig, document, position, context)
+        )
     }
     const completions = await Promise.all(allPromises)
     let completionsOutput = ''
@@ -133,7 +135,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
             return {
                 providerName: curretProviderConfig.provider,
                 modelName: curretProviderConfig.model,
-                completionsProvider: completionsProvider
+                completionsProvider: completionsProvider,
             }
         }
         return undefined

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -102,6 +102,8 @@ export async function createInlineCompletionItemFromMultipleProviders({
 
     const allPromises = multiModelConfigsList.map(async curretProviderConfig => {
         const newConfig = _.cloneDeep(config)
+        // Override some config to ensure we are not logging extra events.
+        newConfig.telemetryLevel = "off"
         // We should only override the fireworks "cody.autocomplete.experimental.fireworksOptions" when added in the config.
         newConfig.autocompleteExperimentalFireworksOptions =
             curretProviderConfig.enableExperimentalFireworksOverrides
@@ -130,7 +132,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
                 isRunningInsideAgent: config.isRunningInsideAgent,
                 createBfgRetriever,
                 isDotComUser: isDotCom(authStatus.endpoint || ''),
-                noAnalytics: true,
+                noInlineAccept: true,
             })
             return {
                 providerName: curretProviderConfig.provider,

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -1,4 +1,4 @@
-import * as fspromises from 'node:fs/promises'
+import fs from 'fs';
 import * as path from 'node:path'
 import { type FileURI, type MultimodelSingleModelConfig, isDotCom } from '@sourcegraph/cody-shared'
 import _ from 'lodash'
@@ -27,16 +27,16 @@ function getLoggingDirPath(): FileURI {
 
 async function createLogsFileIfNotExist(): Promise<string> {
     const dirPath = getLoggingDirPath().fsPath
-    await fspromises.mkdir(dirPath, { recursive: true })
+    await fs.promises.mkdir(dirPath, { recursive: true })
     const fileName = 'cody-custom-completions.jsonl'
     const filePath = path.join(dirPath, fileName)
     if (
-        !(await fspromises
+        !(await fs.promises
             .access(filePath)
             .then(() => true)
             .catch(() => false))
     ) {
-        await fspromises.writeFile(filePath, '')
+        await fs.promises.writeFile(filePath, '')
     }
     return filePath
 }
@@ -62,7 +62,7 @@ async function appendCompletionLogsFile(
         const modelName = result.model
         dataToLog[modelName] = result.completion ? result.completion : ''
     }
-    await fspromises.appendFile(logFilePath, JSON.stringify(dataToLog) + '\n')
+    await fs.promises.appendFile(logFilePath, JSON.stringify(dataToLog) + '\n')
 }
 
 export async function triggerMultiModelAutocompletionsForComparison(

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -1,0 +1,191 @@
+import * as fspromises from 'node:fs/promises'
+import * as path from 'node:path'
+import { type FileURI, type MultimodelSingleModelConfig, isDotCom } from '@sourcegraph/cody-shared'
+import _ from 'lodash'
+import * as vscode from 'vscode'
+import { URI } from 'vscode-uri'
+import { logDebug } from '../log'
+import type { InlineCompletionItemProviderArgs } from './create-inline-completion-item-provider'
+import type { MultiModelCompletionsResults } from './inline-completion-item-provider'
+import { InlineCompletionItemProvider } from './inline-completion-item-provider'
+import { createProviderConfigFromVSCodeConfig } from './providers/create-provider'
+
+function getLoggingDirPath(): FileURI {
+    switch (process.platform) {
+        case 'darwin':
+            return URI.file(
+                `${process.env.HOME}/Library/Caches/com.sourcegraph.cody/multi-model-completion`
+            )
+        case 'linux':
+            return URI.file(`${process.env.HOME}/.cache/com.sourcegraph.cody/multi-model-completion`)
+        case 'win32':
+            return URI.file(`${process.env.LOCALAPPDATA}\\com.sourcegraph.cody\\multi-model-completion`)
+        default:
+            throw new Error(`Unsupported platform: ${process.platform}`)
+    }
+}
+
+async function createLogsFileIfNotExist(): Promise<string> {
+    const dirPath = getLoggingDirPath().fsPath
+    await fspromises.mkdir(dirPath, { recursive: true })
+    const fileName = 'cody-custom-completions.jsonl'
+    const filePath = path.join(dirPath, fileName)
+    if (
+        !(await fspromises
+            .access(filePath)
+            .then(() => true)
+            .catch(() => false))
+    ) {
+        await fspromises.writeFile(filePath, '')
+    }
+    return filePath
+}
+
+async function appendCompletionLogsFile(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    completions: MultiModelCompletionsResults[]
+) {
+    // Add logs to a local file for analysis
+    const logFilePath = await createLogsFileIfNotExist()
+    const prefix = document.getText(new vscode.Range(new vscode.Position(0, 0), position))
+    const suffix = document.getText(
+        new vscode.Range(position, document.positionAt(document.getText().length))
+    )
+    const fileName = path.basename(document.fileName)
+    const dataToLog: { [key: string]: string } = {
+        fileName,
+        prefix,
+        suffix,
+    }
+    for (const result of completions) {
+        const modelName = result.model
+        dataToLog[modelName] = result.completion ? result.completion : ''
+    }
+    await fspromises.appendFile(logFilePath, JSON.stringify(dataToLog) + '\n')
+}
+
+export async function triggerMultiModelAutocompletionsForComparison(
+    allCompletionsProviders: InlineCompletionItemProvider[]
+) {
+    const activeEditor = vscode.window.activeTextEditor
+    if (!activeEditor) {
+        return
+    }
+    const document = activeEditor.document
+    const position = activeEditor.selection.active
+    const context = {
+        triggerKind: vscode.InlineCompletionTriggerKind.Automatic,
+        selectedCompletionInfo: undefined,
+    }
+    const allPromises: Promise<MultiModelCompletionsResults>[] = []
+    for (const provider of allCompletionsProviders) {
+        allPromises.push(provider.manuallyGetCompletionItemsForProvider(document, position, context))
+    }
+    const completions = await Promise.all(allPromises)
+    appendCompletionLogsFile(document, position, completions)
+    let completionsOutput = ''
+    for (const result of completions) {
+        completionsOutput += `Model: ${result.model}\n${result.completion}\n\n`
+    }
+    logDebug('MultiModelAutoComplete:\n', completionsOutput)
+}
+
+export async function createInlineCompletionItemFromMultipleProviders({
+    config,
+    client,
+    statusBar,
+    authProvider,
+    triggerNotice,
+    createBfgRetriever,
+}: InlineCompletionItemProviderArgs): Promise<vscode.Disposable> {
+    // Creates multiple providers to get completions from.
+    // The primary purpose of this method is to get the completions generated from multiple providers,
+    // which helps judge the quality of code completions
+    const authStatus = authProvider.getAuthStatus()
+    if (!authStatus.isLoggedIn || config.autocompleteExperimentalMultiModelCompletions === undefined) {
+        return {
+            dispose: () => {},
+        }
+    }
+
+    const disposables: vscode.Disposable[] = []
+
+    const multiModelConfigsList: MultimodelSingleModelConfig[] = []
+    for (const curretProviderConfig of config.autocompleteExperimentalMultiModelCompletions) {
+        if (curretProviderConfig.provider && curretProviderConfig.model) {
+            multiModelConfigsList.push({
+                provider: curretProviderConfig.provider,
+                model: curretProviderConfig.model,
+                enableExperimentalFireworksOverrides:
+                    curretProviderConfig.enableExperimentalFireworksOverrides ?? false,
+            })
+        }
+    }
+
+    if (multiModelConfigsList.length === 0) {
+        return {
+            dispose: () => {},
+        }
+    }
+
+    const allPromises = multiModelConfigsList.map(async curretProviderConfig => {
+        const newConfig = _.cloneDeep(config)
+        // We should only override the fireworks "cody.autocomplete.experimental.fireworksOptions" when added in the config.
+        newConfig.autocompleteExperimentalFireworksOptions =
+            curretProviderConfig.enableExperimentalFireworksOverrides
+                ? config.autocompleteExperimentalFireworksOptions
+                : undefined
+        // Don't use the advanced provider config to get the model
+        newConfig.autocompleteAdvancedModel = null
+
+        const providerConfig = await createProviderConfigFromVSCodeConfig(
+            client,
+            authStatus,
+            curretProviderConfig.model,
+            curretProviderConfig.provider,
+            newConfig
+        )
+        if (providerConfig) {
+            const authStatus = authProvider.getAuthStatus()
+            const completionsProvider = new InlineCompletionItemProvider({
+                authStatus,
+                providerConfig,
+                statusBar,
+                completeSuggestWidgetSelection: config.autocompleteCompleteSuggestWidgetSelection,
+                formatOnAccept: config.autocompleteFormatOnAccept,
+                disableInsideComments: config.autocompleteDisableInsideComments,
+                triggerNotice,
+                isRunningInsideAgent: config.isRunningInsideAgent,
+                createBfgRetriever,
+                isDotComUser: isDotCom(authStatus.endpoint || ''),
+                noAnalytics: true,
+            })
+            return completionsProvider
+        }
+        // biome-ignore lint/style/noUselessElse: returns undefined if provider config not valid
+        else {
+            return undefined
+        }
+    })
+    const allProviders = await Promise.all(allPromises)
+    const allCompletionsProviders: InlineCompletionItemProvider[] = []
+    for (const provider of allProviders) {
+        if (provider) {
+            allCompletionsProviders.push(provider)
+        }
+    }
+    disposables.push(
+        vscode.commands.registerCommand('cody.multi-model-autocomplete.manual-trigger', () =>
+            triggerMultiModelAutocompletionsForComparison(allCompletionsProviders)
+        )
+    )
+
+    return {
+        dispose: () => {
+            for (const disposable of disposables) {
+                disposable.dispose()
+            }
+        },
+    }
+}

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -103,7 +103,7 @@ export async function createInlineCompletionItemFromMultipleProviders({
     const allPromises = multiModelConfigsList.map(async curretProviderConfig => {
         const newConfig = _.cloneDeep(config)
         // Override some config to ensure we are not logging extra events.
-        newConfig.telemetryLevel = "off"
+        newConfig.telemetryLevel = 'off'
         // We should only override the fireworks "cody.autocomplete.experimental.fireworksOptions" when added in the config.
         newConfig.autocompleteExperimentalFireworksOptions =
             curretProviderConfig.enableExperimentalFireworksOverrides

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -83,6 +83,12 @@ interface CodyCompletionItemProviderConfig {
     isRequestForMultipleModelCompletions?: boolean
 }
 
+export interface MultiModelCompletionsResults {
+    provider: string,
+    model: string,
+    completion?: string
+}
+
 interface CompletionRequest {
     document: vscode.TextDocument
     position: vscode.Position
@@ -605,17 +611,21 @@ export class InlineCompletionItemProvider
         document: vscode.TextDocument,
         position: vscode.Position,
         context: vscode.InlineCompletionContext,
-    ): Promise<string> {
+    ): Promise<MultiModelCompletionsResults> {
         const result = await this.provideInlineCompletionItems(
             document,
             position,
             context,
-            new vscode.CancellationTokenSource().token
-        )
-        const modelName = this.config.providerConfig.model
-        const providerName = this.config.providerConfig.identifier
-        const res = `Provider: ${providerName} modelName: ${modelName} Completion is:\n ${result?.items[0].insertText}\n`
-        return res
+            new vscode.CancellationTokenSource().token,
+        );
+        const model = this.config.providerConfig.model;
+        const provider = this.config.providerConfig.identifier;
+        let completion = result?.items[0].insertText?.toString() || "";
+        return {
+            provider,
+            model,
+            completion,
+        };
     }
 
     public async manuallyTriggerCompletion(): Promise<void> {

--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -608,27 +608,6 @@ export class InlineCompletionItemProvider
         }
     }
 
-    public async manuallyGetCompletionItemsForProvider(
-        document: vscode.TextDocument,
-        position: vscode.Position,
-        context: vscode.InlineCompletionContext
-    ): Promise<MultiModelCompletionsResults> {
-        const result = await this.provideInlineCompletionItems(
-            document,
-            position,
-            context,
-            new vscode.CancellationTokenSource().token
-        )
-        const model = this.config.providerConfig.model
-        const provider = this.config.providerConfig.identifier
-        const completion = result?.items[0].insertText?.toString() || ''
-        return {
-            provider,
-            model,
-            completion,
-        }
-    }
-
     public async manuallyTriggerCompletion(): Promise<void> {
         await vscode.commands.executeCommand('editor.action.inlineSuggest.hide')
         this.lastManualCompletionTimestamp = Date.now()

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -170,10 +170,6 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         ]
     )
 
-    if (finetunedModel) {
-        return { provider: 'fireworks', model: 'fireworks-completions-fine-tuned' }
-    }
-
     if (llamaCode13B) {
         return { provider: 'fireworks', model: 'llama-code-13b' }
     }
@@ -183,6 +179,12 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
     }
 
     if (starCoderHybrid) {
+        // Adding the fine-tuned model here for the A/B test setup.
+        // Among all the users in starcoder-hybrid - some % of them will be redirected to the fine-tuned model.
+        if (finetunedModel) {
+            return { provider: 'fireworks', model: 'fireworks-completions-fine-tuned' }
+        }
+
         return { provider: 'fireworks', model: 'starcoder-hybrid' }
     }
 

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -21,6 +21,51 @@ import { createProviderConfig as createOpenAICompatibleProviderConfig } from './
 import type { ProviderConfig } from './provider'
 import { createProviderConfig as createUnstableOpenAIProviderConfig } from './unstable-openai'
 
+export async function createProviderConfigForModel(
+    client: CodeCompletionsClient,
+    authStatus: AuthStatus,
+    model: string,
+    provider: string,
+    config: ConfigurationWithAccessToken
+): Promise<ProviderConfig | null>  {
+    switch (provider) {
+        case 'fireworks': {
+            return createFireworksProviderConfig({
+                client,
+                model: model,
+                timeouts: config.autocompleteTimeouts,
+                authStatus,
+                config,
+            })
+        }
+        case 'anthropic': {
+            return createAnthropicProviderConfig({ client, model })
+        }
+        case 'experimental-openaicompatible': {
+            return createOpenAICompatibleProviderConfig({
+                client,
+                model: config.autocompleteAdvancedModel ?? model ?? null,
+                timeouts: config.autocompleteTimeouts,
+                authStatus,
+                config,
+            })
+        }
+        case 'experimental-ollama':
+        case 'unstable-ollama': {
+            return createExperimentalOllamaProviderConfig(
+                config.autocompleteExperimentalOllamaOptions
+            )
+        }
+        default:
+            logError(
+                'createProviderConfig',
+                `Unrecognized provider '${config.autocompleteAdvancedProvider}' configured.`
+            )
+            return null
+    }
+}
+
+
 export async function createProviderConfig(
     config: ConfigurationWithAccessToken,
     client: CodeCompletionsClient,

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -21,18 +21,23 @@ import { createProviderConfig as createOpenAICompatibleProviderConfig } from './
 import type { ProviderConfig } from './provider'
 import { createProviderConfig as createUnstableOpenAIProviderConfig } from './unstable-openai'
 
-export async function createProviderConfigForModel(
+export async function createProviderConfigFromVSCodeConfig(
     client: CodeCompletionsClient,
     authStatus: AuthStatus,
-    model: string,
+    model: string | undefined,
     provider: string,
     config: ConfigurationWithAccessToken
-): Promise<ProviderConfig | null>  {
+): Promise<ProviderConfig | null> {
     switch (provider) {
+        case 'unstable-openai': {
+            return createUnstableOpenAIProviderConfig({
+                client,
+            })
+        }
         case 'fireworks': {
             return createFireworksProviderConfig({
                 client,
-                model: model,
+                model: config.autocompleteAdvancedModel ?? model ?? null,
                 timeouts: config.autocompleteTimeouts,
                 authStatus,
                 config,
@@ -52,9 +57,7 @@ export async function createProviderConfigForModel(
         }
         case 'experimental-ollama':
         case 'unstable-ollama': {
-            return createExperimentalOllamaProviderConfig(
-                config.autocompleteExperimentalOllamaOptions
-            )
+            return createExperimentalOllamaProviderConfig(config.autocompleteExperimentalOllamaOptions)
         }
         default:
             logError(
@@ -64,7 +67,6 @@ export async function createProviderConfigForModel(
             return null
     }
 }
-
 
 export async function createProviderConfig(
     config: ConfigurationWithAccessToken,
@@ -79,47 +81,7 @@ export async function createProviderConfig(
     )
     if (providerAndModelFromVSCodeConfig) {
         const { provider, model } = providerAndModelFromVSCodeConfig
-
-        switch (provider) {
-            case 'unstable-openai': {
-                return createUnstableOpenAIProviderConfig({
-                    client,
-                })
-            }
-            case 'fireworks': {
-                return createFireworksProviderConfig({
-                    client,
-                    model: config.autocompleteAdvancedModel ?? model ?? null,
-                    timeouts: config.autocompleteTimeouts,
-                    authStatus,
-                    config,
-                })
-            }
-            case 'anthropic': {
-                return createAnthropicProviderConfig({ client, model })
-            }
-            case 'experimental-openaicompatible': {
-                return createOpenAICompatibleProviderConfig({
-                    client,
-                    model: config.autocompleteAdvancedModel ?? model ?? null,
-                    timeouts: config.autocompleteTimeouts,
-                    authStatus,
-                    config,
-                })
-            }
-            case 'experimental-ollama':
-            case 'unstable-ollama': {
-                return createExperimentalOllamaProviderConfig(
-                    config.autocompleteExperimentalOllamaOptions
-                )
-            }
-            default:
-                logError(
-                    'createProviderConfig',
-                    `Unrecognized provider '${config.autocompleteAdvancedProvider}' configured.`
-                )
-                return null
-        }
+        return createProviderConfigFromVSCodeConfig(client, authStatus, model, provider, config)
     }
 
     /**

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -84,7 +84,7 @@ const MODEL_MAP = {
 
     // Fine-tuned model mapping
     'fireworks-completions-fine-tuned':
-        'fireworks/accounts/sourcegraph/models/codecompletion-m-mixtral-rb-rs-m-go-400k-25e',
+        'fireworks/accounts/sourcegraph/models/codecompletion-mixtral-rust-152k-005e',
 }
 
 type FireworksModel =

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -83,6 +83,8 @@ describe('getConfiguration', () => {
                         return false
                     case 'cody.autocomplete.experimental.fireworksOptions':
                         return undefined
+                    case 'cody.autocomplete.experimental.multiModelCompletions':
+                        return undefined
                     case 'cody.autocomplete.experimental.ollamaOptions':
                         return {
                             model: 'codellama:7b-code',

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -167,6 +167,10 @@ export function getConfiguration(
             'autocomplete.experimental.smartThrottle',
             false
         ),
+        autocompleteExperimentalMultiModelCompletions: getHiddenSetting(
+            'autocomplete.experimental.multiModelCompletions',
+            undefined
+        ),
 
         // Note: In spirit, we try to minimize agent-specific code paths in the VSC extension.
         // We currently use this flag for the agent to provide more helpful error messages

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -44,10 +44,8 @@ import { executeExplainHistoryCommand } from './commands/execute/explain-history
 import { executeUsageExamplesCommand } from './commands/execute/usage-examples'
 import type { CodyCommandArgs } from './commands/types'
 import { newCodyCommandArgs } from './commands/utils/get-commands'
-import {
-    createInlineCompletionItemProvider,
-    createInlineCompletionItemFromMultipleProviders
-} from './completions/create-inline-completion-item-provider'
+import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
+import { createInlineCompletionItemFromMultipleProviders } from './completions/create-multi-model-inline-completion-provider'
 import { getConfiguration, getFullConfig } from './configuration'
 import { EnterpriseContextFactory } from './context/enterprise-context-factory'
 import { exposeOpenCtxExtensionAPIHandle } from './context/openctx'

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -44,7 +44,10 @@ import { executeExplainHistoryCommand } from './commands/execute/explain-history
 import { executeUsageExamplesCommand } from './commands/execute/usage-examples'
 import type { CodyCommandArgs } from './commands/types'
 import { newCodyCommandArgs } from './commands/utils/get-commands'
-import { createInlineCompletionItemProvider } from './completions/create-inline-completion-item-provider'
+import {
+    createInlineCompletionItemProvider,
+    createInlineCompletionItemFromMultipleProviders
+} from './completions/create-inline-completion-item-provider'
 import { getConfiguration, getFullConfig } from './configuration'
 import { EnterpriseContextFactory } from './context/enterprise-context-factory'
 import { exposeOpenCtxExtensionAPIHandle } from './context/openctx'
@@ -661,6 +664,18 @@ const register = async (
                 autocompleteDisposables.push({ dispose: autocompleteFeatureFlagChangeSubscriber })
                 autocompleteDisposables.push(
                     await createInlineCompletionItemProvider({
+                        config,
+                        client: codeCompletionsClient,
+                        statusBar,
+                        authProvider,
+                        triggerNotice: notice => {
+                            void chatManager.triggerNotice(notice)
+                        },
+                        createBfgRetriever: platform.createBfgRetriever,
+                    })
+                )
+                autocompleteDisposables.push(
+                    await createInlineCompletionItemFromMultipleProviders({
                         config,
                         client: codeCompletionsClient,
                         statusBar,


### PR DESCRIPTION
## Context
The goal of this PR is to add a custom command in cody (purely for the internal testing and comparing the completion output from different LLM models), which when triggered will print the completions from multiple providers. This would be very useful to compare completions output from different models.

The way I currently tried to implement the same is:
1. Initialize multiple completions providers at the initialization. The list of providers is picked from the VSCode settings by providing the following config:
```
"cody.autocomplete.experimental.multiModelCompletions": [
    {"provider": "fireworks", "model": "starcoder-hybrid"},
    {"provider": "fireworks", "model": "fireworks-completions-fine-tuned", "enableExperimentalFireworksOverrides": true},
    {"provider": "anthropic", "model": "claude-3-haiku-20240307"},
  ]
```
2. Whenever the custom command is invoked, collect the (TextDocument, position etc) from the vscode api and call [provideInlineCompletionItems](https://sourcegraph.com/github.com/sourcegraph/cody@5c69fc9/-/blob/vscode/src/completions/inline-completion-item-provider.ts?L198) on all the initialized providers
3. Since we are logging the completions data and metrics, asking for completions on multiple providers could lead to unexpected logging, so I have tried to the condition to skip logging whenever, the completions are called for this vscode command. For eg: [see this ](https://github.com/sourcegraph/cody/pull/4048/files#diff-a2dca3f7cbfa2847ddc325842db1723618f70febf6f26d372c7f8adf3d475bafR183)

## Test plan
1. Manually start the debugger on this branch and trigger the vscode command `Get Completions for multiple autocomplete models`
2. The output should include completions as well as completions requests from all the providers.
3. Verified that we are skipping logging part.

https://github.com/sourcegraph/cody/assets/20701220/689037b2-72e2-427f-a8af-e20f58b50227
