### PR TITLE
Bump BFG version

### DIFF
--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -13,7 +13,7 @@ import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
 // Do not include 'v' in this string.
-const defaultBfgVersion = '5.3.11523'
+const defaultBfgVersion = '5.3.16454'
 
 // We use this Promise to only have one downloadBfg running at once.
 let serializeBfgDownload: Promise<string | null> = Promise.resolve(null)


### PR DESCRIPTION
Bump BFG version to include https://github.com/sourcegraph/bfg-private/pull/184

## Test plan

- Embedding indexing succeeds for https://github.com/huggingface/transformers repo (that fails on main)