### PR TITLE
VS Code: use `enablement` for Cody commands

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -285,7 +285,7 @@
         "command": "cody.command.edit-code",
         "category": "Cody Command",
         "title": "Edit Code",
-        "when": "cody.activated && editorTextFocus",
+        "enablement": "cody.activated && editorTextFocus",
         "icon": "$(wand)"
       },
       {
@@ -293,54 +293,54 @@
         "category": "Cody Command",
         "title": "Explain Code",
         "icon": "$(output)",
-        "when": "cody.activated && editorFocus"
+        "enablement": "cody.activated && editorFocus"
       },
       {
         "command": "cody.command.unit-tests",
         "category": "Cody Command",
         "title": "Generate Unit Tests",
         "icon": "$(package)",
-        "when": "cody.activated && editorTextFocus"
+        "enablement": "cody.activated && editorTextFocus"
       },
       {
         "command": "cody.command.document-code",
         "category": "Cody Command",
         "title": "Document Code",
         "icon": "$(book)",
-        "when": "cody.activated && editorTextFocus"
+        "enablement": "cody.activated && editorTextFocus"
       },
       {
         "command": "cody.command.smell-code",
         "category": "Cody Command",
         "title": "Find Code Smells",
         "icon": "$(checklist)",
-        "when": "cody.activated && editorFocus"
+        "enablement": "cody.activated && editorFocus"
       },
       {
         "command": "cody.menu.custom-commands",
         "category": "Cody Menu",
         "title": "Custom Commands",
         "icon": "$(tools)",
-        "when": "cody.activated && workspaceFolderCount > 0"
+        "enablement": "cody.activated && workspaceFolderCount > 0"
       },
       {
         "command": "cody.menu.commands-settings",
         "category": "Cody Settings",
         "title": "Custom Commands Settings",
         "icon": "$(gear)",
-        "when": "cody.activated"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.command.usageExamples",
         "category": "Cody Command",
         "title": "Usage Examples",
-        "when": "cody.activated && editorTextFocus && config.cody.experimental.noodle && (editorLangId === typescript || editorLangId === typescriptreact)"
+        "enablement": "cody.activated && editorTextFocus && config.cody.experimental.noodle && (editorLangId === typescript || editorLangId === typescriptreact)"
       },
       {
         "command": "cody.command.explain-history",
         "category": "Cody Command",
         "title": "Explain Code History",
-        "when": "cody.activated && editorTextFocus && config.cody.experimental.noodle"
+        "enablement": "cody.activated && editorTextFocus && config.cody.experimental.noodle"
       },
       {
         "command": "cody.auth.signout",
@@ -378,21 +378,21 @@
         "title": "Cody Settings",
         "group": "Cody",
         "icon": "$(settings-gear)",
-        "when": "cody.activated"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.show-page",
         "category": "Cody",
         "title": "Open Account Page",
         "group": "Cody",
-        "when": "cody.activated"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.show-rate-limit-modal",
         "category": "Cody",
         "title": "Show Rate Limit Modal",
         "group": "Cody",
-        "when": "cody.activated"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.guardrails.debug",
@@ -404,32 +404,32 @@
         "command": "cody.menu.commands",
         "category": "Cody Menu",
         "title": "Cody Commands",
-        "when": "cody.activated",
+        "enablement": "cody.activated",
         "icon": "$(cody-logo)"
       },
       {
         "command": "cody.autocomplete.openTraceView",
         "category": "Cody",
         "title": "Open Autocomplete Trace View",
-        "when": "cody.activated && config.cody.autocomplete && editorHasFocus && !editorReadonly"
+        "enablement": "cody.activated && config.cody.autocomplete.enabled && editorFocus && !editorReadonly"
       },
       {
         "command": "cody.autocomplete.manual-trigger",
         "category": "Cody",
         "title": "Trigger Autocomplete at Cursor",
-        "when": "cody.activated && config.cody.autocomplete && editorHasFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
+        "enablement": "cody.activated && config.cody.autocomplete.enabled && editorFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
         "command": "cody.multi-model-autocomplete.manual-trigger",
         "category": "Cody",
         "title": "Get Completions for multiple autocomplete models",
-        "when": "cody.activated && config.cody.autocomplete.experimental.multiModelCompletions && config.cody.autocomplete && editorHasFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
+        "enablement": "cody.activated && config.cody.autocomplete.experimental.multiModelCompletions && config.cody.autocomplete.enabled && editorFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
         "command": "cody.chat.panel.new",
         "category": "Cody",
         "title": "New Chat",
-        "when": "cody.activated",
+        "enablement": "cody.activated",
         "group": "Cody",
         "icon": "$(new-comment-icon)"
       },
