### PR TITLE
Edit: introduce CodyTaskState.Reverting and FixupTask.retryID

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyTaskState.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyTaskState.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
-typealias CodyTaskState = String // One of: Idle, Working, Inserting, Applying, Formatting, Applied, Finished, Error, Pending
+typealias CodyTaskState = String // One of: Idle, Working, Inserting, Applying, Formatting, Applied, Reverting, Finished, Error, Pending
 

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Constants.kt
@@ -71,6 +71,7 @@ object Constants {
   const val Applying = "Applying"
   const val Formatting = "Formatting"
   const val Applied = "Applied"
+  const val Reverting = "Reverting"
   const val Finished = "Finished"
   const val Error = "Error"
   const val Pending = "Pending"

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditTask.kt
@@ -3,7 +3,7 @@ package com.sourcegraph.cody.protocol_generated
 
 data class EditTask(
   val id: String,
-  val state: CodyTaskState, // Oneof: Idle, Working, Inserting, Applying, Formatting, Applied, Finished, Error, Pending
+  val state: CodyTaskState, // Oneof: Idle, Working, Inserting, Applying, Formatting, Applied, Reverting, Finished, Error, Pending
   val error: CodyError? = null,
   val selectionRange: Range,
   val instruction: String? = null,

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -57,6 +57,10 @@ export class FixupTask {
      * they may run into an error that we can't anticipate
      */
     public formattingResolver: ((value: boolean) => void) | null = null
+    /**
+     * The ID of the task that is created when a user retries a task.
+     */
+    public retryID: FixupTaskID | undefined
 
     constructor(
         /**

--- a/vscode/src/non-stop/codelenses/items.ts
+++ b/vscode/src/non-stop/codelenses/items.ts
@@ -34,6 +34,7 @@ export function getLensesForTask(task: FixupTask): vscode.CodeLens[] {
             const skip = getFormattingSkipLens(codeLensRange, task.id)
             return [title, skip]
         }
+        case CodyTaskState.Reverting:
         case CodyTaskState.Applied: {
             const accept = getAcceptLens(codeLensRange, task.id)
             const retry = getRetryLens(codeLensRange, task.id)

--- a/vscode/src/non-stop/utils.ts
+++ b/vscode/src/non-stop/utils.ts
@@ -33,6 +33,11 @@ export enum CodyTaskState {
      */
     Applied = 'Applied',
     /**
+     * The response has been applied to the document, and we are satisfied enough to present it to the user.
+     * This is a transitional state from Applied to a terminal state which is triggered by a user undoing or retrying a change.
+     */
+    Reverting = 'Reverting',
+    /**
      * Terminal state. The response has been "accepted" by the user. This is either by:
      * - Clicking "Accept" via the CodeLens
      * - Saving the document


### PR DESCRIPTION
I am introducing an automation on top of Fixup and need to be able to track when a Fixup for a region is done. "retry" is actually an "undo" on the old FixupTask and then a new FixupTask is created. Before this commit there was no way to link the old task to the new retried task.

This commit introduces a field on FixupTask which records the new task's ID. Additionally a "Reverting" state is introduced which occurs while undoing a task before it enters a terminal state. We then adjust "retry" to only set the terminal state once the new FixupTask is created. This makes it possible to set the retryID field before updating the task a terminal state.

## Test Plan

Added the following debug line to FixupController.createTask

``` typescript
task.onDidStateChange(state => {
    console.log('onDidStateChange', task.id, state, task.retryID)
})
```


First did an edit followed by an undo. Expectation is that for the undo we now have a Reverting state introduced:

```
onDidStateChange lwszk Working undefined
onDidStateChange lwszk Applying undefined
onDidStateChange lwszk Formatting undefined
onDidStateChange lwszk Applied undefined
onDidStateChange lwszk Reverting undefined
onDidStateChange lwszk Finished undefined
```

Secondly did a edit followed by a retry. Expectation is we enter reverting state, create the new task, finish the old task with retryID set, then continue with the new task:


``` typescript
onDidStateChange lwszqu Working undefined
onDidStateChange lwszqu Applying undefined
onDidStateChange lwszqu Formatting undefined
onDidStateChange lwszqu Applied undefined
onDidStateChange lwszqu Reverting undefined
onDidStateChange lwtj Working undefined
onDidStateChange lwtj Applying undefined
onDidStateChange lwszqu Finished lwtj
onDidStateChange lwtj Formatting undefined
onDidStateChange lwtj Applied undefined
```
