### PR TITLE
space key no longer triggers commit of selected mention item

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -12,6 +12,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Changed
 
+- Chat: Pressing <kbd>Space</kbd> no longer accepts an @-mention item. Press <kbd>Tab</kbd> or <kbd>Enter</kbd> instead. [pull/4154](https://github.com/sourcegraph/cody/pull/4154)
+
 ## [1.18.0]
 
 ### Added

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -1,14 +1,8 @@
 import { FloatingPortal, flip, offset, shift, useFloating } from '@floating-ui/react'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { LexicalTypeaheadMenuPlugin, MenuOption } from '@lexical/react/LexicalTypeaheadMenuPlugin'
-import {
-    $createTextNode,
-    COMMAND_PRIORITY_NORMAL,
-    KEY_SPACE_COMMAND,
-    type LexicalEditor,
-    type TextNode,
-} from 'lexical'
-import { type FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
+import { $createTextNode, COMMAND_PRIORITY_NORMAL, type TextNode } from 'lexical'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import styles from './atMentions.module.css'
 
 import {
@@ -159,65 +153,28 @@ export default function MentionsPlugin(): JSX.Element | null {
                 { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
             ) =>
                 anchorElementRef.current && (
-                    <>
-                        <SpaceKeyTrigger
-                            editor={editor}
-                            options={options}
-                            selectedIndex={selectedIndex}
-                            selectOptionAndCleanUp={selectOptionAndCleanUp}
-                        />
-                        <FloatingPortal root={anchorElementRef.current}>
-                            <div
-                                ref={refs.setFloating}
-                                style={{
-                                    position: strategy,
-                                    top: y ?? 0,
-                                    left: x ?? 0,
-                                    width: 'max-content',
-                                }}
-                                className={clsx(styles.popover)}
-                            >
-                                <OptionsList
-                                    query={query ?? ''}
-                                    options={options}
-                                    selectedIndex={selectedIndex}
-                                    setHighlightedIndex={setHighlightedIndex}
-                                    selectOptionAndCleanUp={selectOptionAndCleanUp}
-                                />
-                            </div>
-                        </FloatingPortal>
-                    </>
+                    <FloatingPortal root={anchorElementRef.current}>
+                        <div
+                            ref={refs.setFloating}
+                            style={{
+                                position: strategy,
+                                top: y ?? 0,
+                                left: x ?? 0,
+                                width: 'max-content',
+                            }}
+                            className={clsx(styles.popover)}
+                        >
+                            <OptionsList
+                                query={query ?? ''}
+                                options={options}
+                                selectedIndex={selectedIndex}
+                                setHighlightedIndex={setHighlightedIndex}
+                                selectOptionAndCleanUp={selectOptionAndCleanUp}
+                            />
+                        </div>
+                    </FloatingPortal>
                 )
             }
         />
     )
-}
-
-/**
- * Makes it so that typing <Space> also triggers selection of the option (just like Enter and Tab).
- */
-const SpaceKeyTrigger: FunctionComponent<{
-    editor: LexicalEditor
-    options: MentionTypeaheadOption[]
-    selectedIndex: number | null
-    selectOptionAndCleanUp: (option: MentionTypeaheadOption) => void
-}> = ({ editor, options, selectedIndex, selectOptionAndCleanUp }) => {
-    useEffect(() => {
-        return editor.registerCommand(
-            KEY_SPACE_COMMAND,
-            (event: KeyboardEvent | null) => {
-                if (options === null || selectedIndex === null || options[selectedIndex] == null) {
-                    return false
-                }
-                if (event !== null) {
-                    event.preventDefault()
-                    event.stopImmediatePropagation()
-                }
-                selectOptionAndCleanUp(options[selectedIndex])
-                return true
-            },
-            COMMAND_PRIORITY_NORMAL
-        )
-    }, [editor, options, selectedIndex, selectOptionAndCleanUp])
-    return null
 }


### PR DESCRIPTION
This behavior existed to preserve parity with the pre-Lexical-editor behavior, but I think we should remove it because it will interfere with more complex @-mentions where the "query" does need to include spaces. (For example, think about @-mentioning a title of a doc with spaces in it.)



## Test plan

CI