### PR TITLE
VS Code: Patch Release 1.16.7

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -2,22 +2,13 @@
 
 This is a log of all notable changes to Cody for VS Code. [Unreleased] changes are included in the nightly pre-release builds.
 
-## [Unreleased]
+## [1.16.6]
 
 ### Added
 
-- Search: A new `Search Code` command added to the `Commands` sidebar for Cody's Natural Language Search. [pull/3991](https://github.com/sourcegraph/cody/pull/3991)
-- Context Menu: Added commands to send file to chat as @-mention from the explorer context menu. [pull/4000](https://github.com/sourcegraph/cody/pull/4000)
-  - `Add File to Chat`: Add file to the current opened chat, or start a new chat if no panel is opened.
-  - `New Chat with File Content`: Opens a new chat with the file content when no existing chat panel is open.
-- Chat: New optimization for prompt quality and token usage, deduplicating context items, and optimizing token allocation. [pull/3929](https://github.com/sourcegraph/cody/pull/3929)
-- Document Code/Generate Tests: User selections are now matched against known symbol ranges, and adjusted in cases where a user selection in a suitable subset of one of these ranges. [pull/4031](https://github.com/sourcegraph/cody/pull/4031)
-- Extension: Added the `vscode.git` extension to the `extensionDependencies` list. [pull/4110](https://github.com/sourcegraph/cody/pull/4110)
-
 ### Fixed
 
-- Autocomplete: Handle incomplete Ollama response chunks gracefully. [pull/4066](https://github.com/sourcegraph/cody/pull/4066)
-- Edit: Improved handling of responses that contain HTML entities. [pull/4085](https://github.com/sourcegraph/cody/pull/4085)
+- Chat: Fixed a bug where the chat model dropdown would not work on first click. [pull/](https://github.com/sourcegraph/cody/pull/)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,16 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+## [1.16.5]
+
+### Added
+
+### Fixed
+
+- Tutorial: Fixed a bug where the tutorial would not open on first authentication. [pull/4108](https://github.com/sourcegraph/cody/pull/4108)
+
+### Changed
+
 ## [1.16.4]
 
 ### Added

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,14 +12,24 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
   - `New Chat with File Content`: Opens a new chat with the file content when no existing chat panel is open.
 - Chat: New optimization for prompt quality and token usage, deduplicating context items, and optimizing token allocation. [pull/3929](https://github.com/sourcegraph/cody/pull/3929)
 - Document Code/Generate Tests: User selections are now matched against known symbol ranges, and adjusted in cases where a user selection in a suitable subset of one of these ranges. [pull/4031](https://github.com/sourcegraph/cody/pull/4031)
-- Edit: Added a maximum timeout to the formatting logic, so the Edit does not appear stuck if the users' formatter takes a particularly long amount of tiem. [pull/4113](https://github.com/sourcegraph/cody/pull/4113)
 - Extension: Added the `vscode.git` extension to the `extensionDependencies` list. [pull/4110](https://github.com/sourcegraph/cody/pull/4110)
 
 ### Fixed
 
 - Autocomplete: Handle incomplete Ollama response chunks gracefully. [pull/4066](https://github.com/sourcegraph/cody/pull/4066)
 - Edit: Improved handling of responses that contain HTML entities. [pull/4085](https://github.com/sourcegraph/cody/pull/4085)
-- Edit: Fixes cases where the formatting on an Edit would not respect the editor tab size with certain formatters. [pull/4111](https://github.com/sourcegraph/cody/pull/4111)
+
+### Changed
+
+## [1.16.6]
+
+### Added
+
+- Edit: Added a maximum timeout to the formatting logic, so the Edit does not appear stuck if the users' formatter takes a particularly long amount of tiem. [pull/4113](https://github.com/sourcegraph/cody/pull/4113)
+
+### Fixed
+
+- Edit: Fixed cases where the formatting of an Edit would not respect the editor tab size with certain formatters. [pull/4111](https://github.com/sourcegraph/cody/pull/4111)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,15 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Search: A new `Search Code` command added to the `Commands` sidebar for Cody's Natural Language Search. [pull/3991](https://github.com/sourcegraph/cody/pull/3991)
+- Context Menu: Added commands to send file to chat as @-mention from the explorer context menu. [pull/4000](https://github.com/sourcegraph/cody/pull/4000)
+  - `Add File to Chat`: Add file to the current opened chat, or start a new chat if no panel is opened.
+  - `New Chat with File Content`: Opens a new chat with the file content when no existing chat panel is open.
+- Chat: New optimization for prompt quality and token usage, deduplicating context items, and optimizing token allocation. [pull/3929](https://github.com/sourcegraph/cody/pull/3929)
+- Document Code/Generate Tests: User selections are now matched against known symbol ranges, and adjusted in cases where a user selection in a suitable subset of one of these ranges. [pull/4031](https://github.com/sourcegraph/cody/pull/4031)
+- Edit: Added a maximum timeout to the formatting logic, so the Edit does not appear stuck if the users' formatter takes a particularly long amount of tiem. [pull/4113](https://github.com/sourcegraph/cody/pull/4113)
+- Extension: Added the `vscode.git` extension to the `extensionDependencies` list. [pull/4110](https://github.com/sourcegraph/cody/pull/4110)
+
 ### Fixed
 
 - Autocomplete: Handle incomplete Ollama response chunks gracefully. [pull/4066](https://github.com/sourcegraph/cody/pull/4066)

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This is a log of all notable changes to Cody for VS Code. [Unreleased] changes are included in the nightly pre-release builds.
 
-## [1.16.6]
+## [1.16.7]
 
 ### Added
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,10 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Autocomplete: Handle incomplete Ollama response chunks gracefully. [pull/4066](https://github.com/sourcegraph/cody/pull/4066)
+- Edit: Improved handling of responses that contain HTML entities. [pull/4085](https://github.com/sourcegraph/cody/pull/4085)
+- Edit: Fixes cases where the formatting on an Edit would not respect the editor tab size with certain formatters. [pull/4111](https://github.com/sourcegraph/cody/pull/4111)
+
 ### Changed
 
 ## [1.16.5]

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -20,6 +20,7 @@ import { countCode } from '../services/utils/code-count'
 
 import { PersistenceTracker } from '../common/persistence-tracker'
 import { lines } from '../completions/text-processing'
+import { sleep } from '../completions/utils'
 import { getInput } from '../edit/input/get-input'
 import type { ExtensionClient } from '../extension-client'
 import type { AuthProvider } from '../services/AuthProvider'
@@ -867,15 +868,27 @@ export class FixupController
             return false
         }
 
+        /**
+         * Maximum amount of time to spend formatting.
+         * If the formatter takes longer than this then we will skip formatting completely.
+         */
+        const formattingTimeout = 1000
         const formattingChanges =
-            (await vscode.commands.executeCommand<vscode.TextEdit[]>(
-                'vscode.executeFormatDocumentProvider',
-                document.uri,
-                {
-                    tabSize: getEditorTabSize(document.uri, vscode.workspace, vscode.window),
-                    insertSpaces: getEditorInsertSpaces(document.uri, vscode.workspace, vscode.window),
-                } satisfies vscode.FormattingOptions
-            )) || []
+            (await Promise.race([
+                vscode.commands.executeCommand<vscode.TextEdit[]>(
+                    'vscode.executeFormatDocumentProvider',
+                    document.uri,
+                    {
+                        tabSize: getEditorTabSize(document.uri, vscode.workspace, vscode.window),
+                        insertSpaces: getEditorInsertSpaces(
+                            document.uri,
+                            vscode.workspace,
+                            vscode.window
+                        ),
+                    }
+                ),
+                sleep(formattingTimeout),
+            ])) || []
 
         const formattingChangesInRange = formattingChanges.filter(change =>
             rangeToFormat.contains(change.range)

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -7,6 +7,7 @@ import {
     type PromptString,
     displayPathBasename,
     getEditorInsertSpaces,
+    getEditorTabSize,
     telemetryRecorder,
 } from '@sourcegraph/cody-shared'
 
@@ -871,9 +872,9 @@ export class FixupController
                 'vscode.executeFormatDocumentProvider',
                 document.uri,
                 {
-                    tabSize: document.uri,
+                    tabSize: getEditorTabSize(document.uri, vscode.workspace, vscode.window),
                     insertSpaces: getEditorInsertSpaces(document.uri, vscode.workspace, vscode.window),
-                }
+                } satisfies vscode.FormattingOptions
             )) || []
 
         const formattingChangesInRange = formattingChanges.filter(change =>

--- a/vscode/src/services/AuthProvider.ts
+++ b/vscode/src/services/AuthProvider.ts
@@ -357,6 +357,10 @@ export class AuthProvider {
         const isLoggedIn = isAuthenticated(authStatus)
         authStatus.isLoggedIn = isLoggedIn
 
+        await this.storeAuthInfo(url, token)
+        this.syncAuthStatus(authStatus)
+        await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
+
         // If the extension is authenticated on startup, it can't be a user's first
         // ever authentication. We store this to prevent logging first-ever events
         // for already existing users.
@@ -366,9 +370,6 @@ export class AuthProvider {
             this.handleFirstEverAuthentication()
         }
 
-        await this.storeAuthInfo(url, token)
-        this.syncAuthStatus(authStatus)
-        await vscode.commands.executeCommand('setContext', 'cody.activated', isLoggedIn)
         return { authStatus, isLoggedIn }
     }
 

--- a/vscode/webviews/Components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/Components/modelSelectField/ModelSelectField.tsx
@@ -37,7 +37,7 @@ export const ModelSelectField: React.FunctionComponent<{
 
     const onModelSelect = useCallback(
         (model: ModelProvider): void => {
-            if (showCodyProBadge && selectedModel.codyProOnly) {
+            if (showCodyProBadge && model.codyProOnly) {
                 getVSCodeAPI().postMessage({
                     command: 'links',
                     value: 'https://sourcegraph.com/cody/subscription',
@@ -52,11 +52,11 @@ export const ModelSelectField: React.FunctionComponent<{
             getVSCodeAPI().postMessage({
                 command: 'event',
                 eventName: 'CodyVSCodeExtension:chooseLLM:clicked',
-                properties: { LLM_provider: selectedModel.model },
+                properties: { LLM_provider: model.model },
             })
             parentOnModelSelect(model)
         },
-        [showCodyProBadge, selectedModel, parentOnModelSelect]
+        [showCodyProBadge, parentOnModelSelect]
     )
 
     const onPopoverOpen = useCallback((): void => {


### PR DESCRIPTION
## BRANCH OFF v1.16.6 - DO NOT MERGE TO MAIN

This pull request updates the logic for selecting a model in the `ModelSelectField` component to fix an issue where clicking on a non-default model on first click does not work as expected.

Issue:

In the `ModelSelectField` component, the `selectedModel` is derived from the `models` prop and represents the default model which everyone has access to.

The `onModelSelect` callback function is responsible for handling the selection of a new model. When a user clicks on a different model in the dropdown, this callback function is called with the newly selected model as a parameter.

The issue arose because the onModelSelect callback was using the `selectedModel` instead of the `model` parameter when checking for the `codyProOnly` condition and sending the telemetry event, which is still set as the initial value.

Fixes:

1. **Update model selection condition**: The condition for showing the Cody Pro badge and redirecting to the subscription page has been updated. Instead of checking the `codyProOnly` property of the `selectedModel`, it now checks the `codyProOnly` property of the `model` param being selected.
2. **Update event properties**: The `LLM_provider` property in the `CodyVSCodeExtension:chooseLLM:clicked` event is now set to the `model.model` value instead of `selectedModel.model`.
3. **Optimize dependency array**: The dependency array for the `onModelSelect` callback has been updated to remove the `selectedModel` dependency, as it is no longer used.

These changes ensure that the Cody Pro badge and subscription link are displayed correctly when selecting a Cody Pro-only model.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Start Cody dev from this branch
2. Sign into to Cody with Free user
3. Open a new chat and choose any other LLM
4. Verify clicking on Pro only model will open the subscription page in your browser


https://github.com/sourcegraph/cody/assets/68532117/76c8765b-b9af-498a-83f1-36ae58f2a33d

