### PR TITLE
Fix release changelog script

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -37,7 +37,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
-- Chat: Fixed a bug where the chat model dropdown would not work on first click. [pull/](https://github.com/sourcegraph/cody/pull/)
+- Chat: Fixed a bug where the chat model dropdown would not work on first click. [pull/4122](https://github.com/sourcegraph/cody/pull/4122)
 
 ### Changed
 

--- a/vscode/scripts/github-changelog.ts
+++ b/vscode/scripts/github-changelog.ts
@@ -93,7 +93,7 @@ function extractRepoAndNumberFromLink(
             link
         )
     if (!matches?.groups) {
-        throw new Error(`Malformed link: ${link}`)
+        return undefined
     }
     return {
         owner: matches.groups.owner,
@@ -142,6 +142,9 @@ async function main(): Promise<void> {
                 if (json?.user?.login) {
                     author = json.user.login
                 }
+            } else {
+                console.warn(`Could not extract owner/repo/number from link: ${change.link}`)
+                continue
             }
         }
 


### PR DESCRIPTION
I noticed the 1.16.7 release failed due to a malformed link. This PR fixes the link but also makes it so the script handles malformed links gracefully.

See: https://github.com/sourcegraph/cody/actions/workflows/vscode-stable-release.yml

## Test plan

- `cd vscode`
- `pnpm run github-changelog`
- `cat GITHUB_CHANGELOG.md`