### PR TITLE
Agent: add `mode` parameter to editCommands/code

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditCommands_CodeParams.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/EditCommands_CodeParams.kt
@@ -1,8 +1,17 @@
 @file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
 package com.sourcegraph.cody.protocol_generated
 
+import com.google.gson.annotations.SerializedName
+
 data class EditCommands_CodeParams(
   val instruction: String,
   val model: String? = null,
-)
+  val mode: ModeEnum? = null, // Oneof: edit, insert
+) {
+
+  enum class ModeEnum {
+    @SerializedName("edit") Edit,
+    @SerializedName("insert") Insert,
+  }
+}
 

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -819,7 +819,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerAuthenticatedRequest('editCommands/code', params => {
             const instruction = PromptString.unsafe_fromUserQuery(params.instruction)
             const args: ExecuteEditArguments = {
-                configuration: { instruction, model: params.model },
+                configuration: { instruction, model: params.model, mode: params.mode ?? 'edit' },
             }
             return this.createEditTask(executeEdit(args).then(task => task && { type: 'edit', task }))
         })

--- a/vscode/src/commands/execute/doc.ts
+++ b/vscode/src/commands/execute/doc.ts
@@ -117,7 +117,7 @@ export async function executeDocCommand(
 ): Promise<EditCommandResult | undefined> {
     return wrapInActiveSpan('command.doc', async span => {
         span.setAttribute('sampled', true)
-        logDebug('executeDocCommand', 'executing', { args })
+        logDebug('executeDocCommand', 'executing', { verbose: args })
 
         let prompt = PromptString.fromDefaultCommands(defaultCommands, 'doc')
         if (args?.additionalInstruction) {
@@ -137,6 +137,13 @@ export async function executeDocCommand(
         }
 
         const { range, insertionPoint } = getDocumentableRange(editor)
+
+        const selectionText = document?.getText(range)
+        logDebug('executeDocCommand', `selectionText: ${selectionText}`)
+
+        if (!selectionText?.trim()) {
+            throw new Error('Cannot document an empty selection.')
+        }
 
         return {
             type: 'edit',

--- a/vscode/src/edit/prompt/models/generic.ts
+++ b/vscode/src/edit/prompt/models/generic.ts
@@ -67,9 +67,7 @@ const GENERIC_PROMPTS: Record<EditIntent, PromptVariant> = {
             This is part of the file: {filePath}
 
             The user has the following code in their selection:
-            <${PROMPT_TOPICS.SELECTED}>
-            {selectedText}
-            </${PROMPT_TOPICS.SELECTED}>
+            <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
 
             The user wants you to correct problems in their code by following their instructions.
             Provide your fixed code using the following instructions:
@@ -80,9 +78,7 @@ const GENERIC_PROMPTS: Record<EditIntent, PromptVariant> = {
     test: {
         instruction: psDedent`
             Here is my selected code from my codebase file {filePath}, enclosed in <${PROMPT_TOPICS.SELECTED}> tags:
-            <${PROMPT_TOPICS.SELECTED}>
-            {selectedText}
-            </${PROMPT_TOPICS.SELECTED}>
+            <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
 
             As my programming assistant and an expert in testing code, follow instructions below to generate code for my selected code: {instruction}
 
@@ -106,9 +102,7 @@ const GENERIC_PROMPTS: Record<EditIntent, PromptVariant> = {
             This is part of the file: {filePath}
 
             The user has the following code in their selection:
-            <${PROMPT_TOPICS.SELECTED}>
-            {selectedText}
-            </${PROMPT_TOPICS.SELECTED}>
+            <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
 
             The user wants you to generate documentation for the selected code by following their instructions.
             Provide your generated documentation using the following instructions:
@@ -128,7 +122,7 @@ export const buildGenericPrompt = (
                 system: GENERIC_PROMPTS.edit.system,
                 instruction: GENERIC_PROMPTS.edit.instruction
                     .replaceAll('{instruction}', instruction)
-                    .replaceAll('{selectedText}', selectedText?.trimEnd())
+                    .replaceAll('{selectedText}', selectedText)
                     .replaceAll('{filePath}', PromptString.fromDisplayPath(uri)),
             }
         case 'add':
@@ -143,7 +137,7 @@ export const buildGenericPrompt = (
                 system: GENERIC_PROMPTS.fix.system,
                 instruction: GENERIC_PROMPTS.fix.instruction
                     .replaceAll('{instruction}', instruction)
-                    .replaceAll('{selectedText}', selectedText?.trimEnd())
+                    .replaceAll('{selectedText}', selectedText)
                     .replaceAll('{filePath}', PromptString.fromDisplayPath(uri)),
             }
         case 'test':
@@ -151,7 +145,7 @@ export const buildGenericPrompt = (
                 system: GENERIC_PROMPTS.test.system,
                 instruction: GENERIC_PROMPTS.test.instruction
                     .replaceAll('{instruction}', instruction)
-                    .replaceAll('{selectedText}', selectedText?.trimEnd())
+                    .replaceAll('{selectedText}', selectedText)
                     .replaceAll('{filePath}', PromptString.fromDisplayPath(uri)),
             }
         case 'doc':
@@ -159,7 +153,7 @@ export const buildGenericPrompt = (
                 system: GENERIC_PROMPTS.doc.system,
                 instruction: GENERIC_PROMPTS.doc.instruction
                     .replaceAll('{instruction}', instruction)
-                    .replaceAll('{selectedText}', selectedText?.trimEnd())
+                    .replaceAll('{selectedText}', selectedText)
                     .replaceAll('{filePath}', PromptString.fromDisplayPath(uri)),
             }
     }

--- a/vscode/src/edit/prompt/models/generic.ts
+++ b/vscode/src/edit/prompt/models/generic.ts
@@ -67,7 +67,9 @@ const GENERIC_PROMPTS: Record<EditIntent, PromptVariant> = {
             This is part of the file: {filePath}
 
             The user has the following code in their selection:
-            <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
+            <${PROMPT_TOPICS.SELECTED}>
+            {selectedText}
+            </${PROMPT_TOPICS.SELECTED}>
 
             The user wants you to correct problems in their code by following their instructions.
             Provide your fixed code using the following instructions:
@@ -78,7 +80,9 @@ const GENERIC_PROMPTS: Record<EditIntent, PromptVariant> = {
     test: {
         instruction: psDedent`
             Here is my selected code from my codebase file {filePath}, enclosed in <${PROMPT_TOPICS.SELECTED}> tags:
-            <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
+            <${PROMPT_TOPICS.SELECTED}>
+            {selectedText}
+            </${PROMPT_TOPICS.SELECTED}>
 
             As my programming assistant and an expert in testing code, follow instructions below to generate code for my selected code: {instruction}
 
@@ -102,7 +106,9 @@ const GENERIC_PROMPTS: Record<EditIntent, PromptVariant> = {
             This is part of the file: {filePath}
 
             The user has the following code in their selection:
-            <${PROMPT_TOPICS.SELECTED}>{selectedText}</${PROMPT_TOPICS.SELECTED}>
+            <${PROMPT_TOPICS.SELECTED}>
+            {selectedText}
+            </${PROMPT_TOPICS.SELECTED}>
 
             The user wants you to generate documentation for the selected code by following their instructions.
             Provide your generated documentation using the following instructions:
@@ -122,7 +128,7 @@ export const buildGenericPrompt = (
                 system: GENERIC_PROMPTS.edit.system,
                 instruction: GENERIC_PROMPTS.edit.instruction
                     .replaceAll('{instruction}', instruction)
-                    .replaceAll('{selectedText}', selectedText)
+                    .replaceAll('{selectedText}', selectedText?.trimEnd())
                     .replaceAll('{filePath}', PromptString.fromDisplayPath(uri)),
             }
         case 'add':
@@ -137,7 +143,7 @@ export const buildGenericPrompt = (
                 system: GENERIC_PROMPTS.fix.system,
                 instruction: GENERIC_PROMPTS.fix.instruction
                     .replaceAll('{instruction}', instruction)
-                    .replaceAll('{selectedText}', selectedText)
+                    .replaceAll('{selectedText}', selectedText?.trimEnd())
                     .replaceAll('{filePath}', PromptString.fromDisplayPath(uri)),
             }
         case 'test':
@@ -145,7 +151,7 @@ export const buildGenericPrompt = (
                 system: GENERIC_PROMPTS.test.system,
                 instruction: GENERIC_PROMPTS.test.instruction
                     .replaceAll('{instruction}', instruction)
-                    .replaceAll('{selectedText}', selectedText)
+                    .replaceAll('{selectedText}', selectedText?.trimEnd())
                     .replaceAll('{filePath}', PromptString.fromDisplayPath(uri)),
             }
         case 'doc':
@@ -153,7 +159,7 @@ export const buildGenericPrompt = (
                 system: GENERIC_PROMPTS.doc.system,
                 instruction: GENERIC_PROMPTS.doc.instruction
                     .replaceAll('{instruction}', instruction)
-                    .replaceAll('{selectedText}', selectedText)
+                    .replaceAll('{selectedText}', selectedText?.trimEnd())
                     .replaceAll('{filePath}', PromptString.fromDisplayPath(uri)),
             }
     }

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -82,7 +82,7 @@ export type ClientRequests = {
     'commands/custom': [{ key: string }, CustomCommandResult]
 
     // Trigger commands that edit the code.
-    'editCommands/code': [{ instruction: string; model?: string }, EditTask]
+    'editCommands/code': [{ instruction: string; model?: string; mode?: 'edit' | 'insert' }, EditTask]
     'editCommands/test': [null, EditTask]
     'editCommands/document': [null, EditTask]
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -83,7 +83,11 @@ export type ClientRequests = {
 
     // Trigger commands that edit the code.
     'editCommands/code': [
-        { instruction: string; model?: string | undefined | null; mode?: 'edit' | 'insert' },
+        {
+            instruction: string
+            model?: string | undefined | null
+            mode?: 'edit' | 'insert' | undefined | null
+        },
         EditTask,
     ]
     'editCommands/test': [null, EditTask]


### PR DESCRIPTION
This change adds a new `mode` parameter to the `editCommands/code` request in the agent protocol. The `mode` parameter can be either `'edit'` or `'insert'`, and it allows the client to specify whether the edit command should perform an edit or an insertion operation.

The corresponding changes have been made in the Kotlin binding and the TypeScript agent implementation to support this new parameter.

2: add checks for empty selection in doc and test commands

This change adds checks for empty selections in the `executeDocCommand` and `executeTestEditCommand` functions. If the selected text is empty (AFTER we have expanded the range and not before), the functions will throw an error to prevent the commands from executing on an empty selection.

The changes also include some minor logging improvements to provide more verbose information about the arguments being passed to the commands. This also prevent sending invalid request to the LLM that would return unhelpful response that would break the user's document. 


~3. Cleaned up the format for the prompt where we wrap the selection code in to make sure they are all standardized. See more context in https://sourcegraph.slack.com/archives/C05AGQYD528/p1716585733323689~ 

^ will more this to a separate PR once the recordings token is fixed

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

We already have an agent side test for the "insert" and "edit" mode: https://sourcegraph.com/github.com/sourcegraph/cody@vscode-v1.18.2/-/blob/agent/src/index.test.ts?L1283-1333

Follow the test plan in https://github.com/sourcegraph/jetbrains/pull/1649 to verify the change works with client

Here is a Demo with the changes made in this PR & https://github.com/sourcegraph/jetbrains/pull/1649

https://github.com/sourcegraph/cody/assets/68532117/b1805a4d-e94d-4a5a-8f85-1d4d878ce51d

