### PR TITLE
only run windows e2e on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" == "push" ] && [ "$GITHUB_REF" == "refs/heads/main" ]; then
             echo 'matrix=["ubuntu","windows","macos"]' >> $GITHUB_OUTPUT
           else
-            echo 'matrix=["ubuntu","windows"]' >> $GITHUB_OUTPUT
+            echo 'matrix=["ubuntu"]' >> $GITHUB_OUTPUT
           fi
 
   test-unit:


### PR DESCRIPTION
This test is flaky and fails often. We should fix it, but in the meantime, it slows us down on every push and PR waiting for it to finish before we can rerun other actions.



## Test plan

CI