### PR TITLE
fix chat input colors on light themes

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.module.css
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.module.css
@@ -15,8 +15,3 @@
         background-color: unset !important;
     }
 }
-
-/* State: Disabled or editor unfocused */
-.button:is(:not(.editorFocused), :disabled) {
-    --tint-color: color-mix(in srgb, var(--vscode-button-secondaryBackground) 60%, var(--vscode-button-secondaryForeground));
-}

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.module.css
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.module.css
@@ -57,6 +57,11 @@ button > .model-title-with-icon {
 }
 
 /* Show link as normal text in popover. */
-[cmdk-list] .model-title-with-icon {
-    color: var(--vscode-foreground) !important;
+[cmdk-list] [role="option"] {
+    &:not([aria-selected="true"]) .model-title-with-icon:is(a) {
+        color: var(--vscode-foreground) !important;
+    }
+    &[aria-selected="true"] .model-title-with-icon:is(a) {
+        color: var(--vscode-list-activeSelectionForeground) !important;
+    }
 }

--- a/vscode/webviews/components/shadcn/ui/button.tsx
+++ b/vscode/webviews/components/shadcn/ui/button.tsx
@@ -12,7 +12,7 @@ const buttonVariants = cva(
                 outline:
                     'tw-border tw-border-input tw-bg-background hover:tw-bg-accent hover:tw-text-accent-foreground',
                 toolbarItem:
-                    'tw-border tw-border-input tw-bg-none hover:tw-text-accent-foreground disabled:!tw-opacity-100 disabled:tw-border-transparent',
+                    'tw-border tw-border-input tw-bg-none hover:tw-text-accent-foreground disabled:tw-border-transparent',
                 secondary: 'tw-bg-secondary tw-text-secondary-foreground hover:tw-bg-secondary/80',
                 ghost: 'hover:tw-bg-accent hover:tw-text-accent-foreground',
                 link: 'tw-text-primary tw-underline-offset-4 hover:tw-underline',

--- a/vscode/webviews/components/shadcn/ui/toolbar.module.css
+++ b/vscode/webviews/components/shadcn/ui/toolbar.module.css
@@ -38,14 +38,8 @@
 }
 
 .button--primary {
-    color: color-mix(in lch, var(--vscode-button-secondaryForeground) 50%, var(--vscode-button-foreground));
-    background-color: var(--tint-color);
-    &:disabled {
-        --tint-color: color-mix(in srgb, var(--vscode-button-secondaryBackground) 70%, var(--vscode-button-secondaryForeground));
-    }
-    &:enabled {
-        --tint-color: var(--vscode-button-background);
-    }
+    color: var(--vscode-button-foreground);
+    background-color: var(--vscode-button-background);
 
     &.button--no-icon-start {
         padding-left: calc(2*var(--padding-x));
@@ -56,17 +50,20 @@
     }
 }
 
-.button-secondary {
-    color: color-mix(in lch, var(--vscode-button-secondaryForeground) 60%, transparent);
-    background: transparent;
+.button--secondary {
+    /* Make it look like text in an input. */
+    color: color-mix(in lch, var(--vscode-input-foreground) 60%, transparent);
+    background-color: unset;
+
+    &:enabled:is(:hover, :focus-within) {
+        color: var(--vscode-input-foreground);
+        fill: var(--vscode-input-foreground);
+    }
 }
 
-/* Hover state */
-.button:enabled:is(:hover, :focus-within) {
-    background-color: unset;
-    color: var(--vscode-button-foreground);
-    fill: var(--vscode-button-foreground);
-    &.button--primary {
-        background-color: var(--vscode-button-background);
+.button:disabled {
+    opacity: 0.5;
+    &.button--secondary {
+        opacity: 0.7;
     }
 }

--- a/vscode/webviews/components/shadcn/ui/toolbar.tsx
+++ b/vscode/webviews/components/shadcn/ui/toolbar.tsx
@@ -22,20 +22,17 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip'
 // NOTE(sqs): These components are not from shadcn, but they follow that convention. Some of the
 // styling is still in CSS, not Tailwind.
 
-const buttonVariants = cva(
-    'tw-border-none tw-flex tw-items-center focus-visible:tw-outline-none disabled:!tw-opacity-100',
-    {
-        variants: {
-            variant: {
-                primary: '',
-                secondary: '',
-            },
+const buttonVariants = cva('tw-border-none tw-flex tw-items-center focus-visible:tw-outline-none', {
+    variants: {
+        variant: {
+            primary: '',
+            secondary: '',
         },
-        defaultVariants: {
-            variant: 'secondary',
-        },
-    }
-)
+    },
+    defaultVariants: {
+        variant: 'secondary',
+    },
+})
 
 type IconComponent = ComponentType<{ width?: number | string; height?: number | string }>
 


### PR DESCRIPTION
In many light themes for VS Code, the chat input toolbar had very low or no contrast.

HT @eseliger @toolmantim

Before:
![image](https://github.com/sourcegraph/cody/assets/1976/aea53418-9063-4c6d-be05-4faaf8208d03)


After:

<img width="630" alt="image" src="https://github.com/sourcegraph/cody/assets/1976/94ee1fce-311b-40a9-bb6b-ed70d7fa8c73">


## Test plan

CI