### PR TITLE
Add support for providing visible range by clients

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocument.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ProtocolTextDocument.kt
@@ -7,5 +7,6 @@ data class ProtocolTextDocument(
   val content: String? = null,
   val selection: Range? = null,
   val contentChanges: List<ProtocolTextDocumentContentChangeEvent>? = null,
+  val visibleRange: Range? = null,
 )
 

--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -191,18 +191,24 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
     }
 
     public newTextEditor(document: AgentTextDocument): vscode.TextEditor {
-        const selection: vscode.Selection = document.protocolDocument.selection
+        const protocolSelection = document.protocolDocument.selection
+        const selection: vscode.Selection = protocolSelection
             ? new vscode.Selection(
-                  new vscode.Position(
-                      document.protocolDocument.selection.start.line,
-                      document.protocolDocument.selection.start.character
-                  ),
-                  new vscode.Position(
-                      document.protocolDocument.selection.end.line,
-                      document.protocolDocument.selection.end.character
-                  )
+                  new vscode.Position(protocolSelection.start.line, protocolSelection.start.character),
+                  new vscode.Position(protocolSelection.end.line, protocolSelection.end.character)
               )
             : new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))
+
+        const protocolVisibleRange = document.protocolDocument.visibleRange
+        const visibleRange = protocolVisibleRange
+            ? new vscode.Selection(
+                  new vscode.Position(
+                      protocolVisibleRange.start.line,
+                      protocolVisibleRange.start.character
+                  ),
+                  new vscode.Position(protocolVisibleRange.end.line, protocolVisibleRange.end.character)
+              )
+            : selection
 
         return {
             // Looking at the implementation of the extension, we only need
@@ -229,7 +235,7 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
             },
             setDecorations: () => {},
             viewColumn: vscode.ViewColumn.Active,
-            visibleRanges: [selection],
+            visibleRanges: [visibleRange],
             show: () => {},
             hide: () => {},
         }

--- a/vscode/src/jsonrpc/TextDocumentWithUri.ts
+++ b/vscode/src/jsonrpc/TextDocumentWithUri.ts
@@ -58,4 +58,8 @@ export class ProtocolTextDocumentWithUri {
     public get selection(): Range | undefined {
         return this.underlying.selection
     }
+
+    public get visibleRange(): Range | undefined {
+        return this.underlying.visibleRange
+    }
 }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -546,6 +546,7 @@ export interface ProtocolTextDocument {
     content?: string
     selection?: Range
     contentChanges?: ProtocolTextDocumentContentChangeEvent[]
+    visibleRange?: Range
 }
 
 export interface ProtocolTextDocumentContentChangeEvent {


### PR DESCRIPTION
## Changes

Add support for visible ranges for the client IDEs.
See also: https://github.com/sourcegraph/jetbrains/pull/1551

## Test plan

I'm not able to find scenario in which visible range wins over smart selection (see [selection.ts:43](https://github.com/sourcegraph/cody/blob/main/vscode/src/commands/context/selection.ts#L43)) but I verified in the debugger that it works as expected, and it might fix some corner case issues we observed with not perfect document context.