### PR TITLE
Makes "undefined" check more resillient

### DIFF
--- a/agent/src/panicWhenClientIsOutOfSync.ts
+++ b/agent/src/panicWhenClientIsOutOfSync.ts
@@ -40,7 +40,7 @@ export function panicWhenClientIsOutOfSync(
             params.doPanic(diff)
         }
 
-        if (typeof clientSourceOfTruthDocument.selection === 'object') {
+        if ((clientSourceOfTruthDocument.selection ?? undefined) !== undefined) {
             const clientCompareObject = {
                 selection: clientSourceOfTruthDocument.selection,
                 // Ignoring visibility for now. It was causing low-priority panics


### PR DESCRIPTION
Typescript !== TypeSafe. In this case messages coming over the JsonRPC are null instead of undefined.

And `typeof null` is obviously...`object`!

We should (and will) be resolving this on a more robust higher level but for now having the most resillient null/undefined, even if not the prettiest, is solves the issue.


## Test plan

- unit tests still pass.
- Checked that manually setting to null does not break
