### PR TITLE
support changing chat model after chat session has begun

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SerializedChatMessage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/SerializedChatMessage.kt
@@ -9,6 +9,7 @@ data class SerializedChatMessage(
   val editorState: Any? = null,
   val speaker: SpeakerEnum, // Oneof: human, assistant, system
   val text: String? = null,
+  val model: String? = null,
 ) {
 
   enum class SpeakerEnum {

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -190,6 +190,7 @@ describe('Agent', () => {
             expect(lastMessage).toMatchInlineSnapshot(
                 `
               {
+                "model": "anthropic/claude-3-sonnet-20240229",
                 "speaker": "assistant",
                 "text": "Hello there! I'm Claude, an AI assistant created by Anthropic. It's nice to meet you. How can I help you today?",
               }
@@ -339,6 +340,7 @@ describe('Agent', () => {
   "interactions": [
     {
       "assistantMessage": {
+        "model": "anthropic/claude-2.0",
         "speaker": "assistant",
         "text": " I'm Claude, an AI assistant created by Anthropic.",
       },

--- a/lib/shared/src/chat/transcript/index.ts
+++ b/lib/shared/src/chat/transcript/index.ts
@@ -8,7 +8,16 @@ export interface SerializedChatTranscript {
     /** A unique and opaque identifier for this transcript. */
     id: string
 
+    /**
+     * The chat model used for the chat session.
+     *
+     * @deprecated The chat model is now a per-message property instead of applying to the entire
+     * chat session, to allow users to change the model partway through the chat. Use the last
+     * {@link SerializedChatMessage.model} instead. Can remove in v1.22 (after 1 major release,
+     * v1.20, where both fields are written).
+     */
     chatModel?: string
+
     chatTitle?: string
     interactions: SerializedChatInteraction[]
     lastInteractionTimestamp: string

--- a/lib/shared/src/chat/transcript/messages.ts
+++ b/lib/shared/src/chat/transcript/messages.ts
@@ -15,6 +15,15 @@ export interface ChatMessage extends Message {
      * back to editing the text for invalid values.
      */
     editorState?: unknown
+
+    /**
+     * The model used to generate this chat message response. Not set on human messages.
+     *
+     * NOTE: The chat model used to be a property of the entire chat session and was not changeable
+     * after the chat session had begun. Now that field, {@link SerializedChatTranscript.chatModel},
+     * is deprecated, and this field should be used instead.
+     */
+    model?: string
 }
 
 // An unsafe version of the {@link ChatMessage} that has the PromptString
@@ -28,6 +37,7 @@ export interface SerializedChatMessage {
     editorState?: unknown
     speaker: 'human' | 'assistant' | 'system'
     text?: string // Changed from PromptString
+    model?: string
 }
 
 export interface ChatError {

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -13,6 +13,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Changed
 
 - Chat: Pressing <kbd>Space</kbd> no longer accepts an @-mention item. Press <kbd>Tab</kbd> or <kbd>Enter</kbd> instead. [pull/4154](https://github.com/sourcegraph/cody/pull/4154)
+- Chat: You can now change the model after you send a chat message. Subsequent messages will be sent using your selected model. [pull/4189](https://github.com/sourcegraph/cody/pull/4189)
 
 ## [1.18.0]
 

--- a/vscode/src/chat/chat-view/SimpleChatModel.ts
+++ b/vscode/src/chat/chat-view/SimpleChatModel.ts
@@ -67,6 +67,7 @@ export class SimpleChatModel {
             error = this.messages.pop()?.error
         }
         this.messages.push({
+            model: this.modelID,
             ...message,
             speaker: 'assistant',
             error,
@@ -80,6 +81,7 @@ export class SimpleChatModel {
             lastMessage?.speaker === 'assistant' ? this.messages.pop() : undefined
         // Then add a new assistant message with error added
         this.messages.push({
+            model: this.modelID,
             ...(lastAssistantMessage ?? {}),
             speaker: 'assistant',
             error: errorToChatError(error),
@@ -162,10 +164,12 @@ export class SimpleChatModel {
         }
         const result: SerializedChatTranscript = {
             id: this.sessionID,
-            chatModel: this.modelID,
             chatTitle: this.getCustomChatTitle(),
             lastInteractionTimestamp: this.sessionID,
             interactions,
+
+            // DEPRECATED: Write this for backcompat.
+            chatModel: this.modelID,
         }
         if (this.selectedRepos) {
             result.enhancedContext = {

--- a/vscode/src/completions/inline-completion-item-provider.test.ts
+++ b/vscode/src/completions/inline-completion-item-provider.test.ts
@@ -251,6 +251,7 @@ describe('InlineCompletionItemProvider', () => {
             get: (key: string) => localStorageData[key],
             update: (key: string, value: unknown) => {
                 localStorageData[key] = value
+                return Promise.resolve()
             },
         } as any as vscode.Memento)
 

--- a/vscode/webviews/chat/Transcript.story.tsx
+++ b/vscode/webviews/chat/Transcript.story.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
 import { Transcript } from './Transcript'
-import { FIXTURE_TRANSCRIPT, FIXTURE_USER_ACCOUNT_INFO } from './fixtures'
+import { FIXTURE_TRANSCRIPT, FIXTURE_USER_ACCOUNT_INFO, transcriptFixture } from './fixtures'
 
 import { RateLimitError, errorToChatError, ps } from '@sourcegraph/cody-shared'
 import type { ComponentProps } from 'react'
@@ -84,44 +84,45 @@ export const WaitingForContext: StoryObj<typeof meta> = {
 
 export const WaitingForAssistantMessageWithContext: StoryObj<typeof meta> = {
     args: {
-        transcript: [
+        transcript: transcriptFixture([
             ...SIMPLE_TRANSCRIPT,
             {
                 speaker: 'human',
                 text: ps`What color is the sky?'`,
                 contextFiles: [{ type: 'file', uri: URI.file('/foo.js') }],
             },
-        ],
-        messageInProgress: { speaker: 'assistant' },
+        ]),
+        messageInProgress: { speaker: 'assistant', model: 'my-llm' },
     },
 }
 
 export const WaitingForAssistantMessageNoContext: StoryObj<typeof meta> = {
     args: {
-        transcript: [
+        transcript: transcriptFixture([
             ...SIMPLE_TRANSCRIPT,
             {
                 speaker: 'human',
                 text: ps`What color is the sky?'`,
                 contextFiles: [],
             },
-        ],
+        ]),
         messageInProgress: { speaker: 'assistant' },
     },
 }
 
 export const AssistantMessageInProgress: StoryObj<typeof meta> = {
     args: {
-        transcript: [
+        transcript: transcriptFixture([
             ...SIMPLE_TRANSCRIPT,
             {
                 speaker: 'human',
                 text: ps`What color is the sky?'`,
                 contextFiles: [{ type: 'file', uri: URI.file('/foo.js') }],
             },
-        ],
+        ]),
         messageInProgress: {
             speaker: 'assistant',
+            model: 'my-model',
             text: ps`The sky is `,
         },
     },
@@ -129,18 +130,18 @@ export const AssistantMessageInProgress: StoryObj<typeof meta> = {
 
 export const WithError: StoryObj<typeof meta> = {
     args: {
-        transcript: [
+        transcript: transcriptFixture([
             ...SIMPLE_TRANSCRIPT,
             { speaker: 'human', text: ps`What color is the sky?'`, contextFiles: [] },
             { speaker: 'assistant', error: errorToChatError(new Error('some error')) },
-        ],
+        ]),
         isTranscriptError: true,
     },
 }
 
 export const WithRateLimitError: StoryObj<typeof meta> = {
     args: {
-        transcript: [
+        transcript: transcriptFixture([
             ...SIMPLE_TRANSCRIPT,
             { speaker: 'human', text: ps`What color is the sky?'`, contextFiles: [] },
             {
@@ -149,7 +150,7 @@ export const WithRateLimitError: StoryObj<typeof meta> = {
                     new RateLimitError('chat messages and commands', 'rate limit error', true)
                 ),
             },
-        ],
+        ]),
         isTranscriptError: true,
     },
 }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -15,7 +15,7 @@ import styles from './Transcript.module.css'
 import { Cell } from './cells/Cell'
 import { ContextCell } from './cells/contextCell/ContextCell'
 import { MessageCell } from './cells/messageCell/MessageCell'
-import { useChatModelContext, useCurrentChatModel } from './models/chatModelContext'
+import { useChatModelContext } from './models/chatModelContext'
 
 export const Transcript: React.FunctionComponent<{
     transcript: ChatMessage[]
@@ -130,7 +130,6 @@ export const Transcript: React.FunctionComponent<{
     }
 
     const { chatModels, onCurrentChatModelChange } = useChatModelContext()
-    const chatModel = useCurrentChatModel()
 
     const messageToTranscriptItem =
         (offset: number) =>
@@ -158,7 +157,6 @@ export const Transcript: React.FunctionComponent<{
                         key={keyIndex}
                         message={message}
                         messageIndexInTranscript={keyIndex}
-                        chatModel={chatModel}
                         isLoading={isLoading}
                         disabled={messageBeingEdited !== undefined && !isItemBeingEdited}
                         showEditButton={message.speaker === 'human'}
@@ -193,7 +191,6 @@ export const Transcript: React.FunctionComponent<{
                         <div className={styles.modelSelectFieldContainer}>
                             <ModelSelectField
                                 models={chatModels}
-                                readOnly={transcript.length > 0}
                                 onModelSelect={onCurrentChatModelChange}
                                 userInfo={userInfo}
                             />
@@ -209,7 +206,6 @@ export const Transcript: React.FunctionComponent<{
                         <MessageCell
                             message={messageInProgress}
                             messageIndexInTranscript={transcript.length}
-                            chatModel={chatModel}
                             isLoading={true}
                             beingEdited={messageBeingEdited}
                             setBeingEdited={setMessageBeingEdited}

--- a/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/MessageCell.tsx
@@ -1,7 +1,6 @@
 import {
     type ChatMessage,
     type Guardrails,
-    type ModelProvider,
     ps,
     reformatBotMessageForChat,
 } from '@sourcegraph/cody-shared'
@@ -15,6 +14,7 @@ import { ChatMessageContent, type CodeBlockActionsProps } from '../../ChatMessag
 import { ErrorItem, RequestErrorItem } from '../../ErrorItem'
 import { FeedbackButtons } from '../../components/FeedbackButtons'
 import { LoadingDots } from '../../components/LoadingDots'
+import { useChatModelByID } from '../../models/chatModelContext'
 import { Cell } from '../Cell'
 import styles from './MessageCell.module.css'
 import { SpeakerIcon } from './SpeakerIcon'
@@ -22,7 +22,6 @@ import { SpeakerIcon } from './SpeakerIcon'
 export const MessageCell: FunctionComponent<{
     message: ChatMessage
     messageIndexInTranscript: number
-    chatModel: ModelProvider | undefined
     isLoading: boolean
     disabled?: boolean
 
@@ -42,7 +41,6 @@ export const MessageCell: FunctionComponent<{
 }> = ({
     message,
     messageIndexInTranscript,
-    chatModel,
     isLoading,
     disabled,
     showEditButton,
@@ -63,6 +61,8 @@ export const MessageCell: FunctionComponent<{
     const isItemBeingEdited = beingEdited === messageIndexInTranscript
 
     const displayMarkdown = useDisplayMarkdown(message)
+
+    const chatModel = useChatModelByID(message.model)
 
     return (
         <Cell

--- a/vscode/webviews/chat/cells/messageCell/SpeakerIcon.tsx
+++ b/vscode/webviews/chat/cells/messageCell/SpeakerIcon.tsx
@@ -11,7 +11,7 @@ import { UserAvatar } from '../../../components/UserAvatar'
 export const SpeakerIcon: FunctionComponent<{
     message: Pick<ChatMessage, 'speaker'>
     userInfo: UserAccountInfo
-    chatModel: ModelProvider | undefined
+    chatModel: Pick<ModelProvider, 'model' | 'title' | 'provider'> | undefined
     size: number
 }> = ({ message, userInfo: { user }, chatModel, size }) => {
     if (message.speaker === 'human') {

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -4,15 +4,22 @@ import { type ChatMessage, ps } from '@sourcegraph/cody-shared'
 import type { UserAccountInfo } from '../Chat'
 import { FILE_MENTION_EDITOR_STATE_FIXTURE } from '../promptEditor/fixtures'
 
+export function transcriptFixture(transcript: ChatMessage[]): ChatMessage[] {
+    return transcript.map(m => ({
+        ...m,
+        model: m.model === undefined && m.speaker !== 'human' ? 'my-model' : m.model,
+    }))
+}
+
 export const FIXTURE_TRANSCRIPT: Record<
     'simple' | 'simple2' | 'codeQuestion' | 'explainCode' | 'explainCode2',
     ChatMessage[]
 > = {
-    simple: [
+    simple: transcriptFixture([
         { speaker: 'human', text: ps`Hello, world!` },
         { speaker: 'assistant', text: ps`Thank you` },
-    ],
-    simple2: [
+    ]),
+    simple2: transcriptFixture([
         {
             speaker: 'human',
             text: ps`What planet are we on?`,
@@ -30,8 +37,8 @@ export const FIXTURE_TRANSCRIPT: Record<
             speaker: 'assistant',
             text: ps`Blue.`,
         },
-    ],
-    codeQuestion: [
+    ]),
+    codeQuestion: transcriptFixture([
         {
             speaker: 'human',
             text: ps`What does \`document.getSelection()?.isCollapsed\` mean? I am trying to use it in a web application that has a textarea and want to manage the user selection.`,
@@ -40,8 +47,8 @@ export const FIXTURE_TRANSCRIPT: Record<
             speaker: 'assistant',
             text: ps`\`document.getSelection()?.isCollapsed\` means that the current selection in the document is collapsed, meaning it is a caret (no text is selected).\n\nThe \`?.\` operator is optional chaining - it will return \`undefined\` if \`document.getSelection()\` returns \`null\` or \`undefined\`.\n\nSo in short, that line is checking if there is currently a text selection in the document, and if not, focusing the textarea.\n\n`,
         },
-    ],
-    explainCode: [
+    ]),
+    explainCode: transcriptFixture([
         {
             speaker: 'human',
             text: ps`Explain the following code at a high level:\n\n\`\`\`\nprivate getNonce(): string {\n  let text = ''\n  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n\`\`\``,
@@ -71,8 +78,8 @@ export const FIXTURE_TRANSCRIPT: Record<
             speaker: 'assistant',
             text: ps`Here is the rewritten code using only hexadecimal encoding:\n\n\`\`\`\nprivate getNonce(): string {\n  let text = ''\n  const possible = '0123456789ABCDEF'\n  for (let i = 0; i < 32; i++) {\n    text += possible.charAt(Math.floor(Math.random() * possible.length))\n  }\n  return text\n}\n\`\`\``,
         },
-    ],
-    explainCode2: [
+    ]),
+    explainCode2: transcriptFixture([
         {
             speaker: 'human',
             text: ps`What does @#Symbol1 in @dir/dir/file-a-1.py do? Also use @README.md:2-8.`,
@@ -97,7 +104,7 @@ export const FIXTURE_TRANSCRIPT: Record<
             speaker: 'assistant',
             text: ps`This code is very cool.`,
         },
-    ],
+    ]),
 }
 
 export const FIXTURE_USER_ACCOUNT_INFO: UserAccountInfo = {

--- a/vscode/webviews/chat/models/chatModelContext.tsx
+++ b/vscode/webviews/chat/models/chatModelContext.tsx
@@ -15,6 +15,22 @@ export function useChatModelContext(): ChatModelContext {
     return useContext(context)
 }
 
+export function useChatModelByID(
+    model: string | undefined
+): Pick<ModelProvider, 'model' | 'title' | 'provider'> | undefined {
+    const { chatModels } = useChatModelContext()
+    return (
+        chatModels?.find(m => m.model === model) ??
+        (model
+            ? {
+                  model,
+                  title: model,
+                  provider: 'unknown',
+              }
+            : undefined)
+    )
+}
+
 export function useCurrentChatModel(): ModelProvider | undefined {
     const { chatModels } = useChatModelContext()
     return chatModels?.find(model => model.default) ?? chatModels?.[0]

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -13,20 +13,11 @@ export const ModelSelectField: React.FunctionComponent<{
 
     userInfo: Pick<UserAccountInfo, 'isCodyProUser' | 'isDotComUser'>
 
-    readOnly?: boolean
-
     className?: string
 
     /** For storybooks only. */
     __storybook__open?: boolean
-}> = ({
-    models,
-    onModelSelect: parentOnModelSelect,
-    userInfo,
-    readOnly,
-    className,
-    __storybook__open,
-}) => {
+}> = ({ models, onModelSelect: parentOnModelSelect, userInfo, className, __storybook__open }) => {
     const usableModels = useMemo(() => models.filter(m => !m.deprecated), [models])
     const selectedModel = usableModels.find(m => m.default) ?? usableModels[0]
 
@@ -112,7 +103,7 @@ export const ModelSelectField: React.FunctionComponent<{
             value={selectedModel.model}
             onChange={onChange}
             className={className}
-            readOnly={readOnly || !userInfo.isDotComUser}
+            readOnly={!userInfo.isDotComUser}
             onOpen={onPopoverOpen}
             __storybook__open={__storybook__open}
             aria-label="Choose a model"


### PR DESCRIPTION
Previously, you could only change the chat model before you started a chat. Now, you can change it at any point.

- Changing a chat model does not re-send previous messages.
- If you change the chat model and then edit a message, it gets sent to the new model (not the original model of the message).

![image](https://github.com/sourcegraph/cody/assets/1976/ee9e374c-3ec2-4a54-bb4b-6be8eabdbcf5)


## Test plan

1. Send a first chat message using any model.
2. Change the model using the model selector.
3. Send a 2nd chat message. Confirm it shows as being from the model you just chose.
4. Change the model to yet another model. Edit the 2nd chat message and send it. Ensure that the response now shows as being from the new model.
5. Close the chat and reopen it. Ensure that the models are still correct (by their icons).