### PR TITLE
Fix: Graphql Fetching blockage when Cody tries to load a cached proxy that can only be loaded behind a proxy

### DIFF
--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -889,7 +889,7 @@ export class SourcegraphGraphQLAPIClient {
     public fetchSourcegraphAPI<T>(
         query: string,
         variables: Record<string, any> = {},
-        timeout = 3000 // Default timeout of 3000ms (3 seconds)
+        timeout = 6000 // Default timeout of 6000ms (6 seconds)
     ): Promise<T | Error> {
         const headers = new Headers(this.config.customHeaders as HeadersInit)
         headers.set('Content-Type', 'application/json; charset=utf-8')

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -889,53 +889,53 @@ export class SourcegraphGraphQLAPIClient {
     public fetchSourcegraphAPI<T>(
         query: string,
         variables: Record<string, any> = {},
-        timeout: number = 2000 // Default timeout of 5000ms (5 seconds)
+        timeout = 2000 // Default timeout of 5000ms (5 seconds)
     ): Promise<T | Error> {
-        const headers = new Headers(this.config.customHeaders as HeadersInit);
-        headers.set('Content-Type', 'application/json; charset=utf-8');
+        const headers = new Headers(this.config.customHeaders as HeadersInit)
+        headers.set('Content-Type', 'application/json; charset=utf-8')
         if (this.config.accessToken) {
-            headers.set('Authorization', `token ${this.config.accessToken}`);
+            headers.set('Authorization', `token ${this.config.accessToken}`)
         }
         if (this.anonymousUserID && !process.env.CODY_WEB_DONT_SET_SOME_HEADERS) {
-            headers.set('X-Sourcegraph-Actor-Anonymous-UID', this.anonymousUserID);
+            headers.set('X-Sourcegraph-Actor-Anonymous-UID', this.anonymousUserID)
         }
-    
-        addTraceparent(headers);
-        addCustomUserAgent(headers);
-    
-        const queryName = query.match(QUERY_TO_NAME_REGEXP)?.[1];
-    
+
+        addTraceparent(headers)
+        addCustomUserAgent(headers)
+
+        const queryName = query.match(QUERY_TO_NAME_REGEXP)?.[1]
+
         const url = buildGraphQLUrl({
             request: query,
             baseUrl: this.config.serverEndpoint,
-        });
-    
+        })
+
         // Create an AbortController instance
-        const controller = new AbortController();
-        const signal = controller.signal;
-    
+        const controller = new AbortController()
+        const signal = controller.signal
+
         // Set a timeout to trigger the abort
-        const timeoutId = setTimeout(() => controller.abort(), timeout);
-    
+        const timeoutId = setTimeout(() => controller.abort(), timeout)
+
         return wrapInActiveSpan(`graphql.fetch${queryName ? `.${queryName}` : ''}`, () =>
             fetch(url, {
                 method: 'POST',
                 body: JSON.stringify({ query, variables }),
                 headers,
-                signal // Pass the signal to the fetch request
+                signal, // Pass the signal to the fetch request
             })
                 .then(response => {
-                    clearTimeout(timeoutId); // Clear the timeout if the request completes in time
-                    return verifyResponseCode(response);
+                    clearTimeout(timeoutId) // Clear the timeout if the request completes in time
+                    return verifyResponseCode(response)
                 })
                 .then(response => response.json() as T)
                 .catch(error => {
                     if (error.name === 'AbortError') {
-                        return new Error(`Request timed out after ${timeout}ms (${url})`);
+                        return new Error(`Request timed out after ${timeout}ms (${url})`)
                     }
-                    return new Error(`accessing Sourcegraph GraphQL API: ${error} (${url})`);
+                    return new Error(`accessing Sourcegraph GraphQL API: ${error} (${url})`)
                 })
-        );
+        )
     }
     // make an anonymous request to the dotcom API
     private fetchSourcegraphDotcomAPI<T>(

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -931,7 +931,7 @@ export class SourcegraphGraphQLAPIClient {
                 .then(response => response.json() as T)
                 .catch(error => {
                     if (error.name === 'AbortError') {
-                        return new Error(`Request timed out after ${timeout}ms (${url})`)
+                        return new Error(`EHOSTUNREACH: Request timed out after ${timeout}ms (${url})`)
                     }
                     return new Error(`accessing Sourcegraph GraphQL API: ${error} (${url})`)
                 })

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -888,40 +888,55 @@ export class SourcegraphGraphQLAPIClient {
 
     public fetchSourcegraphAPI<T>(
         query: string,
-        variables: Record<string, any> = {}
+        variables: Record<string, any> = {},
+        timeout: number = 2000 // Default timeout of 5000ms (5 seconds)
     ): Promise<T | Error> {
-        const headers = new Headers(this.config.customHeaders as HeadersInit)
-        headers.set('Content-Type', 'application/json; charset=utf-8')
+        const headers = new Headers(this.config.customHeaders as HeadersInit);
+        headers.set('Content-Type', 'application/json; charset=utf-8');
         if (this.config.accessToken) {
-            headers.set('Authorization', `token ${this.config.accessToken}`)
+            headers.set('Authorization', `token ${this.config.accessToken}`);
         }
         if (this.anonymousUserID && !process.env.CODY_WEB_DONT_SET_SOME_HEADERS) {
-            headers.set('X-Sourcegraph-Actor-Anonymous-UID', this.anonymousUserID)
+            headers.set('X-Sourcegraph-Actor-Anonymous-UID', this.anonymousUserID);
         }
-
-        addTraceparent(headers)
-        addCustomUserAgent(headers)
-
-        const queryName = query.match(QUERY_TO_NAME_REGEXP)?.[1]
-
+    
+        addTraceparent(headers);
+        addCustomUserAgent(headers);
+    
+        const queryName = query.match(QUERY_TO_NAME_REGEXP)?.[1];
+    
         const url = buildGraphQLUrl({
             request: query,
             baseUrl: this.config.serverEndpoint,
-        })
+        });
+    
+        // Create an AbortController instance
+        const controller = new AbortController();
+        const signal = controller.signal;
+    
+        // Set a timeout to trigger the abort
+        const timeoutId = setTimeout(() => controller.abort(), timeout);
+    
         return wrapInActiveSpan(`graphql.fetch${queryName ? `.${queryName}` : ''}`, () =>
             fetch(url, {
                 method: 'POST',
                 body: JSON.stringify({ query, variables }),
                 headers,
+                signal // Pass the signal to the fetch request
             })
-                .then(verifyResponseCode)
+                .then(response => {
+                    clearTimeout(timeoutId); // Clear the timeout if the request completes in time
+                    return verifyResponseCode(response);
+                })
                 .then(response => response.json() as T)
                 .catch(error => {
-                    return new Error(`accessing Sourcegraph GraphQL API: ${error} (${url})`)
+                    if (error.name === 'AbortError') {
+                        return new Error(`Request timed out after ${timeout}ms (${url})`);
+                    }
+                    return new Error(`accessing Sourcegraph GraphQL API: ${error} (${url})`);
                 })
-        )
+        );
     }
