### PR TITLE
Agent: disable panic check for visibility ranges

### DIFF
--- a/agent/src/panicWhenClientIsOutOfSync.test.ts
+++ b/agent/src/panicWhenClientIsOutOfSync.test.ts
@@ -85,7 +85,7 @@ describe('panicWhenClientIsOutOfSync', () => {
         )
     })
 
-    it.fails('visibleRange', () => {
+    it('visibleRange', () => {
         textDocumentDidChange(
             { ...sourceOfTruth },
             {

--- a/agent/src/panicWhenClientIsOutOfSync.ts
+++ b/agent/src/panicWhenClientIsOutOfSync.ts
@@ -28,12 +28,12 @@ export function panicWhenClientIsOutOfSync(
 
         const clientCompareObject = {
             selection: clientSourceOfTruthDocument.selection,
-            visibleRange: clientSourceOfTruthDocument.visibleRange,
+            // Ignoring visibility for now. It was causing low-priority panics
+            // when we were still debugging higher-priority content/selection
+            // bugs.
         }
-        const serverVisibleRange = serverEditor.visibleRanges?.[0]
         const serverCompareObject = {
             selection: protocolRange(serverEditor.selection),
-            visibleRange: serverVisibleRange ? protocolRange(serverVisibleRange) : undefined,
         }
         if (!isEqual(clientCompareObject, serverCompareObject)) {
             const diff = renderUnifiedDiff(


### PR DESCRIPTION
The agent is panicking on mismatches for visibility ranges, which is probably catching legitimate bugs but they're getting in the way of debugger higher-priority bugs related to content/selection. For now, we can live with minor de-sync between client/server on visibility ranges.


## Test plan

Manually ran JB and confirmed it no longer panicks on visibility range (it still panicks on selection)

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
