### PR TITLE
Replace provider id with OpenCtx for at-mention event names

### DIFF
--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -676,10 +676,13 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     privateMetadata: { source },
                 })
             },
-            withProvider: provider => {
-                telemetryService.log(`CodyVSCodeExtension:at-mention:${provider}:executed`, { source })
+            withProvider: (provider, providerMetadata) => {
+                telemetryService.log(`CodyVSCodeExtension:at-mention:${provider}:executed`, {
+                    source,
+                    providerMetadata,
+                })
                 telemetryRecorder.recordEvent(`cody.at-mention.${provider}`, 'executed', {
-                    privateMetadata: { source },
+                    privateMetadata: { source, providerMetadata },
                 })
             },
         }

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -23,7 +23,7 @@ export async function getChatContextItemsForMention(
     // query repeatedly, which is not needed.
     telemetryRecorder?: {
         empty: () => void
-        withProvider: (type: MentionQuery['provider']) => void
+        withProvider: (type: MentionQuery['provider'], metadata?: { id: string }) => void
     }
 ): Promise<ContextItem[]> {
     const MAX_RESULTS = 20
@@ -54,13 +54,13 @@ export async function getChatContextItemsForMention(
         }
 
         default: {
-            telemetryRecorder?.withProvider('openctx')
-            const openctxClient = openCtx.client
-            if (!openctxClient) {
+            telemetryRecorder?.withProvider('openctx', { id: mentionQuery.provider })
+
+            if (!openCtx.client) {
                 return []
             }
 
-            const items = await openctxClient.mentions(
+            const items = await openCtx.client.mentions(
                 { query: mentionQuery.text },
                 // get mention items for the selected provider only.
                 mentionQuery.provider


### PR DESCRIPTION
## Issue

> We've noticed a few events getting rejected like:
> `cody.at-mention.https://openctx.org/npm/@openctx/provider-sourcegraph-search/executed` due to the feature name length being greater than 60 characters!

This PR logs `cody.at-mention.openctx:executed` for all OpenCtx providers and passes the provider id in the metadata.

## Test plan

unit tests present