### PR TITLE
use clsx instead of classnames

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,9 +423,9 @@ importers:
       axios:
         specifier: ^1.3.6
         version: 1.3.6
-      classnames:
-        specifier: ^2.3.2
-        version: 2.3.2
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       crypto-js:
         specifier: ^4.2.0
         version: 4.2.0
@@ -6368,10 +6368,6 @@ packages:
       static-extend: 0.1.2
     dev: false
 
-  /classnames@2.3.2:
-    resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
-    dev: false
-
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -6427,6 +6423,11 @@ packages:
     engines: {node: '>=0.8'}
     requiresBuild: true
     dev: true
+
+  /clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -12242,6 +12243,7 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1346,7 +1346,7 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "async-mutex": "^0.4.0",
     "axios": "^1.3.6",
-    "classnames": "^2.3.2",
+    "clsx": "^2.1.1",
     "crypto-js": "^4.2.0",
     "detect-indent": "^7.0.1",
     "diff": "^5.2.0",

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -2,7 +2,7 @@ import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 
 import {
     type AuthStatus,
@@ -490,7 +490,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
         : 'Chat has been disabled by your Enterprise instance site administrator'
 
     return (
-        <div className={classNames(styles.innerContainer)}>
+        <div className={clsx(styles.innerContainer)}>
             {
                 <Transcript
                     transcript={transcript}
@@ -508,7 +508,7 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                     guardrails={guardrails}
                 />
             }
-            <form className={classNames(styles.inputRow)}>
+            <form className={clsx(styles.inputRow)}>
                 {/* Don't show chat action buttons on empty chat session unless it's a new cha*/}
 
                 <ChatActions
@@ -593,7 +593,7 @@ const SubmitButton: React.FunctionComponent<ChatUISubmitButtonProps> = ({
     onAbortMessageInProgress,
 }) => (
     <VSCodeButton
-        className={classNames(styles.submitButton, className, disabled && styles.submitButtonDisabled)}
+        className={clsx(styles.submitButton, className, disabled && styles.submitButtonDisabled)}
         type="button"
         disabled={disabled}
         onClick={onAbortMessageInProgress ?? onClick}

--- a/vscode/webviews/Notices/Notice.tsx
+++ b/vscode/webviews/Notices/Notice.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 
 import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 
 import styles from './Notice.module.css'
 
@@ -49,7 +49,7 @@ export const Notice: React.FunctionComponent<React.PropsWithChildren<NoticeProps
     }
 
     return (
-        <div className={classNames(styles.notice, className)}>
+        <div className={clsx(styles.notice, className)}>
             <div className={styles.noticeIcon}>{icon}</div>
             <div className={styles.noticeText}>
                 <h1>{title}</h1>

--- a/vscode/webviews/Popups/Popup.tsx
+++ b/vscode/webviews/Popups/Popup.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 
 import styles from './Popup.module.css'
 
@@ -50,12 +50,12 @@ export const PopupFrame: React.FunctionComponent<
             <>
                 <dialog
                     open={true}
-                    className={classNames(styles.popup, ...(extraClassNames || []))}
+                    className={clsx(styles.popup, ...(extraClassNames || []))}
                     onKeyUp={handleKeyUp}
                 >
                     <div className={styles.row}>{children}</div>
                     {actionButtons && (
-                        <div className={classNames(styles.actionButtonContainer, styles.row)}>
+                        <div className={clsx(styles.actionButtonContainer, styles.row)}>
                             {actionButtons}
                         </div>
                     )}

--- a/vscode/webviews/Troubleshooting/ConnectionIssuesPage.tsx
+++ b/vscode/webviews/Troubleshooting/ConnectionIssuesPage.tsx
@@ -1,7 +1,7 @@
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 
 import type { TelemetryRecorder, TelemetryService } from '@sourcegraph/cody-shared'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import { useCallback, useState } from 'react'
 import type { VSCodeWrapper } from '../utils/VSCodeApi'
 import styles from './ConnectionIssuesPage.module.css'
@@ -61,7 +61,7 @@ export const ConnectionIssuesPage: React.FunctionComponent<
                 </div>
                 <div className={styles.actions}>
                     <VSCodeButton
-                        className={classNames(styles.actionButton)}
+                        className={clsx(styles.actionButton)}
                         type="button"
                         disabled={cooldown}
                         onClick={onRetry}
@@ -69,7 +69,7 @@ export const ConnectionIssuesPage: React.FunctionComponent<
                         {cooldown ? 'Retrying...' : 'Retry Connection'}
                     </VSCodeButton>
                     <VSCodeButton
-                        className={classNames(styles.actionButton)}
+                        className={clsx(styles.actionButton)}
                         appearance="secondary"
                         type="button"
                         onClick={onSignOut}

--- a/vscode/webviews/chat/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent.tsx
@@ -11,7 +11,7 @@ import {
     ShieldIcon,
 } from '../icons/CodeBlockActionIcons'
 
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import styles from './ChatMessageContent.module.css'
 
 export interface CodeBlockActionsProps {
@@ -297,7 +297,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
     return (
         <div
             ref={rootRef}
-            className={classNames(styles.content, className)}
+            className={clsx(styles.content, className)}
             // biome-ignore lint/security/noDangerouslySetInnerHtml: the result is run through dompurify
             dangerouslySetInnerHTML={{
                 // wrapLinksWithCodyCommand opens all links in assistant responses using the

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { type FunctionComponent, useEffect, useRef } from 'react'
 
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 
 import { type ChatMessage, type Guardrails, renderCodyMarkdown } from '@sourcegraph/cody-shared'
 
@@ -184,8 +184,8 @@ export const Transcript: React.FunctionComponent<{
         }
 
     return (
-        <div ref={transcriptContainerRef} className={classNames(className, styles.container)}>
-            <div ref={scrollAnchoredContainerRef} className={classNames(styles.scrollAnchoredContainer)}>
+        <div ref={transcriptContainerRef} className={clsx(className, styles.container)}>
+            <div ref={scrollAnchoredContainerRef} className={clsx(styles.scrollAnchoredContainer)}>
                 {!!chatModels?.length &&
                     onCurrentChatModelChange &&
                     userInfo &&
@@ -222,7 +222,7 @@ export const Transcript: React.FunctionComponent<{
                         />
                     )}
             </div>
-            <div className={classNames(styles.scrollAnchor)}>&nbsp;</div>
+            <div className={clsx(styles.scrollAnchor)}>&nbsp;</div>
         </div>
     )
 }

--- a/vscode/webviews/chat/actions/TranscriptAction.tsx
+++ b/vscode/webviews/chat/actions/TranscriptAction.tsx
@@ -1,6 +1,6 @@
 import type React from 'react'
 
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 
 import styles from './TranscriptAction.module.css'
 
@@ -22,7 +22,7 @@ export const TranscriptAction: React.FunctionComponent<{
     onClick?: () => void
 }> = ({ title, steps, className, onClick }) => {
     return (
-        <details className={classNames(className, styles.container)}>
+        <details className={clsx(className, styles.container)}>
             <summary onClick={onClick} onKeyDown={onClick}>
                 {typeof title === 'string' ? (
                     title

--- a/vscode/webviews/chat/cells/Cell.tsx
+++ b/vscode/webviews/chat/cells/Cell.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import type React from 'react'
 import type { FunctionComponent, PropsWithChildren } from 'react'
 import styles from './Cell.module.css'
@@ -25,7 +25,7 @@ export const Cell: FunctionComponent<
     children,
 }) => (
     <div
-        className={classNames(
+        className={clsx(
             styles.container,
             {
                 [styles.containerStyleAssistant]: style === 'assistant',
@@ -38,6 +38,6 @@ export const Cell: FunctionComponent<
         data-testid={dataTestID}
     >
         <div className={styles.gutter}>{gutterIcon}</div>
-        <div className={classNames(styles.content, contentClassName)}>{children}</div>
+        <div className={clsx(styles.content, contentClassName)}>{children}</div>
     </div>
 )

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -1,5 +1,5 @@
 import type { ContextItem } from '@sourcegraph/cody-shared'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import type React from 'react'
 import { FileLink } from '../../../components/FileLink'
 import { SourcegraphLogo } from '../../../icons/SourcegraphLogo'
@@ -86,7 +86,7 @@ export const ContextCell: React.FunctionComponent<{
                                     isTooLarge={
                                         item.type === 'file' && item.isTooLarge && item.source === 'user'
                                     }
-                                    className={classNames(styles.fileLink, MENTION_CLASS_NAME)}
+                                    className={clsx(styles.fileLink, MENTION_CLASS_NAME)}
                                 />
                             </li>
                         ))}

--- a/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
@@ -6,7 +6,7 @@ import {
     reformatBotMessageForChat,
 } from '@sourcegraph/cody-shared'
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import type { ComponentProps, FunctionComponent } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../Chat'
 import { serializedPromptEditorStateFromChatMessage } from '../../../promptEditor/PromptEditor'
@@ -71,13 +71,13 @@ export const MessageCell: FunctionComponent<{
                 <SpeakerIcon message={message} userInfo={userInfo} chatModel={chatModel} size={24} />
             }
             disabled={disabled}
-            containerClassName={classNames(styles.cellContainer, {
+            containerClassName={clsx(styles.cellContainer, {
                 [styles.focused]: isItemBeingEdited,
                 [styles.disabled]: disabled,
             })}
             data-testid="message"
         >
-            <div className={classNames(message.speaker === 'human' && styles.humanMessageContainer)}>
+            <div className={clsx(message.speaker === 'human' && styles.humanMessageContainer)}>
                 <div className={styles.messageContent}>
                     {message.error ? (
                         typeof message.error === 'string' ? (

--- a/vscode/webviews/chat/components/FeedbackButtons.tsx
+++ b/vscode/webviews/chat/components/FeedbackButtons.tsx
@@ -1,5 +1,5 @@
 import { VSCodeButton, VSCodeLink } from '@vscode/webview-ui-toolkit/react'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import { useCallback, useState } from 'react'
 import { CODY_FEEDBACK_URL } from '../../../src/chat/protocol'
 import styles from './FeedbackButtons.module.css'
@@ -25,11 +25,11 @@ export const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = ({
     )
 
     return (
-        <div className={classNames(styles.feedbackButtons, className)}>
+        <div className={clsx(styles.feedbackButtons, className)}>
             {!feedbackSubmitted && (
                 <>
                     <VSCodeButton
-                        className={classNames(styles.feedbackButton)}
+                        className={clsx(styles.feedbackButton)}
                         appearance="icon"
                         type="button"
                         onClick={() => onFeedbackBtnSubmit('thumbsUp')}
@@ -37,7 +37,7 @@ export const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = ({
                         <i className="codicon codicon-thumbsup" />
                     </VSCodeButton>
                     <VSCodeButton
-                        className={classNames(styles.feedbackButton)}
+                        className={clsx(styles.feedbackButton)}
                         appearance="icon"
                         type="button"
                         onClick={() => onFeedbackBtnSubmit('thumbsDown')}
@@ -48,7 +48,7 @@ export const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = ({
             )}
             {feedbackSubmitted === 'thumbsUp' && (
                 <VSCodeButton
-                    className={classNames(styles.feedbackButton)}
+                    className={clsx(styles.feedbackButton)}
                     appearance="icon"
                     type="button"
                     disabled={true}
@@ -61,7 +61,7 @@ export const FeedbackButtons: React.FunctionComponent<FeedbackButtonsProps> = ({
             {feedbackSubmitted === 'thumbsDown' && (
                 <span className={styles.thumbsDownFeedbackContainer}>
                     <VSCodeButton
-                        className={classNames(styles.feedbackButton)}
+                        className={clsx(styles.feedbackButton)}
                         appearance="icon"
                         type="button"
                         disabled={true}

--- a/vscode/webviews/components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/components/EnhancedContextSettings.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 import { VSCodeButton, VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 
 import {
     type ContextGroup,
@@ -437,7 +437,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     )
 
     return (
-        <div className={classNames(popupStyles.popupHost)} onKeyDown={onKeyDown}>
+        <div className={clsx(popupStyles.popupHost)} onKeyDown={onKeyDown}>
             <PopupFrame
                 isOpen={isOpen}
                 onDismiss={handleDismiss}
@@ -489,7 +489,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                 </div>
             </PopupFrame>
             <VSCodeButton
-                className={classNames(
+                className={clsx(
                     styles.settingsBtns,
                     styles.settingsIndicator,
                     enabled && styles.settingsIndicatorActive
@@ -504,7 +504,7 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
                 {enabled ? <i className="codicon codicon-sparkle" /> : <SparkleSlash />}
             </VSCodeButton>
             <VSCodeButton
-                className={classNames(
+                className={clsx(
                     styles.settingsBtns,
                     styles.settingsBtn,
                     isOpen && styles.settingsBtnActive

--- a/vscode/webviews/components/FileLink.tsx
+++ b/vscode/webviews/components/FileLink.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import type React from 'react'
 
 import {
@@ -65,7 +65,7 @@ export const FileLink: React.FunctionComponent<FileLinkProps & { className?: str
     }
 
     return (
-        <div className={classNames(styles.linkContainer, className)}>
+        <div className={clsx(styles.linkContainer, className)}>
             {isTooLarge && <i className="codicon codicon-warning" title={WARNING} />}
             <a
                 className={styles.linkButton}
@@ -75,15 +75,10 @@ export const FileLink: React.FunctionComponent<FileLinkProps & { className?: str
                 onClick={logFileLinkClicked}
             >
                 <i
-                    className={classNames(
-                        'codicon',
-                        `codicon-${source === 'user' ? 'mention' : 'file'}`
-                    )}
+                    className={clsx('codicon', `codicon-${source === 'user' ? 'mention' : 'file'}`)}
                     title={getFileSourceIconTitle(source)}
                 />
-                <div className={classNames(styles.path, isTooLarge && styles.excluded)}>
-                    {pathWithRange}
-                </div>
+                <div className={clsx(styles.path, isTooLarge && styles.excluded)}>{pathWithRange}</div>
             </a>
         </div>
     )

--- a/vscode/webviews/components/UserAvatar.tsx
+++ b/vscode/webviews/components/UserAvatar.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import type { FunctionComponent } from 'react'
 import type { UserAccountInfo } from '../Chat'
 import styles from './UserAvatar.module.css'
@@ -32,7 +32,7 @@ export const UserAvatar: FunctionComponent<Props> = ({ user, size, className }) 
 
         return (
             <img
-                className={classNames(styles.userAvatar, className)}
+                className={clsx(styles.userAvatar, className)}
                 src={url}
                 role="presentation"
                 title={title}
@@ -45,7 +45,7 @@ export const UserAvatar: FunctionComponent<Props> = ({ user, size, className }) 
     return (
         <div
             title={title}
-            className={classNames(styles.userAvatar, className)}
+            className={clsx(styles.userAvatar, className)}
             style={{ width: `${size}px`, height: `${size}px` }}
         >
             <span className={styles.initials}>

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -1,5 +1,5 @@
 import type { ModelProvider } from '@sourcegraph/cody-shared'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import { type FunctionComponent, useCallback, useMemo } from 'react'
 import type { UserAccountInfo } from '../../Chat'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
@@ -161,7 +161,7 @@ const ModelTitleWithIcon: FunctionComponent<{
     modelAvailability?: ModelAvailability
 }> = ({ model, showIcon, showProvider, modelAvailability }) => (
     <span
-        className={classNames(styles.modelTitleWithIcon, {
+        className={clsx(styles.modelTitleWithIcon, {
             [styles.disabled]: modelAvailability !== 'available',
         })}
         title={

--- a/vscode/webviews/components/platform/Button.tsx
+++ b/vscode/webviews/components/platform/Button.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon } from '@heroicons/react/16/solid'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import {
     type ButtonHTMLAttributes,
     type ComponentType,
@@ -40,7 +40,7 @@ export const Button = forwardRef<
     ) => (
         <button
             type={type}
-            className={classNames(
+            className={clsx(
                 styles.button,
                 {
                     [styles.buttonPrimary]: appearance === 'primary',

--- a/vscode/webviews/components/platform/Popover.tsx
+++ b/vscode/webviews/components/platform/Popover.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import {
     type FunctionComponent,
     type HTMLAttributes,
@@ -79,7 +79,7 @@ export const Popover: FunctionComponent<{
             ref={popoverEl}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
-            className={classNames(styles.popover, className)}
+            className={clsx(styles.popover, className)}
         >
             {visible ? children : null}
         </aside>

--- a/vscode/webviews/components/platform/SelectList.tsx
+++ b/vscode/webviews/components/platform/SelectList.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import { type FunctionComponent, type ReactNode, useCallback, useEffect, useRef } from 'react'
 import { FLOATING_WIDGET_CLASS_NAME } from './FloatingWidget'
 import styles from './SelectList.module.css'
@@ -32,7 +32,7 @@ export const SelectList: FunctionComponent<{
     }, [])
 
     return (
-        <div className={classNames(styles.container, FLOATING_WIDGET_CLASS_NAME, className)}>
+        <div className={clsx(styles.container, FLOATING_WIDGET_CLASS_NAME, className)}>
             <ul
                 className={styles.list}
                 role="radiogroup"

--- a/vscode/webviews/promptEditor/BaseEditor.tsx
+++ b/vscode/webviews/promptEditor/BaseEditor.tsx
@@ -6,7 +6,7 @@ import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary'
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
 import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import {
     $getRoot,
     $getSelection,
@@ -65,7 +65,7 @@ export const BaseEditor: FunctionComponent<Props> = ({
     )
 
     return (
-        <div className={classNames(styles.editorShell, className)}>
+        <div className={clsx(styles.editorShell, className)}>
             <div className={styles.editorContainer}>
                 <LexicalComposer initialConfig={initialConfig}>
                     <PlainTextPlugin

--- a/vscode/webviews/promptEditor/PromptEditor.tsx
+++ b/vscode/webviews/promptEditor/PromptEditor.tsx
@@ -1,6 +1,6 @@
 import { $generateHtmlFromNodes } from '@lexical/html'
 import { type ChatMessage, type ContextItem, escapeHTML } from '@sourcegraph/cody-shared'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import {
     $createTextNode,
     $getRoot,
@@ -121,7 +121,7 @@ export const PromptEditor: FunctionComponent<Props> = ({
 
     return (
         <BaseEditor
-            className={classNames(styles.editor, editorClassName, disabled && styles.disabled)}
+            className={clsx(styles.editor, editorClassName, disabled && styles.disabled)}
             initialEditorState={initialEditorState?.lexicalEditorState ?? null}
             onChange={onBaseEditorChange}
             onFocusChange={onFocusChange}

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -8,7 +8,7 @@ import {
     displayPathDirname,
     parseMentionQuery,
 } from '@sourcegraph/cody-shared'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import { type FunctionComponent, useEffect, useRef } from 'react'
 import {
     FILE_HELP_LABEL,
@@ -43,7 +43,7 @@ export const OptionsList: FunctionComponent<
 
     return (
         <div className={styles.container}>
-            <h3 className={classNames(styles.item, styles.helpItem)}>
+            <h3 className={clsx(styles.item, styles.helpItem)}>
                 <span>{getHelpText(mentionQuery, options)}</span>
                 <br />
             </h3>
@@ -132,7 +132,7 @@ const Item: FunctionComponent<{
         <li
             key={option.key}
             tabIndex={-1}
-            className={classNames(
+            className={clsx(
                 className,
                 styles.optionItem,
                 isSelected && styles.selected,
@@ -150,7 +150,7 @@ const Item: FunctionComponent<{
                     <i className={`codicon codicon-${icon}`} title={item.kind} />
                 )}
                 <span
-                    className={classNames(
+                    className={clsx(
                         styles.optionItemTitle,
                         warning && styles.optionItemTitleWithWarning
                     )}

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -19,7 +19,7 @@ import {
     displayPath,
     scanForMentionTriggerInUserTextInput,
 } from '@sourcegraph/cody-shared'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import { useCurrentChatModel } from '../../../chat/models/chatModelContext'
 import { toSerializedPromptEditorValue } from '../../PromptEditor'
 import {
@@ -208,7 +208,7 @@ export default function MentionsPlugin(): JSX.Element | null {
                                     left: x ?? 0,
                                     width: 'max-content',
                                 }}
-                                className={classNames(styles.popover)}
+                                className={clsx(styles.popover)}
                             >
                                 <OptionsList
                                     query={query ?? ''}

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
@@ -6,7 +6,7 @@ import {
     isWindows,
     setDisplayPathEnvInfo,
 } from '@sourcegraph/cody-shared'
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import { type CSSProperties, useState } from 'react'
 import { URI } from 'vscode-uri'
 import '../../node_modules/@vscode/codicons/dist/codicon.css'
@@ -49,7 +49,7 @@ export const VSCodeViewport: (style?: CSSProperties | undefined) => Decorator = 
 export function VSCodeDecorator(className: string | undefined, style?: CSSProperties): Decorator {
     document.body.dataset.vscodeThemeKind = 'vscode-dark'
     return story => (
-        <div className={classNames(styles.container, className)} style={style}>
+        <div className={clsx(styles.container, className)} style={style}>
             <WithChatContextClient value={dummyChatContextClient}>
                 <ChatModelContextProvider value={useDummyChatModelContext()}>
                     {story()}


### PR DESCRIPTION
`clsx` seems to be used in more projects now (https://npmtrends.com/classnames-vs-clsx), so standardizing on it makes it easier to copy-paste code (eg from shadcn). Also, it's shorter.

No change to any behavior.

```
fastmod -F -e ts,tsx "import classNames from 'classnames'" "import { clsx } from 'clsx'" vscode/
fastmod -F -e ts,tsx 'classNames(' 'clsx(' vscode/
```

## Test plan

CI