### PR TITLE
Edit: Fix incorrect formatting with certain formatters

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -17,6 +17,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Autocomplete: Handle incomplete Ollama response chunks gracefully. [pull/4066](https://github.com/sourcegraph/cody/pull/4066)
 - Edit: Improved handling of responses that contain HTML entities. [pull/4085](https://github.com/sourcegraph/cody/pull/4085)
+- Edit: Fixes cases where the formatting on an Edit would not respect the editor tab size with certain formatters. [pull/4111](https://github.com/sourcegraph/cody/pull/4111)
 
 ### Changed
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -7,6 +7,7 @@ import {
     type PromptString,
     displayPathBasename,
     getEditorInsertSpaces,
+    getEditorTabSize,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
 
@@ -875,9 +876,9 @@ export class FixupController
                 'vscode.executeFormatDocumentProvider',
                 document.uri,
                 {
-                    tabSize: document.uri,
+                    tabSize: getEditorTabSize(document.uri, vscode.workspace, vscode.window),
                     insertSpaces: getEditorInsertSpaces(document.uri, vscode.workspace, vscode.window),
-                }
+                } satisfies vscode.FormattingOptions
             )) || []
 
         const formattingChangesInRange = formattingChanges.filter(change =>


### PR DESCRIPTION
## Description

fixes CODY-1449

closes https://github.com/sourcegraph/cody/pull/4111

closes https://github.com/sourcegraph/cody/issues/3952

Accidental regression from https://github.com/sourcegraph/cody/pull/3734

Wasn't caught due to the fact that VS Code has really poor type enforcement around `executeCommand` :(


## Test plan

1. Make Edits with only the default TypeScript language formatter selected
2. Check indentation is correct

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
