### PR TITLE
added a much-needed run config for spawning the Agent

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -72,6 +72,20 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch Agent port 3113",
+      "program": "${workspaceFolder}/agent/dist/index.js",
+      "runtimeArgs": ["--enable-source-maps", "--preserve-symlinks"],
+      "preLaunchTask": "Build Agent",
+      "env": {
+        "CODY_AGENT_DEBUG_REMOTE": "true",
+        "CODY_AGENT_DEBUG_PORT": "3113"
+      },
+      "sourceMaps": true,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Debug Current File with vitest",
       "autoAttachChildProcesses": true,
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,6 +33,14 @@
       "problemMatcher": "$tsc-watch",
       "options": { "cwd": "vscode" },
       "isBackground": true
+    },
+    {
+      "type": "shell",
+      "label": "Build Agent",
+      "command": "pnpm install && pnpm build",
+      "options": {
+        "cwd": "${workspaceFolder}/agent"
+      }
     }
   ]
 }


### PR DESCRIPTION
Added a launch config for spawning the Agent on port 3113, so JetBrains can attach.

## Test plan

This is not code, but rather dev infrastructure, so it's tested manually by launching the configuration.
