### PR TITLE
do not open enhanced context popover by default on new installs

### DIFF
--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -2,7 +2,6 @@ import { type FrameLocator, type Locator, expect } from '@playwright/test'
 import { isWindows } from '@sourcegraph/cody-shared'
 import {
     atMentionMenuItem,
-    closeEnhancedContextSettings,
     createEmptyChatPanel,
     expectContextCellCounts,
     focusChatInputAtEnd,
@@ -437,7 +436,6 @@ test.extend<ExpectedEvents>({
     // Verify the chat input has the selected code as an @-mention item
     const chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
     const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
-    await closeEnhancedContextSettings(page, chatFrame)
     await expect(chatInput).toHaveText('@buzz.ts:2-13 ')
 
     // Repeat the above steps to add another code selection as an @-mention item.

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -60,17 +60,7 @@ export async function createEmptyChatPanel(
     const chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
     const chatInputs = chatFrame.getByRole('textbox', { name: 'Chat message' })
 
-    await closeEnhancedContextSettings(page, chatFrame)
-
     return [chatFrame, chatInputs.last(), chatInputs.first(), chatInputs]
-}
-
-export async function closeEnhancedContextSettings(page: Page, chatFrame: FrameLocator): Promise<void> {
-    // Hide the enhanced context box in case it popped up (as it does on new installs).
-    const enhancedContextCheckbox = chatFrame.locator('#enhanced-context-checkbox')
-    await expect(enhancedContextCheckbox).toBeFocused()
-    await page.keyboard.press('Escape')
-    await expect(enhancedContextCheckbox).not.toBeVisible()
 }
 
 export async function focusChatInputAtEnd(chatInput: Locator): Promise<void> {

--- a/vscode/test/e2e/context-settings.test.ts
+++ b/vscode/test/e2e/context-settings.test.ts
@@ -35,6 +35,10 @@ test.extend<ExpectedEvents>({
     const chatFrame = await newChat(page)
 
     // Opening the enhanced context settings should focus the checkbox for toggling it.
+    const openEnhancedContextButton = chatFrame.getByRole('button', {
+        name: 'Configure automatic code context',
+    })
+    await openEnhancedContextButton.click()
     const enhancedContextCheckbox = chatFrame.locator('#enhanced-context-checkbox')
     await expect(enhancedContextCheckbox).toBeFocused()
 
@@ -109,6 +113,11 @@ test.extend<ExpectedEvents>({
 
     await sidebarSignin(page, sidebar)
     const chatFrame = await newChat(page)
+
+    const openEnhancedContextButton = chatFrame.getByRole('button', {
+        name: 'Configure automatic code context',
+    })
+    await openEnhancedContextButton.click()
 
     // Because there are no repositories in the workspace, none should be selected by default.
     await expect(chatFrame.getByText('No repositories selected')).toBeVisible()

--- a/vscode/test/e2e/local-embeddings.test.ts
+++ b/vscode/test/e2e/local-embeddings.test.ts
@@ -105,8 +105,12 @@ test.extend<helpers.WorkspaceDirectory>({
     await sidebar?.getByRole('button', { name: 'Sign In to Your Enterprise Instance' }).hover()
     await openFile(page, 'main.c')
     await sidebarSignin(page, sidebar)
-    // The Enhanced Context settings is opened on first chat by default
     const chatFrame = await newChat(page)
+
+    const openEnhancedContextButton = chatFrame.getByRole('button', {
+        name: 'Configure automatic code context',
+    })
+    await openEnhancedContextButton.click()
 
     // Embeddings is visible at first as cody-engine starts...
     await expect(chatFrame.getByText('Embeddings')).toBeVisible()
@@ -122,6 +126,12 @@ test('git repositories without a remote should explain the issue', async ({ page
     await openFile(page, 'main.c')
     await sidebarSignin(page, sidebar)
     const chatFrame = await newChat(page)
+
+    const openEnhancedContextButton = chatFrame.getByRole('button', {
+        name: 'Configure automatic code context',
+    })
+    await openEnhancedContextButton.click()
+
     await expect(chatFrame.locator('.codicon-circle-slash')).toBeVisible({
         timeout: 60000,
     })
@@ -168,6 +178,11 @@ test
     await openFile(page, 'main.c')
     await sidebarSignin(page, sidebar)
     const chatFrame = await newChat(page)
+
+    const openEnhancedContextButton = chatFrame.getByRole('button', {
+        name: 'Configure automatic code context',
+    })
+    await openEnhancedContextButton.click()
 
     const enableEmbeddingsButton = chatFrame.getByText('Enable Embeddings')
     // This may take a while, we download and start cody-engine

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -291,7 +291,6 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                                         isTranscriptError={isTranscriptError}
                                         welcomeMessage={welcomeMessageMarkdown}
                                         guardrails={attributionEnabled ? guardrails : undefined}
-                                        isNewInstall={isNewInstall}
                                         userContextFromSelection={userContextFromSelection}
                                     />
                                 </WithContextProviders>

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -27,7 +27,6 @@ const meta: Meta<typeof Chat> = {
         telemetryService: null as any,
         telemetryRecorder: null as any,
         isTranscriptError: false,
-        isNewInstall: false,
         userContextFromSelection: [],
     } satisfies React.ComponentProps<typeof Chat>,
 

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -28,7 +28,6 @@ interface ChatboxProps {
     isTranscriptError: boolean
     userInfo: UserAccountInfo
     guardrails?: Guardrails
-    isNewInstall: boolean
     userContextFromSelection?: ContextItem[]
 }
 
@@ -43,7 +42,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     chatEnabled = true,
     userInfo,
     guardrails,
-    isNewInstall,
     userContextFromSelection,
 }) => {
     const feedbackButtonsOnSubmit = useCallback(
@@ -187,7 +185,6 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
                 insertButtonOnSubmit={insertButtonOnSubmit}
                 isTranscriptError={isTranscriptError}
                 userInfo={userInfo}
-                isNewInstall={isNewInstall}
                 chatEnabled={chatEnabled}
                 userContextFromSelection={userContextFromSelection}
                 postMessage={postMessage}

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -33,7 +33,6 @@ export const Transcript: React.FunctionComponent<{
     insertButtonOnSubmit: CodeBlockActionsProps['insertButtonOnSubmit']
     isTranscriptError?: boolean
     userInfo: UserAccountInfo
-    isNewInstall?: boolean
     chatEnabled?: boolean
     userContextFromSelection?: ContextItem[]
     postMessage?: ApiPostMessage
@@ -48,7 +47,6 @@ export const Transcript: React.FunctionComponent<{
     insertButtonOnSubmit,
     isTranscriptError,
     userInfo,
-    isNewInstall,
     chatEnabled = true,
     userContextFromSelection,
     postMessage,
@@ -77,7 +75,6 @@ export const Transcript: React.FunctionComponent<{
                     key={messageIndexInTranscript}
                     message={message}
                     userInfo={userInfo}
-                    isNewInstall={isNewInstall}
                     chatEnabled={chatEnabled}
                     isFirstMessage={messageIndexInTranscript === 0}
                     isSent={true}
@@ -146,7 +143,6 @@ export const Transcript: React.FunctionComponent<{
                     isFirstMessage={transcript.length === 0}
                     isSent={false}
                     userInfo={userInfo}
-                    isNewInstall={isNewInstall}
                     chatEnabled={chatEnabled}
                     isEditorInitiallyFocused={transcript.length === 0}
                     userContextFromSelection={userContextFromSelection}

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -18,7 +18,6 @@ const isMac = isMacOS()
 export const HumanMessageCell: FunctionComponent<{
     message: ChatMessage | null
     userInfo: UserAccountInfo
-    isNewInstall?: boolean
     chatEnabled?: boolean
     userContextFromSelection?: ContextItem[]
 
@@ -38,7 +37,6 @@ export const HumanMessageCell: FunctionComponent<{
 }> = ({
     message,
     userInfo,
-    isNewInstall,
     chatEnabled = true,
     userContextFromSelection,
     isFirstMessage,
@@ -60,7 +58,6 @@ export const HumanMessageCell: FunctionComponent<{
             content={
                 <HumanMessageEditor
                     userInfo={userInfo}
-                    isNewInstall={isNewInstall}
                     userContextFromSelection={userContextFromSelection}
                     initialEditorState={initialEditorState}
                     placeholder={

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -17,7 +17,6 @@ import { Toolbar } from './toolbar/Toolbar'
  */
 export const HumanMessageEditor: FunctionComponent<{
     userInfo: UserAccountInfo
-    isNewInstall?: boolean
     userContextFromSelection?: ContextItem[]
 
     initialEditorState: SerializedPromptEditorState | undefined
@@ -41,7 +40,6 @@ export const HumanMessageEditor: FunctionComponent<{
     __storybook__focus?: boolean
 }> = ({
     userInfo,
-    isNewInstall,
     userContextFromSelection,
     initialEditorState,
     placeholder,
@@ -191,7 +189,6 @@ export const HumanMessageEditor: FunctionComponent<{
             {!disabled && (
                 <Toolbar
                     userInfo={userInfo}
-                    isNewInstall={isNewInstall}
                     isEditorFocused={isEditorFocused || isFocusWithin}
                     isParentHovered={isHovered}
                     onMentionClick={onMentionClick}

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.tsx
@@ -15,7 +15,6 @@ import styles from './Toolbar.module.css'
  */
 export const Toolbar: FunctionComponent<{
     userInfo: UserAccountInfo
-    isNewInstall?: boolean
 
     isEditorFocused: boolean
 
@@ -34,7 +33,6 @@ export const Toolbar: FunctionComponent<{
     className?: string
 }> = ({
     userInfo,
-    isNewInstall,
     isEditorFocused,
     isParentHovered,
     onMentionClick,
@@ -79,7 +77,6 @@ export const Toolbar: FunctionComponent<{
                 />
             )}
             <EnhancedContextSettings
-                defaultOpen={isNewInstall}
                 presentationMode={userInfo.isDotComUser ? 'consumer' : 'enterprise'}
                 onCloseByEscape={focusEditor}
             />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -193,7 +193,6 @@ export const App: FunctionComponent = () => {
                             telemetryRecorder={telemetryRecorder}
                             isTranscriptError={isTranscriptError}
                             userContextFromSelection={[]}
-                            isNewInstall={false}
                         />
                     </ChatModelContextProvider>
                 )


### PR DESCRIPTION
This helped with discoverability but I'm removing this for the prerelease build because it seems like we'll change this UI a lot before the next release and it was causing flakiness. If we don't make progress on that new UI as hoped, then we probably need to add it back to avoid losing a lot of users who don't know how to set up context.

Added https://linear.app/sourcegraph/issue/CODY-1781/check-whether-we-need-to-go-back-to-showing-enhanced-context-popover to track this to make sure we don't miss it for the release.



## Test plan

CI