### PR TITLE
fix typos and simplify keyboard shortcut mention

### DIFF
--- a/vscode/walkthroughs/edit.md
+++ b/vscode/walkthroughs/edit.md
@@ -6,9 +6,9 @@ You can ask Cody to perform code edits using the Edit Code command. This will ed
 
 To get started: select code in your editor, right click, and choose "Cody → Edit Code".
 
-You can also use the default keyboard shortcut of `Option` `K` on macOS and `Alt` `K` on Windows & Linux.
+You can also use the default keyboard shortcut of `Opt+K`/`Alt+K`.
 
 **✨ Pro-tips for code editing with Cody**
-<br>• You can open the 💡 menu, with an "Cody: Edit Code" option, by selecting any line of code and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.
-<br>• If you start an empty line and open the 💡 menu (using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux) you can use "Cody: Generate Code" to generate new lines of code based on instructions.
+<br>• You can open the 💡 menu, with an "Cody: Edit Code" option, by selecting any line of code and using the keyboard shortcut `Cmd+.`/`Ctrl+.`.
+<br>• If you start an empty line and open the 💡 menu (using the keyboard shortcut `Cmd+.`/`Ctrl+.`) you can use "Cody: Generate Code" to generate new lines of code based on instructions.
 <br>• You define your own custom code editing commands using [Custom Commands (Beta)](https://sourcegraph.com/docs/cody/custom-commands), by setting the [`commands.<id>.mode` property](https://sourcegraph.com/docs/cody/capabilities/commands#commands-id-mode).

--- a/vscode/walkthroughs/fix.md
+++ b/vscode/walkthroughs/fix.md
@@ -5,5 +5,5 @@
 Something wrong with your code? Use Cody’s "Ask Cody to Fix" command to fix it, or explain the problem.
 
 **✨ Pro-tips for fixing code with Cody**
-<br>• You can open the 💡 menu, with an "Ask Cody to Fix" option, by moving the cursor over any line of code with an error and using the keyboard short `Command` `.` on macOS or `Crtl` `.` on Windows & Linux.
-<br>• You can also right click on any items in the "Problems" tab of VS Code and select "Ask Cody to Fix"
+<br>• You can open the 💡 menu, with an "Ask Cody to Fix" option, by moving the cursor over any line of code with an error and using the keyboard shortcut `Cmd+.`/`Ctrl+.`.
+<br>• You can also right click on any items in the "Problems" tab of VS Code and select "Ask Cody to Fix".


### PR DESCRIPTION
- Crtl -> Ctrl
- Remove the "for macOS" and "for Windows & Linux" since those are self-explanatory IMO.
- Fix "keyboard short"



## Test plan

CI