### PR TITLE
fix race conditions in sending and editing messages

### DIFF
--- a/lib/shared/src/sourcegraph-api/errors.ts
+++ b/lib/shared/src/sourcegraph-api/errors.ts
@@ -97,10 +97,12 @@ export function isAbortError(error: unknown): error is AbortError {
         isError(error) &&
         // custom abort error
         ((error instanceof AbortError && error.isAbortError) ||
+            error.name === 'AbortError' ||
             // http module
             error.message === 'aborted' ||
             // fetch
             error.message.includes('The operation was aborted') ||
+            error.message === 'This operation was aborted' ||
             error.message.includes('The user aborted a request'))
     )
 }

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -137,13 +137,15 @@ export class ChatManager implements vscode.Disposable {
         command,
     }: ExecuteChatArguments): Promise<ChatSession | undefined> {
         const provider = await this.chatPanelsManager.getNewChatPanel()
-        await provider?.handleUserMessageSubmission(
+        const abortSignal = provider.startNewSubmitOrEditOperation()
+        await provider.handleUserMessageSubmission(
             uuid.v4(),
             text,
             submitType,
             contextFiles ?? [],
             editorState,
             addEnhancedContext ?? true,
+            abortSignal,
             source,
             command
         )
@@ -160,7 +162,7 @@ export class ChatManager implements vscode.Disposable {
             mode === 'new-chat'
                 ? await this.chatPanelsManager.getNewChatPanel()
                 : await this.chatPanelsManager.getActiveChatPanel()
-        await provider?.handleGetUserEditorContext(uri)
+        await provider.handleGetUserEditorContext(uri)
     }
 
     private async editChatHistory(treeItem?: vscode.TreeItem): Promise<void> {

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -26,6 +26,7 @@ import {
     Typewriter,
     allMentionProvidersMetadata,
     hydrateAfterPostMessage,
+    isAbortError,
     isDefined,
     isError,
     isFileURI,
@@ -265,6 +266,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     message.contextFiles ?? [],
                     message.editorState,
                     message.addEnhancedContext ?? false,
+                    this.startNewSubmitOrEditOperation(),
                     'chat'
                 )
                 break
@@ -453,6 +455,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         userContextFiles: ContextItem[],
         editorState: ChatMessage['editorState'],
         addEnhancedContext: boolean,
+        abortSignal: AbortSignal,
         source?: EventSource,
         command?: DefaultChatCommands
     ): Promise<void> {
@@ -500,21 +503,25 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 if (submitType === 'user-newchat' && !this.chatModel.isEmpty()) {
                     span.addEvent('clearAndRestartSession')
                     await this.clearAndRestartSession()
+                    abortSignal.throwIfAborted()
                 }
 
                 this.chatModel.addHumanMessage({ text: inputText, editorState })
                 await this.saveSession()
+                abortSignal.throwIfAborted()
 
                 this.postEmptyMessageInProgress()
 
                 // Add user's current selection as context for chat messages.
                 const selectionContext = source === 'chat' ? await getContextFileFromSelection() : []
+                abortSignal.throwIfAborted()
 
                 const userContextItems: ContextItemWithContent[] = await resolveContextItems(
                     this.editor,
                     [...userContextFiles, ...selectionContext],
                     inputText
                 )
+                abortSignal.throwIfAborted()
 
                 span.setAttribute('strategy', this.config.useContext)
                 const prompter = new DefaultPrompter(
@@ -566,9 +573,13 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 }
 
                 try {
-                    const prompt = await this.buildPrompt(prompter, sendTelemetry)
-                    this.streamAssistantResponse(requestID, prompt, span, firstTokenSpan)
+                    const prompt = await this.buildPrompt(prompter, abortSignal, sendTelemetry)
+                    abortSignal.throwIfAborted()
+                    this.streamAssistantResponse(requestID, prompt, span, firstTokenSpan, abortSignal)
                 } catch (error) {
+                    if (isAbortErrorOrSocketHangUp(error as Error)) {
+                        return
+                    }
                     if (isRateLimitError(error)) {
                         this.postError(error, 'transcript')
                     } else {
@@ -582,6 +593,19 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 }
             })
         })
