### PR TITLE
Agent: handle `null` values where we previously only handled `undefined`

### DIFF
--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -75,7 +75,7 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
             const changes = applyContentChanges(fromCache, document.contentChanges)
             contentChanges.push(...changes.contentChanges)
             document.underlying.content = changes.newText
-        } else if (typeof document.content === 'string') {
+        } else if (document.content !== undefined) {
             // Full document sync.
             for (const change of calculateContentChanges(fromCache, document.content)) {
                 contentChanges.push(change)
@@ -93,20 +93,6 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         if (!document.visibleRange) {
             // No changes to the visible range, populate from cache
             document.underlying.visibleRange = fromCache.protocolDocument.visibleRange
-        }
-
-        // The client may send null values that we convert to undefined here.
-        if (document.content === null) {
-            document.underlying.content = undefined
-        }
-        if (document.contentChanges === null) {
-            document.underlying.contentChanges = undefined
-        }
-        if (document.selection === null) {
-            document.underlying.selection = undefined
-        }
-        if (document.visibleRange === null) {
-            document.underlying.visibleRange = undefined
         }
 
         fromCache.update(document)

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -337,7 +337,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 ? vscode.Uri.parse(clientInfo.workspaceRootUri)
                 : vscode.Uri.from({
                       scheme: 'file',
-                      path: clientInfo.workspaceRootPath,
+                      path: clientInfo.workspaceRootPath ?? undefined,
                   })
             try {
                 await initializeVscodeExtension(
@@ -819,7 +819,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerAuthenticatedRequest('editCommands/code', params => {
             const instruction = PromptString.unsafe_fromUserQuery(params.instruction)
             const args: ExecuteEditArguments = {
-                configuration: { instruction, model: params.model },
+                configuration: { instruction, model: params.model ?? undefined },
             }
             return this.createEditTask(executeEdit(args).then(task => task && { type: 'edit', task }))
         })
@@ -1004,9 +1004,9 @@ export class Agent extends MessageHandler implements ExtensionClient {
 
         this.registerAuthenticatedRequest('remoteRepo/list', async ({ query, first, afterId }) => {
             const result = await this.extension.enterpriseContextFactory.repoSearcher.list(
-                query,
+                query ?? undefined,
                 first,
-                afterId
+                afterId ?? undefined
             )
             return {
                 repos: result.repos,
@@ -1242,7 +1242,11 @@ export class Agent extends MessageHandler implements ExtensionClient {
                 } else if (message.type === 'errors') {
                     panel.messageInProgressChange.fire(message)
                 } else if (message.type === 'attribution') {
-                    panel.pushAttribution(message)
+                    panel.pushAttribution({
+                        ...message,
+                        attribution: message.attribution ?? undefined,
+                        error: message.error ?? undefined,
+                    })
                 }
 
                 this.notify('webview/postMessage', {

--- a/agent/src/cli/evaluate-autocomplete/triggerAutocomplete.ts
+++ b/agent/src/cli/evaluate-autocomplete/triggerAutocomplete.ts
@@ -114,7 +114,7 @@ export async function triggerAutocomplete(parameters: AutocompleteParameters): P
                 resultTypechecks,
                 resultParses,
                 resultNonInsertPatch: true,
-                event: result.completionEvent,
+                event: result.completionEvent ?? undefined,
                 info,
             })
         } else if (patches.length > 0) {
@@ -126,7 +126,7 @@ export async function triggerAutocomplete(parameters: AutocompleteParameters): P
                     range,
                     resultExact: true,
                     resultParses,
-                    event: result.completionEvent,
+                    event: result.completionEvent ?? undefined,
                     resultTypechecks,
                 })
             } else {
@@ -136,7 +136,7 @@ export async function triggerAutocomplete(parameters: AutocompleteParameters): P
                     range,
                     resultText: text,
                     resultParses,
-                    event: result.completionEvent,
+                    event: result.completionEvent ?? undefined,
                     resultTypechecks,
                 })
             }
@@ -146,7 +146,7 @@ export async function triggerAutocomplete(parameters: AutocompleteParameters): P
                 info,
                 range,
                 resultEmpty: true,
-                event: result.completionEvent,
+                event: result.completionEvent ?? undefined,
                 resultParses,
             })
         }

--- a/lib/shared/src/models/types.ts
+++ b/lib/shared/src/models/types.ts
@@ -17,7 +17,7 @@ type Models = typeof ModelProvider
 /**
  * Available models for Edit.
  * This is either:
- * - one of the availble options (dotcom)
+ * - one of the available options (dotcom)
  * - an unknown `string` (enterprise)
  */
 export type EditModel =

