### PR TITLE
VS Code: Release 1.16.4

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -28,6 +28,16 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Edit: The "Document Code" and "Generate Tests" commands now execute with a single click/action, rather than requiring the user to specify the range first. The range can be modified from the normal Edit input. [pull/4071](https://github.com/sourcegraph/cody/pull/4071)
 - Chat: The model selector now groups chat model choices by characteristics (such as "More Accurate", "Balanced", "Faster", and "Ollama") and indicates the default choice. [pull/4033](https://github.com/sourcegraph/cody/pull/4033)
 
+## [1.16.4]
+
+### Added
+
+### Fixed
+
+- Chat: Fixed a bug where the entire Cody chat view would appear blank when clicking the chat model dropdown. [pull/4098](https://github.com/sourcegraph/cody/pull/4098)
+
+### Changed
+
 ## [1.16.3]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Update CHANGELOG and version number to reflect the VS Code: Release 1.16.4 #4098 

- PR: https://github.com/sourcegraph/cody/pull/4098
- DIFF: https://github.com/sourcegraph/cody/compare/vscode-v1.16.3...v1.16.4?expand=1

Pipeline for 1.16.4 release has been started: https://github.com/sourcegraph/cody/actions/runs/9006884383

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

See details in PR: https://github.com/sourcegraph/cody/pull/4098