### PR TITLE
Reseting document content properties is happening too late in the code

### DIFF
--- a/agent/src/AgentWorkspaceDocuments.ts
+++ b/agent/src/AgentWorkspaceDocuments.ts
@@ -65,6 +65,20 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         }
         const { document: fromCache } = cached
 
+        // The client may send null values that we convert to undefined here.
+        if (document.content === null) {
+            document.underlying.content = undefined
+        }
+        if (document.contentChanges === null) {
+            document.underlying.contentChanges = undefined
+        }
+        if (document.selection === null) {
+            document.underlying.selection = undefined
+        }
+        if (document.visibleRange === null) {
+            document.underlying.visibleRange = undefined
+        }
+
         // We have seen this document before, which means we mutate the existing
         // document to reflect the latest chagnes. For each URI, we keep a
         // singleton document so that `AgentTextDocument.getText()` always
@@ -93,20 +107,6 @@ export class AgentWorkspaceDocuments implements vscode_shim.WorkspaceDocuments {
         if (!document.visibleRange) {
             // No changes to the visible range, populate from cache
             document.underlying.visibleRange = fromCache.protocolDocument.visibleRange
-        }
-
-        // The client may send null values that we convert to undefined here.
-        if (document.content === null) {
-            document.underlying.content = undefined
-        }
-        if (document.contentChanges === null) {
-            document.underlying.contentChanges = undefined
-        }
-        if (document.selection === null) {
-            document.underlying.selection = undefined
-        }
-        if (document.visibleRange === null) {
-            document.underlying.visibleRange = undefined
         }
 
         fromCache.update(document)


### PR DESCRIPTION
## Test plan

Just run any client with with `cody-agent.panic-when-out-of-sync` - it should not fail immediately.