### PR TITLE
swallow hidePopover exception

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: Fixed a bug where the entire Cody chat view would appear blank. [pull/4062](https://github.com/sourcegraph/cody/pull/4062)
+
 ### Changed
 
 - Search: Cody's Natural Language Search has been moved to a new quick pick interface, and the search box has been removed from the sidebar. [pull/3991](https://github.com/sourcegraph/cody/pull/3991)

--- a/vscode/webviews/components/platform/Popover.tsx
+++ b/vscode/webviews/components/platform/Popover.tsx
@@ -58,7 +58,9 @@ export const Popover: FunctionComponent<{
         if (!popoverEl.current || !anchor) {
             return
         }
-        popoverEl.current.hidePopover()
+        try {
+            popoverEl.current.hidePopover()
+        } catch {}
         if (anchorWasFocused) {
             anchor.focus()
         }


### PR DESCRIPTION
Attempt to fix issue reported by 2 people where the Cody webview was blank in VS Code and the following error appeared in the devtools console:

```
Uncaught DOMException: Failed to execute 'hidePopover' on 'HTMLElement': Invalid on popover elements that aren't already showing. This might have been the result of the "beforetoggle" event handler changing the state of this popover.
```



## Test plan

CI