### PR TITLE
VS Code: Release 1.18.2

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -32,6 +32,16 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: The chat UI has been updated to make messages editable in-place and stream down from the top. [pull/4209](https://github.com/sourcegraph/cody/pull/4209)
 - Chat: Improved chat model selector UI with GPT-4o now as a recommended model, improved usability for Cody Free users, and a chat models documentation link. [pull/4254](https://github.com/sourcegraph/cody/pull/4254)
 
+## [1.18.2]
+
+### Added
+
+- Feature flags for the fine-tuning model experiment for code completions. [pull/4245](https://github.com/sourcegraph/cody/pull/4245) 
+
+### Fixed
+
+### Changed
+
 ## [1.18.1]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "cody-ai",
   "private": true,
   "displayName": "Cody: AI Coding Assistant with Autocomplete & Chat",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "publisher": "sourcegraph",
   "license": "Apache-2.0",
   "icon": "resources/cody.png",


### PR DESCRIPTION
Patch release follow-up based on https://github.com/sourcegraph/cody/blob/main/vscode/CONTRIBUTING.md

## Test plan
- version/CHANGELOG only

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
