### PR TITLE
Tutorial: Temporarily disable sidebar link

### DIFF
--- a/vscode/src/services/tree-views/support-items.ts
+++ b/vscode/src/services/tree-views/support-items.ts
@@ -1,4 +1,3 @@
-import { FeatureFlag } from '@sourcegraph/cody-shared'
 import { releaseType } from '../../release'
 import { version } from '../../version'
 import type { CodySidebarTreeItem } from './treeViewItems'
@@ -42,12 +41,15 @@ export const SupportSidebarItems: CodySidebarTreeItem[] = [
         command: { command: 'cody.sidebar.releaseNotes' },
         contextValue: 'cody.version',
     },
-    {
-        title: 'Tutorial',
-        icon: 'tasklist',
-        command: { command: 'cody.sidebar.tutorial' },
-        requireFeature: FeatureFlag.CodyInteractiveTutorial,
-    },
+    // Note: Currently disabled due to an issue where this occasionally evaluates the feature flag
+    // __before__ the user is fully finished authenticating. This will cache an incorrectly
+    // false value which inteferes with the balance of an ongoing A/B test.
+    // {
+    //     title: 'Tutorial',
+    //     icon: 'tasklist',
+    //     command: { command: 'cody.sidebar.tutorial' },
+    //     requireFeature: FeatureFlag.CodyInteractiveTutorial,
+    // },
     {
         title: 'Documentation',
         icon: 'book',


### PR DESCRIPTION
## Description

**Issue:**
- We have an issue with the balance of an A/B test. This appears to be because we evaluate a feature flag before we know that the user has authenticated. I'm going to temporarily disable the sidebar item, as we're mainly focused on showing this to the user on the first auth, this is just an additional input.

I can't replicate the issue myself reliably, but I'm expecting that this should solve the balance. I will create an issue to follow up on this when confirmed

## Test plan

1. N/A - Disabling feature that is only additional.
2. Check "Tutorial" does not appear in the sidebar

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
