### PR TITLE
Revert v2 naming on v1 event

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -315,14 +315,10 @@ function writeCompletionEvent<SubFeature extends string, Action extends string, 
     legacyParams?: LegacyParams
 ): void {
     const extDetails = getExtensionDetails(getConfiguration(vscode.workspace.getConfiguration()))
-    telemetryService.log(
-        `${logPrefix(extDetails.ide)}:completion:${subfeature ? `${subfeature}:` : ''}${action}`,
-        legacyParams,
-        {
-            agent: true,
-            hasV2Event: true, // this helper translates the event for us
-        }
-    )
+    telemetryService.log(`${logPrefix(extDetails.ide)}:completion:${name}`, legacyParams, {
+        agent: true,
+        hasV2Event: true, // this helper translates the event for us
+    })
     /**
      * Extract interaction ID from the full legacy params for convenience
      */


### PR DESCRIPTION
This PR reverts this [change](https://github.com/sourcegraph/cody/pull/4077/files) which accidentally updated the logging for the v1 completion events to use the v2 naming convention. 

## Test plan
CI + locally 
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
