### PR TITLE
LSP context: deterministic test snapshots

### DIFF
--- a/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.integration.test.ts
+++ b/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.integration.test.ts
@@ -163,11 +163,11 @@ describe.skipIf(isWindows())('LspLightRetriever', () => {
         expect(contextSnippets.length).toBe(1)
         // TODO: add only constructor to context snippets
         expect(contextSnippets[0].content).toMatchInlineSnapshot(`
-          "interface GreeterConfig {
+          "Greeter.greeting: string
+          GreeterConfig.message: string
+          interface GreeterConfig {
               message: string
           }
-          Greeter.greeting: string
-          GreeterConfig.message: string
           Greeter.greet(): string
           export class Greeter {
               greeting: string;
@@ -197,8 +197,7 @@ describe.skipIf(isWindows())('LspLightRetriever', () => {
           "export interface LabelledValue {
               label: string;
           }
-          export enum Color { Red, Green, Blue }
-          Color.Green = 1
+          Animal.name: string
           export class Animal {
               name: string;
               color: Color;
@@ -212,8 +211,9 @@ describe.skipIf(isWindows())('LspLightRetriever', () => {
                   console.log(\`\${this.name} moved \${distanceInMeters}m. Color: \${Color[this.color]}\`);
               }
           }
+          Color.Green = 1
           Animal.color: Color
-          Animal.name: string
+          export enum Color { Red, Green, Blue }
           new Dog(name: string, color: Color): Dog"
         `
         )
@@ -260,11 +260,11 @@ describe.skipIf(isWindows())('LspLightRetriever', () => {
               color?: Color;
               width?: number;
           }
-          export enum Color { Red, Green, Blue }
           export interface Square {
               color: Color
               area: number
           }
+          export enum Color { Red, Green, Blue }
           createSquare(config: SquareConfig, version?: number): VersionedSquare (+1 overload)"
         `)
     })
@@ -278,12 +278,12 @@ describe.skipIf(isWindows())('LspLightRetriever', () => {
 
         expect(contextSnippets.length).toBe(1)
         expect(contextSnippets[0].content).toMatchInlineSnapshot(`
-          "export enum Color { Red, Green, Blue }
-          export interface Square {
+          "export interface Square {
               color: Color
               area: number
           }
           Color.Green = 1
+          export enum Color { Red, Green, Blue }
           export interface SquareConfig {
               color?: Color;
               width?: number;

--- a/vscode/src/graph/lsp/symbol-context-snippets.ts
+++ b/vscode/src/graph/lsp/symbol-context-snippets.ts
@@ -438,7 +438,14 @@ export async function getSymbolContextSnippets(
             return snippet
         }
 
-        const relatedDefinitions = Array.from(snippet.relatedDefinitionKeys?.values())
+        let relatedDefinitionKeys = Array.from(snippet.relatedDefinitionKeys?.values())
+
+        if (process.env.VITEST) {
+            // Sort related definition keys to keep test snapshots stable on CI.
+            relatedDefinitionKeys = relatedDefinitionKeys.sort((a, b) => b.localeCompare(a))
+        }
+
+        const relatedDefinitions = relatedDefinitionKeys
             .map(key => {
                 if (key === snippet.key) {
                     return undefined


### PR DESCRIPTION
- Fixes the LSP-context test CI flakes caused by the unpredictable resolution order of the nested symbols.
- Closes https://github.com/sourcegraph/cody-issues/issues/335

## Test plan

CI
