### PR TITLE
adding FIM finetuned model hosted on fireworks

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -20,12 +20,12 @@ export enum FeatureFlag {
     // Enable the FineTuned model as the default model via Fireworks
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
-    CodyAutocompleteFIMFineTunedModelBaseFeatureFlag = 'cody-autocomplete-fim-finetuned-model-base-flag',
-    CodyAutocompleteFIMFineTunedModelControl = 'cody-autocomplete-fim-finetuned-model-control',
-    CodyAutocompleteFIMFineTunedModelVariant1 = 'cody-autocomplete-fim-finetuned-model-variant1',
-    CodyAutocompleteFIMFineTunedModelVariant2 = 'cody-autocomplete-fim-finetuned-model-variant2',
-    CodyAutocompleteFIMFineTunedModelVariant3 = 'cody-autocomplete-fim-finetuned-model-variant3',
-    CodyAutocompleteFIMFineTunedModelVariant4 = 'cody-autocomplete-fim-finetuned-model-variant4',
+    CodyAutocompleteFIMFineTunedModelBaseFeatureFlag = 'cody-autocomplete-fim-fine-tuned-model-base-feature-flag',
+    CodyAutocompleteFIMFineTunedModelControl = 'cody-autocomplete-fim-fine-tuned-model-control',
+    CodyAutocompleteFIMFineTunedModelVariant1 = 'cody-autocomplete-fim-fine-tuned-model-variant-1',
+    CodyAutocompleteFIMFineTunedModelVariant2 = 'cody-autocomplete-fim-fine-tuned-model-variant-2',
+    CodyAutocompleteFIMFineTunedModelVariant3 = 'cody-autocomplete-fim-fine-tuned-model-variant-3',
+    CodyAutocompleteFIMFineTunedModelVariant4 = 'cody-autocomplete-fim-fine-tuned-model-variant-4',
 
     // Enables Claude 3 if the user is in our holdout group
     CodyAutocompleteClaude3 = 'cody-autocomplete-claude-3',

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -18,7 +18,15 @@ export enum FeatureFlag {
     // Enable StarCoder2 7b and 15b as the default model via Fireworks
     CodyAutocompleteStarCoder2Hybrid = 'cody-autocomplete-starcoder2-hybrid',
     // Enable the FineTuned model as the default model via Fireworks
-    CodyAutocompleteFineTunedModel = 'cody-autocomplete-finetuned-model',
+
+    // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
+    CodyAutocompleteFIMFineTunedModelBaseFeatureFlag = 'cody-autocomplete-fim-finetuned-model-base-flag',
+    CodyAutocompleteFIMFineTunedModelControl = 'cody-autocomplete-fim-finetuned-model-control',
+    CodyAutocompleteFIMFineTunedModelVariant1 = 'cody-autocomplete-fim-finetuned-model-variant1',
+    CodyAutocompleteFIMFineTunedModelVariant2 = 'cody-autocomplete-fim-finetuned-model-variant2',
+    CodyAutocompleteFIMFineTunedModelVariant3 = 'cody-autocomplete-fim-finetuned-model-variant3',
+    CodyAutocompleteFIMFineTunedModelVariant4 = 'cody-autocomplete-fim-finetuned-model-variant4',
+
     // Enables Claude 3 if the user is in our holdout group
     CodyAutocompleteClaude3 = 'cody-autocomplete-claude-3',
     // Enables the bfg-mixed context retriever that will combine BFG with the default local editor

--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -20,7 +20,7 @@ export enum FeatureFlag {
     // Enable the FineTuned model as the default model via Fireworks
 
     // Enable various feature flags to experiment with FIM trained fine-tuned models via Fireworks
-    CodyAutocompleteFIMFineTunedModelBaseFeatureFlag = 'cody-autocomplete-fim-fine-tuned-model-base-feature-flag',
+    CodyAutocompleteFIMFineTunedModelBaseFeatureFlag = 'cody-autocomplete-fim-fine-tuned-model-experiment-flag',
     CodyAutocompleteFIMFineTunedModelControl = 'cody-autocomplete-fim-fine-tuned-model-control',
     CodyAutocompleteFIMFineTunedModelVariant1 = 'cody-autocomplete-fim-fine-tuned-model-variant-1',
     CodyAutocompleteFIMFineTunedModelVariant2 = 'cody-autocomplete-fim-fine-tuned-model-variant-2',

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -14,6 +14,10 @@ import {
 } from './anthropic'
 import { createProviderConfig as createExperimentalOllamaProviderConfig } from './experimental-ollama'
 import {
+    FIREWORKS_FIM_FINE_TUNED_MODEL_1,
+    FIREWORKS_FIM_FINE_TUNED_MODEL_2,
+    FIREWORKS_FIM_FINE_TUNED_MODEL_3,
+    FIREWORKS_FIM_FINE_TUNED_MODEL_4,
     type FireworksOptions,
     createProviderConfig as createFireworksProviderConfig,
 } from './fireworks'
@@ -150,6 +154,51 @@ export async function createProviderConfig(
     return createAnthropicProviderConfig({ client })
 }
 
+async function resolveFinetunedModelProviderFromFeatureFlags(): Promise<{
+    provider: string
+    model?: FireworksOptions['model'] | AnthropicOptions['model']
+} | null> {
+    /**
+     * The traffic allocated to the fine-tuned-base feature flag is further split between multiple feature flag in function.
+     */
+    const [finetuneControl, finetuneVariant1, finetuneVariant2, finetuneVariant3, finetuneVariant4] =
+        await Promise.all([
+            featureFlagProvider.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteFIMFineTunedModelControl
+            ),
+            featureFlagProvider.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteFIMFineTunedModelVariant1
+            ),
+            featureFlagProvider.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteFIMFineTunedModelVariant2
+            ),
+            featureFlagProvider.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteFIMFineTunedModelVariant3
+            ),
+            featureFlagProvider.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteFIMFineTunedModelVariant4
+            ),
+        ])
+    if (finetuneVariant1) {
+        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_1 }
+    }
+    if (finetuneVariant2) {
+        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_2 }
+    }
+    if (finetuneVariant3) {
+        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_3 }
+    }
+    if (finetuneVariant4) {
+        return { provider: 'fireworks', model: FIREWORKS_FIM_FINE_TUNED_MODEL_4 }
+    }
+    if (finetuneControl) {
+        return { provider: 'fireworks', model: 'starcoder-hybrid' }
+    }
+
+    // Extra free traffic - redirect to the current production model which could be different than control
+    return { provider: 'fireworks', model: 'starcoder-hybrid' }
+}
+
 async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
     configuredProvider: string | null
 ): Promise<{
@@ -160,15 +209,21 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         return { provider: configuredProvider }
     }
 
