### PR TITLE
Explain the warning icon in repo picker

### DIFF
--- a/vscode/src/context/repo-picker.ts
+++ b/vscode/src/context/repo-picker.ts
@@ -176,7 +176,7 @@ export class RemoteRepoPicker implements vscode.Disposable {
             const inWorkspace = workspaceRepos.has(repo.id)
             const shortName = repo.name.slice(repo.name.lastIndexOf('/') + 1)
             const item = {
-                label: `${isIgnored ? '$(warning) ' : ''}${shortName}`,
+                label: `${shortName}${isIgnored ? ' - $(warning) Ignored' : ''}`,
                 name: repo.name,
                 id: repo.id,
                 description: inWorkspace ? 'In your workspace' : '',


### PR DESCRIPTION
c.f. https://github.com/sourcegraph/cody/pull/4059#issuecomment-2103878481

Let the user know why we show a warning somtimes.

## Test plan

- Set an overwrite policy (e.g. `{ "include": [], "exclude": [{ "repoNamePattern": "cody" }] }`) and connect to an enterprise instance (e.g. s2)
- Pick models for chat and observe the window
<img width="822" alt="Screenshot 2024-05-10 at 12 43 31" src="https://github.com/sourcegraph/cody/assets/458591/a1ac6ba0-9e48-4f23-8362-bcd145597d22">
