### PR TITLE
Keybind: Alt + L for starting new chat with @-selection

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 - Chat: Integerated OpenCtx providers with @-mention context menu. [pull/4201](https://github.com/sourcegraph/cody/pull/4201/files)
+- Keybinding: Assign the same keyboard shortcut for starting a new chat to the "New Chat with Selection" command.
 
 ### Fixed
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -629,6 +629,11 @@
         "when": "cody.activated && !editorReadonly && editorTextFocus && editorHasSelection"
       },
       {
+        "command": "cody.mention.selection.new",
+        "key": "alt+l",
+        "when": "cody.activated && !editorReadonly && editorTextFocus && editorHasSelection"
+      },
+      {
         "command": "cody.tutorial.chat",
         "key": "alt+l",
         "when": "cody.activated && cody.tutorialActive"


### PR DESCRIPTION
RE: https://linear.app/sourcegraph/issue/CODY-1686/enable-code-chat-with-alt-l-shortcut-before-cody-launch 
CONTEXT: https://sourcegraph.slack.com/archives/C04MSD3DP5L/p1716395608291109

> want: if i have a selection and a start a new chat, bring that selection into the chat

Assign new chat keybinding to the "New Chat with Selection" command.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Build cody from this branch
2. Select some code in your editor
3. Press `ALT+L` to start new chat with @selection

![add](https://github.com/sourcegraph/cody/assets/68532117/1dccb255-002f-437e-9e8e-3a2f4eeba219)
