### PR TITLE
show LLM avatar in chat transcript while message is loading

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -763,7 +763,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     // =======================================================================
 
     private postEmptyMessageInProgress(): void {
-        this.postViewTranscript({ speaker: 'assistant' })
+        this.postViewTranscript({ speaker: 'assistant', model: this.chatModel.modelID })
     }
 
     private postViewTranscript(messageInProgress?: ChatMessage): void {
@@ -931,6 +931,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 this.postViewTranscript({
                     speaker: 'assistant',
                     text: PromptString.unsafe_fromLLMResponse(content),
+                    model: this.chatModel.modelID,
                 })
             },
             close: content => {


### PR DESCRIPTION
This fixes a bug where no LLM avatar was shown until the message was complete.



## Test plan

Type a chat message and hit send. Ensure that the LLM avatar shows up even while the message is being received.