### PR TITLE
Cody PLG: Add GPT-4o to model list

### DIFF
--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -57,6 +57,17 @@ const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
         uiGroup: ModelUIGroup.Speed,
     },
     {
+        title: 'GPT-4o',
+        model: 'openai/gpt-4o',
+        provider: 'OpenAI',
+        default: false,
+        codyProOnly: true,
+        usage: [ModelUsage.Chat, ModelUsage.Edit],
+        contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
+        deprecated: false,
+        uiGroup: ModelUIGroup.Accuracy,
+    },
+    {
         title: 'GPT-4 Turbo',
         model: 'openai/gpt-4-turbo',
         provider: 'OpenAI',

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: New optimization for prompt quality and token usage, deduplicating context items, and optimizing token allocation. [pull/3929](https://github.com/sourcegraph/cody/pull/3929)
 - Document Code/Generate Tests: User selections are now matched against known symbol ranges, and adjusted in cases where a user selection in a suitable subset of one of these ranges. [pull/4031](https://github.com/sourcegraph/cody/pull/4031)
 - Extension: Added the `vscode.git` extension to the `extensionDependencies` list. [pull/4110](https://github.com/sourcegraph/cody/pull/4110)
+- Chat: The new `GPT-4o` model is available for Cody Pro users. [pull/4164](https://github.com/sourcegraph/cody/pull/4164)
 
 ### Fixed
 


### PR DESCRIPTION
FOLLOW UP ON https://github.com/sourcegraph/sourcegraph/pull/62640

Do not merge this until https://github.com/sourcegraph/sourcegraph/pull/62640 is deployed

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Check if the new gpt 4o shows up on the model list.


Can confirm gpt-4o model ID works when connect directly to the open AI endpoint in dev mode:

<img width="1076" alt="image" src="https://github.com/sourcegraph/cody/assets/68532117/78ed6c7e-1770-4b10-b0d4-5a64cca613f0">
