### PR TITLE
Show latest pr & issues automatically in options list

### DIFF
--- a/lib/shared/src/mentions/providers/githubMentions.ts
+++ b/lib/shared/src/mentions/providers/githubMentions.ts
@@ -125,7 +125,6 @@ class GithubContextMentionProvider implements ContextMentionProvider<typeof Gith
                 : await githubClient.request('GET /issues', {
                       per_page: 10,
                       pulls: false,
-                      filter: 'all',
                   })
 
             signal?.throwIfAborted?.()

--- a/lib/shared/src/mentions/providers/githubMentions.ts
+++ b/lib/shared/src/mentions/providers/githubMentions.ts
@@ -24,17 +24,15 @@ class GithubContextMentionProvider implements ContextMentionProvider<typeof Gith
          * - github:issue:1234
          * - github:issue:sourcegraph/cody/1234
          */
-        const [_, kind, id] = query.split(':')
-
-        if (!kind || !id) {
+        const [_, kind, id = ''] = query.split(':')
+        if (!kind) {
             return []
         }
+
         const [ownerOrNumber = '', repoName = '', numberText = ''] = id.split('/')
 
-        const number = ownerOrNumber && repoName ? Number(numberText) : Number(ownerOrNumber)
-        if (!number) {
-            return []
-        }
+        const number =
+            (ownerOrNumber && repoName ? Number(numberText) : Number(ownerOrNumber)) || undefined
 
         let codebases: { owner: string; repoName: string }[] = []
 
@@ -77,71 +75,75 @@ class GithubContextMentionProvider implements ContextMentionProvider<typeof Gith
     }
 
     private async getPullRequestItems(
-        details: { owner: string; repoName: string; pullNumber: number },
+        details: { owner: string; repoName: string; pullNumber?: number },
         signal?: AbortSignal
     ): Promise<ContextItemFromProvider<typeof GithubContextId>[]> {
         try {
-            const pullRequest = await githubClient.request(
-                'GET /repos/{owner}/{repo}/pulls/{pull_number}',
-                {
-                    owner: details.owner,
-                    repo: details.repoName,
-                    pull_number: details.pullNumber,
-                }
-            )
+            const pullRequests = details.pullNumber
+                ? [
+                      await githubClient.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+                          owner: details.owner,
+                          repo: details.repoName,
+                          pull_number: details.pullNumber,
+                      }),
+                  ]
+                : await githubClient.request('GET /repos/{owner}/{repo}/pulls', {
+                      owner: details.owner,
+                      repo: details.repoName,
+                      per_page: 10,
+                  })
 
             signal?.throwIfAborted?.()
 
-            if (!pullRequest) {
-                return []
-            }
-
-            return [
-                {
-                    ...details,
-                    type: 'github_pull_request',
-                    uri: URI.parse(pullRequest.html_url),
-                    title: `#${pullRequest.number} ${pullRequest.title}`,
-                    source: ContextItemSource.Github,
-                    provider: 'github',
-                },
-            ]
+            return pullRequests.map(pullRequest => ({
+                ...details,
+                pullNumber: pullRequest.number,
+                type: 'github_pull_request',
+                uri: URI.parse(pullRequest.html_url),
+                title: `#${pullRequest.number} ${pullRequest.title}`,
+                source: ContextItemSource.Github,
+                provider: 'github',
+            }))
         } catch (error) {
             return []
         }
     }
 
     private async getIssueItems(
-        details: { owner: string; repoName: string; issueNumber: number },
+        details: { owner: string; repoName: string; issueNumber?: number },
         signal?: AbortSignal
     ): Promise<ContextItemFromProvider<typeof GithubContextId>[]> {
         try {
-            const issue = await githubClient.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
-                owner: details.owner,
-                repo: details.repoName,
-                issue_number: details.issueNumber,
-            })
+            const issues = details.issueNumber
+                ? [
+                      await githubClient.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+                          owner: details.owner,
+                          repo: details.repoName,
+                          issue_number: details.issueNumber,
+                      }),
+                  ]
+                : await githubClient.request('GET /issues', {
+                      per_page: 10,
+                      pulls: false,
+                      filter: 'all',
+                  })
 
             signal?.throwIfAborted?.()
 
