### PR TITLE
VS Code: Release 1.16.3

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -28,6 +28,17 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Edit: The "Document Code" and "Generate Tests" commands now execute with a single click/action, rather than requiring the user to specify the range first. The range can be modified from the normal Edit input. [pull/4071](https://github.com/sourcegraph/cody/pull/4071)
 - Chat: The model selector now groups chat model choices by characteristics (such as "More Accurate", "Balanced", "Faster", and "Ollama") and indicates the default choice. [pull/4033](https://github.com/sourcegraph/cody/pull/4033)
 
+## [1.16.3]
+
+### Added
+
+### Fixed
+
+- Tutorial: Fixed telemetry when activating the tutorial on first authentication. [pull/4068](https://github.com/sourcegraph/cody/pull/4068)
+- Tutorial: Improved the reliability and discoverability of the Edit command. [pull/4068](https://github.com/sourcegraph/cody/pull/4068)
+
+### Changed
+
 ## [1.16.2]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Update CHANGELOG and version number to reflect the patch release started in https://github.com/sourcegraph/cody/actions/runs/9003635159

diff: https://github.com/sourcegraph/cody/compare/vscode-v1.16.2...vscode-v1.16.3

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Patch release pipeline has been started in https://github.com/sourcegraph/cody/actions/runs/9003635159