### PR TITLE
Tutorial: Handle auth __after__ we sync

### DIFF
--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -358,6 +358,10 @@ export class AuthProvider {
         const isLoggedIn = isAuthenticated(authStatus)
         authStatus.isLoggedIn = isLoggedIn
 
+        await this.storeAuthInfo(url, token)
+        this.syncAuthStatus(authStatus)
+        await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
+
         // If the extension is authenticated on startup, it can't be a user's first
         // ever authentication. We store this to prevent logging first-ever events
         // for already existing users.
@@ -367,9 +371,6 @@ export class AuthProvider {
             this.handleFirstEverAuthentication()
         }
 
-        await this.storeAuthInfo(url, token)
-        this.syncAuthStatus(authStatus)
-        await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
         return { authStatus, isLoggedIn }
     }
 


### PR DESCRIPTION
## Description

OK, I think this is finally the issue with the tutorial race condition:
1. We call `handleFirstEverAuthentication`, which kick starts the tutorial logic (which eventually evals a feature flag)
2. We call `this.storeAuthInfo`

This logic meant the feature flag call could have happened before the auth info was stored, so it would incorrectly get the feature flag for the user, and then we would cache this value.

## Test plan

Verified by manually modifying the code to force `storeAuthInfo` to always happen after a delay

Verified that switching this logic works without the delay


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
