### PR TITLE
Cody Ignore: Default to allowing files for dotcom until the policy is fetched

### DIFF
--- a/lib/shared/src/cody-ignore/context-filters-provider.ts
+++ b/lib/shared/src/cody-ignore/context-filters-provider.ts
@@ -143,7 +143,11 @@ export class ContextFiltersProvider implements vscode.Disposable {
     }
 
     public async isUriIgnored(uri: vscode.Uri): Promise<IsIgnored> {
-        if (allowedSchemes.has(uri.scheme) || this.hasAllowEverythingFilters()) {
+        if (
+            allowedSchemes.has(uri.scheme) ||
+            (this.lastContextFiltersResponse === null && graphqlClient.isDotCom()) ||
+            this.hasAllowEverythingFilters()
+        ) {
             return false
         }
         if (this.hasIgnoreEverythingFilters()) {

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -365,7 +365,7 @@ export class SourcegraphGraphQLAPIClient {
     }
 
     /**
-     * If set, anonymousUID is trasmitted as 'X-Sourcegraph-Actor-Anonymous-UID'
+     * If set, anonymousUID is transmitted as 'X-Sourcegraph-Actor-Anonymous-UID'
      * which is automatically picked up by Sourcegraph backends 5.2+
      */
     public setAnonymousUserID(anonymousUID: string): void {


### PR DESCRIPTION
sourcegraph.com can set Cody Ignore policy, however it is unlikely to. There's a window from startup until the ignore policy is fetched where we conservatively default to ignoring files. For users on slow connections, that could be a long time.

This changes the rules so that for dotcom accounts, we will liberally assume all files are allowed until the policy is fetched. This ensures dotcom users should not see Cody Ignore notices.

## Test plan

`pnpm test:unit`

Manual test:

1. Run the JetBrains plugin, sign in to dotcom, open a file. Close that IDE.
2. Run in VSCode with agent:debug configuration.
3. Run JetBrains in IntelliJ with `CODY_AGENT_DEBUG_PORT=3113;CODY_AGENT_DEBUG_REMOTE=true;CODY_JETBRAINS_FEATURES=cody.feature.inline-edits=true`
4. As quickly as possible, cmd-shift-H to run "Document" command.

You should not see the notification that your file is ignored because of admin policy.