### PR TITLE
Chat: Improve visibility for context display and settings

### DIFF
--- a/vscode/test/e2e/chat-edits.test.ts
+++ b/vscode/test/e2e/chat-edits.test.ts
@@ -41,7 +41,7 @@ test.extend<ExpectedEvents>({
     // Submit three new messages
     await lastChatInput.fill('One')
     await lastChatInput.press('Enter')
-    await expect(chatFrame.getByText('One')).toBeVisible()
+    await expect(chatFrame.getByText('One', { exact: true })).toBeVisible()
     await lastChatInput.fill('Two')
     await lastChatInput.press('Enter')
     await expect(chatFrame.getByText('Two')).toBeVisible()
@@ -53,7 +53,7 @@ test.extend<ExpectedEvents>({
     // The text area should automatically get the focuse,
     // and contains the original message text,
     // The submit button will also be replaced with "Update Message" button
-    await chatFrame.getByText('One').hover()
+    await chatFrame.getByText('One', { exact: true }).hover()
     await focusChatInputAtEnd(firstChatInput)
     await expect(firstChatInput).toBeFocused()
     await expect(firstChatInput).toHaveText('One')
@@ -71,11 +71,13 @@ test.extend<ExpectedEvents>({
     // Only two messages are left after the edit (e.g. "One", "Four"),
     // as all the messages after the edited message have be removed
     await expect(chatInputs).toHaveCount(3 /* 2 + the 1 for the next not-yet-sent message */)
-    await expect(chatFrame.getByText('One')).toBeVisible()
+    await expect(chatFrame.getByText('One', { exact: true })).toBeVisible()
     await expect(chatFrame.getByText('Two')).not.toBeVisible()
     await expect(chatFrame.getByText('Three')).not.toBeVisible()
     await expect(chatFrame.getByText('Four')).toBeVisible()
 
     // Chat input should still have focus.
     await expect(secondChatInput).toBeFocused()
+
+    expect(chatFrame.getByText('repository could not be automatically matched')).toBeDefined()
 })

--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -1,6 +1,4 @@
 import { type Locator, expect } from '@playwright/test'
-
-import { isMacOS } from '@sourcegraph/cody-shared'
 import * as mockServer from '../fixtures/mock-server'
 import { createEmptyChatPanel, sidebarExplorer, sidebarSignin } from './common'
 import {
@@ -132,7 +130,7 @@ test.extend<ExpectedEvents>({
     // (`Cody: New Chat`) to switch back to the chat window we already opened and check that the
     // input is focused.
     await page.getByText("fizzbuzz.push('Buzz')").click()
-    await page.keyboard.press(`${isMacOS() ? 'Opt' : 'Alt'}+L`)
+    await page.keyboard.press('Alt+L')
     await expect(firstChatInput).toBeFocused()
 
     // Submit a new chat question from the command menu.
@@ -241,15 +239,17 @@ test.extend<DotcomUrlOverride>({ dotcomUrl: mockServer.SERVER_URL })(
         await expect(humanRow0.toolbar.modelSelector).toBeVisible()
         await expect(humanRow0.toolbar.submit).toBeVisible()
         await expect(chatPanel.getByText('Optimized for Accuracy')).not.toBeVisible()
-        await expect(chatPanel.getByText('Automatic code context')).not.toBeVisible()
+        await expect(chatPanel.getByText('Automatic code context', { exact: true })).not.toBeVisible()
         // Open the model selector toolbar popover.
         await humanRow0.toolbar.modelSelector.click()
         await expect(chatPanel.getByText('Optimized for Accuracy')).toBeVisible()
-        await expect(chatPanel.getByText('Automatic code context')).not.toBeVisible()
+        await expect(chatPanel.getByText('Automatic code context', { exact: true })).not.toBeVisible()
         // Now click to the enhanced context toolbar popover. All toolbar items should still be visible, and the new popover should be open.
         await humanRow0.toolbar.enhancedContext.click()
         await expect(chatPanel.getByText('Optimized for Accuracy')).not.toBeVisible()
-        await expect(chatPanel.getByText('Automatic code context')).toBeVisible()
+        await expect(
+            chatPanel.getByText('Automatic code context', { exact: true }).first()
+        ).toBeVisible()
         await expect(humanRow0.toolbar.mention).toBeVisible()
         await expect(humanRow0.toolbar.enhancedContext).toBeVisible()
         await expect(humanRow0.toolbar.modelSelector).toBeVisible()

--- a/vscode/test/e2e/cody-ignore.test.ts
+++ b/vscode/test/e2e/cody-ignore.test.ts
@@ -76,7 +76,13 @@ test.extend<ExpectedEvents>({
     // but the current file is excluded (ignoredByCody.css) and not on the context list
     await expect(chatPanel.getByText('hello from the assistant')).toBeVisible()
     const contextCell = getContextCell(chatPanel)
-    await expect(contextCell).not.toBeVisible()
+
+    // The context cell should be visible on all chat messages even if no context was included.
+    await expect(contextCell).toBeVisible()
+    await expect(chatPanel.getByRole('option', { name: 'ignoredByCody.css' })).not.toBeVisible()
+
+    // The repository should not be found as embeddings are not supported in e2e tests.
+    await expect(chatPanel.getByText('Repository Not Found')).toBeVisible()
 
     /* TEST: At-file - Ignored file does not show up as context when using @-mention */
     await chatInput.focus()

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -96,12 +96,12 @@ export const Transcript: React.FunctionComponent<{
                     // response to finish.
                     isEditorInitiallyFocused={isLastHumanMessage}
                 />,
-                (message.contextFiles && message.contextFiles.length > 0) || isLastMessage ? (
-                    <ContextCell
-                        key={`${messageIndexInTranscript}-context`}
-                        contextFiles={message.contextFiles}
-                    />
-                ) : null,
+                <ContextCell
+                    key={`${messageIndexInTranscript}-context`}
+                    contextFiles={message.contextFiles}
+                    isLastHumanMessage={isLastHumanMessage}
+                    isDotComUser={userInfo.isDotComUser}
+                />,
             ].filter(isDefined)
         ) : (
             <AssistantMessageCell

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -63,11 +63,8 @@ export const Transcript: React.FunctionComponent<{
         const isLoading = Boolean(
             messageInProgress && messageInProgress.speaker === 'assistant' && !messageInProgress.text
         )
-        const isLastMessage = messageIndexInTranscript === transcript.length - 1
         const isLastHumanMessage =
-            message.speaker === 'human' &&
-            (messageIndexInTranscript === transcript.length - 1 ||
-                messageIndexInTranscript === transcript.length - 2)
+            message.speaker === 'human' && messageIndexInTranscript >= transcript.length - 2
 
         return message.speaker === 'human' ? (
             [

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
@@ -32,7 +32,7 @@
     align-items: center;
     gap: 0.35rem;
 }
-.stats {
+.stats, .repo-count {
     font-weight: normal;
     opacity: 0.6;
 }
@@ -63,4 +63,10 @@
     margin-top: 0.5rem;
     padding: 0.5rem;
     border: solid 1px var(--vscode-sideBarSectionHeader-border);
+}
+
+.repo-count {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.2rem;
 }

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.module.css
@@ -53,3 +53,14 @@
 .file-link {
     padding: 2px 4px 2px 2px;
 }
+
+.info {
+    font-size: smaller;
+    opacity: 0.6;
+}
+
+.settings-container {
+    margin-top: 0.5rem;
+    padding: 0.5rem;
+    border: solid 1px var(--vscode-sideBarSectionHeader-border);
+}

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -38,10 +38,13 @@ export const ContextCell: React.FunctionComponent<{
     }
 
     const fileCount = usedContext.length ? new Set(usedContext.map(file => file.uri.toString())).size : 0
+    const repoCount = isDotComUser ? 0 : new Set(usedContext.map(file => file.repoName)).size
     const excludedCount = excludedAtContext.length
 
     const enhancedContextProviders = useEnhancedContextContext()?.groups?.[0]?.providers
     const isEnhancedContextReady = enhancedContextProviders?.some(p => p.state === 'ready') ?? false
+
+    console.log(repoCount, 'repoCount')
 
     let fileCountLabel = 'None'
     if (fileCount) {
@@ -56,6 +59,7 @@ export const ContextCell: React.FunctionComponent<{
                 ? '⚠ Repository Not Found'
                 : '⚠ Automatic Code Context Unavailable'
     }
+
     // The info message to display when no context is used.
     const enhancedContextStatusInfo =
         // Only show the enhanced context status message on the last human message,
@@ -122,6 +126,15 @@ export const ContextCell: React.FunctionComponent<{
                                     />
                                 </li>
                             ))}
+                            {repoCount && (
+                                <li key="repo-count" className={styles.listItem}>
+                                    <span className={styles.repoCount}>
+                                        <i className="codicon codicon-sparkle" />
+                                        Automatic Code Context: Using {repoCount} Repositor
+                                        {repoCount > 1 ? 'ies' : 'y'}
+                                    </span>
+                                </li>
+                            )}
                         </ul>
                     ) : (
                         <div className={styles.listItem}>

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -51,9 +51,10 @@ export const ContextCell: React.FunctionComponent<{
                 : ''
         }`
     } else if (!isEnhancedContextReady) {
-        fileCountLabel = !(isDotComUser && enhancedContextProviders?.length)
-            ? '⚠ Repository Not Found'
-            : '⚠ Automatic Code Context Unavailable'
+        fileCountLabel =
+            !isDotComUser && !enhancedContextProviders?.length
+                ? '⚠ Repository Not Found'
+                : '⚠ Automatic Code Context Unavailable'
     }
     // The info message to display when no context is used.
     const enhancedContextStatusInfo =

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -1,6 +1,10 @@
 import type { ContextItem } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
 import type React from 'react'
+import {
+    EnhancedContextSettingsComponent,
+    useEnhancedContextContext,
+} from '../../../components/EnhancedContextSettings'
 import { FileLink } from '../../../components/FileLink'
 import { SourcegraphLogo } from '../../../icons/SourcegraphLogo'
 import { MENTION_CLASS_NAME } from '../../../promptEditor/nodes/ContextItemMentionNode'
@@ -8,7 +12,6 @@ import { getVSCodeAPI } from '../../../utils/VSCodeApi'
 import { LoadingDots } from '../../components/LoadingDots'
 import { Cell } from '../Cell'
 import styles from './ContextCell.module.css'
-
 /**
  * A component displaying the context for a human message.
  */
@@ -16,9 +19,12 @@ export const ContextCell: React.FunctionComponent<{
     contextFiles: ContextItem[] | undefined
     className?: string
 
+    isLastHumanMessage: boolean
+    isDotComUser: boolean
+
     /** For use in storybooks only. */
     __storybook__initialOpen?: boolean
-}> = ({ contextFiles, className, __storybook__initialOpen }) => {
+}> = ({ contextFiles, className, isLastHumanMessage, isDotComUser, __storybook__initialOpen }) => {
     const usedContext = []
     const excludedAtContext = []
     if (contextFiles) {
@@ -31,12 +37,39 @@ export const ContextCell: React.FunctionComponent<{
         }
     }
 
-    const fileCount = new Set(usedContext.map(file => file.uri.toString())).size
-    let fileCountLabel = `${fileCount} file${fileCount > 1 ? 's' : ''}`
-    if (excludedAtContext.length) {
-        const excludedAtUnit = excludedAtContext.length === 1 ? 'mention' : 'mentions'
-        fileCountLabel = `${fileCountLabel} — ${excludedAtContext.length} ${excludedAtUnit} excluded`
+    const fileCount = usedContext.length ? new Set(usedContext.map(file => file.uri.toString())).size : 0
+    const excludedCount = excludedAtContext.length
+
+    const enhancedContextProviders = useEnhancedContextContext()?.groups?.[0]?.providers
+    const isEnhancedContextReady = enhancedContextProviders?.some(p => p.state === 'ready') ?? false
+
+    let fileCountLabel = 'None'
+    if (fileCount) {
+        fileCountLabel = `${fileCount} file${fileCount > 1 ? 's' : ''}${
+            excludedCount
+                ? ` — ${excludedCount} ${excludedCount === 1 ? 'mention' : 'mentions'} excluded`
+                : ''
+        }`
+    } else if (!isEnhancedContextReady) {
+        fileCountLabel = !(isDotComUser && enhancedContextProviders?.length)
+            ? '⚠ Repository Not Found'
+            : '⚠ Automatic Code Context Unavailable'
     }
+    // The info message to display when no context is used.
+    const enhancedContextStatusInfo =
+        // Only show the enhanced context status message on the last human message,
+        // as history messages may not have the same reason for not having context.
+        !isLastHumanMessage || isEnhancedContextReady
+            ? 'No automatic code context was included. Try @mentioning to include specific context.'
+            : // On last human message, show the reason why the context was not included.
+              enhancedContextProviders?.length
+              ? '⚠ The automatic code context is not ready...'
+              : // When no providers are available, Display instructions to enable the feature.
+                `⚠ Your local repository could not be automatically matched to one on your Sourcegraph instance. ${
+                    isDotComUser
+                        ? 'Follow the instructions below to enable codebase context.'
+                        : 'Add the repository below to enable codebase context.'
+                }`
 
     function logContextOpening() {
         getVSCodeAPI().postMessage({
@@ -49,14 +82,14 @@ export const ContextCell: React.FunctionComponent<{
         })
     }
 
-    return contextFiles === undefined || contextFiles.length !== 0 ? (
+    return (
         <Cell
             style="context"
             gutterIcon={<SourcegraphLogo width={20} height={20} />}
             containerClassName={className}
             data-testid="context"
         >
-            {contextFiles === undefined ? (
+            {contextFiles === undefined && isLastHumanMessage ? (
                 <LoadingDots />
             ) : (
                 <details className={styles.details} open={__storybook__initialOpen}>
@@ -70,30 +103,39 @@ export const ContextCell: React.FunctionComponent<{
                             Context <span className={styles.stats}>&mdash; {fileCountLabel}</span>
                         </h4>
                     </summary>
-                    <ul className={styles.list}>
-                        {contextFiles?.map((item, i) => (
-                            // biome-ignore lint/suspicious/noArrayIndexKey: stable order
-                            <li key={i} className={styles.listItem}>
-                                <FileLink
-                                    uri={item.uri}
-                                    repoName={item.repoName}
-                                    revision={item.revision}
-                                    source={item.source}
-                                    range={item.range}
-                                    title={item.title}
-                                    isTooLarge={
-                                        item.type === 'file' && item.isTooLarge && item.source === 'user'
-                                    }
-                                    isIgnored={
-                                        item.type === 'file' && item.isIgnored && item.source === 'user'
-                                    }
-                                    className={clsx(styles.fileLink, MENTION_CLASS_NAME)}
-                                />
-                            </li>
-                        ))}
-                    </ul>
+                    {contextFiles?.length ? (
+                        <ul className={styles.list}>
+                            {contextFiles.map((item, i) => (
+                                // biome-ignore lint/suspicious/noArrayIndexKey: stable order
+                                <li key={i} className={styles.listItem}>
+                                    <FileLink
+                                        uri={item.uri}
+                                        repoName={item.repoName}
+                                        revision={item.revision}
+                                        source={item.source}
+                                        range={item.range}
+                                        title={item.title}
+                                        isTooLarge={item.source === 'user' && item.isTooLarge}
+                                        isIgnored={item.source === 'user' && item.isIgnored}
+                                        className={clsx(styles.fileLink, MENTION_CLASS_NAME)}
+                                    />
+                                </li>
+                            ))}
+                        </ul>
+                    ) : (
+                        <div className={styles.listItem}>
+                            <div className={styles.info}>{enhancedContextStatusInfo}</div>
+                            {isLastHumanMessage && !isEnhancedContextReady && (
+                                <div className={styles.settingsContainer}>
+                                    <EnhancedContextSettingsComponent
+                                        presentationMode={isDotComUser ? 'consumer' : 'enterprise'}
+                                    />
+                                </div>
+                            )}
+                        </div>
+                    )}
                 </details>
             )}
         </Cell>
-    ) : null
+    )
 }

--- a/vscode/webviews/components/EnhancedContextSettings.tsx
+++ b/vscode/webviews/components/EnhancedContextSettings.tsx
@@ -57,7 +57,7 @@ export interface EnhancedContextEventHandlersT {
     onShouldBuildSymfIndex: (provider: LocalSearchProvider) => void
 }
 
-function useEnhancedContextContext(): EnhancedContextContextT {
+export function useEnhancedContextContext(): EnhancedContextContextT {
     return React.useContext(EnhancedContextContext)
 }
 
@@ -346,7 +346,22 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     __storybook__open,
     onCloseByEscape,
     className,
-}): React.ReactNode => {
+}): React.ReactNode => (
+    <ToolbarPopoverItem
+        aria-label="Configure automatic code context"
+        tooltip="Configure automatic code context"
+        iconStart={BookMarkedIcon}
+        iconEnd={null}
+        __storybook__open={__storybook__open}
+        onCloseByEscape={onCloseByEscape}
+        popoverContent={() => <EnhancedContextSettingsComponent presentationMode={presentationMode} />}
+        className={className}
+    />
+)
+
+export const EnhancedContextSettingsComponent: React.FunctionComponent<{
+    presentationMode: 'consumer' | 'enterprise'
+}> = ({ presentationMode }) => {
     const events = useEnhancedContextEventHandlers()
     const context = useEnhancedContextContext()
 
@@ -363,43 +378,32 @@ export const EnhancedContextSettings: React.FunctionComponent<EnhancedContextSet
     )
 
     return (
-        <ToolbarPopoverItem
-            aria-label="Configure automatic code context"
-            tooltip="Configure automatic code context"
-            iconStart={BookMarkedIcon}
-            iconEnd={null}
-            __storybook__open={__storybook__open}
-            onCloseByEscape={onCloseByEscape}
-            popoverContent={() => (
-                <div className={styles.container}>
-                    <h1>Automatic code context</h1>
-                    {presentationMode === EnhancedContextPresentationMode.Consumer ? (
-                        context.groups.length > 0 ? (
-                            <dl className={styles.foldersList}>
-                                {context.groups.map(group => (
-                                    <ContextGroupComponent
-                                        key={group.displayName}
-                                        group={group}
-                                        allGroups={context.groups}
-                                    />
-                                ))}
-                            </dl>
-                        ) : (
-                            <p className="tw-text-sm tw-text-muted-foreground">
-                                No automatic code context is available
-                            </p>
-                        )
-                    ) : (
-                        <CompactGroupsComponent
-                            groups={context.groups}
-                            handleChoose={handleChooseRemoteSearchRepo}
-                            handleRemove={handleRemoveRemoteSearchRepo}
-                        />
-                    )}
-                </div>
+        <div className={styles.container}>
+            <h1>Automatic code context</h1>
+            {presentationMode === EnhancedContextPresentationMode.Consumer ? (
+                context.groups.length > 0 ? (
+                    <dl className={styles.foldersList}>
+                        {context.groups.map(group => (
+                            <ContextGroupComponent
+                                key={group.displayName}
+                                group={group}
+                                allGroups={context.groups}
+                            />
+                        ))}
+                    </dl>
+                ) : (
+                    <p className="tw-text-sm tw-text-muted-foreground">
+                        No automatic code context is available
+                    </p>
+                )
+            ) : (
+                <CompactGroupsComponent
+                    groups={context.groups}
+                    handleChoose={handleChooseRemoteSearchRepo}
+                    handleRemove={handleRemoveRemoteSearchRepo}
+                />
             )}
-            className={className}
-        />
+        </div>
     )
 }
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody-issues/issues/164

Code Changes:
- Add isLastHumanMessage and isDotComUser props to `ContextCell`
- Display informative status message when no context is available
- Show enhanced context settings UI when `Automatic Code Context (Auto Context)` is not available in the ContextCell of the last human message
- Refactor ContextCell to handle various context states more gracefully

### Key changes

- [x] Always show the Context row when enhanced context is enabled for the message (even when there are no context items fetched or when there are errors)
- [ ] show it when enhanced context is disabled for the message if there are any context items (this occurs when the user @-mentioned something in their message)
- [x] Inside the Context details element, include an item at the bottom for Enhanced Context settings, warnings etc.
- [x] Include a "Repository Not Found" warning on Context row label for Enterprise

### Acceptance criteria

PLG:

<img width="805" alt="Screenshot 2024-05-22 at 11 43 51 AM" src="https://github.com/sourcegraph/cody/assets/68532117/d973b866-da27-4193-a981-3540ac3d0262">


- [x] Enhanced Context settings are visible inside the context details element
- [ ] Clicking “Settings” opens the Enhanced Context popover - TBD
- [ ] Clicking “Settings” logs an event - TBD

Enterprise:

- [x] Enhanced Context settings are visible inside the context details element
- [x] The number of repositories being used is shown
  - ![image](https://github.com/sourcegraph/cody/assets/68532117/5dbb7714-ebe1-4349-975a-76aa869d5b7b)
- [x] “Repository Not Found” warning is shown on context row if no repo is matched
  - ![image](https://github.com/sourcegraph/cody/assets/68532117/e4598eba-b59f-4dfd-986e-dabc0c37f7c1)
- [ ] Clicking “Settings” opens the Enhanced Context popover - TBD
- [ ] Clicking “Settings” logs an event - TBD


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Start Cody from this branch
2. TBC

## Demo

When codebase context is enabled but users opted-out or no context was included (for both enterprise users and plg users)

<img width="955" alt="Screenshot 2024-05-22 at 11 45 48 AM" src="https://github.com/sourcegraph/cody/assets/68532117/0046ef76-45ab-44b4-8562-5aa6eee6342f">

### DotCom Users

https://github.com/sourcegraph/cody/assets/68532117/83381729-f703-400b-813b-98646918d9f9

### Enterprise Users

<img width="790" alt="Screenshot 2024-05-22 at 11 25 03 AM" src="https://github.com/sourcegraph/cody/assets/68532117/12d96331-40f1-4034-bca9-03468abc71a2">
