### PR TITLE
Measure upstream health and attach median to autocomplete events

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -2309,6 +2309,7 @@ log:
 
                       return function inner() {}
 
+
                       
                   </selected>
               - speaker: assistant
@@ -11768,6 +11769,262 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-05-06T23:26:11.157Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 635bd88b29afc0d3a63da8a994fc93c3
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 194
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/healthz
+      response:
+        bodySize: 34
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 34
+          text: 273635_2024-05-09_5.4-e37a78bbd300
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:12:55 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "34"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 939
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:12:55.276Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: a764a28eda8397a9e6b1a9afaa351050
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_4a92106dd3be39a589d6e2d0a6e32b705744d4007d74518fdfd1dbf953176dc6
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 278
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/healthz
+      response:
+        bodySize: 34
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 34
+          text: 273635_2024-05-09_5.4-e37a78bbd300
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:12:55 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "34"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 939
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:12:55.328Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 07b98a6d87b223d87fe2a6efc3dd8d3d
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 290
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/healthz
+      response:
+        bodySize: 34
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 34
+          text: 273635_2024-05-09_5.4-e37a78bbd300
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:12:55 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "34"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 939
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:12:55.411Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 5c74073496986f546230ca24c5f5a57e
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 278
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/healthz
+      response:
+        bodySize: 34
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 34
+          text: 273635_2024-05-09_5.4-e37a78bbd300
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:12:55 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "34"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 939
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:12:55.448Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -7197,5 +7197,131 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 344d4d95cd35e633eb077cd29e1902ec
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 207
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://demo.sourcegraph.com/healthz
+      response:
+        bodySize: 5
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 5
+          text: 5.4.0
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:13:01 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "5"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 974
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:13:00.733Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 3ad60459294e55762bdc24a0bdb76f1c
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 280
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://demo.sourcegraph.com/healthz
+      response:
+        bodySize: 5
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 5
+          text: 5.4.0
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:13:01 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "5"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 974
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:13:00.793Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
   pages: []
   version: "1.2"

--- a/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
+++ b/agent/recordings/enterpriseMainBranchClient_759014996/recording.har.yaml
@@ -1811,5 +1811,131 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: ba98e8a703d0a79648405fb098fd1efd
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 231
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.sourcegraph.com/healthz
+      response:
+        bodySize: 34
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 34
+          text: 273635_2024-05-09_5.4-e37a78bbd300
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:13:02 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "34"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 976
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:13:01.883Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: f5b2cdbfe30396c5c6df2cf1f895acfa
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_964f5256e709a8c5c151a63d8696d5c7ac81604d179405864d88ff48a9232364
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: enterpriseMainBranchClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.sourcegraph.com
+        headersSize: 315
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.sourcegraph.com/healthz
+      response:
+        bodySize: 34
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 34
+          text: 273635_2024-05-09_5.4-e37a78bbd300
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:13:02 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "34"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 976
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:13:01.937Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
   pages: []
   version: "1.2"

--- a/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
+++ b/agent/recordings/rateLimitedClient_2043004676/recording.har.yaml
@@ -1504,5 +1504,131 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 635bd88b29afc0d3a63da8a994fc93c3
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: rateLimitedClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 198
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/healthz
+      response:
+        bodySize: 34
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 34
+          text: 273635_2024-05-09_5.4-e37a78bbd300
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:13:00 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "34"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 939
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:13:00.166Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: aecd680f6680c3f9f29acc2db0370621
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_8c77b24d9f3d0e679509263c553887f2887d67d33c4e3544039c1889484644f5
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: rateLimitedClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 282
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/healthz
+      response:
+        bodySize: 34
+        content:
+          mimeType: text/plain; charset=utf-8
+          size: 34
+          text: 273635_2024-05-09_5.4-e37a78bbd300
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 10 May 2024 16:13:00 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: content-length
+            value: "34"
+          - name: connection
+            value: keep-alive
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: x-content-type-options
+            value: nosniff
+        headersSize: 939
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-10T16:13:00.221Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
   pages: []
   version: "1.2"

