### PR TITLE
VS Code: remove extension dependencies

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -92,7 +92,6 @@
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
   "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
-  "extensionDependencies": ["vscode.git"],
   "contributes": {
     "walkthroughs": [
       {


### PR DESCRIPTION
- Having `"extensionDependencies": ["vscode.git"]` disables Cody in restricted workspaces. Reverting to the manual Git extension initialization we already have in place.

## Test plan

CI
