### PR TITLE
fix styling for bullet lists

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -21,6 +21,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Menu: Fixes an issue where the `Add Selection to Cody Chat` context menu item was incorrectly disabled when no new chat was open. [pull/4242](https://github.com/sourcegraph/cody/pull/4242)
 - Fixed an issue where the test file name was incorrectly inserted with the unit test command. [pull/4262](https://github.com/sourcegraph/cody/pull/4262)
 - Chat: Fixed a long-standing bug where it was not possible to copy code from Cody's response before it was finished. [pull/4268](https://github.com/sourcegraph/cody/pull/4268)
+- Chat: Fixed a bug where list bullets or numbers were not shown in chat responses. [pull/4294](https://github.com/sourcegraph/cody/pull/4294)
 
 ### Changed
 

--- a/vscode/webviews/chat/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent.module.css
@@ -173,3 +173,9 @@ body[data-vscode-theme-kind='vscode-light'] .content pre > code {
 .content > *:last-child {
     margin-bottom: 0;
 }
+
+.content ul, .content ol {
+    margin-block: 1rem;
+    padding-inline-start: 2rem;
+    list-style: revert;
+}


### PR DESCRIPTION
The introduction of Tailwind's reset meant that list elements were not showing any bullet or number. This un-resets the CSS within Markdown-rendered content.



## Test plan

CI