### PR TITLE
git repo name logs for public repos

### DIFF
--- a/vscode/src/repository/repo-metadata-from-git-api.ts
+++ b/vscode/src/repository/repo-metadata-from-git-api.ts
@@ -24,7 +24,9 @@ export class RepoMetadatafromGitApi {
             return this.cache.get(gitUrl)
         }
         const repoMetaData = await this.metadataFromGit(gitUrl)
-        this.cache.set(gitUrl, repoMetaData)
+        if (repoMetaData) {
+            this.cache.set(gitUrl, repoMetaData)
+        }
         return repoMetaData
     }
 
@@ -42,8 +44,7 @@ export class RepoMetadatafromGitApi {
         const metadata = { owner, repoName, isPublic: false }
         try {
             const response = await fetch(apiUrl, { method: 'HEAD' })
-            const repoData = await response.json()
-            metadata.isPublic = response.ok && repoData.private === false
+            metadata.isPublic = response.ok
             return metadata
         } catch (error) {
             return undefined


### PR DESCRIPTION
## Context
1. Follow up on https://github.com/sourcegraph/cody/pull/3882 PR - Git repo logging for public repos
2. If the user asks a question in chat without opening a file in editor, we cache `undefined` value for the visibility. This PR changes this behaviour by only caching the values which are not `undefined`.  

## Test plan
1. Start the debugger from this branch.
2. Click on the new chat and ask a question without opening any file: The `gitMetadata` should be empty.
3. Open any file and click on the new chat and ask a question. The telemetry response should have an additional field gitMetadata, reflecting the git url and commit of the repo. If the repo is private, the field will be empty

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