--- a/vscode/src/chat/chat-view/SidebarViewController.ts
+++ b/vscode/src/chat/chat-view/SidebarViewController.ts
@@ -119,7 +119,7 @@ export class SidebarViewController implements vscode.WebviewViewProvider {
                 break
             }
             case 'event':
-                telemetryService.log(message.eventName, message.properties)
+                telemetryService.log(message.eventName, message.properties ?? undefined)
                 break
             case 'links':
                 void openExternalLinks(message.value)

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -273,7 +273,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 await this.handleEdit(
                     uuid.v4(),
                     PromptString.unsafe_fromUserQuery(message.text),
-                    message.index,
+                    message.index ?? undefined,
                     message.contextFiles ?? [],
                     message.editorState,
                     message.addEnhancedContext || false
@@ -308,10 +308,10 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 void openExternalLinks(message.value)
                 break
             case 'openFile':
-                await openFile(message.uri, message.range, this.webviewPanel?.viewColumn)
+                await openFile(message.uri, message.range ?? undefined, this.webviewPanel?.viewColumn)
                 break
             case 'openLocalFileWithRange':
-                await openLocalFileWithRange(message.filePath, message.range)
+                await openLocalFileWithRange(message.filePath, message.range ?? undefined)
                 break
             case 'newFile':
                 handleCodeFromSaveToNewFile(message.text)
@@ -325,7 +325,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 break
             }
             case 'context/choose-remote-search-repo': {
-                await this.handleChooseRemoteSearchRepo(message.explicitRepos)
+                await this.handleChooseRemoteSearchRepo(message.explicitRepos ?? undefined)
                 break
             }
             case 'context/remove-remote-search-repo':
@@ -351,7 +351,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 await this.clearAndRestartSession()
                 break
             case 'event':