-            if (!issue) {
-                return []
-            }
-
-            return [
-                {
-                    ...details,
-                    type: 'github_issue',
-                    uri: URI.parse(issue.html_url),
-                    title: `#${issue.number} ${issue.title}`,
-                    source: ContextItemSource.Github,
-                    provider: 'github',
-                },
-            ]
+            return issues.map(issue => ({
+                ...details,
+                issueNumber: issue.number,
+                type: 'github_issue',
+                uri: URI.parse(issue.html_url),
+                title: `#${issue.number} ${issue.title}`,
+                source: ContextItemSource.Github,
+                provider: 'github',
+            }))
         } catch {
             return []
         }
     }
+
     private async getPullRequestItemsWithContent(
         details: { owner: string; repoName: string; pullNumber: number },
         signal?: AbortSignal

--- a/vscode/src/chat/context/constants.ts
+++ b/vscode/src/chat/context/constants.ts
@@ -6,6 +6,8 @@ export const NO_FILE_MATCHES_LABEL = 'No files found'
 export const NO_SYMBOL_MATCHES_HELP_LABEL = ' (language extensions may be loading)'
 export const PACKAGE_HELP_LABEL = 'Search for a package to include...'
 export const NO_PACKAGE_MATCHES_LABEL = 'No packages found'
+export const GITHUB_HELP_LABEL = 'Search for a Github issue or pr to include...'
+export const NO_GITHUB_MATCHES_LABEL = 'No Github issue or pr found'
 export const FILE_RANGE_TOOLTIP_LABEL = 'Type a line range to include, e.g. 5-10...'
 export const LARGE_FILE_WARNING_LABEL =
     'File too large. Add line range with : or use @# to choose a symbol'

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -201,8 +201,10 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
             return `@github:pull:${contextItem.owner}/${contextItem.repoName}/${contextItem.pullNumber}`
 
         case 'github_issue':
-            return `@github:pull:${contextItem.owner}/${contextItem.repoName}/${contextItem.issueNumber}`
+            return `@github:issue:${contextItem.owner}/${contextItem.repoName}/${contextItem.issueNumber}`
     }
+    // @ts-ignore
+    throw new Error(`unrecognized context item type ${contextItem.type}`)
 }
 
 export function $createContextItemMentionNode(

--- a/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/OptionsList.tsx
@@ -13,9 +13,11 @@ import {
     FILE_HELP_LABEL,
     FILE_RANGE_TOOLTIP_LABEL,
     GENERAL_HELP_LABEL,
+    GITHUB_HELP_LABEL,
     IGNORED_FILE_WARNING_LABEL,
     LARGE_FILE_WARNING_LABEL,
     NO_FILE_MATCHES_LABEL,
+    NO_GITHUB_MATCHES_LABEL,
     NO_PACKAGE_MATCHES_LABEL,
     NO_SYMBOL_MATCHES_HELP_LABEL,
     NO_SYMBOL_MATCHES_LABEL,
@@ -108,6 +110,8 @@ function getHelpText(mentionQuery: MentionQuery, options: MentionTypeaheadOption
             return options.length > 0 || mentionQuery.text.length < 3
                 ? PACKAGE_HELP_LABEL
                 : NO_PACKAGE_MATCHES_LABEL
+        case 'github':
+            return options.length > 0 ? GITHUB_HELP_LABEL : NO_GITHUB_MATCHES_LABEL
         case 'symbol':
             return options.length > 0 || !mentionQuery.text.length
                 ? SYMBOL_HELP_LABEL


### PR DESCRIPTION
For the at-mention GitHub context, this PR adds the functionality which shows the latest PRs and issues in the options list when no issue/PR number has been typed yet. 

If the user types `@gh:issue:` cody will show the list of the latest issues assigned to the user. 
If the user types `@gh:pr:` cody will show the list of the latest PRs for the opened repo. 

Demo: https://www.loom.com/share/36c483d356464580b655c6f228c02fc9

## Test plan

- Open cody 
- Type `@gh:pr:`, and it should show you the list of the latest PRs from the repo.
- Type `@gh:issue:`, and it should show you the list of assigned issues.