### PR TITLE
Move auto-accept logic from Agent to client for now, workaround for Issue 315 for GA

### DIFF
--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -1024,7 +1024,7 @@ export class FixupController
         // notification back to the Agent after we finish applying the
         // changes. https://github.com/sourcegraph/cody-issues/issues/315 is one example
         // of a bug caused by auto-accepting here, but there were others as well.
-        if (!isRunningInsideAgent) {
+        if (!isRunningInsideAgent()) {
             if (task.state === CodyTaskState.Applied) {
                 // User has changed an applied task, so we assume the user has accepted
                 // the change and wants to take control.  This helps ensure that the


### PR DESCRIPTION
This fix must be paired with a [sourcegraph/jetbrains PR](https://github.com/sourcegraph/jetbrains/pull/1603) that moves the logic to the client.

## Test plan

Everyone has try to break it -- specifically:

- the Accept lens group (with Edit/Retry, Undo, Show Diff) should _always_ be shown after requesting a Document Code
- It should auto-accept your current edit if you start another one somewhere else in the document.

This is already covered by the test plan, so it just needs to be re-run with this specific feature in mind.