### PR TITLE
PATCH: VS Code: Release 1.16.4

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,16 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+## [1.16.4]
+
+### Added
+
+### Fixed
+
+- Chat: Fixed a bug where the entire Cody chat view would appear blank on chat model selection. [pull/](https://github.com/sourcegraph/cody/pull/)
+
+### Changed
+
 ## [1.16.3]
 
 ### Added

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -16,7 +16,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Chat: Fixed a bug where the entire Cody chat view would appear blank on chat model selection. [pull/](https://github.com/sourcegraph/cody/pull/)
+- Chat: Fixed a bug where the entire Cody chat view would appear blank when clicking the chat model dropdown. [pull/4098](https://github.com/sourcegraph/cody/pull/4098)
 
 ### Changed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/vscode/webviews/Components/platform/Popover.tsx
+++ b/vscode/webviews/Components/platform/Popover.tsx
@@ -39,23 +39,23 @@ export const Popover: FunctionComponent<{
     const [anchorWasFocused, setAnchorWasFocused] = useState(false)
 
     const showPopover = useCallback((): void => {
-        if (!popoverEl.current || !anchor) {
+        if (!popoverEl.current || !anchor || popoverEl.current?.open) {
             return
         }
-
         setAnchorWasFocused(document.activeElement === anchor)
 
         // Need to call showPopover before getPopoverDimensions because it needs to be displayed in
         // order to calculate its dimensions.
-        popoverEl.current.showPopover()
-
+        try {
+            popoverEl.current.showPopover()
+        } catch {}
         const { top, left, right } = getPopoverDimensions(position, anchor, popoverEl.current)
         popoverEl.current.style.top = top
         if (left !== undefined) popoverEl.current.style.left = left
         if (right !== undefined) popoverEl.current.style.right = right
     }, [anchor, position])
     const hidePopover = useCallback((): void => {
-        if (!popoverEl.current || !anchor) {
+        if (!popoverEl.current || !anchor || !popoverEl.current?.open) {
             return
         }
         try {


### PR DESCRIPTION
## DO NOT MERGE: This is used for backporting a fix for a feature that no longer exists in main

CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1715185252614139?thread_ts=1714774753.189799&cid=C05AGQYD528

fix: resolve blank chat view and improve Popover error handling

https://github.com/sourcegraph/cody/assets/68532117/a35d6be7-97b8-430c-90be-871b2bf3ccb5


This commit addresses two main issues in the VS Code extension:
1. Fixes a bug where the Cody chat view would appear blank when selecting a different model.
2. Enhances error handling in the Popover component to prevent crashes when attempting to show a popover that is already open.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Start VS Code Insider 1.79.0 https://update.code.visualstudio.com/1.79.0-insider/darwin-universal/insider
2. Open Cody Chat to verify the Cody  Chat View goes blank when you click on the model dropdown list
3. Start Cody debug mode from this branch
4. Verify clicking on the model dropdown list doesn't cause the chat view to go blank

### After

NOTE: The styling issue is not related to this change and is an older version of VS Code issue.

![image](https://github.com/sourcegraph/cody/assets/68532117/de5fb69e-d72d-4df5-925d-9280062da7f7)
 

### Before 

![image](https://github.com/sourcegraph/cody/assets/68532117/00d1c323-4b3c-405e-9c6e-0eb7716131e7)

![image](https://github.com/sourcegraph/cody/assets/68532117/67d066e4-a64e-4c1c-b668-d166779a3445)
