### PR TITLE
use cmdk for existing @-mention UI

### DIFF
--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -3,6 +3,7 @@ import type { AddressInfo } from 'node:net'
 import { expect } from '@playwright/test'
 import { isWindows } from '@sourcegraph/cody-shared'
 import {
+    atMentionMenuHeading,
     createEmptyChatPanel,
     expectContextCellCounts,
     getContextCell,
@@ -59,15 +60,13 @@ test.extend<ExpectedEvents>({
     await chatInput.focus()
     await page.keyboard.type('@')
     await expect(
-        chatPanelFrame.getByRole('heading', {
-            name: 'Search for a file to include, or type # for symbols...',
-        })
+        atMentionMenuHeading(chatPanelFrame, 'Search for a file to include, or type # for symbols...')
     ).toBeVisible()
     await page.keyboard.press('Backspace')
 
     // No results
     await chatInput.fill('@definitelydoesntexist')
-    await expect(chatPanelFrame.getByRole('heading', { name: 'No files found' })).toBeVisible()
+    await expect(atMentionMenuHeading(chatPanelFrame, 'No files found')).toBeVisible()
 
     // Clear the input so the next test doesn't detect the same text already visible from the previous
     // check (otherwise the test can pass even without the filter working).
@@ -79,7 +78,7 @@ test.extend<ExpectedEvents>({
     //   and assert that it contains `fixtures` to ensure this check isn't passing because the fixture folder no
     //   longer matches.
     await chatInput.fill('@fixtures') // fixture is in the test project folder name, but not in the relative paths.
-    await expect(chatPanelFrame.getByRole('heading', { name: 'No files found' })).toBeVisible()
+    await expect(atMentionMenuHeading(chatPanelFrame, 'No files found')).toBeVisible()
 
     // Includes dotfiles after just "."
     await chatInput.fill('@.')
@@ -195,7 +194,7 @@ test.extend<ExpectedEvents>({
     await expect(chatInput).toHaveText('Explain the @Main.java !file')
 
     //  "ArrowLeft" / "ArrowRight" keys alter the query input for @-mentions.
-    const noMatches = chatPanelFrame.getByRole('heading', { name: 'No files found' })
+    const noMatches = atMentionMenuHeading(chatPanelFrame, 'No files found')
     await chatInput.pressSequentially(' @abcdefg')
     await expect(chatInput).toHaveText('Explain the @Main.java ! @abcdefgfile')
     await noMatches.hover()
@@ -454,13 +453,11 @@ test.extend<ExpectedEvents>({
 
     // Symbol empty state shows tooltip to search for a symbol
     await chatInput.fill('@#')
-    await expect(
-        chatPanelFrame.getByRole('heading', { name: /^Search for a symbol to include/ })
-    ).toBeVisible()
+    await expect(atMentionMenuHeading(chatPanelFrame, /^Search for a symbol to include/)).toBeVisible()
 
     // Symbol empty symbol results updates tooltip title to show no symbols found
     await chatInput.fill('@#invalide')
-    await expect(chatPanelFrame.getByRole('heading', { name: /^No symbols found/ })).toBeVisible()
+    await expect(atMentionMenuHeading(chatPanelFrame, /^No symbols found/)).toBeVisible()
 
     // Clicking on a file in the selector should autocomplete the file in chat input with added space
     await chatInput.clear()

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -1,6 +1,12 @@
 import path from 'node:path'
 import { expect } from '@playwright/test'
-import { createEmptyChatPanel, getContextCell, sidebarExplorer, sidebarSignin } from './common'
+import {
+    atMentionMenuHeading,
+    createEmptyChatPanel,
+    getContextCell,
+    sidebarExplorer,
+    sidebarSignin,
+} from './common'
 import { type ExpectedEvents, test } from './helpers'
 
 /**
@@ -76,7 +82,7 @@ test.extend<ExpectedEvents>({
     await chatInput.focus()
     await chatInput.clear()
     await chatInput.fill('@ignoredByCody')
-    await expect(chatPanel.getByRole('heading', { name: 'No files found' })).toBeVisible()
+    await expect(atMentionMenuHeading(chatPanel, 'No files found')).toBeVisible()
     await chatInput.clear()
     await chatInput.fill('@ignore')
     await expect(

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -86,3 +86,10 @@ export async function expectContextCellCounts(
         { timeout: counts.timeout }
     )
 }
+
+export function atMentionMenuHeading(chatPanel: FrameLocator, text: string | RegExp): Locator {
+    // Can't just use getByRole because the [cmdk-group-heading] is the aria-labelledby of the
+    // [cmdk-group-items], which Playwright deems hidden when it is empty (because its height is 0),
+    // but we still want to be able to get the label for testing even when the list below is empty.
+    return chatPanel.locator('[cmdk-group-heading]', { hasText: text })
+}

--- a/vscode/webviews/components/shadcn/ui/command.tsx
+++ b/vscode/webviews/components/shadcn/ui/command.tsx
@@ -69,9 +69,7 @@ CommandList.displayName = CommandPrimitive.List.displayName
 const CommandEmpty = React.forwardRef<
     React.ElementRef<typeof CommandPrimitive.Empty>,
     React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
-    <CommandPrimitive.Empty ref={ref} className="tw-py-6 tw-text-center tw-text-md" {...props} />
-))
+>((props, ref) => <CommandPrimitive.Empty ref={ref} className="tw-p-3 tw-text-md" {...props} />)
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName
 

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.module.css
@@ -1,91 +1,30 @@
 .container {
     min-width: 180px;
-    font-size: var(--vscode-font-size);
-    padding: 0 5px 5px 5px; /* match VS Code quickpick padding */
+    max-height: 330px;
 }
 
-:root {
-    --item-height: 22px; /* match VS Code quickpick item height */
-    --item-padding-y: 0.2rem;
-    --item-padding-x: 11px; /* match VS Code quickpick padding */
-    --description-font-size: 0.9em; /* match VS Code quickpick description */
-}
-
-.list {
-    max-height: calc(8*var(--item-height));
-    overflow-y: scroll;
-    list-style: none;
-    padding: var(--list-padding-y) 0;
-    margin: 0;
-
-    border-top: 1px solid var(--vscode-pickerGroup-border);
-    margin-top: -1px;
-}
-
-.item {
-    display: flex;
-    min-height: calc(var(--item-height) - 2*var(--item-padding-y));
-    padding: var(--item-padding-y) var(--item-padding-x);
-}
-
-.help-item {
-    opacity: 0.75;
-    padding: 5px var(--item-padding-x);
-    user-select: none;
-    font-size: inherit;
-    font-weight: normal;
-    margin: 0;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-}
-
-/* Hide scrollbar */
-.list {
+/* Hide scroll bar. */
+.container [cmdk-list] {
     scrollbar-width: none;
 }
-.list::-webkit-scrollbar {
+.container [cmdk-list]::-webkit-scrollbar {
     display: none;
 }
 
-/* Scroll snap */
-.list {
-    scroll-snap-type: y mandatory;
-    scroll-behavior: auto;
-}
-.option-item {
-    scroll-snap-align: end;
+:root {
+    --description-font-size: 0.9em; /* match VS Code quickpick description */
 }
 
-
-.option-item {
-    cursor: pointer;
-    border-radius: 3px;
-}
-
-.option-item.selected {
-    color: var(--vscode-list-activeSelectionForeground);
-    background-color: var(--vscode-list-activeSelectionBackground);
-}
-.option-item:hover:not(.selected):not(.disabled) {
-    color: var(--vscode-list-hoverForeground);
-    background-color: var(--vscode-list-hoverBackground);
-}
-.option-item.disabled {
-    cursor: default;
-}
-
-body[data-vscode-theme-kind='vscode-high-contrast-light'] .option-item.selected,
-body[data-vscode-theme-kind='vscode-high-contrast'] .option-item.selected {
-    outline: 1px dashed var(--vscode-contrastActiveBorder);
-    outline-offset: -1px;
+.item {
+    line-height: 1.2;
 }
 
 /* Option item content */
 .option-item {
     display: flex;
     flex-direction: column;
-    gap: calc(0.75*var(--item-padding-y));
+    gap: 0.2rem;
+    overflow: hidden;
 }
 .option-item-title, .option-item-description, .option-item-warning {
     white-space: nowrap;
@@ -105,8 +44,4 @@ body[data-vscode-theme-kind='vscode-high-contrast'] .option-item.selected {
 .option-item-warning {
     font-size: var(--description-font-size);
     opacity: 0.7;
-}
-
-.title-help-icon {
-    margin-left: 0.25rem;
 }

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -8,7 +8,7 @@ import {
     parseMentionQuery,
 } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
-import { type FunctionComponent, useLayoutEffect, useRef } from 'react'
+import { type FunctionComponent, useEffect, useRef } from 'react'
 import {
     FILE_HELP_LABEL,
     FILE_RANGE_TOOLTIP_LABEL,
@@ -37,8 +37,8 @@ export const OptionsList: FunctionComponent<
     // Scroll selected into view. Needs `setTimeout` because we need to wait for all DOM mutations.
     // The `cmdk` package handles this when using its own input, but here we need to use the Lexical
     // editor's input because the user is still typing into the Lexical editor.
-    useLayoutEffect(() => {
-        setTimeout(() => {
+    useEffect(() => {
+        const timeoutHandle = setTimeout(() => {
             if (ref.current && selectedIndex !== null) {
                 const selected = ref.current.querySelector('[aria-selected="true"]')
 
@@ -53,6 +53,7 @@ export const OptionsList: FunctionComponent<
                 selected?.scrollIntoView({ block: 'nearest' })
             }
         })
+        return () => clearTimeout(timeoutHandle)
     }, [selectedIndex])
 
     const mentionQuery = parseMentionQuery(query, [])
@@ -80,8 +81,7 @@ export const OptionsList: FunctionComponent<
                                 setHighlightedIndex(i)
                                 selectOptionAndCleanUp(option)
                             }}
-                            onMouseEnter={() => setHighlightedIndex(i)}
-                            className={clsx(styles.item, selectedIndex === i && styles.selected)}
+                            className={styles.item}
                         >
                             <ItemContent query={mentionQuery} option={option} />
                         </CommandItem>

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.module.css
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.module.css
@@ -9,6 +9,7 @@
 }
 
 .reset-anchor {
+    /* Without this, the popover position jitters by +/- ~13px. */
     top: 0 !important;
     left: 0 !important;
 }


### PR DESCRIPTION
No (or very minor) change in UI, no change in behavior. Just uses `cmdk` instead of our own custom menu list for @-mentions.

![image](https://github.com/sourcegraph/cody/assets/1976/aa00263c-ef45-471c-a01b-8ec41c3d2ef7)


## Test plan

CI