### PR TITLE
VS Code: Release 1.16.2

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,8 +13,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Chat: Fixed a bug where the entire Cody chat view would appear blank. [pull/4062](https://github.com/sourcegraph/cody/pull/4062)
-
 ### Changed
 
 - Search: Cody's Natural Language Search has been moved to a new quick pick interface, and the search box has been removed from the sidebar. [pull/3991](https://github.com/sourcegraph/cody/pull/3991)
@@ -22,6 +20,16 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
   - `Add Code to Chat`: Add selected code to the current opened chat, or new chat if no panel is opened.
   - `New Chat with Code`: Opens a new chat with the selected code when no existing chat panel is open and code is selected in the editor.
 - Fixes an issue where triggering a recipe with no open editor window will cause unexpected behavior. [pull/3911](https://github.com/sourcegraph/cody/pull/3911)
+
+## [1.16.2]
+
+### Added
+
+### Fixed
+
+- Chat: Fixed a bug where the entire Cody chat view would appear blank. [pull/4062](https://github.com/sourcegraph/cody/pull/4062)
+
+### Changed
 
 ## [1.16.1]
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Update CHANGELOG and version number to reflect the patch release started in https://github.com/sourcegraph/cody/actions/runs/8976036958/job/24651990534 

diff: https://github.com/sourcegraph/cody/compare/vscode-v1.16.1...bee/v1.16.2?expand=1

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Patch release pipeline has been started in https://github.com/sourcegraph/cody/actions/runs/8976036958/job/24651990534