### PR TITLE
add `languageId` to completion events `privateMetadata` V2 telemetry

### DIFF
--- a/vscode/src/completions/logger.ts
+++ b/vscode/src/completions/logger.ts
@@ -138,6 +138,7 @@ interface SuggestedEventPayload extends SharedEventPayload {
     read: boolean
     accepted: boolean
     completionsStartedSinceLastSuggestion: number
+    languageId: string
 }
 
 /** Emitted when a completion was fully accepted by the user */


### PR DESCRIPTION
Adding `languageId` to the event payload for v2 telemetry. Since we are using the `splitSafeMetadata`, the `languageId` gets added to the `privateMetadadata`

## Test plan
Tested locally

<img width="742" alt="image" src="https://github.com/sourcegraph/cody/assets/32119652/6dc3c22a-999f-4616-9f62-0526f7c9851e">

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
