### PR TITLE
Agent: add incremental document syncing and fire content changes

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocument.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocument.kt
@@ -6,5 +6,6 @@ data class ProtocolTextDocument(
   val filePath: String? = null,
   val content: String? = null,
   val selection: Range? = null,
+  val contentChanges: List<ProtocolTextDocumentContentChangeEvent>? = null,
 )
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocumentContentChangeEvent.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocumentContentChangeEvent.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class ProtocolTextDocumentContentChangeEvent(
+  val range: Range,
+  val text: String,
+)
+

--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -8,6 +8,8 @@ import { logDebug, logError } from '@sourcegraph/cody-shared'
 import { doesFileExist } from '../../vscode/src/commands/utils/workspace-files'
 import { resetActiveEditor } from '../../vscode/src/editor/active-editor'
 import { AgentTextDocument } from './AgentTextDocument'
+import { applyContentChanges } from './applyContentChanges'
+import { calculateContentChanges } from './calculateContentChanges'
 import { clearArray } from './clearArray'
 import * as vscode_shim from './vscode-shim'
 
@@ -31,12 +33,30 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
     public activeDocumentFilePath: vscode.Uri | null = null
 
     public openUri(uri: vscode.Uri): AgentTextDocument {
-        return this.loadedDocument(ProtocolTextDocumentWithUri.from(uri))
+        return this.loadAndUpdateDocument(ProtocolTextDocumentWithUri.from(uri))
     }
-    public loadedDocument(document: ProtocolTextDocumentWithUri): AgentTextDocument {
+    public loadAndUpdateDocument(document: ProtocolTextDocumentWithUri): AgentTextDocument {
+        return this.loadAndUpdateDocumentWithChanges(document).document
+    }
+    public loadAndUpdateDocumentWithChanges(document: ProtocolTextDocumentWithUri): {
+        document: AgentTextDocument
+        contentChanges: vscode.TextDocumentContentChangeEvent[]
+    } {
         const fromCache = this.agentDocuments.get(document.underlying.uri)
         if (!fromCache) {
-            return new AgentTextDocument(document)
+            return { document: new AgentTextDocument(document), contentChanges: [] }
+        }
+
+        const contentChanges: vscode.TextDocumentContentChangeEvent[] = []
+
+        if (document.contentChanges && document.contentChanges.length > 0) {
+            const changes = applyContentChanges(fromCache, document.contentChanges)
+            contentChanges.push(...changes.contentChanges)
+            document.underlying.content = changes.newText
+        } else if (document.content !== undefined) {
+            for (const change of calculateContentChanges(fromCache, document.content)) {
+                contentChanges.push(change)
+            }
         }
 
         if (document.content === undefined) {
@@ -49,7 +69,7 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
 
         fromCache.update(document)
 
-        return fromCache
+        return { document: fromCache, contentChanges }
     }
 
     public setActiveTextEditor(textEditor: vscode.TextEditor): void {
@@ -74,8 +94,15 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         return this.agentDocuments.get(uriString)
     }
 
-    public addDocument(document: ProtocolTextDocumentWithUri): AgentTextDocument {
-        const agentDocument = this.loadedDocument(document)
+    public loadDocument(document: ProtocolTextDocumentWithUri): AgentTextDocument {
+        return this.loadDocumentWithChanges(document).document
+    }
+    public loadDocumentWithChanges(document: ProtocolTextDocumentWithUri): {
+        document: AgentTextDocument
+        contentChanges: vscode.TextDocumentContentChangeEvent[]
+    } {
+        const { document: agentDocument, contentChanges } =
+            this.loadAndUpdateDocumentWithChanges(document)
         this.agentDocuments.set(document.underlying.uri, agentDocument)
 
         const tabs: vscode.Tab[] = []
@@ -107,7 +134,7 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         }
         vscode_shim.onDidChangeVisibleTextEditors.fire(vscode_shim.visibleTextEditors)
 
-        return agentDocument
+        return { document: agentDocument, contentChanges }
     }
 
     public deleteDocument(uri: vscode.Uri): void {
@@ -141,7 +168,7 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
                 logError('vscode.workspace.openTextDocument', `unable to read non-file URI: ${uri}`)
             }
         }
-        return Promise.resolve(this.loadedDocument(document))
+        return Promise.resolve(this.loadAndUpdateDocument(document))
     }
 
     public async reset(): Promise<void> {

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -320,7 +320,7 @@ export class TestClient extends MessageHandler {
             return result
         })
         this.registerRequest('textDocument/openUntitledDocument', params => {
-            this.workspace.addDocument(ProtocolTextDocumentWithUri.fromDocument(params))
+            this.workspace.loadDocument(ProtocolTextDocumentWithUri.fromDocument(params))
             this.notify('textDocument/didOpen', params)
             return Promise.resolve(true)
         })
