### PR TITLE
slightly clearer message in context popover for git repo subdirs

### DIFF
--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -114,7 +114,7 @@ test.extend<helpers.WorkspaceDirectory>({
     await expect(chatFrame.locator('.codicon-circle-slash')).toBeVisible({
         timeout: 60000,
     })
-    await expect(chatFrame.getByText('Folder is not a Git repository.')).toBeVisible()
+    await expect(chatFrame.getByText('Folder is not a Git repository root.')).toBeVisible()
 })
 
 test('git repositories without a remote should explain the issue', async ({ page, sidebar }) => {

--- a/vscode/webviews/components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/components/EnhancedContextSettings.tsx
@@ -282,7 +282,7 @@ function contextProviderState(provider: ContextProvider): React.ReactNode {
                     case 'not-a-git-repo':
                         return (
                             <p className={styles.providerExplanatoryText}>
-                                Folder is not a Git repository.
+                                Folder is not a Git repository root.
                             </p>
                         )
                     case 'git-repo-has-no-remote':


### PR DESCRIPTION
If you open a subdir of a Git repository as the VS Code workspace root folder, then Cody will show `Folder is not a Git repository` as the embeddings status in the enhanced context popover. This is true, but it can be confusing. The ideal behavior is to make embeddings "just work" in this case, but in the meantime, this message is slightly clearer and should indicate to users that embeddings would work if they open up the Git repository root dir in the editor.

Reported by @martinamps

## Test plan

CI