### PR TITLE
keep quickpicks (esp for edit) open if focus is lost

### DIFF
--- a/vscode/src/commands/menus/command-builder.ts
+++ b/vscode/src/commands/menus/command-builder.ts
@@ -105,7 +105,7 @@ export class CustomCommandsBuilderMenu {
             title: 'New Custom Cody Command: Prompt',
             prompt: 'Enter the instructions for Cody to follow and answer.',
             placeHolder: 'e.g. Create five different test cases for the selected code',
-            ignoreFocusOut: false,
+            ignoreFocusOut: true,
             validateInput: (input: string) => (input.length ? null : 'Command prompt cannot be empty.'),
         })
         return prompt ? this.addContext({ prompt }) : null

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -195,9 +195,6 @@ export const getInput = async (
                 telemetryRecorder.recordEvent('cody.fixup.input.model', 'selected')
 
                 if (acceptedItem.codyProOnly && !isCodyPro) {
-                    // Temporarily ignore focus out, so that the user can return to the quick pick if desired.
-                    modelInput.input.ignoreFocusOut = true
-
                     const option = await vscode.window.showInformationMessage(
                         'Upgrade to Cody Pro',
                         {
@@ -213,8 +210,6 @@ export const getInput = async (
                         void vscode.env.openExternal(vscode.Uri.parse(ACCOUNT_UPGRADE_URL.toString()))
                     }
 
-                    // Restore the default focus behaviour
-                    modelInput.input.ignoreFocusOut = false
                     return
                 }
 

--- a/vscode/src/edit/input/quick-pick.ts
+++ b/vscode/src/edit/input/quick-pick.ts
@@ -36,6 +36,7 @@ export const createQuickPick = ({
     value = '',
 }: QuickPickConfiguration): QuickPick => {
     const quickPick = vscode.window.createQuickPick()
+    quickPick.ignoreFocusOut = true
     quickPick.title = title
     quickPick.placeholder = placeHolder
     quickPick.value = value

--- a/vscode/src/search/SearchViewProvider.ts
+++ b/vscode/src/search/SearchViewProvider.ts
@@ -249,7 +249,7 @@ export class SearchViewProvider implements vscode.Disposable {
         quickPick.placeholder = 'Searching...'
         quickPick.matchOnDescription = true
         quickPick.matchOnDetail = true
-        quickPick.ignoreFocusOut = false
+        quickPick.ignoreFocusOut = true
         quickPick.buttons = searchQuickPickButtons
         quickPick.onDidAccept(() => (quickPick.selectedItems[0] as SymfResultQuickPickItem)?.onSelect())
 


### PR DESCRIPTION
If the user has (for example) an Cmd+K edit quickpick open, then switches to their web browser to copy some information to paste into the edit quickpick input, then VS Code will close the quickpick. Many users set `"workbench.quickOpen.closeOnFocusLost": false,` in their VS Code settings to prevent this globally because it's annoying, so only users without that setting will experience this annoyance. All of the Cody quickpicks should remain when the user switches away because they are invoked through explicit user action and may have valuable unsaved input provided by the user.

Reported by @martinamps



## Test plan

Run Cmd+K. Cmd+Tab to another application. Ensure VS Code does not hide the edit quickpick.