### PR TITLE
Revert "only run windows e2e on main"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" == "push" ] && [ "$GITHUB_REF" == "refs/heads/main" ]; then
             echo 'matrix=["ubuntu","windows","macos"]' >> $GITHUB_OUTPUT
           else
-            echo 'matrix=["ubuntu"]' >> $GITHUB_OUTPUT
+            echo 'matrix=["ubuntu","windows"]' >> $GITHUB_OUTPUT
           fi
 
   test-unit:


### PR DESCRIPTION
Reverts sourcegraph/cody#4052

This change was incorrect and affected unit tests not e2e tests.

## Test plan

CI