### PR TITLE
Include access token when exporting traces for enterprise

### DIFF
--- a/vscode/src/services/open-telemetry/CodyTraceExport.ts
+++ b/vscode/src/services/open-telemetry/CodyTraceExport.ts
@@ -8,8 +8,18 @@ export class CodyTraceExporter extends OTLPTraceExporter {
     private isTracingEnabled = false
     private queuedSpans: Map<string, { span: ReadableSpan; enqueuedAt: number }> = new Map()
 
-    constructor({ traceUrl, isTracingEnabled }: { traceUrl: string; isTracingEnabled: boolean }) {
-        super({ url: traceUrl, httpAgentOptions: { rejectUnauthorized: false } })
+    constructor({
+        traceUrl,
+        accessToken,
+        isTracingEnabled,
+    }: { traceUrl: string; accessToken: string | null; isTracingEnabled: boolean }) {
+        super({
+            url: traceUrl,
+            httpAgentOptions: { rejectUnauthorized: false },
+            headers: {
+                ...(accessToken ? { Authorization: `token ${accessToken}` } : {}),
+            },
+        })
         this.isTracingEnabled = isTracingEnabled
     }
 

--- a/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
+++ b/vscode/src/services/open-telemetry/OpenTelemetryService.node.ts
@@ -18,7 +18,7 @@ import { ConsoleBatchSpanExporter } from './console-batch-span-exporter'
 
 export type OpenTelemetryServiceConfig = Pick<
     ConfigurationWithAccessToken,
-    'serverEndpoint' | 'experimentalTracing' | 'debugVerbose'
+    'serverEndpoint' | 'experimentalTracing' | 'debugVerbose' | 'accessToken'
 >
 
 export class OpenTelemetryService {
@@ -73,7 +73,11 @@ export class OpenTelemetryService {
         // Add the default tracer exporter used in production.
         this.tracerProvider.addSpanProcessor(
             new BatchSpanProcessor(
-                new CodyTraceExporter({ traceUrl, isTracingEnabled: this.isTracingEnabled })
+                new CodyTraceExporter({
+                    traceUrl,
+                    isTracingEnabled: this.isTracingEnabled,
+                    accessToken: this.config.accessToken,
+                })
             )
         )
 


### PR DESCRIPTION
I remember we had some issues in the past where trace uploading to the SG instance didn't work because auth was missing. This change includes the access token. I tried it on S2 and while I didn't see any issues, logs also did not progress into GCP suggesting we also need to change the Cloud otel config first.

Traces are disabled by default unless you're on PLG (where the FF is enabled for some % of users) or you manually enable it so this won't break any setups.

## Test plan

- CI
- Connected to S2 and enable traces via `"cody.experimental.tracing": true`. Observe that nothing throws but traces still won't be showing up in GCP traces yet

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
