### PR TITLE
Edit: do not inject responsePrefix on typewriter.update()

### DIFF
--- a/vscode/src/edit/provider.ts
+++ b/vscode/src/edit/provider.ts
@@ -77,7 +77,7 @@ export class EditProvider {
             multiplexer.sub(responseTopic, {
                 onResponse: async (content: string) => {
                     text += content
-                    typewriter.update(responsePrefix + text)
+                    typewriter.update(text)
                     return Promise.resolve()
                 },
                 onTurnComplete: async () => {


### PR DESCRIPTION
CONTEXT: https://sourcegraph.slack.com/archives/C05AGQYD528/p1716415682614109
CLOSE: https://github.com/sourcegraph/jetbrains/issues/1597

I suspect the issue is caused by injecting the `responsePrefix` repeatedly on every new stream response during the `typewriter.update()` step, a change we made when we first refactored fixup away from the old MessageProvider in https://github.com/sourcegraph/cody/pull/2549. 

I believe this can be safely removed because when we first received a response from the LLM,  the 
 multiplexer would publish the `responsePrefix`, which will then notify the topic subscribers which then run the [typewriter.update() ](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/edit/provider.ts?L80) step. This is why injecting the `responsePrefix` seems redundant as typewriter should not be responsible for handling `responsePrefix`during stream.

Moreover, when [handleFixupEdit & handleFixupInsert](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/edit/provider.ts?L250%3A1-265%3A1) receive the response text from `typewriter`, we would then remove the injected `responsePrefix` with [responseTransformer](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/edit/output/response-transformer.ts?L35%3A1-60%3A1), causing the issue we are seeing.

Note: This has been a long-standing issue, but finally caught by the agent!

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

### Before

- Stream always starts with `<CODE` tags
- The returned code breaks the current file because of the random code it insert during streaming

https://github.com/sourcegraph/cody/assets/68532117/14ffbdbb-e9dc-412c-b0fa-d745b21fb3d2

![image](https://github.com/sourcegraph/cody/assets/68532117/07575e5d-7a45-4d08-afa7-aa0ce3cd3c50)


### After

- No `<CODE` tag  at the beginning of the stream.
- Returned code is not broken

https://github.com/sourcegraph/cody/assets/68532117/5437871d-99fd-4228-8808-59abae827526