@@ -437,7 +437,7 @@
         "command": "workbench.action.moveEditorToNewWindow",
         "category": "Cody",
         "title": "Pop out",
-        "when": "cody.activated",
+        "enablement": "cody.activated",
         "group": "Cody",
         "icon": "$(link-external)"
       },
@@ -454,7 +454,7 @@
         "title": "Rename Chat",
         "group": "Cody",
         "icon": "$(edit)",
-        "when": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated && cody.hasChatHistory"
       },
       {
         "command": "cody.chat.history.clear",
@@ -462,7 +462,7 @@
         "title": "Delete All Chats",
         "group": "Cody",
         "icon": "$(trash)",
-        "when": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated && cody.hasChatHistory"
       },
       {
         "command": "cody.chat.history.delete",
@@ -470,7 +470,7 @@
         "title": "Delete Chat",
         "group": "Cody",
         "icon": "$(trash)",
-        "when": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated && cody.hasChatHistory"
       },
       {
         "command": "cody.chat.history.export",
@@ -478,7 +478,7 @@
         "title": "Export Chats as JSON",
         "group": "Cody",
         "icon": "$(arrow-circle-down)",
-        "when": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated && cody.hasChatHistory"
       },
       {
         "command": "cody.chat.history.panel",
@@ -486,7 +486,7 @@
         "title": "Chat History",
         "group": "Cody",
         "icon": "$(list-unordered)",
-        "when": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated && cody.hasChatHistory"
       },
       {
         "command": "cody.search.index-update",
@@ -494,7 +494,7 @@
         "group": "Cody",
         "title": "Update search index for current workspace folder",
         "icon": "$(refresh)",
-        "when": "cody.activated"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.mention.selection",
@@ -502,7 +502,7 @@
         "group": "Chat",
         "title": "Add Selection to Cody Chat",
         "icon": "$(mention)",
-        "when": "cody.activated && editorHasSelection && !explorerViewletFocus && cody.hasNewChatOpened"
+        "enablement": "cody.activated && editorHasSelection && !explorerViewletFocus && cody.hasNewChatOpened"
       },
       {
         "command": "cody.mention.selection.new",
@@ -510,7 +510,7 @@
         "group": "Chat",
         "title": "New Chat with Selection",
         "icon": "$(mention)",
-        "when": "cody.activated && editorHasSelection && !explorerViewletFocus && !cody.hasNewChatOpened"
+        "enablement": "cody.activated && editorHasSelection && !explorerViewletFocus && !cody.hasNewChatOpened"
       },
       {
         "command": "cody.mention.file",
@@ -518,7 +518,7 @@
         "group": "Chat",
         "title": "Add File to Cody Chat",
         "icon": "$(mention)",
-        "when": "cody.activated && resourceScheme == file && cody.hasNewChatOpened"
+        "enablement": "cody.activated && resourceScheme == file && cody.hasNewChatOpened"
       },
       {
         "command": "cody.mention.file.new",
@@ -526,7 +526,7 @@
         "group": "Chat",
         "title": "New Chat with File",
         "icon": "$(mention)",
-        "when": "cody.activated && resourceScheme == file && !cody.hasNewChatOpened"
+        "enablement": "cody.activated && resourceScheme == file && !cody.hasNewChatOpened"
       },
       {
         "command": "cody.chat.panel.reset",
@@ -534,12 +534,12 @@
         "title": "New Chat Session",
         "group": "Cody",
         "icon": "$(clear-all)",
-        "when": "cody.activated && cody.hasChatHistory"
+        "enablement": "cody.activated && cody.hasChatHistory"
       },
       {
         "command": "cody.embeddings.resolveIssue",
         "title": "Cody Embeddings",
-        "when": "cody.embeddings.hasIssue"
+        "enablement": "cody.embeddings.hasIssue"
       },
       {
         "command": "cody.debug.export.logs",
@@ -558,7 +558,7 @@
         "category": "Cody Debug",
         "group": "Debug",
         "title": "Enable Debug Mode",
-        "when": "!config.cody.debug.verbose"
+        "enablement": "!config.cody.debug.verbose"
       },
       {
         "command": "cody.debug.reportIssue",
@@ -579,12 +579,12 @@
         "group": "Search",
         "icon": "$(search)",
         "title": "Natural Language Search Code (Beta)",
-        "when": "cody.activated && workspaceFolderCount > 0"
+        "enablement": "cody.activated && workspaceFolderCount > 0"
       },
       {
         "command": "cody.test.set-context-filters",
         "title": "[Internal] Set Context Filters Overwrite",
-        "when": "cody.activated && cody.devOrTest"
+        "enablement": "cody.activated && cody.devOrTest"
       }
     ],
     "keybindings": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -285,7 +285,7 @@
         "command": "cody.command.edit-code",
         "category": "Cody Command",
         "title": "Edit Code",
