### PR TITLE
Remove unused RemoteSearch methods

### DIFF
--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -155,7 +155,6 @@ export type {
     FilenameContextFetcher,
     IndexedKeywordContextFetcher,
     LocalEmbeddingsFetcher,
-    IRemoteSearch,
     Result,
     SearchPanelFile,
     SearchPanelSnippet,

--- a/lib/shared/src/local-context/index.ts
+++ b/lib/shared/src/local-context/index.ts
@@ -1,7 +1,7 @@
 import type { URI } from 'vscode-uri'
 
 import type { RangeData } from '..'
-import type { ContextItem, ContextItemFile } from '../codebase-context/messages'
+import type { ContextItem } from '../codebase-context/messages'
 import type { PromptString } from '../prompt/prompt-string'
 import type { EmbeddingsSearchResult } from '../sourcegraph-api/graphql/client'
 
@@ -18,13 +18,6 @@ export interface FilenameContextFetcher {
 export interface LocalEmbeddingsFetcher {
     getContext(query: PromptString, numResults: number): Promise<EmbeddingsSearchResult[]>
 }
-
-// Minimal interface so inline edit can use remote search for context.
-export interface IRemoteSearch {
-    setWorkspaceUri(uri: URI): Promise<void>
-    search(query: PromptString): Promise<ContextItemFile[]>
-}
-
 interface Point {
     row: number
     col: number

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -71,10 +71,7 @@ export async function getEnhancedContext({
         //  Get search (symf or remote search) context if config is not set to 'embeddings' only
         const remoteSearchContextItemsPromise =
             providers.remoteSearch && strategy !== 'embeddings'
-                ? retrieveContextGracefully(
-                      searchRemote(providers.remoteSearch, text),
-                      'remote-search'
-                  )
+                ? retrieveContextGracefully(searchRemote(providers.remoteSearch, text), 'remote-search')
                 : []
         const localSearchContextItemsPromise =
             providers.symf && strategy !== 'embeddings'
@@ -123,10 +120,7 @@ async function getEnhancedContextFromRanker({
             : []
 
         const remoteSearchContextItemsPromise = providers.remoteSearch
-            ? retrieveContextGracefully(
-                  searchRemote(providers.remoteSearch, text),
-                  'remote-search'
-              )
+            ? retrieveContextGracefully(searchRemote(providers.remoteSearch, text), 'remote-search')
             : []
 
         const keywordContextItemsPromise = (async () => [

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -71,7 +71,7 @@ export async function getEnhancedContext({
         //  Get search (symf or remote search) context if config is not set to 'embeddings' only
         const remoteSearchContextItemsPromise =
             providers.remoteSearch && strategy !== 'embeddings'
-                ? await retrieveContextGracefully(
+                ? retrieveContextGracefully(
                       searchRemote(providers.remoteSearch, text),
                       'remote-search'
                   )
@@ -123,7 +123,7 @@ async function getEnhancedContextFromRanker({
             : []
 
         const remoteSearchContextItemsPromise = providers.remoteSearch
-            ? await retrieveContextGracefully(
+            ? retrieveContextGracefully(
                   searchRemote(providers.remoteSearch, text),
                   'remote-search'
               )


### PR DESCRIPTION
`RemoteSearch` implemented `IRemoteSearch` to allow remote searches in Edit/
Fix. We no longer pull in this remote context, so we can simplify and remove
the extra logic.

This PR also fixes a tiny issue where we awaited the remote search promise
after it's already resolved.

## Test plan

Covered by existing tests. Manually tested VSCode extension.