### PR TITLE
Agent: soften panic assertions

### DIFF
--- a/agent/src/panicWhenClientIsOutOfSync.ts
+++ b/agent/src/panicWhenClientIsOutOfSync.ts
@@ -33,7 +33,7 @@ export function panicWhenClientIsOutOfSync(
                     text: clientSourceOfTruthDocument.content ?? '',
                 },
                 {
-                    header: `${clientSourceOfTruthDocument.uri} (server side)`,
+                    header: `${serverDocument.uri} (server side)`,
                     text: serverDocument.content ?? '',
                 }
             )
@@ -57,7 +57,7 @@ export function panicWhenClientIsOutOfSync(
                         text: JSON.stringify(clientCompareObject, null, 2),
                     },
                     {
-                        header: `${clientSourceOfTruthDocument.uri} (server side)`,
+                        header: `${serverDocument.uri} (server side)`,
                         text: JSON.stringify(serverCompareObject, null, 2),
                     }
                 )

--- a/agent/src/panicWhenClientIsOutOfSync.ts
+++ b/agent/src/panicWhenClientIsOutOfSync.ts
@@ -4,6 +4,16 @@ import type { ProtocolTextDocument } from './protocol-alias'
 import { renderUnifiedDiff } from './renderUnifiedDiff'
 import { protocolRange, vscodeRange } from './vscode-type-converters'
 
+// Allows the client to send a "source of truth" document that reflects the
+// client's current state.  Should only be used during testing (or local
+// development) to ensure that the document state on the client and server match
+// each other. This function exits the process on the first mis-match by
+// default, unless a custom `doPanic` function is provided (only used for
+// testing this function).
+// The motivation to create this function was that we've spent quite a while
+// debugging document synchronization bugs in the JetBrains plugin. These bugs
+// can be very difficult to debug, esp. when looking at raw logs of
+// line/character numbers.
 export function panicWhenClientIsOutOfSync(
     mostRecentlySentClientDocument: ProtocolTextDocument,
     serverEditor: AgentTextEditor,
@@ -12,7 +22,11 @@ export function panicWhenClientIsOutOfSync(
     const serverDocument = serverEditor.document
     if (mostRecentlySentClientDocument.testing?.sourceOfTruthDocument) {
         const clientSourceOfTruthDocument = mostRecentlySentClientDocument.testing.sourceOfTruthDocument
-        if (clientSourceOfTruthDocument.content !== serverDocument.content) {
+
+        if (
+            typeof clientSourceOfTruthDocument.content === 'string' && // Skip content assertion if the client doesn't send content
+            clientSourceOfTruthDocument.content !== serverDocument.content
+        ) {
             const diff = renderUnifiedDiff(
                 {
                     header: `${clientSourceOfTruthDocument.uri} (client side)`,
@@ -26,27 +40,29 @@ export function panicWhenClientIsOutOfSync(
             params.doPanic(diff)
         }
 
-        const clientCompareObject = {
-            selection: clientSourceOfTruthDocument.selection,
-            // Ignoring visibility for now. It was causing low-priority panics
-            // when we were still debugging higher-priority content/selection
-            // bugs.
-        }
-        const serverCompareObject = {
-            selection: protocolRange(serverEditor.selection),
-        }
-        if (!isEqual(clientCompareObject, serverCompareObject)) {
-            const diff = renderUnifiedDiff(
-                {
-                    header: `${clientSourceOfTruthDocument.uri} (client side)`,
-                    text: JSON.stringify(clientCompareObject, null, 2),
-                },
-                {
-                    header: `${clientSourceOfTruthDocument.uri} (server side)`,
-                    text: JSON.stringify(serverCompareObject, null, 2),
-                }
-            )
-            params.doPanic(diff)
+        if (typeof clientSourceOfTruthDocument.selection === 'object') {
+            const clientCompareObject = {
+                selection: clientSourceOfTruthDocument.selection,
+                // Ignoring visibility for now. It was causing low-priority panics
+                // when we were still debugging higher-priority content/selection
+                // bugs.
+            }
+            const serverCompareObject = {
+                selection: protocolRange(serverEditor.selection),
+            }
+            if (!isEqual(clientCompareObject, serverCompareObject)) {
+                const diff = renderUnifiedDiff(
+                    {
+                        header: `${clientSourceOfTruthDocument.uri} (client side)`,
+                        text: JSON.stringify(clientCompareObject, null, 2),
+                    },
+                    {
+                        header: `${clientSourceOfTruthDocument.uri} (server side)`,
+                        text: JSON.stringify(serverCompareObject, null, 2),
+                    }
+                )
+                params.doPanic(diff)
+            }
         }
     }
 

--- a/agent/src/renderUnifiedDiff.test.ts
+++ b/agent/src/renderUnifiedDiff.test.ts
@@ -71,4 +71,18 @@ describe('renderUnifiedDiff', () => {
             i"
         `)
     })
+
+    it('trailing whitespace', () => {
+        expect(
+            diff(['a ', 'b  ', 'c   '].join('\n'), ['a ', 'b ', 'c '].join('\n'))
+        ).toMatchInlineSnapshot(`
+          "--- a
+          +++ b
+            a␣
+          - b␣␣
+          - c␣␣␣
+          + b␣
+          + c␣"
+        `)
+    })
 })

--- a/agent/src/renderUnifiedDiff.ts
+++ b/agent/src/renderUnifiedDiff.ts
@@ -12,7 +12,12 @@ export function renderUnifiedDiff(
         // TODO: may want to limit the context size. We currently show all lines
         // including the ones that have no diff.
         for (const part of parts) {
-            lines.push(prefix + part)
+            // Replace trailing white characters with '␣' to make it easier to
+            // debug whitespace diffs.
+            const withHighlightedTrailingWhitespace = part.replace(/(\s+)$/, match =>
+                '␣'.repeat(match.length)
+            )
+            lines.push(prefix + withHighlightedTrailingWhitespace)
         }
     }
     return lines.join('\n')


### PR DESCRIPTION
Previously, we would panic the agent process if the "source of truth"
document didn't match 100% between the client/server. Now, we soften the
assertion to only compare "source of truth" properties that are defined
by the client. This gives the client freedom to leave out some
properties (like content).

The motivation for this change is that the JB client can't always give a
100% correct answer in some scenarios. For example, on caret changes, we
only know the "logical position" (line/character), we don't know the
offset, or even the document contents. Just as we are calling
`Document.getText()`, the caret may already become outdated by mutation
on another thread.## Test plan

## Test Plan

Manually tested with JB. 
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
