### PR TITLE
Hide ignored files that come back from the remote-search endpoint

### DIFF
--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -106,6 +106,19 @@ export class PromptBuilder {
                 result.ignored.push(userContextItem)
                 continue
             }
+            // Special-case remote context here. We can usually rely on the remote context to honor
+            // any context filters but in case of client side overwrites, we want a file that is
+            // ignored on a client to always be treated as ignored.
+            if (
+                userContextItem.type === 'file' &&
+                (userContextItem.uri.scheme === 'https' || userContextItem.uri.scheme === 'http') &&
+                userContextItem.repoName &&
+                contextFiltersProvider.isRepoNameIgnored(userContextItem.repoName)
+            ) {
+                result.ignored.push(userContextItem)
+                continue
+            }
+
             // Skip context items that have already been seen
             if (this.seenContext.has(id)) {
                 result.duplicate.push(userContextItem)


### PR DESCRIPTION
Closes CODY-1390

Special-case remote context here. We can usually rely on the remote context to honor any context filters but in case of client side overwrites, we want a file that is ignored on a client to always be treated as ignored.

Note that we currently do not enhanced context items that are not included at all (since those also contains items that are already part of the transcript etc), so the outcome of this PR is to simply filter these results from being part of the prompt. [Started a thread about that](https://sourcegraph.com/github.com/sourcegraph/cody@6bd1abc392814b7e973ecd23d3c278bc80005873/-/blob/vscode/src/chat/chat-view/prompt.ts?L73).  

## Test plan

<img width="560" alt="Screenshot 2024-05-06 at 16 23 28" src="https://github.com/sourcegraph/cody/assets/458591/0a964d01-a212-4e73-babd-6ef676596e4a">

