### PR TITLE
Skip logging empty context status

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -815,15 +815,15 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     private postContextStatus(): void {
-        const status = this.contextStatusAggregator.status
-        // Only log non-empty status.
-        if (status.length > 0) {
-            logDebug('SimpleChatPanelProvider', 'postContextStatusToWebView', JSON.stringify(status))
-        }
+        const { status } = this.contextStatusAggregator
         void this.postMessage({
             type: 'enhanced-context',
             enhancedContextStatus: { groups: status },
         })
+        // Only log non-empty status to reduce noises.
+        if (status.length > 0) {
+            logDebug('SimpleChatPanelProvider', 'postContextStatus', JSON.stringify(status))
+        }
     }
 
     /**

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -815,16 +815,14 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     private postContextStatus(): void {
-        logDebug(
-            'SimpleChatPanelProvider',
-            'postContextStatusToWebView',
-            JSON.stringify(this.contextStatusAggregator.status)
-        )
+        const status = this.contextStatusAggregator.status
+        // Only log non-empty status.
+        if (status.length > 0) {
+            logDebug('SimpleChatPanelProvider', 'postContextStatusToWebView', JSON.stringify(status))
+        }
         void this.postMessage({
             type: 'enhanced-context',
-            enhancedContextStatus: {
-                groups: this.contextStatusAggregator.status,
-            },
+            enhancedContextStatus: { groups: status },
         })
     }
 


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1715096388594779

![image](https://github.com/sourcegraph/cody/assets/68532117/7203c90b-f9bb-4d98-8dba-d55f61e6b926)

Currently, we are logging the postContextStatusToWebView event on empty status.

This PR updates to log non-empty status to reduce the noises in our debug logs.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Check your debug log to confirm if Cody is still logging empty status `[]`