### PR TITLE
Simplify upstream latency collector and measure gateway latency

### DIFF
--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -149,6 +149,7 @@ export class TestClient extends MessageHandler {
                 REDACTED_SRC_ACCESS_TOKEN: params.credentials.redactedToken,
                 CODY_TELEMETRY_EXPORTER: params.telemetryExporter ?? 'testing',
                 DISABLE_FEATURE_FLAGS: params.areFeatureFlagsEnabled ? undefined : 'true',
+                DISABLE_UPSTREAM_HEALTH_PINGS: 'true',
                 CODY_LOG_EVENT_MODE: params.logEventMode,
                 ...process.env,
             },

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -348,7 +348,7 @@ export interface CompletionBookkeepingEvent {
     id: CompletionLogID
     params: Omit<
         SharedEventPayload,
-        'items' | 'otherCompletionProviderEnabled' | 'otherCompletionProviders' | 'upstreamRtt'
+        'items' | 'otherCompletionProviderEnabled' | 'otherCompletionProviders'
     >
     // The timestamp when the completion request started
     startedAt: number

--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -118,8 +118,9 @@ interface SharedEventPayload extends InteractionIDPayload {
     /** A list of known completion providers that are also enabled with this user. */
     otherCompletionProviders: string[]
 
-    /** The median of the last upstream requests */
-    medianUpstreamLatency?: number
+    /** The round trip timings to reach the Sourcegraph and Cody Gateway instances. */
+    upstreamLatency?: number
+    gatewayLatency?: number
 }
 
 /**
@@ -347,7 +348,7 @@ export interface CompletionBookkeepingEvent {
     id: CompletionLogID
     params: Omit<
         SharedEventPayload,
-        'items' | 'otherCompletionProviderEnabled' | 'otherCompletionProviders' | 'medianUpstreamLatency'
+        'items' | 'otherCompletionProviderEnabled' | 'otherCompletionProviders' | 'upstreamRtt'
     >
     // The timestamp when the completion request started
     startedAt: number
@@ -831,7 +832,8 @@ function getSharedParams(event: CompletionBookkeepingEvent): SharedEventPayload 
         items: event.items.map(i => ({ ...i })),
         otherCompletionProviderEnabled: otherCompletionProviders.length > 0,
         otherCompletionProviders,
-        medianUpstreamLatency: upstreamHealthProvider.getMedianDuration(),
+        upstreamLatency: upstreamHealthProvider.getUpstreamLatency(),
+        gatewayLatency: upstreamHealthProvider.getGatewayLatency(),
     }
 }
 

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -69,6 +69,10 @@ export class UpstreamHealthProvider implements vscode.Disposable {
         }
 
         try {
+            if (process.env.DISABLE_UPSTREAM_HEALTH_PINGS === 'true') {
+                return
+            }
+
             if (!this.config) {
                 throw new Error('UpstreamHealthProvider not initialized')
             }

--- a/vscode/src/services/UpstreamHealthProvider.ts
+++ b/vscode/src/services/UpstreamHealthProvider.ts
@@ -3,7 +3,10 @@ import {
     type ConfigurationWithAccessToken,
     addCustomUserAgent,
     addTraceparent,
+    dotcomTokenToGatewayToken,
+    isDotCom,
     logDebug,
+    wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
 import { fetch } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
@@ -11,7 +14,6 @@ import type * as vscode from 'vscode'
 // We choose an interval that gives us a reasonable aggregate without causing
 // too many requests
 const PING_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
-const TWO_HOURS_MS = 2 * 60 * 60 * 1000
 
 /**
  * A provider that regularly pings the connected Sourcegraph instance to
@@ -20,8 +22,9 @@ const TWO_HOURS_MS = 2 * 60 * 60 * 1000
  * You can query it to get aggregates of the most recent pings.
  */
 export class UpstreamHealthProvider implements vscode.Disposable {
-    // Array sorted by duration for easy median calculation
-    private recentDurationsSorted: { timestamp: number; duration: number }[] = []
+    private lastUpstreamLatency?: number
+    private lastGatewayLatency?: number
+    private fastPathAccessToken?: string
 
     private config: Pick<
         ConfigurationWithAccessToken,
@@ -29,21 +32,34 @@ export class UpstreamHealthProvider implements vscode.Disposable {
     > | null = null
     private nextTimeoutId: NodeJS.Timeout | null = null
 
-    public getMedianDuration(): number | undefined {
+    public getUpstreamLatency(): number | undefined {
         if (!this.config) {
             return undefined
         }
-        if (this.recentDurationsSorted.length === 0) {
+        return this.lastUpstreamLatency
+    }
+
+    public getGatewayLatency(): number | undefined {
+        if (!this.config) {
             return undefined
         }
-        return this.recentDurationsSorted[Math.floor(this.recentDurationsSorted.length / 2)].duration
+        return this.lastGatewayLatency
     }
 
     public onConfigurationChange(
         newConfig: Pick<ConfigurationWithAccessToken, 'serverEndpoint' | 'customHeaders' | 'accessToken'>
     ): this {
         this.config = newConfig
-        this.recentDurationsSorted = []
+        this.lastUpstreamLatency = undefined
+        this.lastGatewayLatency = undefined
+
+        this.fastPathAccessToken =
+            newConfig.accessToken &&
+            // Require the upstream to be dotcom
+            isDotCom(newConfig.serverEndpoint)
+                ? dotcomTokenToGatewayToken(newConfig.accessToken)
+                : undefined
+
         this.measure()
         return this
     }
@@ -53,7 +69,6 @@ export class UpstreamHealthProvider implements vscode.Disposable {
             clearTimeout(this.nextTimeoutId)
         }
 
-        const start = Date.now()
         try {
             if (!this.config) {
                 throw new Error('UpstreamHealthProvider not initialized')
@@ -67,35 +82,56 @@ export class UpstreamHealthProvider implements vscode.Disposable {
             addTraceparent(headers)
             addCustomUserAgent(headers)
             const url = new URL('/healthz', this.config.serverEndpoint)
+            const upstreamResult = await wrapInActiveSpan('upstream-latency.upstream', span => {
+                span.setAttribute('sampled', true)
+                return measureLatencyToUri(headers, url.toString())
+            })
 
-            // We use a GET request even though we do not want to consume the
-            // body to avoid internal networks interfering with the request.
-            //
-            // To make sure the content is garbage collected, we'll ensure that
-            // the body is consumed. We don't use undici yet but that might
-            // change in the future:
-            //
-            // https://undici.nodejs.org/#/?id=garbage-collection
-            const response = await fetch(url.toString(), { method: 'GET', headers })
-            void response.arrayBuffer() // consume the body
-
-            const duration = Date.now() - start
-            this.pushDuration(duration)
-
-            logDebug(
-                'UpstreamHealth',
-                `Ping took ${Math.round(duration)}ms (Median: ${Math.round(
-                    this.getMedianDuration() ?? 0
-                )}ms)`,
-                {
-                    verbose: {
-                        duration,
-                        url,
-                        status: response.status,
-                        headers: headersToObject(response.headers),
-                    },
+            // We don't want to congest the network so we run the test in serial
+            if (this.fastPathAccessToken) {
+                const headers = new Headers()
+                headers.set('Content-Type', 'application/json; charset=utf-8')
+                headers.set('Authorization', `Bearer ${this.fastPathAccessToken}`)
+                addTraceparent(headers)
+                addCustomUserAgent(headers)
+                const uri = 'https://cody-gateway.sourcegraph.com/healthz'
+                const gatewayResult = await wrapInActiveSpan('upstream-latency.gateway', span => {
+                    span.setAttribute('sampled', true)
+                    return measureLatencyToUri(headers, uri)
+                })
+                if (!('error' in gatewayResult)) {
+                    this.lastGatewayLatency = gatewayResult.latency
                 }
-            )
+            }
+
+            if ('error' in upstreamResult) {
+                this.lastUpstreamLatency = undefined
+
+                logDebug('UpstreamHealth', 'Failed to ping upstream host', {
+                    verbose: {
+                        error: upstreamResult.error,
+                    },
+                })
+            } else {
+                this.lastUpstreamLatency = upstreamResult.latency
+
+                logDebug(
+                    'UpstreamHealth',
+                    `Ping took ${Math.round(upstreamResult.latency)}ms ${
+                        this.lastGatewayLatency
+                            ? `(Gateway: ${Math.round(this.lastGatewayLatency)}ms)`
+                            : ''
+                    }`,
+                    {
+                        verbose: {
+                            Latency: upstreamResult.latency,
+                            url,
+                            status: upstreamResult.response.status,
+                            headers: headersToObject(upstreamResult.response.headers),
+                        },
+                    }
+                )
+            }
         } catch (error) {
             // We don't care about errors here, we just want to measure the latency
         } finally {
@@ -112,22 +148,6 @@ export class UpstreamHealthProvider implements vscode.Disposable {
             clearTimeout(this.nextTimeoutId)
         }
     }
-
-    private pushDuration(duration: number): void {
-        const entry = { timestamp: Date.now(), duration }
-
-        // Delete items that are older than 2 hours
-        this.recentDurationsSorted = this.recentDurationsSorted.filter(
-            item => Date.now() - item.timestamp < TWO_HOURS_MS
-        )
-
-        const position = this.recentDurationsSorted.findIndex(item => item.duration > duration)
-        if (position === -1) {
-            this.recentDurationsSorted.push(entry)
-        } else {
-            this.recentDurationsSorted.splice(position, 0, entry)
-        }
-    }
 }
 
 export const upstreamHealthProvider = new UpstreamHealthProvider()
@@ -138,4 +158,26 @@ function headersToObject(headers: BrowserOrNodeResponse['headers']) {
         result[key] = value
     }
     return result
+}
+
+async function measureLatencyToUri(
+    headers: Headers,
+    uri: string
+): Promise<{ latency: number; response: BrowserOrNodeResponse } | { error: Error }> {
+    try {
+        const start = performance.now()
+        // We use a GET request even though we do not want to consume the
+        // body to avoid internal networks interfering with the request.
+        //
+        // To make sure the content is garbage collected, we'll ensure that
+        // the body is consumed. We don't use undici yet but that might
+        // change in the future:
+        //
+        // https://undici.nodejs.org/#/?id=garbage-collection
+        const response = await fetch(uri, { method: 'GET', headers })
+        void response.arrayBuffer() // consume the body
+        return { latency: performance.now() - start, response }
+    } catch (error: any) {
+        return { error }
+    }
 }


### PR DESCRIPTION
Closes CODY-1605

This PR changes the way we track upstream latency (= RTT to the Sourcegraph instance). Instead of measuring every 10 minutes and then exporting the median to the completion metadata, I thought that it might be simpler to include the last measurement with the completion data (and then we can run an aggregation on that). While coding, completion suggestions should happen more frequent then every 10 minutes so this will give us a higher resolution while we avoid to maintain a list.

Additionally, I've added a second parameter to measure the latency to Gateway. This is only turned on for Free/Pro users right now (to avoid outgoing traffic in air-gapped instances). 

Furthermore I added tracing to the upstream pings. With our current rate limit, one two two traces every ~10 minutes _should be fine_ (again I assume this happen far less frequently than completion suggestions) but we can revisit this later.

The benefit of exporting this as a trace is that we can later forward the trace to the SG instance and convert it to a metric.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
<img width="1421" alt="Screenshot 2024-05-16 at 14 41 54" src="https://github.com/sourcegraph/cody/assets/458591/a134ea81-3da6-4aad-abc2-d652e8da205e">
