### PR TITLE
Test Command: Fix issue with inserting test file name with unit test

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -19,7 +19,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixes issues with chat commands where selection context is removed from context items. [pull/4229](https://github.com/sourcegraph/cody/pull/4229)
 - Chat: Fixes intermittent issues with `Add Selection to Cody Chat` where sometimes the @-mention would not actually be added. [pull/4237](https://github.com/sourcegraph/cody/pull/4237)
 - Menu: Fixes an issue where the `Add Selection to Cody Chat` context menu item was incorrectly disabled when no new chat was open. [pull/4242](https://github.com/sourcegraph/cody/pull/4242)
-- Fixed an issue where the test file name was incorrectly inserted with the unit test command. [pull/](https://github.com/sourcegraph/cody/pull/)
+- Fixed an issue where the test file name was incorrectly inserted with the unit test command. [pull/4262](https://github.com/sourcegraph/cody/pull/4262)
 
 ### Changed
 

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -19,6 +19,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixes issues with chat commands where selection context is removed from context items. [pull/4229](https://github.com/sourcegraph/cody/pull/4229)
 - Chat: Fixes intermittent issues with `Add Selection to Cody Chat` where sometimes the @-mention would not actually be added. [pull/4237](https://github.com/sourcegraph/cody/pull/4237)
 - Menu: Fixes an issue where the `Add Selection to Cody Chat` context menu item was incorrectly disabled when no new chat was open. [pull/4242](https://github.com/sourcegraph/cody/pull/4242)
+- Fixed an issue where the test file name was incorrectly inserted with the unit test command. [pull/](https://github.com/sourcegraph/cody/pull/)
 
 ### Changed
 

--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -96,21 +96,23 @@ export class EditProvider {
                         this.config.task.id,
                         this.config.task.destinationFile
                     )
-                } else {
-                    // Listen to test file name suggestion from responses
-                    // Allows Cody to let us know which test file we should add the new content to
-                    let filepath = ''
-                    multiplexer.sub(PROMPT_TOPICS.FILENAME.toString(), {
-                        onResponse: async (content: string) => {
-                            filepath += content
-                            void this.handleFileCreationResponse(filepath, true)
-                            return Promise.resolve()
-                        },
-                        onTurnComplete: async () => {
-                            return Promise.resolve()
-                        },
-                    })
                 }
+
+                // Listen to test file name suggestion from responses and create the file if we don't have one.
+                // This allows Cody to let us know which test file we should add the new content to.
+                // NOTE: Keep this multiplexer even if a destination file is set to catch the PROMPT_TOPICS.
+                let filepath = ''
+                multiplexer.sub(PROMPT_TOPICS.FILENAME.toString(), {
+                    onResponse: async (content: string) => {
+                        filepath += content
+                        // handleFileCreationResponse will verify if task.destinationFile is set before creating a new file.
+                        void this.handleFileCreationResponse(filepath, true)
+                        return Promise.resolve()
+                    },
+                    onTurnComplete: async () => {
+                        return Promise.resolve()
+                    },
+                })
             }
 
             this.abortController = new AbortController()


### PR DESCRIPTION
RE: https://github.com/sourcegraph/cody/issues/3963

This PR fixes an issue with test command inserting test file name at the top of the unit test

![image](https://github.com/sourcegraph/cody/assets/68532117/34aa9739-5628-4921-9a7a-5aad4daa5c38)


> The inclusion of a file path at the top is a bug.

I suspect the issue was introduced in [#3759](https://sourcegraph.com/github.com/sourcegraph/cody/-/commit/db6d4eb84bd32b6141bb93e732d14c40a5775613?visible=3) where we updated to only subscribe to the multiplexer for file creation if we couldn't locate the test file internally. This becomes an issue when we ask for the LLM to always return the test file name in the [PROMPT_TOPICS.FILENAME](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/edit/prompt/models/generic.ts?L88) in our prompt.

- Fixes an issue where the test file name was incorrectly inserted when using the unit test command
- Ensures the test file name suggestion from Cody is properly handled and the file is created if necessary
- Keeps the multiplexer subscription for the test file name suggestion even if a destination file is set, to ensure any text returned by Cody wrapped in the PROMPT_TOPICS.FILENAME tags are properly handled

## Repro Steps

1. In the latest stable Cody build, open the Cody repo
2. Go to any file that already has a `.test.ts` file, [vscode/src/release.ts?L13-16](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/release.ts?L13-16) for example
3. Execute the test command
4. Verify the file path is included with the generated test

https://github.com/sourcegraph/cody/assets/68532117/7ea66551-859d-48ac-a77a-c358856996ac

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Start Cody in debug mode from this branch
2. Go to any file that already has a `.test.ts` file, [vscode/src/release.ts?L13-16](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/release.ts?L13-16) for example
3. Execute the test command
4. Verify the file path is no longer included with the generated test
5. Also verify files without existing test files are still working as expected:

https://github.com/sourcegraph/cody/assets/68532117/4a590689-ecf9-4ab9-a2f3-113593864f9a

