### PR TITLE
Cody Ignore: sample repo-name-resolver spans

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -156,8 +156,12 @@ export class ContextFiltersProvider implements vscode.Disposable {
             return 'non-file-uri'
         }
 
-        const repoNames = await wrapInActiveSpan('repoNameResolver.getRepoNamesFromWorkspaceUri', () =>
-            this.getRepoNamesFromWorkspaceUri?.(uri)
+        const repoNames = await wrapInActiveSpan(
+            'repoNameResolver.getRepoNamesFromWorkspaceUri',
+            span => {
+                span.setAttribute('sampled', true)
+                return this.getRepoNamesFromWorkspaceUri?.(uri)
+            }
         )
 
         if (!repoNames) {


### PR DESCRIPTION
Sample repo-name-resolver spans to analyze real-world performance during internal Cody Ignore testing.
Thanks @philipp-spiess for the tip!

## Test plan

N/a
