### PR TITLE
TreeViewProvider: Do not refresh on init

### DIFF
--- a/vscode/src/services/tree-views/TreeViewProvider.ts
+++ b/vscode/src/services/tree-views/TreeViewProvider.ts
@@ -18,7 +18,6 @@ export class TreeViewProvider implements vscode.TreeDataProvider<vscode.TreeItem
         private readonly featureFlagProvider: FeatureFlagProvider
     ) {
         this.treeItems = getCodyTreeItems(type)
-        void this.refresh()
     }
 
     /**


### PR DESCRIPTION
## Description

Issue:
- We call `refresh` in the constructor of `TreeViewProvider`
  - This is an async method that will possibly check for the existence of a feature flag too
- This constructor is called before we finish authenticating, so we have a race condition where we check for a feature flag before the user is authenticated

Fix:
- We already call `refresh` when we have a valid change that should trigger a refresh:
  - Auth change
  - Reset called
- Auth change is triggered when the editor is loaded too, so we can be confident that this will be executed

## Test plan

The easiest way to recreate this is to check the interactive tutorial works:
1. Ensure you are in the interactive tutorial group
2. Reset VS Code insiders to start a fresh editor:
(macos)
```
rm -rf $HOME/.vscode-insiders
rm -rf $HOME/Library/Caches/com.microsoft.VSCodeInsiders
rm -rf $HOME/Library/Application\ Support/Code\ -\ Insiders
rm -rf $HOME/Library/Saved\ Application\ State/com.microsoft.VSCodeInsiders.savedState
```
3. Rebuild the extension and open VS Code Insiders
```
CODY_RELEASE_TYPE=stable pnpm release:dry-run && code-insiders --install-extension dist/cody.vsix && code-insiders .
```
4. Authenticate and check that the tutorial opens, AND is visible in the sidebar

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
