### PR TITLE
Ollama: handle incomplete response chunks

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Autocomplete: Handle incomplete Ollama response chunks gracefully. [pull/4066](https://github.com/sourcegraph/cody/pull/4066)
+
 ### Changed
 
 - Search: Cody's Natural Language Search has been moved to a new quick pick interface, and the search box has been removed from the sidebar. [pull/3991](https://github.com/sourcegraph/cody/pull/3991)


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/cody/issues/4008
- In the Ollama autocomplete client, ignore cut-in-the-middle response chunks and continue streaming.

## Test plan

Tested locally.
