### PR TITLE
fix: ensure range is RangeData instance

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -120,6 +120,12 @@ export class SimpleChatModel {
         return this.messages
     }
 
+    // De-hydrate because vscode.Range serializes to `[start, end]` in JSON.
+    // TODO: we should use a different type for `getMessages` to make the range hydration explicit.
+    public getDehydratedMessages(): readonly ChatMessage[] {
+        return this.messages.map(prepareChatMessage)
+    }
+
     public getChatTitle(): string {
         if (this.customChatTitle) {
             return this.customChatTitle

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -60,7 +60,7 @@ export class DefaultPrompter implements IPrompter {
             }
 
             // Add existing chat transcript messages
-            const reverseTranscript = [...chat.getMessages()].reverse()
+            const reverseTranscript = [...chat.getDehydratedMessages()].reverse()
             const transcriptLimitReached = promptBuilder.tryAddMessages(reverseTranscript)
             if (transcriptLimitReached) {
                 logDebug(

--- a/vscode/src/prompt-builder/unique-context.ts
+++ b/vscode/src/prompt-builder/unique-context.ts
@@ -56,12 +56,10 @@ export function getUniqueContextItems(reversedItems: ContextItem[]): ContextItem
  * @returns boolean whether the `itemToAdd` is unique.
  */
 export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: ContextItem[]): boolean {
-    // Ensure the range is a RangeData instance
     const itemToAddRange = itemToAdd.range
     const itemToAddDisplayPath = getContextItemDisplayPath(itemToAdd)
 
     for (const item of uniqueItems) {
-        // Ensure the range is a RangeData instance
         const currentItemRange = item.range
         const currentItemDisplayPath = getContextItemDisplayPath(item)
 

--- a/vscode/src/prompt-builder/unique-context.ts
+++ b/vscode/src/prompt-builder/unique-context.ts
@@ -2,7 +2,6 @@ import {
     type ContextItem,
     type RangeData,
     displayPath as getDisplayPath,
-    toRangeData,
 } from '@sourcegraph/cody-shared'
 import { getContextItemTokenUsageType } from './utils'
 
@@ -56,26 +55,23 @@ export function getUniqueContextItems(reversedItems: ContextItem[]): ContextItem
  * @returns boolean whether the `itemToAdd` is unique.
  */
 export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: ContextItem[]): boolean {
-    const itemToAddRange = itemToAdd.range
     const itemToAddDisplayPath = getContextItemDisplayPath(itemToAdd)
+    const itemToAddRange = itemToAdd.range
 
     for (const item of uniqueItems) {
-        const currentItemRange = item.range
-        const currentItemDisplayPath = getContextItemDisplayPath(item)
-
         // Check for existing items with the same display path
-        if (currentItemDisplayPath === itemToAddDisplayPath) {
+        if (getContextItemDisplayPath(item) === itemToAddDisplayPath) {
             // Assume context with no range contains full file content (unique)
-            if (item === itemToAdd || !currentItemRange) {
+            if (item === itemToAdd || !item.range) {
                 return false // Duplicate found.
             }
 
             // Duplicates if overlapping ranges on the same lines,
             // or if one range contains the other.
-            if (currentItemRange && itemToAddRange) {
+            if (item.range && itemToAddRange) {
                 return !(
-                    rangesOnSameLines(currentItemRange, itemToAddRange) ||
-                    rangeContainsLines(currentItemRange, itemToAddRange)
+                    rangesOnSameLines(item.range, itemToAddRange) ||
+                    rangeContainsLines(item.range, itemToAddRange)
                 )
             }
         }
@@ -90,10 +86,6 @@ export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: Context
  * - The end of the outer range is greater than or equal to the end of the inner range.
  */
 function rangeContainsLines(outerRange: RangeData, innerRange: RangeData): boolean {
-    // Ensure the range is a RangeData instance
-    outerRange = toRangeData(outerRange)
-    innerRange = toRangeData(innerRange)
-
     return outerRange.start.line <= innerRange.start.line && outerRange.end.line >= innerRange.end.line
 }
 
@@ -101,11 +93,7 @@ function rangeContainsLines(outerRange: RangeData, innerRange: RangeData): boole
  * Checks if both ranges are on the same lines.
  */
 function rangesOnSameLines(range1: RangeData, range2: RangeData): boolean {
-    // Ensure the range is a RangeData instance
-    range1 = toRangeData(range1)
-    range2 = toRangeData(range2)
-
-    return range1.start.line === range2.start.line && range1.end.line === range2.end.line
+    return range1.start?.line === range2.start?.line && range1.end?.line === range2.end?.line
 }
 
 /**


### PR DESCRIPTION
Follow-up https://github.com/sourcegraph/cody/pull/3929

This commit addresses an issue where the range property of a ContextItem object might not be an instance of the RangeData class. The changes ensure that the range property is always an instance of RangeData before performing any operations on it.

Currently, some contexts are not using the correct RangeData format, which would cause the checks to fail in `vscode/src/prompt-builder/unique-context.ts` with the error `Cannot read properties of undefined (reading: 'line').`:

<img width="1398" alt="Screenshot 2024-05-07 at 8 09 18 PM" src="https://github.com/sourcegraph/cody/assets/68532117/29b0a354-5e02-449b-b9a8-ac884e4b5dc2">


To reproduce, try to build Cody from main with indexed search and local embeddings enabled, and then ask Cody a question: `tell me about SecretStorage?`

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Build Cody from this branch and start debug mode
2. Open the code repository and make sure enhanced context is enabled, with search and embeddings status shown as `indexed`
3. Ask Cody: `tell me about SecretStorage?`
4. Verify your question was submitted successfully and you are able to get a response from Cody. Before this change, your question will be stuck in the context search phase, and your question will not be sent to the LLM.

<img width="1606" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/5ea4daba-fa01-4e2d-8321-5a257357ce03">
