### PR TITLE
remove "(by OpenCtx)" in @-mention menu

### DIFF
--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -135,8 +135,8 @@ export async function openCtxMentionProviders(): Promise<ContextMentionProviderM
             .filter(provider => provider.features?.mentions)
             .map(provider => ({
                 id: provider.providerUri,
-                title: provider.name + ' (by OpenCtx)',
-                queryLabel: `Search using ${provider.name} provider`,
+                title: provider.name,
+                queryLabel: provider.name,
                 emptyLabel: 'No results found',
             }))
     } catch (error) {


### PR DESCRIPTION
We want these to feel native.

Also the heading of the @-mention menu when you've selected a provider now just contains the provider name itself, instead of `Search using PROVIDER provider`, which could be ungrammatical or clunky. We should have a way in the OpenCtx `meta` result to specify the right label here, but for now, this suffices.



## Test plan

CI