### PR TITLE
Search: Add refresh buttons to Search Code menu

### DIFF
--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -203,9 +203,7 @@ export class SearchViewProvider implements vscode.Disposable {
         const quickPick = vscode.window.createQuickPick()
         quickPick.placeholder =
             'Search… (e.g. "password hashing", "connection retries", a symbol name, or a topic)'
-        quickPick.items = [
-            { label: 'Search for code using a natural language query.', alwaysShow: true },
-        ]
+        quickPick.items = []
         quickPick.title = 'Natural Language Code Search (Beta)'
         quickPick.buttons = searchQuickPickButtons
         quickPick.matchOnDescription = false

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -202,7 +202,7 @@ export class SearchViewProvider implements vscode.Disposable {
     private async getSearchQueryInput(): Promise<void> {
         const quickPick = vscode.window.createQuickPick()
         quickPick.placeholder =
-            'Examples: "password hashing", "connection retries", a symbol name, or a topic.'
+            'Search… (e.g. "password hashing", "connection retries", a symbol name, or a topic)'
         quickPick.items = [
             { label: 'Search for code using a natural language query.', alwaysShow: true },
         ]


### PR DESCRIPTION
RE: https://sourcegraph.slack.com/archives/C05AGQYD528/p1715122290764839?thread_ts=1715122026.830309&cid=C05AGQYD528

- replace the input box for search query with quickPick 
  - as input box does not allow us to add buttons
- add buttons to refresh index to the quick pick menu


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Click on Search Code (Beta) on your sidebar
2. Verify the refresh buttons are showing up on the upper right of the menu
3. Search for something to ensure the search feature still works

### After

![image](https://github.com/sourcegraph/cody/assets/68532117/7efede50-1ddc-468f-8556-305640aea05f)


### Before

No buttons on the upper right

![image](https://github.com/sourcegraph/cody/assets/68532117/7638edc2-cc8d-4c63-8aa2-64c0576e10d1)
