### PR TITLE
Update description and messaging

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,8 +1,8 @@
 # AI that knows your entire codebase
 
-[Cody](https://about.sourcegraph.com/cody?utm_source=marketplace.visualstudio.com&utm_medium=referral) is an AI coding assistant that can write, understand, fix, and find your code. Cody is powered by Sourcegraph’s code graph, and has knowledge of your entire codebase. Install Cody to get started with free AI-powered autocomplete, chat, commands, and more.
+[Cody](https://about.sourcegraph.com/cody?utm_source=marketplace.visualstudio.com&utm_medium=referral) is an AI coding assistant that helps you understand, write, and fix code faster. It uses advanced search to pull context from both local and remote codebases so that you can use context about APIs, symbols, and usage patterns from across your entire codebase at any scale, all from within VS Code. Plus, Cody Pro users can choose from the latest large language models—like GPT-4o and Claude 3 Opus—to customize Cody to their needs.
 
-Cody is now generally available. If you're using Cody Pro, make sure to update to the latest version of the IDE extension to get the latest features and unlimited rate limits.
+Install Cody to get started with free AI-powered autocomplete, chat, commands, and more.
 
 ## Autocomplete
 
@@ -59,9 +59,9 @@ You can find detailed information about Cody's available plans [on our website](
 
 Cody works for any programming language because it uses LLMs trained on broad data. Cody works great with Python, Go, JavaScript, and TypeScript code.
 
-## Code Graph
+## Code Search
 
-Cody is powered by Sourcegraph’s code graph, and uses context of your codebase to extend its capabilities. By using context from the entire repository, Cody is able to give more accurate answers and generate idiomatic code.
+Cody is powered by Sourcegraph’s code search, which it uses to retrieve context from your codebase and extend its capabilities. By using context from entire projects, Cody can give more accurate answers and generate idiomatic code.
 
 For example:
 
@@ -71,7 +71,7 @@ For example:
 
 ## Cody Enterprise
 
-Cody Enterprise is able to retrieve context from your entire remote codebase using Sourcegraph search. This gives Cody the ability to understand and answer questions about all of your code, even the repositories that don't live on your local machine.
+Cody Enterprise can search context from your entire remote codebase using Sourcegraph's code search. This allows Cody to answer questions about all of your code, even the repositories that don't live on your local machine.
 
 [Contact us](https://about.sourcegraph.com/contact/request-info?utm_source=marketplace.visualstudio.com&utm_medium=referral) to set up a trial of Cody Enterprise. If you’re an existing Sourcegraph Enterprise customer, contact your technical advisor.
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -6,7 +6,7 @@
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",
-  "description": "AI coding assistant that understands your codebase. Cody brings autocomplete, chat, and commands to your IDE, helping you generate code, write unit tests, create documentation, and explain complex or legacy code using AI. Choose from several LLMs including GPT-3.5 Turbo, GPT-4 Turbo, and Claude 3, or run local models using Ollama. Cody supports all major languages including JavaScript, TypeScript, Python, Java, Go, and C/C++.",
+  "description": "AI coding assistant that uses search and codebase context to help you write code faster. Cody brings autocomplete, chat, and commands to VS Code, so you can generate code, write unit tests, create docs, and explain complex code using AI. Choose from the latest LLMs, including GPT-4o and Claude 3.",
   "scripts": {
     "postinstall": "pnpm download-wasm",
     "dev": "pnpm run -s dev:desktop",


### PR DESCRIPTION
Updates VS Code extension meta description and README:

- Meta description was >300 chars, so it was getting cut off in the marketplace. New description is 297 chars.
- README and meta description are both also updated for new messaging that refers to code search rather than general code understanding (see "Cody Messaging" in Notion for details)

## Test plan

Copy changes only.
