### PR TITLE
openctx: store mention specific fields separately

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/ContextItem.kt
@@ -147,10 +147,8 @@ data class ContextItemOpenCtx(
   val isTooLarge: Boolean? = null,
   val provider: String? = null,
   val type: TypeEnum, // Oneof: openctx
-  val originalUri: String,
   val providerUri: String,
-  val description: String? = null,
-  val data: Any? = null,
+  val mention: MentionParams? = null,
 ) : ContextItem() {
 
   enum class TypeEnum {

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MentionParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MentionParams.kt
@@ -1,0 +1,8 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class MentionParams(
+  val uri: String,
+  val data: Any? = null,
+)
+

--- a/lib/shared/src/codebase-context/messages.ts
+++ b/lib/shared/src/codebase-context/messages.ts
@@ -174,13 +174,11 @@ export interface ContextItemOpenCtx extends ContextItemCommon {
     provider: 'openctx'
     title: string
     uri: URI
-    /**
-     * originalUri is stored since vscode-uri will incorrectly escape query parameters in toString.
-     */
-    originalUri: string
     providerUri: string
-    description?: string
-    data?: any
+    mention?: {
+        uri: string
+        data?: any
+    }
 }
 
 /**

--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -68,11 +68,15 @@ export async function getChatContextItemsForMention(
 
             return items.map(
                 (item): ContextItemOpenCtx => ({
-                    ...item,
                     type: 'openctx',
+                    title: item.title,
+                    providerUri: item.providerUri,
                     uri: URI.parse(item.uri),
-                    originalUri: item.uri,
                     provider: 'openctx',
+                    mention: {
+                        uri: item.uri,
+                        data: item.data,
+                    },
                 })
             )
         }

--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -18,6 +18,7 @@ import {
     isCodyIgnoredFile,
     isDefined,
     isWindows,
+    logError,
     openCtx,
     toRangeData,
 } from '@sourcegraph/cody-shared'
@@ -330,9 +331,14 @@ async function resolveContextMentionProviderContextItem(
         return []
     }
 
+    if (!item.mention) {
+        logError('OpenCtx', 'resolving context item is missing mention parameter', item)
+        return []
+    }
+
     const mention = {
-        ...item,
-        uri: item.originalUri,
+        ...item.mention,
+        title: item.title,
     }
 
     const items = await openCtxClient.items({ message: input.toString(), mention }, item.providerUri)
@@ -344,7 +350,6 @@ async function resolveContextMentionProviderContextItem(
                       type: 'openctx',
                       title: item.title,
                       uri: URI.parse(item.url || item.providerUri),
-                      originalUri: item.url || item.providerUri,
                       providerUri: item.providerUri,
                       content: item.ai.content,
                       provider: 'openctx',


### PR DESCRIPTION
This is to make it clearer in ContextItemOpenCtx which fields are for before and after resolving a context item.

Additionally we remove the unused description field.

Test Plan: CI