### PR TITLE
Fix selection range for chat commands

### DIFF
--- a/vscode/src/commands/execute/explain.ts
+++ b/vscode/src/commands/execute/explain.ts
@@ -39,16 +39,11 @@ async function explainCommand(
         prompt = ps`${prompt} ${args.additionalInstruction}`
     }
 
-    // fetches the context file from the current cursor position using getContextFileFromCursor().
-    const contextFiles: ContextItem[] = []
+    const cs =
+        (await getContextFileFromCursor(args?.range?.start))[0] ||
+        (await getContextFileFromCurrentFile())[0]
+    const contextFiles: ContextItem[] = [cs]
 
-    const currentSelection = await getContextFileFromCursor(args?.range?.start)
-    contextFiles.push(...currentSelection)
-
-    const currentFile = await getContextFileFromCurrentFile()
-    contextFiles.push(...currentFile)
-
-    const cs = currentSelection[0] ?? currentFile[0]
     if (cs) {
         const range = cs.range && ps`:${displayLineRange(cs.range)}`
         prompt = prompt.replaceAll(

--- a/vscode/src/commands/execute/smell.ts
+++ b/vscode/src/commands/execute/smell.ts
@@ -20,6 +20,7 @@ import { type ExecuteChatArguments, executeChat } from './ask'
 import type { Span } from '@opentelemetry/api'
 import { isUriIgnoredByContextFilterWithNotification } from '../../cody-ignore/context-filter'
 import { getEditor } from '../../editor/active-editor'
+import { getContextFileFromCurrentFile } from '../context/current-file'
 
 /**
  * Generates the prompt and context files with arguments for the 'smell' command.
@@ -38,12 +39,11 @@ async function smellCommand(
         prompt = ps`${prompt} ${args.additionalInstruction}`
     }
 
-    const contextFiles: ContextItem[] = []
+    const cs =
+        (await getContextFileFromCursor(args?.range?.start))[0] ||
+        (await getContextFileFromCurrentFile())[0]
+    const contextFiles: ContextItem[] = [cs]
 
-    const currentSelection = await getContextFileFromCursor()
-    contextFiles.push(...currentSelection)
-
-    const cs = currentSelection[0]
     if (cs) {
         const range = cs.range && ps`:${displayLineRange(cs.range)}`
         prompt = prompt.replaceAll(

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -92,9 +92,8 @@ test.extend<ExpectedEvents>({
     await expectContextCellCounts(contextCell, { files: 1 })
     await contextCell.click()
     // The context should show the file with the correct range
-    await expect(chatPanel.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
-    // If a context item is a subcontext of an existing context item, it should not be added to avoid duplication.
-    await expect(chatPanel.getByRole('link', { name: 'index.html:2-10' })).not.toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'index.html:2-10' })).toBeVisible()
+    await expect(chatPanel.getByRole('link', { name: 'index.html:1-11' })).not.toBeVisible()
     const disabledEditButtons = chatPanel.getByTitle('Cannot Edit Command').locator('i')
     const editLastMessageButton = chatPanel.getByRole('button', { name: /^Edit Last Message/ })
     // Edit button and Edit Last Message are shown on all command messages.


### PR DESCRIPTION
## Changes

Fixes incorrect selection choice for commands.

Before:

![image](https://github.com/sourcegraph/cody/assets/1519649/4604b763-983d-45f9-9dc1-0afe55ef29fb)


After:

![image](https://github.com/sourcegraph/cody/assets/1519649/8f9d618c-eae1-4ab4-a443-4c2490e16f72)


## Test plan

Run Explain and Smell commands in a long file with a short selection and without any selection at all.
Answers should be relevant to the selected lines, cursor position, or a visible fragment of the code.
