### PR TITLE
allow scrolling with mouse of chat message editor

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -18,6 +18,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Autocomplete: Handle incomplete Ollama response chunks gracefully. [pull/4066](https://github.com/sourcegraph/cody/pull/4066)
 - Edit: Improved handling of responses that contain HTML entities. [pull/4085](https://github.com/sourcegraph/cody/pull/4085)
+- Chat: Fixed an issue where the chat message editor field was not able to be scrolled with the mouse or trackpad. [pull/4127](https://github.com/sourcegraph/cody/pull/4127)
 
 ### Changed
 

--- a/vscode/webviews/promptEditor/PromptEditor.module.css
+++ b/vscode/webviews/promptEditor/PromptEditor.module.css
@@ -10,7 +10,12 @@
     padding: 0.4375rem 50px 0.5625rem 0.5rem;
     font: inherit;
     width: 100%;
-    overflow: hidden;
+
+    /* Scroll */
+    overflow: auto;
+
+    /* A visible scrollbar interferes with the EnhancedContextSettings element. It's still scrollable with the mouse/trackpad and arrow keys. */
+    scrollbar-width: none;
 
     /* Don't allow the input box to become larger than the webview to avoid submit buttons going off the screen */
     max-height: 80vh; /* 80% of viewport height */


### PR DESCRIPTION
Previously, when the user had entered a very long message in chat (with many lines, specifically more than 80% of the viewport height), it was not possible to scroll the chat message editor up/down with the mouse or trackpad. This was a bug. (Arrow keys would still scroll it by moving the text insertion point.)

Now, it is possible to scroll with the mouse or trackpad.

Reported by @martinamps



## Test plan

Type a very long (tall) message into chat, like "a" (hit shift+enter many times) "a". Ensure that the chat message editor allows scrolling up/down with the mouse or trackpad.