### PR TITLE
Edit: Add maximum timeout to formatter logic

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
   - `New Chat with File Content`: Opens a new chat with the file content when no existing chat panel is open.
 - Chat: New optimization for prompt quality and token usage, deduplicating context items, and optimizing token allocation. [pull/3929](https://github.com/sourcegraph/cody/pull/3929)
 - Document Code/Generate Tests: User selections are now matched against known symbol ranges, and adjusted in cases where a user selection in a suitable subset of one of these ranges. [pull/4031](https://github.com/sourcegraph/cody/pull/4031)
+- Edit: Added a maximum timeout to the formatting logic, so the Edit does not appear stuck if the users' formatter takes a particularly long amount of tiem. [pull/4113](https://github.com/sourcegraph/cody/pull/4113)
 
 ### Fixed
 

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -19,6 +19,7 @@ import { countCode } from '../services/utils/code-count'
 
 import { PersistenceTracker } from '../common/persistence-tracker'
 import { lines } from '../completions/text-processing'
+import { sleep } from '../completions/utils'
 import { getInput } from '../edit/input/get-input'
 import type { ExtensionClient } from '../extension-client'
 import type { AuthProvider } from '../services/AuthProvider'
@@ -889,7 +890,7 @@ export class FixupController
                         ),
                     }
                 ),
-                new Promise<void>(resolve => setTimeout(resolve, formattingTimeout)),
+                sleep(formattingTimeout),
             ])) || []
 
         const formattingChangesInRange = formattingChanges.filter(change =>

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -889,12 +889,7 @@ export class FixupController
                         ),
                     }
                 ),
-                new Promise<void>(resolve =>
-                    setTimeout(() => {
-                        telemetryRecorder.recordEvent('cody.fixup.formatting', 'timedOut')
-                        resolve()
-                    }, formattingTimeout)
-                ),
+                new Promise<void>(resolve => setTimeout(resolve, formattingTimeout)),
             ])) || []
 
         const formattingChangesInRange = formattingChanges.filter(change =>


### PR DESCRIPTION
## Description

If an Edit takes longer than 1000ms to format, it's likely that something has gone wrong.

This is a poor UX so we will stop formatting automatically when this happens.
 
## Test plan

1. Tested by lowering the formatter timer to a small value (10ms)
2. Running edits
3. Checking that the formatting step is skipped

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