-    const [starCoder2Hybrid, starCoderHybrid, llamaCode13B, claude3, finetunedModel] = await Promise.all(
-        [
+    const [starCoder2Hybrid, starCoderHybrid, llamaCode13B, claude3, finetunedFIMModelExperiment] =
+        await Promise.all([
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
             featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteFineTunedModel),
-        ]
-    )
+            featureFlagProvider.evaluateFeatureFlag(
+                FeatureFlag.CodyAutocompleteFIMFineTunedModelBaseFeatureFlag
+            ),
+        ])
+
+    if (finetunedFIMModelExperiment) {
+        // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
+        return await resolveFinetunedModelProviderFromFeatureFlags()
+    }
 
     if (llamaCode13B) {
         return { provider: 'fireworks', model: 'llama-code-13b' }
@@ -179,12 +234,6 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
     }
 
     if (starCoderHybrid) {
-        // Adding the fine-tuned model here for the A/B test setup.
-        // Among all the users in starcoder-hybrid - some % of them will be redirected to the fine-tuned model.
-        if (finetunedModel) {
-            return { provider: 'fireworks', model: 'fireworks-completions-fine-tuned' }
-        }
-
         return { provider: 'fireworks', model: 'starcoder-hybrid' }
     }
 

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -6,8 +6,8 @@ import {
     featureFlagProvider,
 } from '@sourcegraph/cody-shared'
 
+import * as vscode from 'vscode'
 import { logError } from '../../log'
