### PR TITLE
LLM Models: add GPT-4o support

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -57,6 +57,17 @@ const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
         uiGroup: ModelUIGroup.Speed,
     },
     {
+        title: 'GPT-4o',
+        model: 'openai/gpt-4o',
+        provider: 'OpenAI',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
+        deprecated: false,
+        uiGroup: ModelUIGroup.Balanced,
+    },
+    {
         title: 'GPT-4 Turbo',
         model: 'openai/gpt-4-turbo',
         provider: 'OpenAI',


### PR DESCRIPTION
Fixes CODY-1536

Previously, we only supported GPT-4 Turbo and GPT-3.5. This PR adds additional support for GPT-4o, which seems to be both more powerful than GPT-4 while offering faster latency.


## Test plan
 I wasn't able to test this change locally so I'm going to leave this as a draft. More details in https://github.com/sourcegraph/sourcegraph/pull/62639

With a local build, it looks like this but when I send a message with gpt-4o it works but it's too slow to be GPT-4o (which responds super quickly in ChatGPT). Given that I'm sending the request to dotcom, I'm not sure what model we're using instead. I see gpt-4o in the logs
```
█ logEvent (telemetry disabled): CodyVSCodeExtension:chat-question:executed  {
  "details": "VSCode",
  "properties": {
    "requestID": "854ac15d-51dc-41de-b1f5-742066fd981d",
    "chatModel": "openai/gpt-4o",
```

![CleanShot 2024-05-13 at 22 20 32@2x](https://github.com/sourcegraph/cody/assets/1408093/8e838774-3c37-4760-a15b-a5bc90b030d3)


<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
