### PR TITLE
[Bug Fix] Naming of v2 telemetry events and update `writeCompletionEvent` helper function [Easy Review]

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -191,6 +191,7 @@ function logCompletionSuggestedEvent(params: SuggestedEventPayload): void {
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
     writeCompletionEvent(
+        null,
         'suggested',
         {
             version: 0,
@@ -204,6 +205,7 @@ function logCompletionAcceptedEvent(params: AcceptedEventPayload): void {
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
     writeCompletionEvent(
+        null,
         'accepted',
         {
             version: 0,
@@ -217,6 +219,7 @@ function logCompletionPartiallyAcceptedEvent(params: PartiallyAcceptedEventPaylo
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
     writeCompletionEvent(
+        null,
         'partiallyAccepted',
         {
             version: 0,
@@ -230,7 +233,8 @@ export function logCompletionPersistencePresentEvent(params: PersistencePresentE
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
     writeCompletionEvent(
-        'persistence:present',
+        'persistence',
+        'present',
         {
             version: 0,
             metadata,
@@ -243,7 +247,8 @@ export function logCompletionPersistenceRemovedEvent(params: PersistenceRemovedE
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
     writeCompletionEvent(
-        'persistence:present',
+        'persistence',
+        'removed',
         {
             version: 0,
             metadata,
@@ -255,17 +260,17 @@ export function logCompletionPersistenceRemovedEvent(params: PersistenceRemovedE
 function logCompletionNoResponseEvent(params: NoResponseEventPayload): void {
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
-    writeCompletionEvent('noResponse', { version: 0, metadata, privateMetadata }, params)
+    writeCompletionEvent(null, 'noResponse', { version: 0, metadata, privateMetadata }, params)
 }
 function logCompletionErrorEvent(params: ErrorEventPayload): void {
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
-    writeCompletionEvent('error', { version: 0, metadata, privateMetadata }, params)
+    writeCompletionEvent(null, 'error', { version: 0, metadata, privateMetadata }, params)
 }
 export function logCompletionFormatEvent(params: FormatEventPayload): void {
     // Use automatic splitting for now - make this manual as needed
     const { metadata, privateMetadata } = splitSafeMetadata(params)
-    writeCompletionEvent('format', { version: 0, metadata, privateMetadata }, params)
+    writeCompletionEvent(null, 'format', { version: 0, metadata, privateMetadata }, params)
 }
 /**
  * The following events are added to ensure the logging bookkeeping works as expected in production
@@ -281,29 +286,39 @@ export function logCompletionBookkeepingEvent(
         | 'containsOpeningTag'
         | 'synthesizedFromParallelRequest'
 ): void {
-    writeCompletionEvent(name)
+    writeCompletionEvent(null, name)
 }
 
 /**
  * writeCompletionEvent is the underlying helper for various logCompletion*
  * functions. It writes telemetry in the appropriate format to both the v1
  * and v2 telemetry.
+ *
+ * @param subfeature Subfeature can optionally be provided to be added as part of the event feature.
+ * e.g. 'cody.completion.subfeature'. DO NOT include a 'cody.*' prefix.
+ *  MUST start with lower case and ONLY have letters and '.'.
+ * @param action action is required to represent the verb associated with an event occurrence.
+ * e.g. 'executed', MUST start with lower case and ONLY have letters and '.'.
+ * @param params Telemetry V2 parameters
+ * @param legacyParam legacyParams are passed through as-is the legacy event logger for backwards
+ * compatibility. All relevant arguments should also be set on the params
+ * object.
  */
-function writeCompletionEvent<Name extends string, LegacyParams extends {}>(
-    name: KnownString<Name>,
+function writeCompletionEvent<SubFeature extends string, Action extends string, LegacyParams extends {}>(
+    subfeature: KnownString<SubFeature> | null,
+    action: KnownString<Action>,
     params?: TelemetryEventParameters<{ [key: string]: number }, BillingProduct, BillingCategory>,
-    /**
-     * legacyParams are passed through as-is the legacy event logger for backwards
-     * compatibility. All relevant arguments should also be set on the params
-     * object.
-     */
     legacyParams?: LegacyParams
 ): void {
     const extDetails = getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration()))
-    telemetryService.log(`${logPrefix(extDetails.ide)}:completion:${name}`, legacyParams, {
-        agent: true,
-        hasV2Event: true, // this helper translates the event for us
-    })
+    telemetryService.log(
+        `${logPrefix(extDetails.ide)}:completion:${subfeature ? `${subfeature}:` : ''}${action}`,
+        legacyParams,
+        {
+            agent: true,
+            hasV2Event: true, // this helper translates the event for us
+        }
+    )
     /**
      * Extract interaction ID from the full legacy params for convenience
      */
@@ -314,8 +329,14 @@ function writeCompletionEvent<Name extends string, LegacyParams extends {}>(
      * New telemetry automatically adds extension context - we do not need to
      * include platform in the name of the event. However, we MUST prefix the
      * event with 'cody.' to have the event be categorized as a Cody event.
+     *
+     * We use an if/else statement here because the typechecker gets confused.
      */
-    telemetryRecorder.recordEvent('cody.completion', name, params)
+    if (subfeature) {
+        telemetryRecorder.recordEvent(`cody.completion.${subfeature}`, action, params)
+    } else {
+        telemetryRecorder.recordEvent('cody.completion', action, params)
+    }
 }
 
 export interface CompletionBookkeepingEvent {


### PR DESCRIPTION
This PR fixes completion events that were not getting logged on v2 telemetry because they contained the illegal character "`:`" within `action`. It also updates the helper function `writeCompletionEvent` thats being used to log completion events to accept subfeature as a parameter.

## Test plan
CI & Locally
<img width="725" alt="image" src="https://github.com/sourcegraph/cody/assets/32119652/9d11a480-59b5-49ac-961a-b5ecbaa76dc1">

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