-        "enablement": "cody.activated && editorTextFocus",
+        "enablement": "cody.activated",
         "icon": "$(wand)"
       },
       {
@@ -293,28 +293,28 @@
         "category": "Cody Command",
         "title": "Explain Code",
         "icon": "$(output)",
-        "enablement": "cody.activated && editorFocus"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.command.unit-tests",
         "category": "Cody Command",
         "title": "Generate Unit Tests",
         "icon": "$(package)",
-        "enablement": "cody.activated && editorTextFocus"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.command.document-code",
         "category": "Cody Command",
         "title": "Document Code",
         "icon": "$(book)",
-        "enablement": "cody.activated && editorTextFocus"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.command.smell-code",
         "category": "Cody Command",
         "title": "Find Code Smells",
         "icon": "$(checklist)",
-        "enablement": "cody.activated && editorFocus"
+        "enablement": "cody.activated"
       },
       {
         "command": "cody.menu.custom-commands",
@@ -334,13 +334,13 @@
         "command": "cody.command.usageExamples",
         "category": "Cody Command",
         "title": "Usage Examples",
-        "enablement": "cody.activated && editorTextFocus && config.cody.experimental.noodle && (editorLangId === typescript || editorLangId === typescriptreact)"
+        "enablement": "cody.activated && config.cody.experimental.noodle && (editorLangId === typescript || editorLangId === typescriptreact)"
       },
       {
         "command": "cody.command.explain-history",
         "category": "Cody Command",
         "title": "Explain Code History",
-        "enablement": "cody.activated && editorTextFocus && config.cody.experimental.noodle"
+        "enablement": "cody.activated && config.cody.experimental.noodle"
       },
       {
         "command": "cody.auth.signout",
@@ -411,19 +411,19 @@
         "command": "cody.autocomplete.openTraceView",
         "category": "Cody",
         "title": "Open Autocomplete Trace View",
-        "enablement": "cody.activated && config.cody.autocomplete.enabled && editorFocus && !editorReadonly"
+        "enablement": "cody.activated && config.cody.autocomplete.enabled"
       },
       {
         "command": "cody.autocomplete.manual-trigger",
         "category": "Cody",
         "title": "Trigger Autocomplete at Cursor",
-        "enablement": "cody.activated && config.cody.autocomplete.enabled && editorFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
+        "enablement": "cody.activated && config.cody.autocomplete.enabled && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
         "command": "cody.multi-model-autocomplete.manual-trigger",
         "category": "Cody",
         "title": "Get Completions for multiple autocomplete models",
-        "enablement": "cody.activated && config.cody.autocomplete.experimental.multiModelCompletions && config.cody.autocomplete.enabled && editorFocus && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
+        "enablement": "cody.activated && config.cody.autocomplete.experimental.multiModelCompletions && config.cody.autocomplete.enabled && !editorReadonly && !editorHasSelection && !inlineSuggestionsVisible"
       },
       {
         "command": "cody.chat.panel.new",
@@ -539,7 +539,7 @@
       {
         "command": "cody.embeddings.resolveIssue",
         "title": "Cody Embeddings",
-        "enablement": "cody.embeddings.hasIssue"
+        "enablement": "cody.activated && cody.embeddings.hasIssue"
       },
       {
         "command": "cody.debug.export.logs",

--- a/vscode/src/completions/create-multi-model-inline-completion-provider.ts
+++ b/vscode/src/completions/create-multi-model-inline-completion-provider.ts
@@ -83,13 +83,13 @@ export async function createInlineCompletionItemFromMultipleProviders({
     const disposables: vscode.Disposable[] = []
 
     const multiModelConfigsList: MultimodelSingleModelConfig[] = []
-    for (const curretProviderConfig of config.autocompleteExperimentalMultiModelCompletions) {
-        if (curretProviderConfig.provider && curretProviderConfig.model) {
+    for (const currentProviderConfig of config.autocompleteExperimentalMultiModelCompletions) {
+        if (currentProviderConfig.provider && currentProviderConfig.model) {
             multiModelConfigsList.push({
-                provider: curretProviderConfig.provider,
-                model: curretProviderConfig.model,
+                provider: currentProviderConfig.provider,
+                model: currentProviderConfig.model,
                 enableExperimentalFireworksOverrides:
-                    curretProviderConfig.enableExperimentalFireworksOverrides ?? false,
+                    currentProviderConfig.enableExperimentalFireworksOverrides ?? false,
             })
         }
     }
@@ -100,13 +100,13 @@ export async function createInlineCompletionItemFromMultipleProviders({
         }
     }
 
-    const allPromises = multiModelConfigsList.map(async curretProviderConfig => {
+    const allPromises = multiModelConfigsList.map(async currentProviderConfig => {
         const newConfig = _.cloneDeep(config)
         // Override some config to ensure we are not logging extra events.
         newConfig.telemetryLevel = 'off'
         // We should only override the fireworks "cody.autocomplete.experimental.fireworksOptions" when added in the config.
         newConfig.autocompleteExperimentalFireworksOptions =
-            curretProviderConfig.enableExperimentalFireworksOverrides
+            currentProviderConfig.enableExperimentalFireworksOverrides
                 ? config.autocompleteExperimentalFireworksOptions
                 : undefined
         // Don't use the advanced provider config to get the model
@@ -115,8 +115,8 @@ export async function createInlineCompletionItemFromMultipleProviders({
         const providerConfig = await createProviderConfigFromVSCodeConfig(
             client,
             authStatus,
-            curretProviderConfig.model,
-            curretProviderConfig.provider,
+            currentProviderConfig.model,
+            currentProviderConfig.provider,
             newConfig
         )
         if (providerConfig) {
@@ -135,8 +135,8 @@ export async function createInlineCompletionItemFromMultipleProviders({
                 noInlineAccept: true,
             })
             return {
-                providerName: curretProviderConfig.provider,
-                modelName: curretProviderConfig.model,
+                providerName: currentProviderConfig.provider,
+                modelName: currentProviderConfig.model,
                 completionsProvider: completionsProvider,
             }
         }


### PR DESCRIPTION
- The `when` configuration field is not applicable to commands:
    - To verify disable autocomplete and observe that all autocomplete commands are still visible in the command list.
    - The related JSON schema in VS Code sources confirms this: https://github.com/microsoft/vscode/blob/29aeab1cbb350107a7bd5962b5e7efe745e0a3ec/src/vs/workbench/services/actions/common/menusExtensionPoint.ts#L729-L773. The `when` field is missing. Only `enablement` is specified.
    - The VS Code document is misleading: https://code.visualstudio.com/api/extension-guides/command#controlling-when-a-command-shows-up-in-the-command-palette
- This PR changes all `when` fields to `enablement` to hide Cody commands under certain conditions.
    - **Design input required**: we use `"cody.activated && editorTextFocus"` in multiple places. It does nothing in the current version of the extension, but with the `enablement` field, it hides the respective command from the quick pick menu (shift+command+P) even when it's opened from the editor. Technically, the editor is not focused anymore; the quick menu is. So this configuration can be treated as: "the command will be hidden from the commands list, but will be available via keybindings if `editorTextFocus`".
    - Related discussion: https://github.com/microsoft/vscode/issues/124755. 
- Resulted from the question here https://github.com/sourcegraph/cody/pull/4048#issuecomment-2100259530
- Created a follow-up to prevent such issues in the future https://github.com/sourcegraph/cody/issues/4156

## Test plan

1. Start the extension locally.
2. Disable autocomplete.
3. Observe that the manual trigger command IS NOT present in the commands list (shift+cmd+P).
4. Enable autocomplete.
5. Observe that the manual trigger command IS present in the commands list (shift+cmd+P).

Can be done for all the commands based on the conditions specified in the `enablement` value.
