### PR TITLE
Chat: Include editor selection in chat context by default

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Enterprise: Adds support for the `completions.smartContext` (available in Sourcegraph v5.5.0+) site configuration. [pull/4236](https://github.com/sourcegraph/cody/pull/4236)
 - Chat: Integerated OpenCtx providers with @-mention context menu. [pull/4201](https://github.com/sourcegraph/cody/pull/4201/files)
 - Keybinding: Assign the same keyboard shortcut for starting a new chat to the "New Chat with Selection" command.
+- Chat: Editor selection is now included in all chats by default. []()
 
 ### Fixed
 
@@ -36,7 +37,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
-- Feature flags for the fine-tuning model experiment for code completions. [pull/4245](https://github.com/sourcegraph/cody/pull/4245) 
+- Feature flags for the fine-tuning model experiment for code completions. [pull/4245](https://github.com/sourcegraph/cody/pull/4245)
 
 ### Fixed
 
@@ -52,7 +53,6 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 ### Changed
-
 
 ## [1.18.0]
 

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -66,7 +66,7 @@ import { captureException } from '@sentry/core'
 import type { TelemetryEventParameters } from '@sourcegraph/telemetry'
 import type { URI } from 'vscode-uri'
 import { getContextFileFromUri } from '../../commands/context/file-path'
-import { getContextFileFromCursor } from '../../commands/context/selection'
+import { getContextFileFromCursor, getContextFileFromSelection } from '../../commands/context/selection'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import type { Repo } from '../../context/repo-fetcher'
 import type { RemoteRepoPicker } from '../../context/repo-picker'
@@ -507,9 +507,12 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
                 this.postEmptyMessageInProgress()
 
+                // Add user's current selection as context for chat messages.
+                const selectionContext = source === 'chat' ? await getContextFileFromSelection() : []
+
                 const userContextItems: ContextItemWithContent[] = await resolveContextItems(
                     this.editor,
-                    userContextFiles || [],
+                    [...userContextFiles, ...selectionContext],
                     inputText
                 )
 

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -14,8 +14,6 @@ import {
     uriBasename,
     wrapInActiveSpan,
 } from '@sourcegraph/cody-shared'
-
-import { getContextFileFromSelection } from '../../commands/context/selection'
 import type { RemoteSearch } from '../../context/remote-search'
 import type { VSCodeEditor } from '../../editor/vscode-editor'
 import type { ContextRankingController } from '../../local-context/context-ranking'
@@ -309,8 +307,6 @@ async function getPriorityContext(
 ): Promise<ContextItem[]> {
     return wrapInActiveSpan('chat.context.priority', async () => {
         const priorityContext: ContextItem[] = []
-        const selectionContext = await getContextFileFromSelection()
-        priorityContext.push(...selectionContext)
         if (needsUserAttentionContext(text)) {
             // Query refers to current editor
             priorityContext.push(...getVisibleEditorContext(editor))


### PR DESCRIPTION
## Summary

This change includes the user's current editor selection as context for all new chat messages by default. The selection context is added to the user context items when creating a new chat message.

To support this, the `getContextFileFromSelection` function is now imported and used in `SimpleChatPanelProvider.ts`. If the chat message source is 'chat', the current selection context is retrieved and added to the `userContextFiles` array before resolving the context items.

The selection context retrieval logic is also removed from `getPriorityContext` in `context.ts` since it is now handled in `SimpleChatPanelProvider.ts`.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Build Cody from this branch
3. Highlight some code in your editor
2. Start a new chat and ask Cody about the code you highlighted
3. Submit the question with `Opt + Enter` (enhanced context disabled)
4. Confirm your selection is included as context, and Cody is able to answer your question
5. Start a new empty chat and ask Cody about the code you highlighted
6. Submit the question with `Enter` (enhanced context enabled)
7. Confirm your selection is also included as context with enhanced context added, and Cody is able to answer your question


My highlighted code

![image](https://github.com/sourcegraph/cody/assets/68532117/784216db-7e61-4528-a52e-4ca1e6b8ebc6)

Enhanced Context disabled:

![image](https://github.com/sourcegraph/cody/assets/68532117/32f99fe8-0ca7-4b3e-913e-42823108ad39)

Enhanced Context enabled:

![image](https://github.com/sourcegraph/cody/assets/68532117/820c293d-0242-426d-9050-04f84199fb2f)