--- a/vscode/src/completions/logger.test.ts
+++ b/vscode/src/completions/logger.test.ts
@@ -84,6 +84,7 @@ describe('logger', () => {
             otherCompletionProviders: [],
             providerIdentifier: 'bfl',
             providerModel: 'blazing-fast-llm',
+            medianUpstreamLatency: undefined,
             contextSummary: {
                 retrieverStats: {},
                 strategy: 'none',

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -347,7 +347,7 @@ export interface CompletionBookkeepingEvent {
     id: CompletionLogID
     params: Omit<
         SharedEventPayload,
-        'items' | 'otherCompletionProviderEnabled' | 'otherCompletionProviders'
+        'items' | 'otherCompletionProviderEnabled' | 'otherCompletionProviders' | 'medianUpstreamLatency'
     >
     // The timestamp when the completion request started
     startedAt: number

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -119,7 +119,7 @@ interface SharedEventPayload extends InteractionIDPayload {
     otherCompletionProviders: string[]
 
     /** The median of the last upstream requests */
-    medianUpstreamLatency: number
+    medianUpstreamLatency?: number
 }
 
 /**
@@ -831,7 +831,7 @@ function getSharedParams(event: CompletionBookkeepingEvent): SharedEventPayload 
         items: event.items.map(i => ({ ...i })),
         otherCompletionProviderEnabled: otherCompletionProviders.length > 0,
         otherCompletionProviders,
-        medianUpstreamLatency: upstreamHealthProvider.getMedianDuration() ?? -1,
+        medianUpstreamLatency: upstreamHealthProvider.getMedianDuration(),
     }
 }
 

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -24,6 +24,7 @@ import type {
     PersistenceRemovedEventPayload,
 } from '../common/persistence-tracker/types'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
+import { upstreamHealthProvider } from '../services/UpstreamHealthProvider'
 import { completionProviderConfig } from './completion-provider-config'
 import type { ContextSummary } from './context/context-mixer'
 import type { InlineCompletionsResultSource, TriggerKind } from './get-inline-completions'
@@ -116,6 +117,9 @@ interface SharedEventPayload extends InteractionIDPayload {
 
     /** A list of known completion providers that are also enabled with this user. */
     otherCompletionProviders: string[]
+
+    /** The median of the last upstream requests */
+    medianUpstreamLatency: number
 }
 
 /**
@@ -827,6 +831,7 @@ function getSharedParams(event: CompletionBookkeepingEvent): SharedEventPayload 
         items: event.items.map(i => ({ ...i })),
         otherCompletionProviderEnabled: otherCompletionProviders.length > 0,
         otherCompletionProviders,
+        medianUpstreamLatency: upstreamHealthProvider.getMedianDuration() ?? -1,
     }
 }
 

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -72,6 +72,7 @@ import { localStorage } from './services/LocalStorageProvider'
 import { VSCodeSecretStorage, getAccessToken, secretStorage } from './services/SecretStorageProvider'
 import { registerSidebarCommands } from './services/SidebarCommands'
 import { createStatusBar } from './services/StatusBar'
+import { upstreamHealthProvider } from './services/UpstreamHealthProvider'
 import { setUpCodyIgnore } from './services/cody-ignore'
 import { createOrUpdateEventLogger, telemetryService } from './services/telemetry'
 import { createOrUpdateTelemetryRecorderProvider } from './services/telemetry-v2'
@@ -267,6 +268,7 @@ const register = async (
 
         promises.push(featureFlagProvider.syncAuthStatus())
         graphqlClient.onConfigurationChange(newConfig)
+        upstreamHealthProvider.onConfigurationChange(newConfig)
         githubClient.onConfigurationChange({ authToken: initialConfig.experimentalGithubAccessToken })
         promises.push(
             contextFiltersProvider
@@ -621,7 +623,8 @@ const register = async (
         vscode.commands.registerCommand('cody.debug.outputChannel', () => openCodyOutputChannel()),
         vscode.commands.registerCommand('cody.debug.enable.all', () => enableVerboseDebugMode()),
         vscode.commands.registerCommand('cody.debug.reportIssue', () => openCodyIssueReporter()),
-        new CharactersLogger()
+        new CharactersLogger(),
+        upstreamHealthProvider.onConfigurationChange(initialConfig)
     )
 
     let setupAutocompleteQueue = Promise.resolve() // Create a promise chain to avoid parallel execution

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -1,0 +1,122 @@
+import {
+    type BrowserOrNodeResponse,
+    type ConfigurationWithAccessToken,
+    addCustomUserAgent,
+    addTraceparent,
+    logDebug,
+} from '@sourcegraph/cody-shared'
+import { fetch } from '@sourcegraph/cody-shared'
+import type * as vscode from 'vscode'
+
+// We choose an interval that gives us a reasonable aggregate without causing
+// too many requests
+export const PING_INTERVAL = 10 * 60 * 1000 // 10 minutes
+
+/**
+ * A provider that regularly pings the connected Sourcegraph instance to
+ * understand the latencies between the client and the instance.
+ *
+ * You can query it to get aggregates of the most recent pings.
+ */
+export class UpstreamHealthProvider implements vscode.Disposable {
+    private config: Pick<
+        ConfigurationWithAccessToken,
+        'serverEndpoint' | 'customHeaders' | 'accessToken'
+    > | null = null
+    private recentDurations: { timestamp: number; duration: number }[] = []
+    private nextTimeoutId: NodeJS.Timeout | null = null
+
+    public getMedianDuration(): number | undefined {
+        if (!this.config) {
+            throw new Error('UpstreamHealthProvider not initialized')
+        }
+        if (this.recentDurations.length === 0) {
+            return undefined
+        }
+        const sorted = this.recentDurations.sort((a, b) => a.duration - b.duration)
+        return sorted[Math.floor(sorted.length / 2)].duration
+    }
+
+    public onConfigurationChange(
+        newConfig: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'customHeaders' | 'accessToken'>
+    ): this {
+        this.config = newConfig
+        this.recentDurations = []
+        this.measure()
+        return this
+    }
+
+    private async measure() {
+        console.log('measure')
+        if (this.nextTimeoutId) {
+            clearTimeout(this.nextTimeoutId)
+        }
+
+        const start = Date.now()
+        try {
+            if (!this.config) {
+                throw new Error('UpstreamHealthProvider not initialized')
+            }
+
+            const headers = new Headers(this.config.customHeaders as HeadersInit)
+            headers.set('Content-Type', 'application/json; charset=utf-8')
+            if (this.config.accessToken) {
+                headers.set('Authorization', `token ${this.config.accessToken}`)
+            }
+            addTraceparent(headers)
+            addCustomUserAgent(headers)
+            const url = new URL('/healthz', this.config.serverEndpoint)
+
+            // We use a HEAD request since we do not want to consume the body
+            // and do not want to have the request garbage-collected.
+            //
+            // https://undici.nodejs.org/#/?id=garbage-collection
+            const response = await fetch(url.toString(), { method: 'HEAD', headers })
+
+            const duration = Date.now() - start
+            this.recentDurations.push({ timestamp: Date.now(), duration })
+            // Delete items that are older than 2 hours
+            this.recentDurations = this.recentDurations.filter(
+                item => Date.now() - item.timestamp < 2 * 60 * 60 * 1000
+            )
+            logDebug(
+                'UpstreamHealth',
+                `Ping took ${Math.round(duration)}ms (Median: ${Math.round(
+                    this.getMedianDuration() ?? 0
+                )}ms)`,
+                {
+                    verbose: {
+                        duration,
+                        url,
+                        status: response.status,
+                        headers: headersToObject(response.headers),
+                    },
+                }
+            )
+        } catch (error) {
+            // We don't care about errors here, we just want to measure the latency
+        } finally {
+            // Enqueue a new ping
+            if (this.nextTimeoutId) {
+                clearTimeout(this.nextTimeoutId)
+            }
+            this.nextTimeoutId = setTimeout(this.measure.bind(this), PING_INTERVAL)
+        }
+    }
+
+    public dispose(): void {
+        if (this.nextTimeoutId) {
+            clearTimeout(this.nextTimeoutId)
+        }
+    }
+}
+
+export const upstreamHealthProvider = new UpstreamHealthProvider()
+
+function headersToObject(headers: BrowserOrNodeResponse['headers']) {
+    const result: Record<string, string> = {}
+    for (const [key, value] of headers.entries()) {
+        result[key] = value
+    }
+    return result
+}

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -49,7 +49,6 @@ export class UpstreamHealthProvider implements vscode.Disposable {
     }
 
     private async measure() {
-        console.log('measure')
         if (this.nextTimeoutId) {
             clearTimeout(this.nextTimeoutId)
         }

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -28,7 +28,7 @@ export class UpstreamHealthProvider implements vscode.Disposable {
 
     public getMedianDuration(): number | undefined {
         if (!this.config) {
-            throw new Error('UpstreamHealthProvider not initialized')
+            return undefined
         }
         if (this.recentDurations.length === 0) {
             return undefined


### PR DESCRIPTION
Part-of CODY-1495

This PR adds a new service that continuously pings the upstream Sourcegraph instances `/healthz` endpoint with a `HEAD` request to estimate the RTT to the SG instance.

For now, pings are logged in debug mode and attached to autocomplete events (since we want to use it to investigate autocomplete latencies). Later we might extend this into a Cody Help command (cc @RXminuS)

We also want to upload this data to Prometheus as a follow-up.

## Test plan

- Enable verbose debug mode
- Open the extension spot the new `UpstreamHealth` message. It will update after 10 minutes (or you can overwrite the timeout in `UpstreamHealthProvider`)
- Cause an autocomplete to appear and check the suggested event for a new `medianUpstreamLatency` field.

<img width="808" alt="Screenshot 2024-05-10 at 14 37 40" src="https://github.com/sourcegraph/cody/assets/458591/a1c8b8f0-4607-4582-b567-86801f005cc7">
<img width="1616" alt="Screenshot 2024-05-10 at 14 34 11" src="https://github.com/sourcegraph/cody/assets/458591/f2d1861c-c835-4faa-ab27-c57dd5a25d6f">