### PR TITLE
Clear rate limit error after reset timeout

### DIFF
--- a/vscode/src/completions/inline-completion-item-provider.ts
+++ b/vscode/src/completions/inline-completion-item-provider.ts
@@ -657,6 +657,7 @@ export class InlineCompletionItemProvider
                 description: `${error.userMessage} ${error.retryMessage ?? ''}`.trim(),
                 errorType: error.name,
                 removeAfterSelected: true,
+                removeAfterEpoch: error.retryAfterDate ? Number(error.retryAfterDate) : undefined,
                 onSelect: () => {
                     if (canUpgrade) {
                         telemetryService.log('CodyVSCodeExtension:upsellUsageLimitCTA:clicked', {

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -382,9 +382,16 @@ export function createStatusBar(): CodyStatusBar {
             return stopLoading
         },
         addError(error: StatusBarError) {
-            const errorObject = { error, createdAt: Date.now() }
+            const now = Date.now()
+            const errorObject = { error, createdAt: now }
             errors.push(errorObject)
-            setTimeout(clearOutdatedErrors, Math.min(ONE_HOUR, error.removeAfterEpoch || ONE_HOUR))
+
+            if (error.removeAfterEpoch && error.removeAfterEpoch > now) {
+                setTimeout(clearOutdatedErrors, Math.min(ONE_HOUR, error.removeAfterEpoch - now))
+            } else {
+                setTimeout(clearOutdatedErrors, ONE_HOUR)
+            }
+
             rerender()
 
             return () => {

--- a/vscode/src/services/StatusBar.ts
+++ b/vscode/src/services/StatusBar.ts
@@ -22,6 +22,7 @@ interface StatusBarError {
     description: string
     errorType: StatusBarErrorName
     removeAfterSelected: boolean
+    removeAfterEpoch?: number
     onShow?: () => void
     onSelect?: () => void
 }
@@ -347,7 +348,10 @@ export function createStatusBar(): CodyStatusBar {
         const now = Date.now()
         for (let i = errors.length - 1; i >= 0; i--) {
             const error = errors[i]
-            if (now - error.createdAt >= ONE_HOUR) {
+            if (
+                now - error.createdAt >= ONE_HOUR ||
+                (error.error.removeAfterEpoch && now - error.error.removeAfterEpoch >= 0)
+            ) {
                 errors.splice(i, 1)
             }
         }
@@ -380,7 +384,7 @@ export function createStatusBar(): CodyStatusBar {
         addError(error: StatusBarError) {
             const errorObject = { error, createdAt: Date.now() }
             errors.push(errorObject)
-            setTimeout(clearOutdatedErrors, ONE_HOUR)
+            setTimeout(clearOutdatedErrors, Math.min(ONE_HOUR, error.removeAfterEpoch || ONE_HOUR))
             rerender()
 
             return () => {


### PR DESCRIPTION
Issue: https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1715609038152519

The rate limit error does not clear automatically when the rate limit resets, at least for 1 hour or until the user manually selects the error, even after there is a successful completion. 

![image](https://github.com/sourcegraph/cody/assets/22571395/7986b327-fa7c-4c8c-b36a-784b1cc33d48)

This PR will clear the error at whichever is the earliest between rate limit reset time or 1 hour from error creation. 

## Test plan
Manually tested locally.

- build extension
- set cody override limit to 1 at dotcom
- try code completion
- Cody status icon will turn yellow and show the rate limit error resetting at the same time. (because of override)
- wait from a minute, the error will automatically go away. 