### PR TITLE
Chat: prioritize user-added context items

### DIFF
--- a/vscode/src/prompt-builder/unique-context.test.ts
+++ b/vscode/src/prompt-builder/unique-context.test.ts
@@ -190,7 +190,7 @@ describe('Unique Context Items', () => {
             ])
         })
 
-        it('should return the first item when duplicated items are added after', () => {
+        it('should return the first item when duplicated items are added after except user-added items', () => {
             const user: ContextItem = {
                 ...baseFile,
                 range: {
@@ -210,7 +210,8 @@ describe('Unique Context Items', () => {
 
             expect(getUniqueContextItems([user])).toStrictEqual([user])
             expect(getUniqueContextItems([user, embeddings, embeddings])).toStrictEqual([user])
-            expect(getUniqueContextItems([embeddings, user])).toStrictEqual([embeddings])
+            // User-added items should always have the highest priority.
+            expect(getUniqueContextItems([embeddings, user])).toStrictEqual([user])
         })
 
         it('should return the item with the largest outer range', () => {

--- a/vscode/src/prompt-builder/unique-context.ts
+++ b/vscode/src/prompt-builder/unique-context.ts
@@ -62,6 +62,11 @@ export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: Context
                 return false // Duplicate found.
             }
 
+            // Skip non-duplicated user-added item.
+            if (isUserAddedItem(itemToAdd) && !isUserAddedItem(item)) {
+                continue
+            }
+
             // Duplicates if overlapping ranges on the same lines,
             // or if one range contains the other.
             if (item.range && itemToAddRange) {

--- a/vscode/test/e2e/command-core.test.ts
+++ b/vscode/test/e2e/command-core.test.ts
@@ -91,10 +91,14 @@ test.extend<ExpectedEvents>({
     await page.getByText('Explain Code').click()
     await expectContextCellCounts(contextCell, { files: 1 })
     await contextCell.click()
+
     // The context should show the file with the correct range
     await expect(chatPanel.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
-    // If a context item is a subcontext of an existing context item, it should not be added to avoid duplication.
-    await expect(chatPanel.getByRole('link', { name: 'index.html:2-10' })).not.toBeVisible()
+    // If a context item is a subcontext of an existing context item,
+    // it should be removed to avoid duplication unless it's a user-specified context item.
+    // For chat command, selection context is always included as it's a user-specified context item.
+    await expect(chatPanel.getByRole('link', { name: 'index.html:2-10' })).toBeVisible()
+
     const disabledEditButtons = chatPanel.getByTitle('Cannot Edit Command').locator('i')
     const editLastMessageButton = chatPanel.getByRole('button', { name: /^Edit Last Message/ })
     // Edit button and Edit Last Message are shown on all command messages.


### PR DESCRIPTION
REPLACE https://github.com/sourcegraph/cody/pull/4225

The changes in this commit ensure that user-added context items always have the highest priority when deduplicating context items. This means that if a user-added item is present, it will be included in the unique context items, even if there are other duplicate items.

The test cases have been updated to reflect this behavior, and the `isUniqueContextItem` function has been modified to skip non-duplicated user-added items.


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- [x] Green CI.
- [x] Updated unit test
- [x] Updated e2e tests

## Manual Test Plan

1. Start Debug mode from this branch
2. Run the Explain command
3. You should see that the selection file is included on top of the full file as context

![image](https://github.com/sourcegraph/cody/assets/68532117/fa2e7667-2382-46db-8347-c123df7eadd9)

### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/4e554db3-8d5f-49da-95ce-1b514b6d9ea4)


