### PR TITLE
fix jumpy scroll when submitting followup

### DIFF
--- a/vscode/webviews/chat/Transcript.module.css
+++ b/vscode/webviews/chat/Transcript.module.css
@@ -1,5 +1,10 @@
 .container {
     overflow-x: hidden;
+
+}
+
+.last-human-message {
+    margin-bottom: 2rem;
 }
 
 .welcome-message-cell-content p:first-child {

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -159,6 +159,7 @@ export const Transcript: React.FunctionComponent<{
                             addEnhancedContext,
                         })
                     }}
+                    className={styles.lastHumanMessage}
                 />
             )}
             {transcript.length === 0 && <WelcomeMessageCell welcomeMessage={welcomeMessage} />}

--- a/vscode/webviews/chat/cells/messageCell/BaseMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/BaseMessageCell.tsx
@@ -15,14 +15,19 @@ export const BaseMessageCell: FunctionComponent<{
     focused?: boolean
     disabled?: boolean
     footer?: React.ReactNode
-}> = ({ speaker, speakerIcon, content, contentClassName, focused, disabled, footer }) => (
+    className?: string
+}> = ({ speaker, speakerIcon, content, contentClassName, focused, disabled, footer, className }) => (
     <Cell
         style={speaker === 'human' ? 'human' : 'assistant'}
         gutterIcon={speakerIcon}
-        containerClassName={clsx(styles.cellContainer, {
-            [styles.focused]: focused,
-            [styles.disabled]: disabled,
-        })}
+        containerClassName={clsx(
+            styles.cellContainer,
+            {
+                [styles.focused]: focused,
+                [styles.disabled]: disabled,
+            },
+            className
+        )}
         contentClassName={contentClassName}
         aria-disabled={disabled}
         aria-current={focused}

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -4,7 +4,7 @@ import {
     ps,
     reformatBotMessageForChat,
 } from '@sourcegraph/cody-shared'
-import { type FunctionComponent, useEffect, useMemo, useRef } from 'react'
+import { type FunctionComponent, useMemo } from 'react'
 import type { ApiPostMessage, UserAccountInfo } from '../../../../Chat'
 import { chatModelIconComponent } from '../../../../components/ChatModelIcon'
 import { ChatMessageContent, type CodeBlockActionsProps } from '../../../ChatMessageContent'
@@ -51,22 +51,12 @@ export const AssistantMessageCell: FunctionComponent<{
     const chatModel = useChatModelByID(message.model)
     const ModelIcon = chatModel ? chatModelIconComponent(chatModel.model) : null
 
-    // If this message is in progress and it's out of the viewport when it first appears, scroll to
-    // make it visible or else the user might not realize there is a message streaming in below
-    // their viewport.
-    const someRef = useRef<HTMLElement | null>(null)
-    useEffect(() => {
-        if (isLoading) {
-            someRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
-        }
-    }, [isLoading])
-
     return (
         <BaseMessageCell
             speaker={message.speaker}
             speakerIcon={
                 chatModel && ModelIcon ? (
-                    <span title={`${chatModel.title} by ${chatModel.provider}`} ref={someRef}>
+                    <span title={`${chatModel.title} by ${chatModel.provider}`}>
                         <ModelIcon size={20} />
                     </span>
                 ) : null

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.tsx
@@ -32,6 +32,8 @@ export const HumanMessageCell: FunctionComponent<{
 
     isEditorInitiallyFocused?: boolean
 
+    className?: string
+
     /** For use in storybooks only. */
     __storybook__focus?: boolean
 }> = ({
@@ -44,6 +46,7 @@ export const HumanMessageCell: FunctionComponent<{
     onChange,
     onSubmit,
     isEditorInitiallyFocused,
+    className,
     __storybook__focus,
 }) => {
     const initialEditorState = useMemo(
@@ -75,6 +78,7 @@ export const HumanMessageCell: FunctionComponent<{
                 />
             }
             contentClassName={styles.editor}
+            className={className}
         />
     )
 }


### PR DESCRIPTION
Instead of ensuring the assistant message is visible, make it so it's impossible for it to NOT be visible ever by adding a margin at the bottom of the last human message that will be filled in visually by the subsequent assistant message.

HT @erikars and @Kynlos for reporting this issue

## Test plan

CI