### PR TITLE
chore: Stop uploading indexes to k8s.sgdev.org

### DIFF
--- a/.github/workflows/scip-typescript.yml
+++ b/.github/workflows/scip-typescript.yml
@@ -44,11 +44,6 @@ jobs:
           SRC_ENDPOINT: https://sourcegraph.sourcegraph.com/
           SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_S2 }}
 
-      - name: Upload lsif to Dogfood
-        run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
-          SRC_ACCESS_TOKEN: ${{ secrets.SRC_ACCESS_TOKEN_DOGFOOD }}
       - name: Upload lsif to Demo
         run: pnpm dlx @sourcegraph/src lsif upload -github-token='${{ secrets.GITHUB_TOKEN }}' -no-progress || true
         env:


### PR DESCRIPTION
We're not using k8s.sgdev.org any more

## Test plan

n/a
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