+    }
+
+    private submitOrEditOperation: AbortController | undefined
+    public startNewSubmitOrEditOperation(): AbortSignal {
+        this.submitOrEditOperation?.abort()
+        this.submitOrEditOperation = new AbortController()
+        return this.submitOrEditOperation.signal
+    }
+    private cancelSubmitOrEditOperation(): void {
+        if (this.submitOrEditOperation) {
+            this.submitOrEditOperation.abort()
+            this.submitOrEditOperation = undefined
+        }
     }
 
     /**
@@ -599,6 +623,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         editorState: ChatMessage['editorState'],
         addEnhancedContext = true
     ): Promise<void> {
+        const abortSignal = this.startNewSubmitOrEditOperation()
+
         telemetryService.log('CodyVSCodeExtension:editChatButton:clicked', undefined, {
             hasV2Event: true,
         })
@@ -617,6 +643,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                 contextFiles,
                 editorState,
                 addEnhancedContext,
+                abortSignal,
                 'chat'
             )
         } catch {
@@ -625,7 +652,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     }
 
     private handleAbort(): void {
-        this.cancelInProgressCompletion()
+        this.cancelSubmitOrEditOperation()
+
         telemetryService.log('CodyVSCodeExtension:abortButton:clicked', { hasV2Event: true })
         telemetryRecorder.recordEvent('cody.sidebar.abortButton', 'clicked')
     }
@@ -907,12 +935,14 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
      */
     private async buildPrompt(
         prompter: DefaultPrompter,
+        abortSignal: AbortSignal,
         sendTelemetry?: (contextSummary: any, privateContextStats?: any) => void
     ): Promise<Message[]> {
         const { prompt, context } = await prompter.makePrompt(
             this.chatModel,
             this.authProvider.getAuthStatus().codyApiVersion
         )
+        abortSignal.throwIfAborted()
 
         // Update UI based on prompt construction
         // Includes the excluded context items to display in the UI
@@ -955,7 +985,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         requestID: string,
         prompt: Message[],
         span: Span,
-        firstTokenSpan: Span
+        firstTokenSpan: Span,
+        abortSignal: AbortSignal
     ): void {
         logDebug('SimpleChatPanelProvider', 'streamAssistantResponse', {
             verbose: { requestID, prompt },
@@ -970,37 +1001,48 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             firstTokenSpan.end()
         }
 
+        abortSignal.throwIfAborted()
         this.postEmptyMessageInProgress()
-        this.sendLLMRequest(prompt, {
-            update: content => {
-                measureFirstToken()
-                span.addEvent('update')
-                this.postViewTranscript({
-                    speaker: 'assistant',
-                    text: PromptString.unsafe_fromLLMResponse(content),
-                    model: this.chatModel.modelID,
-                })
-            },
-            close: content => {
-                measureFirstToken()
-                recordExposedExperimentsToSpan(span)
-                span.end()
-                this.addBotMessage(requestID, PromptString.unsafe_fromLLMResponse(content))
-            },
-            error: (partialResponse, error) => {
-                if (!isAbortError(error)) {
+        this.sendLLMRequest(
+            prompt,
+            {
+                update: content => {
+                    abortSignal.throwIfAborted()
+                    measureFirstToken()
+                    span.addEvent('update')
+                    this.postViewTranscript({
+                        speaker: 'assistant',
+                        text: PromptString.unsafe_fromLLMResponse(content),
+                        model: this.chatModel.modelID,
+                    })
+                },
+                close: content => {
+                    abortSignal.throwIfAborted()
+                    measureFirstToken()
+                    recordExposedExperimentsToSpan(span)
+                    span.end()
+                    this.addBotMessage(requestID, PromptString.unsafe_fromLLMResponse(content))
+                },
+                error: (partialResponse, error) => {
+                    if (isAbortErrorOrSocketHangUp(error)) {
+                        throw error
+                    }
                     this.postError(error, 'transcript')
-                }
-                try {
-                    // We should still add the partial response if there was an error
-                    // This'd throw an error if one has already been added
-                    this.addBotMessage(requestID, PromptString.unsafe_fromLLMResponse(partialResponse))
-                } catch {
-                    console.error('Streaming Error', error)
-                }
-                recordErrorToSpan(span, error)
+                    try {
+                        // We should still add the partial response if there was an error
+                        // This'd throw an error if one has already been added
+                        this.addBotMessage(
+                            requestID,
+                            PromptString.unsafe_fromLLMResponse(partialResponse)
+                        )
+                    } catch {
+                        console.error('Streaming Error', error)
+                    }
+                    recordErrorToSpan(span, error)
+                },
             },
-        })
+            abortSignal
+        )
     }
 
     /**
@@ -1013,7 +1055,8 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             update: (response: string) => void
             close: (finalResponse: string) => void
             error: (completedResponse: string, error: Error) => void
-        }
+        },
+        abortSignal: AbortSignal
     ): Promise<void> {
         let lastContent = ''
         const typewriter = new Typewriter({
@@ -1029,9 +1072,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             },
         })
 
-        this.cancelInProgressCompletion()
-        const abortController = new AbortController()
-        this.completionCanceller = () => abortController.abort()
         try {
             const stream = this.chatClient.chat(
                 prompt,
@@ -1039,7 +1079,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                     model: this.chatModel.modelID,
                     maxTokensToSample: this.chatModel.contextWindow.output,
                 },
-                abortController.signal
+                abortSignal
             )
 
             for await (const message of stream) {
@@ -1049,32 +1089,19 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
                         break
                     }
                     case 'complete': {
-                        this.completionCanceller = undefined
                         typewriter.close()
                         typewriter.stop()
                         break
                     }
                     case 'error': {
-                        this.cancelInProgressCompletion()
                         typewriter.close()
                         typewriter.stop(message.error)
                     }
                 }
             }
         } catch (error: unknown) {
-            if (!isAbortError(error as Error)) {
-                this.cancelInProgressCompletion()
-                typewriter.close()
-                typewriter.stop(error as Error)
-            }
-        }
-    }
-
-    private completionCanceller?: () => void
-    private cancelInProgressCompletion(): void {
-        if (this.completionCanceller) {
-            this.completionCanceller()
-            this.completionCanceller = undefined
+            typewriter.close()
+            typewriter.stop(isAbortErrorOrSocketHangUp(error as Error) ? undefined : (error as Error))
         }
     }
 
@@ -1150,7 +1177,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
         if (!oldTranscript) {
             return this.newSession()
         }
-        this.cancelInProgressCompletion()
+        this.cancelSubmitOrEditOperation()
         const newModel = newChatModelFromSerializedChatTranscript(oldTranscript, this.chatModel.modelID)
         this.chatModel = newModel
 
@@ -1183,7 +1210,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
             return
         }
 
-        this.cancelInProgressCompletion()
+        this.cancelSubmitOrEditOperation()
         await this.saveSession()
 
         this.chatModel = new SimpleChatModel(this.chatModel.modelID)
@@ -1280,7 +1307,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
         // Dispose panel when the panel is closed
         panel.onDidDispose(() => {
-            this.cancelInProgressCompletion()
+            this.cancelSubmitOrEditOperation()
             this._webviewPanel = undefined
             this._webview = undefined
             panel.dispose()
@@ -1371,6 +1398,6 @@ function newChatModelFromSerializedChatTranscript(
     )
 }
 
-function isAbortError(error: Error): boolean {
-    return error.message === 'aborted' || error.message === 'socket hang up'
+function isAbortErrorOrSocketHangUp(error: unknown): error is Error {
+    return Boolean(isAbortError(error) || (error && (error as any).message === 'socket hang up'))
 }

--- a/vscode/test/integration/single-root/chat.test.ts
+++ b/vscode/test/integration/single-root/chat.test.ts
@@ -38,7 +38,8 @@ suite('Chat', function () {
             'user',
             [],
             undefined,
-            false
+            false,
+            new AbortController().signal
         )
 
         assert.match((await getTranscript(0)).text?.toString() || '', /^hello from the human$/)
@@ -58,7 +59,8 @@ suite('Chat', function () {
             'user',
             [],
             undefined,
-            false
+            false,
+            new AbortController().signal
         )
 
         // Display text should include file link at the end of message


### PR DESCRIPTION
Fixes intermittent `Cannot set new context used for bot message` errors in chat when you are editing a message.

If a submit or edit operation was aborted, its prompt builder would continue trying to mutate the transcript. Now it fully aborts.

Instead of wrapping ONLY the low-level LLM interaction with cancelation, now the entire submit or edit operations are wrapped in a cancelation.



## Test plan

CI

Also, try spamming new messages by pressing Enter repeatedly in a chat. Previously, you would be likely to get some `Cannot set new context used for bot message` errors, and now, it does not show errors and properly restarts the operation cleanly each time.