### PR TITLE
VS Code: Release 1.18.0

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,14 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+### Fixed
+
+### Changed
+
+## [1.18.0]
+
+### Added
+
 - Search: A new `Search Code` command added to the `Commands` sidebar for Cody's Natural Language Search. [pull/3991](https://github.com/sourcegraph/cody/pull/3991)
 - Context Menu: Added commands to send file to chat as @-mention from the explorer context menu. [pull/4000](https://github.com/sourcegraph/cody/pull/4000)
   - `Add File to Chat`: Add file to the current opened chat, or start a new chat if no panel is opened.

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.16.7",
+  "version": "1.18.0",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
VS Code: Release 1.18.0 - Stable Release.

Blog post: https://github.com/sourcegraph/about/pull/6940

## Test plan

- [x] [vscode/CHANGELOG.md](./CHANGELOG.md)
- [x] [vscode/package.json](./package.json)
