### PR TITLE
Cody Ignore: activate the `vscode.git` before Cody extension via `ensionDependencies`

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -90,6 +90,7 @@
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
   "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
+  "extensionDependencies": ["vscode.git"],
   "contributes": {
     "walkthroughs": [
       {

--- a/vscode/src/repository/git-extension-api.ts
+++ b/vscode/src/repository/git-extension-api.ts
@@ -43,7 +43,11 @@ export async function gitAPIinit(): Promise<vscode.Disposable> {
     }
     // Initialize the git extension if it is available
     try {
-        await extension?.activate().then(() => init())
+        if (!extension?.isActive) {
+            await extension?.activate()
+        }
+
+        init()
     } catch (error) {
         vscodeGitAPI = undefined
         // Display error message if git extension is disabled


### PR DESCRIPTION
- Removes the init delay making the git API instantly available in Cody.
- To ensure that the `vscode.git` extension is activated before your extension, add `extensionDependencies` ([docs](https://code.visualstudio.com/api/references/extension-manifest)) into the `package.json` of your extension:
- It's [safe](https://github.com/microsoft/vscode/blob/main/extensions/git/README.md#git-integration-for-visual-studio-code) to do because the Git extension is bundled with Visual Studio Code. It can be disabled but not uninstalled.

## Test plan

Tested locally.