-
 import {
     type AnthropicOptions,
     createProviderConfig as createAnthropicProviderConfig,
@@ -219,7 +219,13 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
             ),
         ])
 
-    if (finetunedFIMModelExperiment) {
+    // We run fine tuning experiment for VSC client only.
+    // We disable for all agent clients like the JetBrains plugin.
+    const isFinetuningExperimentDisabled = vscode.workspace
+        .getConfiguration()
+        .get<boolean>('cody.advanced.agent.running', false)
+
+    if (!isFinetuningExperimentDisabled && finetunedFIMModelExperiment) {
         // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
         return resolveFinetunedModelProviderFromFeatureFlags()
     }

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -154,10 +154,9 @@ export async function createProviderConfig(
     return createAnthropicProviderConfig({ client })
 }
 
-async function resolveFinetunedModelProviderFromFeatureFlags(): Promise<{
-    provider: string
-    model?: FireworksOptions['model'] | AnthropicOptions['model']
-} | null> {
+async function resolveFinetunedModelProviderFromFeatureFlags(): ReturnType<
+    typeof resolveDefaultProviderFromVSCodeConfigOrFeatureFlags
+> {
     /**
      * The traffic allocated to the fine-tuned-base feature flag is further split between multiple feature flag in function.
      */
@@ -222,7 +221,7 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
 
     if (finetunedFIMModelExperiment) {
         // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
-        return await resolveFinetunedModelProviderFromFeatureFlags()
+        return resolveFinetunedModelProviderFromFeatureFlags()
     }
 
     if (llamaCode13B) {

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -129,7 +129,7 @@ function getMaxContextTokens(model: FireworksModel): number {
         case FIREWORKS_FIM_FINE_TUNED_MODEL_2:
         case FIREWORKS_FIM_FINE_TUNED_MODEL_3:
         case FIREWORKS_FIM_FINE_TUNED_MODEL_4: {
-            return 4096
+            return 3072
         }
         default:
             return 1200

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -95,10 +95,10 @@ const MODEL_MAP = {
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
 
     // Fine-tuned model mapping
-    'fim-fine-tuned-model-variant-1': FIREWORKS_FIM_FINE_TUNED_MODEL_1,
-    'fim-fine-tuned-model-variant-2': FIREWORKS_FIM_FINE_TUNED_MODEL_2,
-    'fim-fine-tuned-model-variant-3': FIREWORKS_FIM_FINE_TUNED_MODEL_3,
-    'fim-fine-tuned-model-variant-4': FIREWORKS_FIM_FINE_TUNED_MODEL_4,
+    [FIREWORKS_FIM_FINE_TUNED_MODEL_1]: FIREWORKS_FIM_FINE_TUNED_MODEL_1,
+    [FIREWORKS_FIM_FINE_TUNED_MODEL_2]: FIREWORKS_FIM_FINE_TUNED_MODEL_2,
+    [FIREWORKS_FIM_FINE_TUNED_MODEL_3]: FIREWORKS_FIM_FINE_TUNED_MODEL_3,
+    [FIREWORKS_FIM_FINE_TUNED_MODEL_4]: FIREWORKS_FIM_FINE_TUNED_MODEL_4,
 }
 
 type FireworksModel =
@@ -129,9 +129,7 @@ function getMaxContextTokens(model: FireworksModel): number {
         case FIREWORKS_FIM_FINE_TUNED_MODEL_2:
         case FIREWORKS_FIM_FINE_TUNED_MODEL_3:
         case FIREWORKS_FIM_FINE_TUNED_MODEL_4: {
-            // We use llama3 8b and mixtral 8x7b variants for the fine-tuning model which support 8_192, 32_768 tokens respectively.
-            // Take a buffer of 1000 tokens
-            return 7192
+            return 2048
         }
         default:
             return 1200

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -129,7 +129,7 @@ function getMaxContextTokens(model: FireworksModel): number {
         case FIREWORKS_FIM_FINE_TUNED_MODEL_2:
         case FIREWORKS_FIM_FINE_TUNED_MODEL_3:
         case FIREWORKS_FIM_FINE_TUNED_MODEL_4: {
-            return 2048
+            return 4096
         }
         default:
             return 1200
@@ -423,6 +423,7 @@ class FireworksProvider extends Provider {
                         ...(self.fireworksConfig?.parameters?.stop || []),
                     ],
                     stream: true,
+                    languageId: self.options.document.languageId,
                 }
 
                 const headers = new Headers()

--- a/vscode/src/completions/providers/fireworks.ts
+++ b/vscode/src/completions/providers/fireworks.ts
@@ -25,7 +25,6 @@ import {
     tokensToChars,
     tracer,
 } from '@sourcegraph/cody-shared'
-
 import { fetch } from '@sourcegraph/cody-shared'
 import { getLanguageConfig } from '../../tree-sitter/language'
 import { getSuffixAfterFirstNewline } from '../text-processing'
@@ -69,6 +68,19 @@ const PROVIDER_IDENTIFIER = 'fireworks'
 const EOT_STARCODER = '<|endoftext|>'
 const EOT_LLAMA_CODE = ' <EOT>'
 
+// Fireworks hosted model identifier strings
+export const FIREWORKS_FIM_FINE_TUNED_MODEL_1 = 'fim-fine-tuned-model-variant-1'
+export const FIREWORKS_FIM_FINE_TUNED_MODEL_2 = 'fim-fine-tuned-model-variant-2'
+export const FIREWORKS_FIM_FINE_TUNED_MODEL_3 = 'fim-fine-tuned-model-variant-3'
+export const FIREWORKS_FIM_FINE_TUNED_MODEL_4 = 'fim-fine-tuned-model-variant-4'
+
+const FIREWORKS_FIM_FINE_TUNED_MODEL_FAMILY = [
+    FIREWORKS_FIM_FINE_TUNED_MODEL_1,
+    FIREWORKS_FIM_FINE_TUNED_MODEL_2,
+    FIREWORKS_FIM_FINE_TUNED_MODEL_3,
+    FIREWORKS_FIM_FINE_TUNED_MODEL_4,
+]
+
 // Model identifiers can be found in https://docs.fireworks.ai/explore/ and in our internal
 // conversations
 const MODEL_MAP = {
@@ -83,8 +95,10 @@ const MODEL_MAP = {
     'llama-code-13b': 'fireworks/accounts/fireworks/models/llama-v2-13b-code',
 
     // Fine-tuned model mapping
-    'fireworks-completions-fine-tuned':
-        'fireworks/accounts/sourcegraph/models/codecompletion-mixtral-rust-152k-005e',
+    'fim-fine-tuned-model-variant-1': FIREWORKS_FIM_FINE_TUNED_MODEL_1,
+    'fim-fine-tuned-model-variant-2': FIREWORKS_FIM_FINE_TUNED_MODEL_2,
+    'fim-fine-tuned-model-variant-3': FIREWORKS_FIM_FINE_TUNED_MODEL_3,
+    'fim-fine-tuned-model-variant-4': FIREWORKS_FIM_FINE_TUNED_MODEL_4,
 }
 
 type FireworksModel =
@@ -111,8 +125,14 @@ function getMaxContextTokens(model: FireworksModel): number {
             // Llama 2 on Fireworks supports up to 4k tokens. We're constraining it here to better
             // compare the results
             return 2048
-        case 'fireworks-completions-fine-tuned':
-            return 2048
+        case FIREWORKS_FIM_FINE_TUNED_MODEL_1:
+        case FIREWORKS_FIM_FINE_TUNED_MODEL_2:
+        case FIREWORKS_FIM_FINE_TUNED_MODEL_3:
+        case FIREWORKS_FIM_FINE_TUNED_MODEL_4: {
+            // We use llama3 8b and mixtral 8x7b variants for the fine-tuning model which support 8_192, 32_768 tokens respectively.
+            // Take a buffer of 1000 tokens
+            return 7192
+        }
         default:
             return 1200
     }
@@ -180,7 +200,10 @@ class FireworksProvider extends Provider {
         const languageConfig = getLanguageConfig(this.options.document.languageId)
 
         // In StarCoder we have a special token to announce the path of the file
-        if (!isStarCoderFamily(this.model) && this.model !== 'fireworks-completions-fine-tuned') {
+        if (
+            !isStarCoderFamily(this.model) &&
+            !FIREWORKS_FIM_FINE_TUNED_MODEL_FAMILY.includes(this.model)
+        ) {
             intro.push(ps`Path: ${PromptString.fromDisplayPath(this.options.document.uri)}`)
         }
 
@@ -192,6 +215,13 @@ class FireworksProvider extends Provider {
                 if (contextPrompts.symbol) {
                     intro.push(
                         ps`Additional documentation for \`${contextPrompts.symbol}\`:\n\n${contextPrompts.content}`
+                    )
+                } else if (FIREWORKS_FIM_FINE_TUNED_MODEL_FAMILY.includes(this.model)) {
+                    // Fine-tuned model have a additional <file_sep> tag.
+                    intro.push(
+                        ps`<file_sep>Here is a reference snippet of code from ${PromptString.fromDisplayPath(
+                            snippet.uri
+                        )}\n${contextPrompts.content}`
                     )
                 } else {
                     intro.push(
@@ -257,7 +287,10 @@ class FireworksProvider extends Provider {
             model,
         } satisfies CodeCompletionsParams
 
-        if (requestParams.model.includes('starcoder2')) {
+        if (
+            requestParams.model.includes('starcoder2') ||
+            FIREWORKS_FIM_FINE_TUNED_MODEL_FAMILY.includes(requestParams.model)
+        ) {
             requestParams.stopSequences = [
                 ...(requestParams.stopSequences || []),
                 '<fim_prefix>',
@@ -322,12 +355,8 @@ class FireworksProvider extends Provider {
             // c.f. https://github.com/facebookresearch/codellama/blob/main/llama/generation.py#L402
             return ps`<PRE> ${intro}${prefix} <SUF>${suffix} <MID>`
         }
-        if (this.model === 'fireworks-completions-fine-tuned') {
-            const fixedPrompt = ps`You are an expert in writing code in many different languages.
-                Your goal is to perform code completion for the following code, keeping in mind the rest of the code and the file meta data.
-                Metadata details: filename: ${filename}. The code of the file until where you have to start completion:
-            `
-            return ps`${intro} \n ${fixedPrompt}\n${prefix}`
+        if (FIREWORKS_FIM_FINE_TUNED_MODEL_FAMILY.includes(this.model)) {
+            return ps`${intro}<fim_suffix>${filename}\n${suffix}<fim_prefix>${prefix}<fim_middle>`
         }
         console.error('Could not generate infilling prompt for', this.model)
         return ps`${intro}${prefix}`


### PR DESCRIPTION
## Context
1. This PR adds the fine-tuning model setup, trained on context aware FIM examples on top of bigcode/the-stack. More details about the training dataset/ modeling/ offline evaluation etc can be found in [this RFC](https://docs.google.com/document/d/1myMceHu7x8gh0B9eb_kRE719AGqVHfZ3py9k_3luym8/edit#bookmark=id.nkenlaow7lyh).
2. We wanted to iterate faster on the modeling changes, i.e. don't want to replace the model string in the client every time we change a model in the backend - So, this PR adds [four variant feature flags and control feature flag](https://github.com/sourcegraph/cody/compare/hitesh/finetuned-fim-model-integration?expand=1#diff-b990afc7444ecfe27e4f42d0b9af949030d8aca26e21a4f090a7c0a0fe19b0ceR24) and the variant based feature-flag names will be send to cody-gateway as is, where the routing to the actual fine-tuned model happens.  
3. The feature flag `cody-autocomplete-fim-finetuned-model-base-flag` added in the setup is treated as the base feature flag and the traffic on this feature flag will decide the traffic of the whole experiment. The traffic on this feature will be divided further into the variant & control feature flags.

## Test plan

### Traffic split sanity:
I have tested the approach of feature flags introduced in this PR on random generated `100k` userids offline and verified that it produces near equal traffic split among the variants and control. For anyone want to reproduce this results, can be done [via this script](https://github.com/sourcegraph/cody-chat-eval/blob/main/code-matching-eval/humaneval/infill_experiment_traffic_distribution_sanity.py).

### New modeling changes:
Local testing
 
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
