### PR TITLE
if no @-mention query, don't try to run query

### DIFF
--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
@@ -68,7 +68,7 @@ export const MentionMenu: FunctionComponent<
 
     const [value, setValue] = useState<string | null>(null)
 
-    const mentionQuery = parseMentionQuery(params.query, params.parentItem)
+    const mentionQuery = parseMentionQuery(params.query ?? '', params.parentItem)
 
     useEffect(() => {
         if (__storybook__focus) {

--- a/vscode/webviews/mentions/mentionMenu/useMentionMenuData.ts
+++ b/vscode/webviews/mentions/mentionMenu/useMentionMenuData.ts
@@ -5,21 +5,21 @@ import { prepareContextItemForMentionMenu } from '../../promptEditor/plugins/atM
 import { useContextProviders } from '../providers'
 
 export interface MentionMenuParams {
-    query: string
+    query: string | null
     parentItem: ContextMentionProviderMetadata | null
 }
 
 export function useMentionMenuParams(): {
     params: MentionMenuParams
-    updateQuery: (query: string) => void
+    updateQuery: (query: string | null) => void
     updateMentionMenuParams: MentionMenuContextValue['updateMentionMenuParams']
 } {
-    const [params, setParams] = useState<MentionMenuParams>({ query: '', parentItem: null })
+    const [params, setParams] = useState<MentionMenuParams>({ query: null, parentItem: null })
 
     return useMemo(
         () => ({
             params,
-            updateQuery: query => setParams(prev => ({ ...prev, query: query ?? '' })),
+            updateQuery: query => setParams(prev => ({ ...prev, query })),
             updateMentionMenuParams: update => setParams(prev => ({ ...prev, ...update })),
         }),
         [params]
@@ -41,19 +41,20 @@ export function useMentionMenuData(
     { remainingTokenBudget, limit }: { remainingTokenBudget: number; limit: number }
 ): MentionMenuData {
     const results = useChatContextItems(params.query, params.parentItem)
-    const queryLower = params.query.toLowerCase()
+    const queryLower = params.query?.toLowerCase() ?? null
 
     const providers = useContextProviders()
 
     return useMemo(
         () => ({
-            providers: params.parentItem
-                ? []
-                : providers.filter(
-                      provider =>
-                          provider.id.toLowerCase().includes(queryLower) ||
-                          provider.title?.toLowerCase().includes(queryLower)
-                  ),
+            providers:
+                params.parentItem || queryLower === null
+                    ? []
+                    : providers.filter(
+                          provider =>
+                              provider.id.toLowerCase().includes(queryLower) ||
+                              provider.title?.toLowerCase().includes(queryLower)
+                      ),
             items: results
                 ?.slice(0, limit)
                 .map(item => prepareContextItemForMentionMenu(item, remainingTokenBudget)),

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -162,7 +162,7 @@ export default function MentionsPlugin(): JSX.Element | null {
 
     return (
         <LexicalTypeaheadMenuPlugin<MentionMenuOption>
-            onQueryChange={query => updateQuery(query ?? '')}
+            onQueryChange={query => updateQuery(query)}
             onSelectOption={onSelectOption}
             onClose={() => {
                 updateMentionMenuParams({ parentItem: null })


### PR DESCRIPTION
This reduces undesirable invocations of querying context items. No behavior change.

## Test plan

CI