### PR TITLE
E2E: remove isMacOS check for Alt+L keybind test

### DIFF
--- a/vscode/test/e2e/chat-input.test.ts
+++ b/vscode/test/e2e/chat-input.test.ts
@@ -1,6 +1,4 @@
 import { type Locator, expect } from '@playwright/test'
-
-import { isMacOS } from '@sourcegraph/cody-shared'
 import * as mockServer from '../fixtures/mock-server'
 import { createEmptyChatPanel, sidebarExplorer, sidebarSignin } from './common'
 import {
@@ -132,7 +130,7 @@ test.extend<ExpectedEvents>({
     // (`Cody: New Chat`) to switch back to the chat window we already opened and check that the
     // input is focused.
     await page.getByText("fizzbuzz.push('Buzz')").click()
-    await page.keyboard.press(`${isMacOS() ? 'Opt' : 'Alt'}+L`)
+    await page.keyboard.press('Alt+L')
     await expect(firstChatInput).toBeFocused()
 
     // Submit a new chat question from the command menu.


### PR DESCRIPTION
The `isMacOS` check is no longer needed in the `chat-input.test.ts` file for testing the Alt+L keybind, as the command directly uses the 'Alt+L' key combination on all platforms. This is because the command is registered under ['alt+l' in the package.json](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/package.json?L617-621)?

This fixes the issue where e2e tests are failing on Mac in main CI.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Green CI.

Run the e2e test locally from this branch: `pnpm test:e2e chat-input` to verify:

![image](https://github.com/sourcegraph/cody/assets/68532117/56b1d1c9-af51-4a12-bef5-256d5b6b048f)


### Before

![image](https://github.com/sourcegraph/cody/assets/68532117/fde1356f-ed62-4c10-adeb-8fa7f4904468)
