### PR TITLE
misc improvements to chat storybooks and removing unused chat-related code/styles

### DIFF
--- a/vscode/.storybook/main.ts
+++ b/vscode/.storybook/main.ts
@@ -11,6 +11,17 @@ const config: StorybookConfig = {
             },
         },
     ],
+    previewHead: head => `
+    ${head}
+    <style>
+      @media (prefers-color-scheme: dark) {
+          body {
+              /* Avoid white flash when changing stories. */
+              background-color: var(--vscode-editor-background, #1f1f1f) !important;
+          }
+      }
+    </style>
+  `,
     framework: {
         name: '@storybook/react-vite',
         options: {},

--- a/vscode/webviews/Chat.module.css
+++ b/vscode/webviews/Chat.module.css
@@ -3,10 +3,14 @@
     display: flex;
     flex-direction: column;
 
+    /* Make it so that after a user submits a followup message, the response is
+       visible when the viewport is scrolled all the way down. */
+    padding-bottom: max(4rem, 15vh);
+
     /* popups use a screen to capture clicks outside the popups; this is
        necessary so that the screen can extend to the extent of the view without
        scrollbars */
-    overflow: clip;
+    overflow: auto;
 }
 
 .chat-disabled {

--- a/vscode/webviews/chat/Transcript.module.css
+++ b/vscode/webviews/chat/Transcript.module.css
@@ -1,12 +1,3 @@
-.container {
-    overflow-x: hidden;
-
-}
-
-.last-human-message {
-    margin-bottom: 2rem;
-}
-
 .welcome-message-cell-content p:first-child {
     margin-top: 0;
 }

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -1,8 +1,6 @@
 import type React from 'react'
 import type { FunctionComponent, ReactNode } from 'react'
 
-import { clsx } from 'clsx'
-
 import { type ChatMessage, type ContextItem, type Guardrails, isDefined } from '@sourcegraph/cody-shared'
 import type { UserAccountInfo } from '../Chat'
 import type { ApiPostMessage } from '../Chat'
@@ -20,7 +18,6 @@ export const Transcript: React.FunctionComponent<{
     transcript: ChatMessage[]
     welcomeMessage?: ReactNode
     messageInProgress: ChatMessage | null
-    className?: string
     feedbackButtonsOnSubmit: (text: string) => void
     copyButtonOnSubmit: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit: CodeBlockActionsProps['insertButtonOnSubmit']
@@ -34,7 +31,6 @@ export const Transcript: React.FunctionComponent<{
     transcript,
     welcomeMessage,
     messageInProgress,
-    className,
     feedbackButtonsOnSubmit,
     copyButtonOnSubmit,
     insertButtonOnSubmit,
@@ -115,7 +111,7 @@ export const Transcript: React.FunctionComponent<{
     }
 
     return (
-        <div className={clsx(className, styles.container)}>
+        <>
             {transcript.flatMap(messageToTranscriptItem)}
             {messageInProgress &&
                 messageInProgress.speaker === 'assistant' &&
@@ -156,7 +152,7 @@ export const Transcript: React.FunctionComponent<{
                 />
             )}
             {transcript.length === 0 && <WelcomeMessageCell welcomeMessage={welcomeMessage} />}
-        </div>
+        </>
     )
 }
 

--- a/vscode/webviews/chat/cells/messageCell/BaseMessageCell.module.css
+++ b/vscode/webviews/chat/cells/messageCell/BaseMessageCell.module.css
@@ -1,7 +1,3 @@
-.cell-container {
-    overflow: hidden;
-}
-
 /* Make footer take up less vertical space */
 .footer {
     margin-top: calc(0.25*var(--cell-spacing));

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -12,7 +12,7 @@ export function transcriptFixture(transcript: ChatMessage[]): ChatMessage[] {
 }
 
 export const FIXTURE_TRANSCRIPT: Record<
-    'simple' | 'simple2' | 'codeQuestion' | 'explainCode' | 'explainCode2',
+    'simple' | 'simple2' | 'codeQuestion' | 'explainCode' | 'explainCode2' | 'long',
     ChatMessage[]
 > = {
     simple: transcriptFixture([
@@ -103,6 +103,35 @@ export const FIXTURE_TRANSCRIPT: Record<
         {
             speaker: 'assistant',
             text: ps`This code is very cool.`,
+        },
+    ]),
+    long: transcriptFixture([
+        {
+            speaker: 'human',
+            text: ps`What are some colors?`,
+            contextFiles: [{ type: 'file', uri: URI.file('dir/dir/file-a-1.py') }],
+        },
+        {
+            speaker: 'assistant',
+            text: ps`Here are some colors:\n\n* Red\n* Green\n* Blue\n* Yellow\n* Cyan\n* Magenta\n* Black\n* White\n`,
+        },
+        {
+            speaker: 'human',
+            text: ps`What are some letters?`,
+            contextFiles: [{ type: 'file', uri: URI.file('dir/dir/file-a-2.py') }],
+        },
+        {
+            speaker: 'assistant',
+            text: ps`Here are some letters:\n\n* A\n* B\n* C\n* D\n* E\n* F\n* G\n* H\n* I\n* J\n* K\n* L\n* M\n* N\n* O\n* P\n* Q\n* R\n* S\n* T\n* U\n* V\n* W\n* X\n* Y\n* Z\n`,
+        },
+        {
+            speaker: 'human',
+            text: ps`What are some numbers?`,
+            contextFiles: [{ type: 'file', uri: URI.file('dir/dir/file-a-3.py') }],
+        },
+        {
+            speaker: 'assistant',
+            text: ps`Here are some numbers:\n\n* 1\n* 2\n* 3\n* 4\n* 5\n* 6\n* 7\n* 8\n* 9\n* 10\n`,
         },
     ]),
 }

--- a/vscode/webviews/promptEditor/BaseEditor.tsx
+++ b/vscode/webviews/promptEditor/BaseEditor.tsx
@@ -6,13 +6,7 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
 import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin'
 import { clsx } from 'clsx'
-import {
-    $getRoot,
-    $getSelection,
-    type EditorState,
-    type LexicalEditor,
-    type SerializedEditorState,
-} from 'lexical'
+import { $getRoot, type EditorState, type LexicalEditor, type SerializedEditorState } from 'lexical'
 import { type FunctionComponent, type RefObject, useMemo } from 'react'
 import styles from './BaseEditor.module.css'
 import { RICH_EDITOR_NODES } from './nodes'
@@ -48,7 +42,6 @@ export const BaseEditor: FunctionComponent<Props> = ({
     'aria-label': ariaLabel,
 
     // KeyboardEventPluginProps
-    onKeyDown,
     onEnterKey,
     onEscapeKey,
 }) => {
@@ -92,11 +85,7 @@ export const BaseEditor: FunctionComponent<Props> = ({
                     <CodeHighlightPlugin />
                     {onFocusChange && <OnFocusChangePlugin onFocusChange={onFocusChange} />}
                     {editorRef && <EditorRefPlugin editorRef={editorRef} />}
-                    <KeyboardEventPlugin
-                        onKeyDown={onKeyDown}
-                        onEnterKey={onEnterKey}
-                        onEscapeKey={onEscapeKey}
-                    />
+                    <KeyboardEventPlugin onEnterKey={onEnterKey} onEscapeKey={onEscapeKey} />
                 </LexicalComposer>
             </div>
         </div>
@@ -105,9 +94,4 @@ export const BaseEditor: FunctionComponent<Props> = ({
 
 export function editorStateToText(editorState: EditorState): string {
     return editorState.read(() => $getRoot().getTextContent())
-}
-
-export function editorSelectionStart(editorState: EditorState): number | null {
-    const points = editorState.read(() => $getSelection()?.getStartEndPoints())
-    return points ? points[0].offset : null
 }

--- a/vscode/webviews/promptEditor/PromptEditor.tsx
+++ b/vscode/webviews/promptEditor/PromptEditor.tsx
@@ -60,7 +60,6 @@ export const PromptEditor: FunctionComponent<Props> = ({
     editorRef: ref,
 
     // KeyboardEventPluginProps
-    onKeyDown,
     onEnterKey,
     onEscapeKey,
 }) => {
@@ -158,7 +157,6 @@ export const PromptEditor: FunctionComponent<Props> = ({
             aria-label="Chat message"
             //
             // KeyboardEventPluginProps
-            onKeyDown={onKeyDown}
             onEnterKey={onEnterKey}
             onEscapeKey={onEscapeKey}
         />

--- a/vscode/webviews/promptEditor/plugins/keyboardEvent.tsx
+++ b/vscode/webviews/promptEditor/plugins/keyboardEvent.tsx
@@ -1,16 +1,13 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
-import { COMMAND_PRIORITY_LOW, KEY_DOWN_COMMAND, KEY_ENTER_COMMAND, KEY_ESCAPE_COMMAND } from 'lexical'
+import { COMMAND_PRIORITY_LOW, KEY_ENTER_COMMAND, KEY_ESCAPE_COMMAND } from 'lexical'
 import { type FunctionComponent, useEffect } from 'react'
-import { editorSelectionStart } from '../BaseEditor'
 
 export interface KeyboardEventPluginProps {
-    onKeyDown?: (event: KeyboardEvent, caretPosition: number) => void
     onEnterKey?: (event: KeyboardEvent | null) => void
     onEscapeKey?: () => void
 }
 
 export const KeyboardEventPlugin: FunctionComponent<KeyboardEventPluginProps> = ({
-    onKeyDown,
     onEnterKey,
     onEscapeKey,
 }) => {
@@ -18,25 +15,6 @@ export const KeyboardEventPlugin: FunctionComponent<KeyboardEventPluginProps> = 
 
     useEffect(() => {
         const disposables: (() => void)[] = []
-        if (onKeyDown) {
-            disposables.push(
-                editor.registerCommand(
-                    KEY_DOWN_COMMAND,
-                    event => {
-                        // HACK(sqs): Without the `setTimeout` wrap, pressing UpArrow in an empty
-                        // editor does not populate the editor with the contents of the last human
-                        // message, and the following error is thrown: `BaseEditor.tsx:58 TypeError:
-                        // Cannot assign to read only property 'dirty' of object
-                        // '#<_RangeSelection>'`.
-                        setTimeout(() =>
-                            onKeyDown?.(event, editorSelectionStart(editor.getEditorState()) ?? 0)
-                        )
-                        return false
-                    },
-                    COMMAND_PRIORITY_LOW
-                )
-            )
-        }
         if (onEnterKey) {
             disposables.push(
                 editor.registerCommand(
@@ -66,7 +44,7 @@ export const KeyboardEventPlugin: FunctionComponent<KeyboardEventPluginProps> = 
                 disposable()
             }
         }
-    }, [editor, onKeyDown, onEscapeKey, onEnterKey])
+    }, [editor, onEscapeKey, onEnterKey])
 
     return null
 }

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
@@ -40,11 +40,6 @@ vscode-button::part(control) {
     border: solid 1px var(--vscode-sideBar-border);
 }
 
-.container--cell {
-    /* Cells have their own border-bottom. */
-    border-bottom: 0 !important;
-}
-
 .container-viewport {
     width: 100vw;
     height: 100vh;

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.module.css
@@ -21,6 +21,11 @@ vscode-button::part(control) {
     text-decoration: none;
 }
 
+.container--webview {
+    max-height: max(500px, calc(100vh - 6rem));
+    overflow: auto;
+}
+
 .container--webview, .container--cell {
     max-width: 80%;
     margin: 2rem auto;


### PR DESCRIPTION
- remove needless onKeyDown Lexical event listener
- avoid white flash when changing stories in dark theme
- remove erroneous VSCodeCell decorator style
- add new chat fixture to test scrolling in storybook
- clean up Transcript and Chat styling and containers

## Test plan

CI