### PR TITLE
Chat UI: Adjust user avatar height to fit content

### DIFF
--- a/vscode/webviews/components/UserAvatar.module.css
+++ b/vscode/webviews/components/UserAvatar.module.css
@@ -6,4 +6,5 @@
     color: var(--vscode-inputOption-activeForeground);
     align-items: center;
     justify-content: center;
+    height: fit-content;
 }


### PR DESCRIPTION
Fix a minor css issue where the height of the user avatar is stretched by adjusting the container height to fit-content. 

Not sure if this is the best solution so any feedback is welcome :D 

![image](https://github.com/sourcegraph/cody/assets/68532117/437b7505-323b-4631-949e-3688338b7a08)

![image](https://github.com/sourcegraph/cody/assets/68532117/da800138-e7b8-418d-aa85-d23a99649a0a)

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Run the explain command and check the user avatar size to verify the user avatar is displaying correctly.

![image](https://github.com/sourcegraph/cody/assets/68532117/1f90cd48-bda5-4423-bc8e-d7c23f2d20b5)
