### PR TITLE
Autocomplete: reproduce buggy prompt where line suffix is missing

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -150,6 +150,122 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 53b60a708d430d769ccd5e7330c637e1
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 348
+        cookies: []
+        headers:
+          - _fromType: array
+            name: accept-encoding
+            value: gzip;q=0
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - _fromType: array
+            name: connection
+            value: keep-alive
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "348"
+          - name: host
+            value: sourcegraph.com
+        headersSize: 378
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            maxTokensToSample: 256
+            messages:
+              - speaker: human
+                text: |-
+                  <filename>src/sum.ts<fim_prefix>// 
+                  export function sum(a: number, b: number): number {
+                      const <fim_suffix>
+                      return finalResult
+                  }
+                  <fim_middle>
+            model: fireworks/starcoder-16b
+            stopSequences:
+              - "\n\n"
+              - "\n\r\n"
+            stream: true
+            temperature: 0.2
+            timeoutMs: 15000
+            topK: 0
+        queryString:
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/code?client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 324
+        content:
+          mimeType: text/event-stream
+          size: 324
+          text: |+
+            event: completion
+            data: {"completion":"finalResult = a + b","stopReason":"stop"}
+
+            event: done
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 23 May 2024 08:35:09 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-23T08:35:09.147Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 9a811079de586f127810c6aeda637e60
       _order: 0
       cache: {}
@@ -10985,6 +11101,120 @@ log:
         status: 401
         statusText: Unauthorized
       startedDateTime: 2024-04-17T15:30:18.096Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 71f731a286efc3e43085105b43ac3aad
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 741
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_b09f01644a4261b32aa2ee4aea4f279ba69a57cff389f9b119b5265e913c0ea4
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: traceparent
+            value: 00-94a901f49aa115e33144547e1415597f-9172bfa2fff339aa-01
+          - _fromType: array
+            name: user-agent
+            value: defaultClient / v1
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: content-length
+            value: "741"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 392
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json; charset=utf-8
+          params: []
+          textJSON:
+            query: >-
+              
+              mutation LogEventMutation($event: String!, $userCookieID: String!, $url: String!, $source: EventSource!, $argument: String, $publicArgument: String, $client: String, $connectedSiteID: String, $hashedLicenseKey: String) {
+                  logEvent(
+              		event: $event
+              		userCookieID: $userCookieID
+              		url: $url
+              		source: $source
+              		argument: $argument
+              		publicArgument: $publicArgument
+              		client: $client
+              		connectedSiteID: $connectedSiteID
+              		hashedLicenseKey: $hashedLicenseKey
+                  ) {
+              		alwaysNil
+              	}
+              }
+            variables:
+              client: VSCODE_CODY_EXTENSION
+              connectedSiteID: SourcegraphWeb
+              event: CodyVSCodeExtension:completion:noResponse
+              source: IDEEXTENSION
+              url: ""
+              userCookieID: ANONYMOUS_USER_COOKIE_ID
+        queryString:
+          - name: LogEventMutation
+            value: null
+        url: https://sourcegraph.com/.api/graphql?LogEventMutation
+      response:
+        bodySize: 26
+        content:
+          mimeType: application/json
+          size: 26
+          text: "{\"data\":{\"logEvent\":null}}"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 23 May 2024 08:35:10 GMT
+          - name: content-type
+            value: application/json
+          - name: content-length
+            value: "26"
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1301
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-23T08:35:09.905Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/__tests__/example-ts/src/sum.ts
+++ b/agent/src/__tests__/example-ts/src/sum.ts
@@ -1,3 +1,4 @@
 export function sum(a: number, b: number): number {
-    /* CURSOR */
+    const /* CURSOR */ = b + a
+    return finalResult
 }

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -56,6 +56,9 @@ describe('Agent', () => {
         workspaceRootUri: workspace.rootUri,
         name: 'defaultClient',
         credentials: TESTING_CREDENTIALS.dotcom,
+        extraConfiguration: {
+            'cody.autocomplete.advanced.provider': 'fireworks',
+        },
     })
 
     // Initialize inside beforeAll so that subsequent tests are skipped if initialization fails.
@@ -145,12 +148,15 @@ describe('Agent', () => {
         expect(valid?.username).toStrictEqual('sourcegraphbot9k-fnwmu')
     }, 10_000)
 
-    describe('Autocomplete', () => {
+    describe.only('Autocomplete', () => {
         it('autocomplete/execute (non-empty result)', async () => {
             await client.openFile(sumUri)
+            const doc = client.workspace.openUri(sumUri)
+            const position = doc.protocolDocument.selection!.start
+            console.log({ position, doc: doc.getText() })
             const completions = await client.request('autocomplete/execute', {
                 uri: sumUri.toString(),
-                position: { line: 1, character: 3 },
+                position,
                 triggerKind: 'Invoke',
             })
             const texts = completions.items.map(item => item.insertText)


### PR DESCRIPTION
Observe how the prompt does not include the `= b + a` suffix. The LLM generates the completion `finalResult = a + b`, which doesn't match the existing code so we return an empty completion.


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