-                telemetryService.log(message.eventName, message.properties)
+                telemetryService.log(message.eventName, message.properties ?? undefined)
                 break
             case 'recordEvent':
                 telemetryRecorder.recordEvent(

--- a/vscode/src/chat/protocol.ts
+++ b/vscode/src/chat/protocol.ts
@@ -50,7 +50,7 @@ export type WebviewMessage =
            */
           command: 'event'
           eventName: string
-          properties: TelemetryEventProperties | undefined
+          properties?: TelemetryEventProperties | undefined | null
       }
     | {
           /**
@@ -82,18 +82,18 @@ export type WebviewMessage =
     | {
           command: 'openFile'
           uri: URI
-          range?: RangeData
+          range?: RangeData | undefined | null
       }
     | {
           command: 'openLocalFileWithRange'
           filePath: string
           // Note: we're not using vscode.Range objects or nesting here, as the protocol
           // tends to munge the type in a weird way (nested fields become array indices).
-          range?: RangeData
+          range?: RangeData | undefined | null
       }
     | ({ command: 'edit' } & WebviewEditMessage)
     | { command: 'context/get-remote-search-repos' }
-    | { command: 'context/choose-remote-search-repo'; explicitRepos?: Repo[] }
+    | { command: 'context/choose-remote-search-repo'; explicitRepos?: Repo[] | undefined | null }
     | { command: 'context/remove-remote-search-repo'; repoId: string }
     | { command: 'embeddings/index' }
     | { command: 'symf/index' }
@@ -107,9 +107,9 @@ export type WebviewMessage =
     | {
           command: 'auth'
           authKind: 'signin' | 'signout' | 'support' | 'callback' | 'simplified-onboarding'
-          endpoint?: string
-          value?: string
-          authMethod?: AuthMethod
+          endpoint?: string | undefined | null
+          value?: string | undefined | null
+          authMethod?: AuthMethod | undefined | null
       }
     | { command: 'abort' }
     | {
@@ -159,7 +159,7 @@ export type ExtensionMessage =
           type: 'search:config'
           workspaceFolderUris: string[]
       }
-    | { type: 'history'; localHistory: UserLocalHistory | null }
+    | { type: 'history'; localHistory?: UserLocalHistory | undefined | null }
     | ({ type: 'transcript' } & ExtensionTranscriptMessage)
     | { type: 'view'; view: View }
     | { type: 'errors'; errors: string }
@@ -170,7 +170,7 @@ export type ExtensionMessage =
      */
     | {
           type: 'userContextFiles'
-          userContextFiles: ContextItem[] | null
+          userContextFiles?: ContextItem[] | undefined | null
       }
     /**
      * Send Context Files to chat view as input context (@-mentions)
@@ -201,11 +201,14 @@ export type ExtensionMessage =
 
 interface ExtensionAttributionMessage {
     snippet: string
-    attribution?: {
-        repositoryNames: string[]
-        limitHit: boolean
-    }
-    error?: string
+    attribution?:
+        | {
+              repositoryNames: string[]
+              limitHit: boolean
+          }
+        | undefined
+        | null
+    error?: string | undefined | null
 }
 
 export type ChatSubmitType = 'user' | 'user-newchat'
@@ -215,20 +218,20 @@ export interface WebviewSubmitMessage extends WebviewContextMessage {
     submitType: ChatSubmitType
 
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
-    editorState?: unknown
+    editorState?: unknown | undefined | null
 }
 
 interface WebviewEditMessage extends WebviewContextMessage {
     text: string
-    index?: number
+    index?: number | undefined | null
 
     /** An opaque value representing the text editor's state. @see {ChatMessage.editorState} */
-    editorState?: unknown
+    editorState?: unknown | undefined | null
 }
 
 interface WebviewContextMessage {
-    addEnhancedContext?: boolean
-    contextFiles?: ContextItem[]
+    addEnhancedContext?: boolean | undefined | null
+    contextFiles?: ContextItem[] | undefined | null
 }
 
 export interface ExtensionTranscriptMessage {

--- a/vscode/src/jsonrpc/TextDocumentWithUri.ts
+++ b/vscode/src/jsonrpc/TextDocumentWithUri.ts
@@ -48,18 +48,18 @@ export class ProtocolTextDocumentWithUri {
     }
 
     public get content(): string | undefined {
-        return this.underlying.content
+        return this.underlying.content ?? undefined
     }
 
     public get contentChanges(): ProtocolTextDocumentContentChangeEvent[] | undefined {
-        return this.underlying.contentChanges
+        return this.underlying.contentChanges ?? undefined
     }
 
     public get selection(): Range | undefined {
-        return this.underlying.selection
+        return this.underlying.selection ?? undefined
     }
 
     public get visibleRange(): Range | undefined {
-        return this.underlying.visibleRange
+        return this.underlying.visibleRange ?? undefined
     }
 }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -53,13 +53,13 @@ export type ClientRequests = {
     // `webview/postMessage`. Returns a new *panel* ID, which can be used to
     // send a chat message via `chat/submitMessage`.
     'chat/restore': [
-        { modelID?: string | null; messages: SerializedChatMessage[]; chatID: string },
+        { modelID?: string | undefined | null; messages: SerializedChatMessage[]; chatID: string },
         string,
     ]
 
     'chat/models': [{ modelUsage: ModelUsage }, { models: ModelProvider[] }]
     'chat/export': [null, ChatExportResult[]]
-    'chat/remoteRepos': [{ id: string }, { remoteRepos?: Repo[] }]
+    'chat/remoteRepos': [{ id: string }, { remoteRepos?: Repo[] | undefined | null }]
 
     // High-level wrapper around webview/receiveMessage and webview/postMessage
     // to submit a chat message. The ID is the return value of chat/id, and the
@@ -82,7 +82,7 @@ export type ClientRequests = {
     'commands/custom': [{ key: string }, CustomCommandResult]
 
     // Trigger commands that edit the code.
-    'editCommands/code': [{ instruction: string; model?: string }, EditTask]
+    'editCommands/code': [{ instruction: string; model?: string | undefined | null }, EditTask]
     'editCommands/test': [null, EditTask]
     'editCommands/document': [null, EditTask]
 
@@ -171,7 +171,7 @@ export type ClientRequests = {
     'attribution/search': [
         { id: string; snippet: string },
         {
-            error: string | null
+            error?: string | undefined | null
             repoNames: string[]
             limitHit: boolean
         },
@@ -207,12 +207,12 @@ export type ClientRequests = {
     'remoteRepo/list': [
         {
             // The user input to perform a fuzzy match with
-            query?: string
+            query?: string | undefined | null
             // The maximum number of results to retrieve
             first: number
             // The repository ID of the last result in the previous
             // page, or `undefined` to start from the beginning.
-            afterId?: string
+            afterId?: string | undefined | null
         },
         {
             // The index of the first result in the filtered repository list.
@@ -238,7 +238,10 @@ export type ServerRequests = {
 
     'textDocument/edit': [TextDocumentEditParams, boolean]
     'textDocument/openUntitledDocument': [UntitledTextDocument, boolean]
-    'textDocument/show': [{ uri: string; options?: TextDocumentShowOptionsParams }, boolean]
+    'textDocument/show': [
+        { uri: string; options?: TextDocumentShowOptionsParams | undefined | null },
+        boolean,
+    ]
     'workspace/edit': [WorkspaceEditParams, boolean]
 
     // Low-level API to handle requests from the VS Code extension to create a
@@ -361,12 +364,12 @@ interface CompletionItemParams {
 
 export interface AutocompleteParams {
     uri: string
-    filePath?: string
+    filePath?: string | undefined | null
     position: Position
     // Defaults to 'Automatic' for autocompletions which were not explicitly
     // triggered.
-    triggerKind?: 'Automatic' | 'Invoke'
-    selectedCompletionInfo?: SelectedCompletionInfo
+    triggerKind?: 'Automatic' | 'Invoke' | undefined | null
+    selectedCompletionInfo?: SelectedCompletionInfo | undefined | null
 }
 
 interface SelectedCompletionInfo {
@@ -382,7 +385,7 @@ export interface AutocompleteResult {
     items: AutocompleteItem[]
 
     /** completionEvent is not deprecated because it's used by non-editor clients like evaluate-autocomplete that need access to book-keeping data to evaluate results. */
-    completionEvent?: CompletionBookkeepingEvent
+    completionEvent?: CompletionBookkeepingEvent | undefined | null
 }
 
 export interface AutocompleteItem {
@@ -397,49 +400,49 @@ export interface ClientInfo {
     workspaceRootUri: string
 
     /** @deprecated Use `workspaceRootUri` instead. */
-    workspaceRootPath?: string
+    workspaceRootPath?: string | undefined | null
 
-    extensionConfiguration?: ExtensionConfiguration
-    capabilities?: ClientCapabilities
+    extensionConfiguration?: ExtensionConfiguration | undefined | null
+    capabilities?: ClientCapabilities | undefined | null
 
     /**
      * Optional tracking attributes to inject into telemetry events recorded
      * by the agent.
      */
-    marketingTracking?: TelemetryEventMarketingTrackingInput
+    marketingTracking?: TelemetryEventMarketingTrackingInput | undefined | null
 }
 
 // The capability should match the name of the JSON-RPC methods.
 interface ClientCapabilities {
-    completions?: 'none'
+    completions?: 'none' | undefined | null
     //  When 'streaming', handles 'chat/updateMessageInProgress' streaming notifications.
-    chat?: 'none' | 'streaming'
+    chat?: 'none' | 'streaming' | undefined | null
     // TODO: allow clients to implement the necessary parts of the git extension.
     // https://github.com/sourcegraph/cody/issues/4165
-    git?: 'none' | 'enabled'
+    git?: 'none' | 'enabled' | undefined | null
     // If 'enabled', the client must implement the progress/start,
     // progress/report, and progress/end notification endpoints.
-    progressBars?: 'none' | 'enabled'
-    edit?: 'none' | 'enabled'
-    editWorkspace?: 'none' | 'enabled'
-    untitledDocuments?: 'none' | 'enabled'
-    showDocument?: 'none' | 'enabled'
-    codeLenses?: 'none' | 'enabled'
-    showWindowMessage?: 'notification' | 'request'
-    ignore?: 'none' | 'enabled'
+    progressBars?: 'none' | 'enabled' | undefined | null
+    edit?: 'none' | 'enabled' | undefined | null
+    editWorkspace?: 'none' | 'enabled' | undefined | null
+    untitledDocuments?: 'none' | 'enabled' | undefined | null
+    showDocument?: 'none' | 'enabled' | undefined | null
+    codeLenses?: 'none' | 'enabled' | undefined | null
+    showWindowMessage?: 'notification' | 'request' | undefined | null
+    ignore?: 'none' | 'enabled' | undefined | null
 }
 
 export interface ServerInfo {
     name: string
-    authenticated?: boolean
-    codyEnabled?: boolean
-    codyVersion?: string | null
-    authStatus?: AuthStatus
+    authenticated?: boolean | undefined | null
+    codyEnabled?: boolean | undefined | null
+    codyVersion?: string | undefined | null
+    authStatus?: AuthStatus | undefined | null
 }
 
 export interface ExtensionConfiguration {
     serverEndpoint: string
-    proxy?: string | null
+    proxy?: string | undefined | null
     accessToken: string
     customHeaders: Record<string, string>
 
@@ -448,22 +451,22 @@ export interface ExtensionConfiguration {
      * recorded. It is currently optional for backwards compatibility, but
      * it is strongly recommended to set this when connecting to Agent.
      */
-    anonymousUserID?: string
+    anonymousUserID?: string | undefined | null
 
-    autocompleteAdvancedProvider?: string
-    autocompleteAdvancedModel?: string | null
-    debug?: boolean
-    verboseDebug?: boolean
-    codebase?: string
+    autocompleteAdvancedProvider?: string | undefined | null
+    autocompleteAdvancedModel?: string | undefined | null
+    debug?: boolean | undefined | null
+    verboseDebug?: boolean | undefined | null
+    codebase?: string | undefined | null
 
     /**
      * When passed, the Agent will handle recording events.
      * If not passed, client must send `graphql/logEvent` requests manually.
      * @deprecated This is only used for the legacy logEvent - use `telemetry` instead.
      */
-    eventProperties?: EventProperties
+    eventProperties?: EventProperties | undefined | null
 
-    customConfiguration?: Record<string, any>
+    customConfiguration?: Record<string, any> | undefined | null
 }
 
 /**
@@ -484,7 +487,10 @@ export interface ExtensionConfiguration {
 interface TelemetryEvent {
     feature: string
     action: string
-    parameters?: TelemetryEventParameters<{ [key: string]: number }, BillingProduct, BillingCategory>
+    parameters?:
+        | TelemetryEventParameters<{ [key: string]: number }, BillingProduct, BillingCategory>
+        | undefined
+        | null
 }
 
 /**
@@ -542,20 +548,23 @@ export interface ProtocolTextDocument {
     // Use TextDocumentWithUri.fromDocument(TextDocument) if you want to parse this `uri` property.
     uri: string
     /** @deprecated use `uri` instead. This property only exists for backwards compatibility during the migration period. */
-    filePath?: string
-    content?: string
-    selection?: Range
-    contentChanges?: ProtocolTextDocumentContentChangeEvent[]
-    visibleRange?: Range
+    filePath?: string | undefined | null
+    content?: string | undefined | null
+    selection?: Range | undefined | null
+    contentChanges?: ProtocolTextDocumentContentChangeEvent[] | undefined | null
+    visibleRange?: Range | undefined | null
 
     // Only used during testing. When defined, the agent server will
     // run additional validation to ensure that the document state of
     // the client is correctly synchronized with the docment state of
     // server.
-    testing?: {
-        selectedText?: string
-        sourceOfTruthDocument?: ProtocolTextDocument
-    }
+    testing?:
+        | {
+              selectedText?: string | undefined | null
+              sourceOfTruthDocument?: ProtocolTextDocument | undefined | null
+          }
+        | undefined
+        | null
 }
 
 export interface ProtocolTextDocumentContentChangeEvent {
@@ -565,7 +574,7 @@ export interface ProtocolTextDocumentContentChangeEvent {
 
 interface ExecuteCommandParams {
     command: string
-    arguments?: any[]
+    arguments?: any[] | undefined | null
 }
 
 export interface DebugMessage {
@@ -582,7 +591,7 @@ export interface ProgressReportParams {
     /** Unique ID for this operation. */
     id: string
     /** (optional) Text message to display in the progress bar */
-    message?: string
+    message?: string | undefined | null
     /**
      * (optional) increment to indicate how much percentage of the total
      * operation has been completed since the last report. The total % of the
@@ -590,24 +599,24 @@ export interface ProgressReportParams {
      * of 10 indicates '10%' of the progress has completed since the last
      * report. Can never be negative, and total can never exceed 100.
      */
-    increment?: number
+    increment?: number | undefined | null
 }
 interface ProgressOptions {
     /**
      * A human-readable string which will be used to describe the
      * operation.
      */
-    title?: string
+    title?: string | undefined | null
     /**
      * The location at which progress should show.
      * Either `location` or `locationViewId` must be set
      */
-    location?: string // one of: 'SourceControl' | 'Window' | 'Notification'
+    location?: string | undefined | null // one of: 'SourceControl' | 'Window' | 'Notification'
     /**
      * The location at which progress should show.
      * Either `location` or `locationViewId` must be set
      */
-    locationViewId?: string
+    locationViewId?: string | undefined | null
 
     /**
      * Controls if a cancel button should show to allow the user to
@@ -615,7 +624,7 @@ interface ProgressOptions {
      * `ProgressLocation.Notification` is supporting to show a cancel
      * button.
      */
-    cancellable?: boolean
+    cancellable?: boolean | undefined | null
 }
 
 export interface WebviewPostMessageParams {
@@ -625,7 +634,7 @@ export interface WebviewPostMessageParams {
 
 export interface WorkspaceEditParams {
     operations: WorkspaceEditOperation[]
-    metadata?: vscode.WorkspaceEditMetadata
+    metadata?: vscode.WorkspaceEditMetadata | undefined | null
 }
 
 export type WorkspaceEditOperation =
@@ -635,32 +644,35 @@ export type WorkspaceEditOperation =
     | EditFileOperation
 
 export interface WriteFileOptions {
-    overwrite?: boolean
-    ignoreIfExists?: boolean
+    overwrite?: boolean | undefined | null
+    ignoreIfExists?: boolean | undefined | null
 }
 
 export interface CreateFileOperation {
     type: 'create-file'
     uri: string
-    options?: WriteFileOptions
+    options?: WriteFileOptions | undefined | null
     textContents: string
-    metadata?: vscode.WorkspaceEditEntryMetadata
+    metadata?: vscode.WorkspaceEditEntryMetadata | undefined | null
 }
 export interface RenameFileOperation {
     type: 'rename-file'
     oldUri: string
     newUri: string
-    options?: WriteFileOptions
-    metadata?: vscode.WorkspaceEditEntryMetadata
+    options?: WriteFileOptions | undefined | null
+    metadata?: vscode.WorkspaceEditEntryMetadata | undefined | null
 }
 export interface DeleteFileOperation {
     type: 'delete-file'
     uri: string
-    deleteOptions?: {
-        readonly recursive?: boolean
-        readonly ignoreIfNotExists?: boolean
-    }
-    metadata?: vscode.WorkspaceEditEntryMetadata
+    deleteOptions?:
+        | {
+              readonly recursive?: boolean | undefined | null
+              readonly ignoreIfNotExists?: boolean | undefined | null
+          }
+        | undefined
+        | null
+    metadata?: vscode.WorkspaceEditEntryMetadata | undefined | null
 }
 export interface EditFileOperation {
     type: 'edit-file'
@@ -670,20 +682,20 @@ export interface EditFileOperation {
 
 export interface UntitledTextDocument {
     uri: string
-    content?: string
-    language?: string
+    content?: string | undefined | null
+    language?: string | undefined | null
 }
 
 export interface TextDocumentEditParams {
     uri: string
     edits: TextEdit[]
-    options?: { undoStopBefore: boolean; undoStopAfter: boolean }
+    options?: { undoStopBefore: boolean; undoStopAfter: boolean } | undefined | null
 }
 
 export interface TextDocumentShowOptionsParams {
-    preserveFocus?: boolean
-    preview?: boolean
-    selection?: Range
+    preserveFocus?: boolean | undefined | null
+    preview?: boolean | undefined | null
+    selection?: Range | undefined | null
 }
 
 export type TextEdit = ReplaceTextEdit | InsertTextEdit | DeleteTextEdit
@@ -691,32 +703,32 @@ export interface ReplaceTextEdit {
     type: 'replace'
     range: Range
     value: string
-    metadata?: vscode.WorkspaceEditEntryMetadata
+    metadata?: vscode.WorkspaceEditEntryMetadata | undefined | null
 }
 export interface InsertTextEdit {
     type: 'insert'
     position: Position
     value: string
-    metadata?: vscode.WorkspaceEditEntryMetadata
+    metadata?: vscode.WorkspaceEditEntryMetadata | undefined | null
 }
 export interface DeleteTextEdit {
     type: 'delete'
     range: Range
-    metadata?: vscode.WorkspaceEditEntryMetadata
+    metadata?: vscode.WorkspaceEditEntryMetadata | undefined | null
 }
 
 export interface EditTask {
     id: string
     state: CodyTaskState
-    error?: CodyError
+    error?: CodyError | undefined | null
     selectionRange: Range
-    instruction?: string
+    instruction?: string | undefined | null
 }
 
 export interface CodyError {
     message: string
-    cause?: CodyError
-    stack?: string
+    cause?: CodyError | undefined | null
+    stack?: string | undefined | null
 }
 
 export interface DisplayCodeLensParams {
@@ -726,7 +738,7 @@ export interface DisplayCodeLensParams {
 
 export interface ProtocolCodeLens {
     range: Range
-    command?: ProtocolCommand
+    command?: ProtocolCommand | undefined | null
     isResolved: boolean
 }
 
@@ -739,21 +751,21 @@ export interface ProtocolCommand {
         }[]
     }
     command: string
-    tooltip?: string
-    arguments?: any[]
+    tooltip?: string | undefined | null
+    arguments?: any[] | undefined | null
 }
 
 export interface NetworkRequest {
     url: string
-    body?: string
-    error?: string
+    body?: string | undefined | null
+    error?: string | undefined | null
 }
 
 export interface ShowWindowMessageParams {
     severity: 'error' | 'warning' | 'information'
     message: string
-    options?: vscode.MessageOptions
-    items?: string[]
+    options?: vscode.MessageOptions | undefined | null
+    items?: string[] | undefined | null
 }
 
 interface FileIdentifier {
@@ -795,5 +807,5 @@ export interface GetFoldingRangeResult {
 
 export interface RemoteRepoFetchState {
     state: 'paused' | 'fetching' | 'errored' | 'complete'
-    error: CodyError | undefined
+    error?: CodyError | undefined | null
 }

--- a/vscode/src/jsonrpc/bfg-protocol.ts
+++ b/vscode/src/jsonrpc/bfg-protocol.ts
@@ -17,11 +17,14 @@ export type Requests = {
     'bfg/initialize': [{ clientName: string }, { serverVersion: string }]
     'bfg/contextAtPosition': [
         { uri: string; content: string; position: Position; maxSnippets: number; maxDepth: number },
-        { symbols?: BFGSymbolContextSnippet[]; files?: BFGFileContextSnippet[] },
+        {
+            symbols?: BFGSymbolContextSnippet[] | undefined | null
+            files?: BFGFileContextSnippet[] | undefined | null
+        },
     ]
     'bfg/contextForIdentifiers': [
         { uri: string; identifiers: string[]; maxSnippets: number; maxDepth: number },
-        { symbols?: BFGSymbolContextSnippet[] },
+        { symbols?: BFGSymbolContextSnippet[] | undefined | null },
     ]
     // biome-ignore lint/suspicious/noConfusingVoidType: this models a function returning void
     'bfg/gitRevision/didChange': [{ gitDirectoryUri: string }, void]

--- a/vscode/src/jsonrpc/context-ranking-protocol.ts
+++ b/vscode/src/jsonrpc/context-ranking-protocol.ts
@@ -11,9 +11,9 @@ interface ComputeFeaturesParams {
 
 export interface RankContextItem {
     documentId: number
-    filePath?: string
+    filePath?: string | undefined | null
     content: string
-    source?: string
+    source?: string | undefined | null
 }
 
 interface RankItemsParams {

--- a/vscode/src/jsonrpc/embeddings-protocol.ts
+++ b/vscode/src/jsonrpc/embeddings-protocol.ts
@@ -5,7 +5,7 @@
 interface InitializeParams {
     codyGatewayEndpoint: string
     indexPath: string
-    chunkingPolicy?: ChunkingPolicy
+    chunkingPolicy?: ChunkingPolicy | undefined | null
 }
 
 interface ChunkingPolicy {

--- a/vscode/src/jsonrpc/protocol.test.ts
+++ b/vscode/src/jsonrpc/protocol.test.ts
@@ -1,0 +1,100 @@
+import { basename, relative } from 'node:path'
+import * as ts from 'typescript'
+import { describe, expect, test } from 'vitest'
+
+describe('protocol null/undefined robustness', () => {
+    testProtocolDefinitionIsRobustToNullUndefinedEquivalence(__dirname + '/agent-protocol.ts')
+    testProtocolDefinitionIsRobustToNullUndefinedEquivalence(__dirname + '/bfg-protocol.ts')
+    testProtocolDefinitionIsRobustToNullUndefinedEquivalence(__dirname + '/context-ranking-protocol.ts')
+    testProtocolDefinitionIsRobustToNullUndefinedEquivalence(__dirname + '/embeddings-protocol.ts')
+    testProtocolDefinitionIsRobustToNullUndefinedEquivalence(__dirname + '/../chat/protocol.ts')
+})
+
+/**
+ * See explanatory message printed for failures below.
+ */
+function testProtocolDefinitionIsRobustToNullUndefinedEquivalence(path: string): void {
+    test(`${basename(path)}`, () => {
+        expect(true).toBe(true)
+        const sourceText = ts.sys.readFile(path)!
+        expect(sourceText).toBeDefined()
+        const sourceFile = ts.createSourceFile(path, sourceText, ts.ScriptTarget.Latest, true)
+
+        const problems: { path: string; pos: number; message: string }[] = []
+        function visit(node: ts.Node): void {
+            if (ts.isInterfaceDeclaration(node) || ts.isTypeLiteralNode(node)) {
+                for (const member of node.members) {
+                    if (ts.isPropertySignature(member)) {
+                        visitPropertySignature(member)
+                    }
+                }
+            }
+
+            ts.forEachChild(node, visit)
+        }
+        function visitPropertySignature(node: ts.PropertySignature): void {
+            // If the PropertySignature has any of `null`, `undefined`, or `?` (denoting an optional
+            // field), make sure it has *all* of them.
+            const hasOptional = Boolean(node.questionToken)
+            const hasNullOrUndefined = Boolean(node.type && isNullOrUndefined(node.type))
+            const hasUnionWithNullOrUndefined =
+                node.type && ts.isUnionTypeNode(node.type) && node.type.types.some(isNullOrUndefined)
+
+            if (hasOptional || hasNullOrUndefined || hasUnionWithNullOrUndefined) {
+                const hasAllMarkers =
+                    hasOptional &&
+                    node.type &&
+                    ts.isUnionTypeNode(node.type) &&
+                    node.type.types.some(type => type.kind === ts.SyntaxKind.UndefinedKeyword) &&
+                    node.type.types.some(
+                        type =>
+                            ts.isLiteralTypeNode(type) && type.literal.kind === ts.SyntaxKind.NullKeyword
+                    )
+                if (!hasAllMarkers) {
+                    problems.push({
+                        path,
+                        pos: node.getStart(),
+                        message: `property "${node.name.getText()}" type must accept null, undefined, and optional ("${node.name.getText()}?: T | undefined | null")`,
+                    })
+                }
+            }
+        }
+
+        visit(sourceFile)
+        if (problems.length > 0) {
+            expect.fail(
+                [
+                    `Invalid protocol definitions: ${problems.length} problems.`,
+                    '',
+                    "Problem: If a property's type includes any of `null`, `undefined`, or `?` (optional field), then it must use *all* of them.",
+                    '',
+                    'Fix: Use `field?: T | null | undefined` instead of `field?: T`.',
+                    '',
+                    'Explanation: To prevent bugs when communicating with peers implemented in different programming languages cross-process RPC protocols must not differentiate between `undefined`, ECMAScript property presence (`hasOwnProperty`), and `null`.',
+                    'Anywhere that a value can be `undefined`, our code needs to handle `null` values or no such property existing, and all must be handled in the same way (and vice versa).',
+                    '',
+                    '',
+                ].join('\n') +
+                    problems
+                        .map(
+                            ({ path, pos, message }) =>
+                                `${relative(process.cwd(), path)}:${lineColonChar(
+                                    sourceFile.getLineAndCharacterOfPosition(pos)
+                                )}: ${message}`
+                        )
+                        .join('\n')
+            )
+        }
+    })
+}
+
+function lineColonChar(lc: ts.LineAndCharacter): string {
+    return `${lc.line + 1}:${lc.character + 1}`
+}
+
+function isNullOrUndefined(node: ts.Node): boolean {
+    return (
+        (ts.isLiteralTypeNode(node) && node.literal.kind === ts.SyntaxKind.NullKeyword) ||
+        node.kind === ts.SyntaxKind.UndefinedKeyword
+    )
+}


### PR DESCRIPTION
To prevent bugs when communicating with peers implemented in different programming languages cross-process RPC protocols must not differentiate between `undefined`, ECMAScript property presence (`hasOwnProperty`), and `null`. Anywhere that a value can be `undefined`, our code needs to handle `null` values or no such property existing, and all must be handled in the same way (and vice versa).

If a property's TypeScript type includes any of `null`, `undefined`, or `?` (optional field), then it must use *all* of them in its TypeScript type. All of those possible TypeScript types must be handled.

This makes it impossible to accidentally only check `if (message.foo === undefined) { ...` in cases where `message` came from a peer that may have sent `message.foo === null`.

Also adds tests that parse all of the protocol `.ts` files to report any regressions.

Closes https://linear.app/sourcegraph/issue/CODY-1829/handle-null-values-in-the-protocol.



## Test plan

CI