### PR TITLE
Ollama: buffer incomplete response chunks

### DIFF
--- a/lib/shared/src/llm-providers/ollama/completions-client.ts
+++ b/lib/shared/src/llm-providers/ollama/completions-client.ts
@@ -60,6 +60,7 @@ export function createOllamaClient(
 
             let insertText = ''
             let stopReason = ''
+            let buffer = ''
 
             for await (const chunk of iterableBody) {
                 if (signal.aborted) {
@@ -67,12 +68,15 @@ export function createOllamaClient(
                     break
                 }
 
+                buffer += chunk.toString()
+
                 for (const chunkString of chunk.toString().split(RESPONSE_SEPARATOR).filter(Boolean)) {
                     let line: OllamaGenerateResponse
 
                     try {
                         line = JSON.parse(chunkString) as OllamaGenerateResponse
-                    } catch {
+                        buffer = ''
+                    } catch (error) {
                         // ignore JSON.parse() errors most probably caused by incomplete chunk and wait for the next one.
                         break
                     }

--- a/lib/shared/src/llm-providers/ollama/completions-client.ts
+++ b/lib/shared/src/llm-providers/ollama/completions-client.ts
@@ -70,7 +70,7 @@ export function createOllamaClient(
 
                 buffer += chunk.toString()
 
-                for (const chunkString of chunk.toString().split(RESPONSE_SEPARATOR).filter(Boolean)) {
+                for (const chunkString of buffer.split(RESPONSE_SEPARATOR).filter(Boolean)) {
                     let line: OllamaGenerateResponse
 
                     try {


### PR DESCRIPTION
- Closes https://github.com/sourcegraph/cody/issues/4008
- Buffer incomplete chunks in the Ollama HTTP client.

## Test plan

Tested locally.
