### PR TITLE
Chat: exclude history items from UI

### DIFF
--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -73,23 +73,20 @@ export class DefaultPrompter implements IPrompter {
             const ignoredContext = { user: 0, enhanced: 0, transcript: 0 }
 
             // Add context from new user-specified context items, e.g. @-mentions, @-uri
-            const newUserContextMessages = await promptBuilder.tryAddContext(
-                'user',
-                this.explicitContext
-            )
-            ignoredContext.user += newUserContextMessages.ignored.length
+            const newUserContext = await promptBuilder.tryAddContext('user', this.explicitContext)
+            ignoredContext.user += newUserContext.ignored.length
 
+            // Lists of context items added from the last human message.
+            // NOTE: For UI display only, not used in the prompt.
+            const context = { used: [] as ContextItem[], ignored: [] as ContextItem[] }
+            // List of valid context items added from the last human message
+            context.used.push(...newUserContext.added.map(c => ({ ...c, isTooLarge: false })))
             // NOTE: Only used for display excluded context from user-specifed context items in UI
-            const ignoredUserContext: ContextItem[] = newUserContextMessages.ignored.map(c => ({
-                ...c,
-                isTooLarge: true,
-            }))
+            context.ignored.push(...newUserContext.ignored.map(c => ({ ...c, isTooLarge: true })))
 
             // Add user and enhanced context from previous messages (chat transcript)
-            const historyContext = await promptBuilder.tryAddContext(
-                'history',
-                reverseTranscript.flatMap(m => m?.contextFiles).filter(isDefined)
-            )
+            const historyItems = reverseTranscript.flatMap(m => m?.contextFiles).filter(isDefined)
+            const historyContext = await promptBuilder.tryAddContext('history', historyItems.reverse())
             ignoredContext.transcript += historyContext.ignored.length
 
             // Get new enhanced context from current editor or broader search when enabled
@@ -104,6 +101,9 @@ export class DefaultPrompter implements IPrompter {
                     'enhanced',
                     newEnhancedContextItems
                 )
+                // Because this enhanced context is added for the last human message,
+                // we will also add it to the context list for display.
+                context.used.push(...newEnhancedMessages.added)
                 ignoredContext.enhanced += newEnhancedMessages.ignored.length
             }
 
@@ -114,10 +114,7 @@ export class DefaultPrompter implements IPrompter {
 
             return {
                 prompt: promptBuilder.build(),
-                context: {
-                    used: promptBuilder.contextItems,
-                    ignored: ignoredUserContext,
-                },
+                context,
             }
         })
     }

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -78,10 +78,10 @@ export class DefaultPrompter implements IPrompter {
 
             // Lists of context items added from the last human message.
             // NOTE: For UI display only, not used in the prompt.
-            const context = { used: [] as ContextItem[], ignored: [] as ContextItem[] }
+            const context: PromptInfo['context'] = { used: [], ignored: [] }
             // List of valid context items added from the last human message
             context.used.push(...newUserContext.added.map(c => ({ ...c, isTooLarge: false })))
-            // NOTE: Only used for display excluded context from user-specifed context items in UI
+            // NOTE: Only used for display excluded context from user-specified context items in UI
             context.ignored.push(...newUserContext.ignored.map(c => ({ ...c, isTooLarge: true })))
 
             // Add user and enhanced context from previous messages (chat transcript)


### PR DESCRIPTION
FOLLOW-UP https://github.com/sourcegraph/cody/pull/3929

Main change is to add `used` and `ignored` context lists for UI display.

Currently, context items from older chat messages are showing up in the last submitted message in the UI after https://github.com/sourcegraph/cody/pull/3929. 
Ideally, it should only display context items added for the lastest message only.

Summary: 

The DefaultPrompter now maintains separate lists for used and ignored context items. These lists are intended for UI display purposes and do not affect the actual prompt construction. The used list contains valid context items added from the last human message, while the ignored list contains user-specified context items that were too large to include.


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

I've also updated the unit test to reflect this change.
No agent recordings update is required as this change should only affect UI when we display which context is used for the last human-submitted message.

1. Submit a message in Chat with enhanced context enabled.
2. Ask a follow-up question to confirm that the context from your first question is not displayed under your second question.

### After

1st question.

<img width="1146" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/900ebda8-1cab-42ed-b11b-b6ac779b26d7">

2nd question: context from the 1st question not included.

<img width="1318" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/fe66fe62-6a36-4626-8d03-df55331dd463">


### Before

1st question.

<img width="1146" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/900ebda8-1cab-42ed-b11b-b6ac779b26d7">

2nd question: Context from the 1st question is also being displayed here

<img width="1327" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/fa628e88-3568-4429-a9f1-64409d5d7720">