@@ -366,7 +366,7 @@ export class TestClient extends MessageHandler {
         const protocolDocument = ProtocolTextDocumentWithUri.from(document.uri, {
             content: updatedContent,
         })
-        this.workspace.addDocument(protocolDocument)
+        this.workspace.loadDocument(protocolDocument)
         return { success: true, protocolDocument }
     }
     private logMessage(params: DebugMessage): void {
@@ -426,7 +426,7 @@ export class TestClient extends MessageHandler {
             content,
             selection: start && end ? { start, end } : undefined,
         }
-        this.workspace.addDocument(ProtocolTextDocumentWithUri.fromDocument(protocolDocument))
+        this.workspace.loadDocument(ProtocolTextDocumentWithUri.fromDocument(protocolDocument))
         this.workspace.activeDocumentFilePath = uri
         this.notify(method, protocolDocument)
     }

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -375,25 +375,26 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerNotification('textDocument/didFocus', (document: ProtocolTextDocument) => {
             const documentWithUri = ProtocolTextDocumentWithUri.fromDocument(document)
             this.workspace.setActiveTextEditor(
-                this.workspace.newTextEditor(this.workspace.addDocument(documentWithUri))
+                this.workspace.newTextEditor(this.workspace.loadDocument(documentWithUri))
             )
         })
 
         this.registerNotification('textDocument/didOpen', document => {
             const documentWithUri = ProtocolTextDocumentWithUri.fromDocument(document)
-            const textDocument = this.workspace.addDocument(documentWithUri)
+            const textDocument = this.workspace.loadDocument(documentWithUri)
             vscode_shim.onDidOpenTextDocument.fire(textDocument)
             this.workspace.setActiveTextEditor(this.workspace.newTextEditor(textDocument))
         })
 
         this.registerNotification('textDocument/didChange', document => {
             const documentWithUri = ProtocolTextDocumentWithUri.fromDocument(document)
-            const textDocument = this.workspace.addDocument(documentWithUri)
+            const { document: textDocument, contentChanges } =
+                this.workspace.loadDocumentWithChanges(documentWithUri)
             const textEditor = this.workspace.newTextEditor(textDocument)
             this.workspace.setActiveTextEditor(textEditor)
             vscode_shim.onDidChangeTextDocument.fire({
                 document: textDocument,
-                contentChanges: [], // TODO: implement this. It was only used by recipes, not autocomplete.
+                contentChanges,
                 reason: undefined,
             })
 

--- a/agent/src/applyContentChanges.test.ts
+++ b/agent/src/applyContentChanges.test.ts
@@ -1,0 +1,38 @@
+import dedent from 'dedent'
+import { describe, expect, it } from 'vitest'
+import { Uri } from 'vscode'
+import { AgentTextDocument } from './AgentTextDocument'
+import { applyContentChanges } from './applyContentChanges'
+
+describe('applyContentChanges', () => {
+    it('basic', () => {
+        const document = AgentTextDocument.from(
+            Uri.file('basic.ts'),
+            dedent`
+        interface Hello {
+            greeting: string
+        }`
+        )
+        const applied = applyContentChanges(document, [
+            {
+                range: { start: { line: 1, character: 1 }, end: { line: 1, character: 9 } },
+                text: 'yolo',
+            },
+            {
+                range: { start: { line: 1, character: 11 }, end: { line: 1, character: 13 } },
+                text: 'hurrah',
+            },
+        ])
+        expect(applied.newText).toMatchInlineSnapshot(`
+          "interface Hello {
+           yoloinhurrah string
+          }"
+        `)
+        expect(applied.contentChanges.map(change => change.text)).toMatchInlineSnapshot(`
+          [
+            "yolo",
+            "hurrah",
+          ]
+        `)
+    })
+})

--- a/agent/src/applyContentChanges.ts
+++ b/agent/src/applyContentChanges.ts
@@ -1,0 +1,35 @@
+import { applyPatch } from 'fast-myers-diff'
+import * as vscode from 'vscode'
+import type { AgentTextDocument } from './AgentTextDocument'
+import type { ProtocolTextDocumentContentChangeEvent } from './protocol-alias'
+
+export function applyContentChanges(
+    document: AgentTextDocument,
+    changes: ProtocolTextDocumentContentChangeEvent[]
+): { newText: string; contentChanges: vscode.TextDocumentContentChangeEvent[] } {
+    const patch: [number, number, string][] = []
+    const contentChanges: vscode.TextDocumentContentChangeEvent[] = []
+
+    for (const change of changes) {
+        const start = document.offsetAt(change.range.start)
+        const end = document.offsetAt(change.range.end)
+        patch.push([start, end, change.text])
+        contentChanges.push({
+            range: new vscode.Range(
+                change.range.start.line,
+                change.range.start.character,
+                change.range.end.line,
+                change.range.end.character
+            ),
+            rangeLength: end - start,
+            rangeOffset: start,
+            text: change.text,
+        })
+    }
+
+    const newText: string[] = []
+    for (const part of applyPatch<string, string>(document.content, patch)) {
+        newText.push(part)
+    }
+    return { newText: newText.join(''), contentChanges }
+}

--- a/agent/src/calculateContentChanges.test.ts
+++ b/agent/src/calculateContentChanges.test.ts
@@ -1,0 +1,35 @@
+import dedent from 'dedent'
+import { describe, expect, it } from 'vitest'
+import { Uri } from 'vscode'
+import { AgentTextDocument } from './AgentTextDocument'
+import { applyContentChanges } from './applyContentChanges'
+import { calculateContentChanges } from './calculateContentChanges'
+
+describe('calculateContentChanges', () => {
+    it('basic', () => {
+        const document = AgentTextDocument.from(
+            Uri.file('basic.ts'),
+            dedent`
+        interface Hello {
+            greeting: string
+        }`
+        )
+        const newText = dedent`
+        interface VeryHelloAgain {
+            greeeting2: Map<string, number>
+        }`
+        const contentChanges = [...calculateContentChanges(document, newText)]
+        const applied = applyContentChanges(document, contentChanges)
+        expect(applied.newText).toStrictEqual(newText)
+        expect(applied.contentChanges.map(change => change.text)).toMatchInlineSnapshot(`
+          [
+            "Very",
+            "Again",
+            "e",
+            "2",
+            "Map<",
+            ", number>",
+          ]
+        `)
+    })
+})

--- a/agent/src/calculateContentChanges.ts
+++ b/agent/src/calculateContentChanges.ts
@@ -1,0 +1,17 @@
+import { calcPatch } from 'fast-myers-diff'
+import * as vscode from 'vscode'
+
+export function* calculateContentChanges(
+    document: vscode.TextDocument,
+    newText: string
+): Generator<vscode.TextDocumentContentChangeEvent> {
+    const edits = calcPatch(document.getText(), newText)
+    for (const [sx, ex, text] of edits) {
+        yield {
+            range: new vscode.Range(document.positionAt(sx), document.positionAt(ex)),
+            rangeOffset: sx,
+            rangeLength: ex - sx,
+            text,
+        }
+    }
+}

--- a/vscode/src/jsonrpc/TextDocumentWithUri.ts
+++ b/vscode/src/jsonrpc/TextDocumentWithUri.ts
@@ -1,7 +1,11 @@
 import * as vscode from 'vscode'
 
 import { logDebug } from '../log'
-import type { ProtocolTextDocument, Range } from './agent-protocol'
+import type {
+    ProtocolTextDocument,
+    ProtocolTextDocumentContentChangeEvent,
+    Range,
+} from './agent-protocol'
 
 /**
  * Wrapper around `ProtocolTextDocument` that also contains a parsed vscode.Uri.
@@ -45,6 +49,10 @@ export class ProtocolTextDocumentWithUri {
 
     public get content(): string | undefined {
         return this.underlying.content
+    }
+
+    public get contentChanges(): ProtocolTextDocumentContentChangeEvent[] | undefined {
+        return this.underlying.contentChanges
     }
 
     public get selection(): Range | undefined {

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -543,6 +543,12 @@ export interface ProtocolTextDocument {
     filePath?: string
     content?: string
     selection?: Range
+    contentChanges?: ProtocolTextDocumentContentChangeEvent[]
+}
+
+export interface ProtocolTextDocumentContentChangeEvent {
+    range: Range
+    text: string
 }
 
 interface ExecuteCommandParams {


### PR DESCRIPTION
Fixes CODY-1388
Fixes CODY-1292

Previously, the agent had two important limitations:

- Clients couldn't synchronize document content incrementally. This hurt performance because clients had to copy the full text contents of files on every minor change.
- The VS Code event `vscode.workspace.onDidChangeTextDocument` never populated the `contentChanges` property. We use this property in several places in the extension, including to track persistence and to support parallel inline edit.

This PR fixes both of those limitations.


## Test plan

See added unit tests.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
