### PR TITLE
update: use toRangeData utility for range conversion

### DIFF
--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -21,6 +21,7 @@ import {
     isCodyIgnoredFile,
     isDefined,
     isWindows,
+    toRangeData,
 } from '@sourcegraph/cody-shared'
 
 import { getOpenTabsUris } from '.'
@@ -226,7 +227,7 @@ async function createContextFileFromUri(
         return []
     }
 
-    const range = selectionRange ? createContextFileRange(selectionRange) : selectionRange
+    const range = toRangeData(selectionRange)
     return [
         type === 'file'
             ? {
@@ -245,19 +246,6 @@ async function createContextFileFromUri(
                   kind: kind!,
               },
     ]
-}
-
-function createContextFileRange(selectionRange: vscode.Range): ContextItem['range'] {
-    return {
-        start: {
-            line: selectionRange.start.line,
-            character: selectionRange.start.character,
-        },
-        end: {
-            line: selectionRange.end.line,
-            character: selectionRange.end.character,
-        },
-    }
 }
 
 /**

--- a/vscode/src/prompt-builder/unique-context.ts
+++ b/vscode/src/prompt-builder/unique-context.ts
@@ -93,7 +93,7 @@ function rangeContainsLines(outerRange: RangeData, innerRange: RangeData): boole
  * Checks if both ranges are on the same lines.
  */
 function rangesOnSameLines(range1: RangeData, range2: RangeData): boolean {
-    return range1.start.line === range2.start.line && range1.end.line === range2.end.line
+    return range1.start?.line === range2.start?.line && range1.end?.line === range2.end?.line
 }
 
 /**


### PR DESCRIPTION
Small change to remove the `createContextFileRange` function, and use the centralized `toRangeData` utility function from the @sourcegraph/cody-shared module to convert the selectionRange to the required ContextItem['range'] format.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

no feature change. CI should stays green