### PR TITLE
VS Code: Release 1.16.7

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -29,6 +29,16 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Edit: The "Document Code" and "Generate Tests" commands now execute with a single click/action, rather than requiring the user to specify the range first. The range can be modified from the normal Edit input. [pull/4071](https://github.com/sourcegraph/cody/pull/4071)
 - Chat: The model selector now groups chat model choices by characteristics (such as "More Accurate", "Balanced", "Faster", and "Ollama") and indicates the default choice. [pull/4033](https://github.com/sourcegraph/cody/pull/4033)
 
+## [1.16.7]
+
+### Added
+
+### Fixed
+
+- Chat: Fixed a bug where the chat model dropdown would not work on first click. [pull/](https://github.com/sourcegraph/cody/pull/)
+
+### Changed
+
 ## [1.16.6]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody AI",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
## Important

 Do not merge to main until 1.16.7 is published

## Summary

Update CHANGELOG and version number to reflect the VS Code: Release 1.16.7 https://github.com/sourcegraph/cody/pull/4121

- PR with detail: https://github.com/sourcegraph/cody/pull/4121
- DIFF: https://github.com/sourcegraph/cody/compare/vscode-v1.16.6...vscode-patch-v1.16.7

Pipeline for 1.16.4 release has been started: https://github.com/sourcegraph/cody/actions/runs/9006884383

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

See details in PR: https://github.com/sourcegraph/cody/pull/4121