### PR TITLE
fix needs-cody-pro model selector bugs

### DIFF
--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -36,7 +36,7 @@ export const ModelSelectField: React.FunctionComponent<{
 
     const onModelSelect = useCallback(
         (model: ModelProvider): void => {
-            if (showCodyProBadge && selectedModel.codyProOnly) {
+            if (showCodyProBadge && model.codyProOnly) {
                 getVSCodeAPI().postMessage({
                     command: 'links',
                     value: 'https://sourcegraph.com/cody/subscription',
@@ -51,11 +51,11 @@ export const ModelSelectField: React.FunctionComponent<{
             getVSCodeAPI().postMessage({
                 command: 'event',
                 eventName: 'CodyVSCodeExtension:chooseLLM:clicked',
-                properties: { LLM_provider: selectedModel.model },
+                properties: { LLM_provider: model.model },
             })
             parentOnModelSelect(model)
         },
-        [showCodyProBadge, selectedModel, parentOnModelSelect]
+        [showCodyProBadge, parentOnModelSelect]
     )
 
     const onPopoverOpen = useCallback((): void => {

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -86,7 +86,11 @@ export const ModelSelectField: React.FunctionComponent<{
                             />
                         ),
                         filterKeywords: [m.title, m.provider],
-                        disabled: modelAvailability(userInfo, m) !== 'available',
+                        // needs-cody-pro models should be clickable (not disabled) so the user can
+                        // be taken to the upgrade page.
+                        disabled: !['available', 'needs-cody-pro'].includes(
+                            modelAvailability(userInfo, m)
+                        ),
                         group: m.uiGroup ?? 'Other',
                     }) satisfies SelectListOption
             ),


### PR DESCRIPTION
- make needs-cody-pro models clickable so the user can upgrade: Fixes an issue with the new model selector where needs-cody-pro models were disabled and therefore not clickable.
- fix bug where model selector would not work on first click: Similar to https://github.com/sourcegraph/cody/pull/4121 (HT @abeatrix).

## Test plan

1. Sign in with a Cody Free (not Pro) user
2. In the chat model selector, select a Cody Pro-only model. The web browser should open to the upgrade page and the model should not be selected in the chat view.
3. Sign in with a Cody Pro user.
4. Select a different model. Ensure that the selected model is used (with `cody.debug.verbose` `true` in user settings).