-
     // make an anonymous request to the dotcom API
     private fetchSourcegraphDotcomAPI<T>(
         query: string,

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -889,7 +889,7 @@ export class SourcegraphGraphQLAPIClient {
     public fetchSourcegraphAPI<T>(
         query: string,
         variables: Record<string, any> = {},
-        timeout = 2000 // Default timeout of 5000ms (5 seconds)
+        timeout = 3000 // Default timeout of 3000ms (3 seconds)
     ): Promise<T | Error> {
         const headers = new Headers(this.config.customHeaders as HeadersInit)
         headers.set('Content-Type', 'application/json; charset=utf-8')

--- a/vscode/webviews/Troubleshooting/ConnectionIssuesPage.tsx
+++ b/vscode/webviews/Troubleshooting/ConnectionIssuesPage.tsx
@@ -43,10 +43,11 @@ export const ConnectionIssuesPage: React.FunctionComponent<
                 </div>
                 <div className={styles.messageContainer}>
                     <p className={styles.message}>
-                        Cody could not start due to a possible connection issue. Possible causes:
+                        Cody could not start due to a connection issue. Possible causes:
                     </p>
                     <ul className={styles.causes}>
                         <li>You don't have internet access</li>
+                        <li>Proxy settings might need to be configured</li>
                         <li>
                             The configured endpoint{' '}
                             {configuredEndpoint && (


### PR DESCRIPTION
Solves https://github.com/sourcegraph/cody/issues/4232
Thanks to Kalan and Bee we finally solved this issue which is the final issue that I found in the proxy settings.

## Before 
https://www.loom.com/share/4865ebf0edd34bdcaf0084aeb31ea4f7 

## After
When you log in again without the proxy and you have a cached result then Cody will log out coz the Graphql requests have a timeout on them. Previously the timeout was so long that the cody would be stuck in loading for many many minutes. 


## Test plan
Tested locally 

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
