### PR TITLE
Agent: close P0 memory leak on `textDocument/didChange`

### DIFF
--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/CodyAgentServer.kt
@@ -86,6 +86,10 @@ interface CodyAgentServer {
   fun testing_requestErrors(params: Null?): CompletableFuture<Testing_RequestErrorsResult>
   @JsonRequest("testing/closestPostData")
   fun testing_closestPostData(params: Testing_ClosestPostDataParams): CompletableFuture<Testing_ClosestPostDataResult>
+  @JsonRequest("testing/memoryUsage")
+  fun testing_memoryUsage(params: Null?): CompletableFuture<Testing_MemoryUsageResult>
+  @JsonRequest("testing/awaitPendingPromises")
+  fun testing_awaitPendingPromises(params: Null?): CompletableFuture<Null?>
   @JsonRequest("testing/progressCancelation")
   fun testing_progressCancelation(params: Testing_ProgressCancelationParams): CompletableFuture<Testing_ProgressCancelationResult>
   @JsonRequest("testing/reset")

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MemoryUsage.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/MemoryUsage.kt
@@ -1,0 +1,11 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class MemoryUsage(
+  val rss: Int,
+  val heapTotal: Int,
+  val heapUsed: Int,
+  val external: Int,
+  val arrayBuffers: Int,
+)
+

--- a/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_MemoryUsageResult.kt
+++ b/agent/bindings/kotlin/lib/src/main/kotlin/com/sourcegraph/cody/protocol_generated/Testing_MemoryUsageResult.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FunctionName", "ClassName", "unused", "EnumEntryName", "UnusedImport")
+package com.sourcegraph.cody.protocol_generated
+
+data class Testing_MemoryUsageResult(
+  val usage: MemoryUsage,
+)
+

--- a/agent/src/TestClient.ts
+++ b/agent/src/TestClient.ts
@@ -135,7 +135,15 @@ export class TestClient extends MessageHandler {
         const recordingDirectory = path.join(agentDir, 'recordings')
         const agentScript = path.join(agentDir, 'dist', 'index.js')
 
-        const args = bin === 'node' ? ['--enable-source-maps', agentScript, 'jsonrpc'] : ['jsonrpc']
+        const args =
+            bin === 'node'
+                ? [
+                      '--enable-source-maps',
+                      // '--expose-gc', // Uncoment when running memory.test.ts
+                      agentScript,
+                      'jsonrpc',
+                  ]
+                : ['jsonrpc']
 
         const child = spawn(bin, args, {
             stdio: 'pipe',

--- a/agent/src/memory.test.ts
+++ b/agent/src/memory.test.ts
@@ -1,0 +1,74 @@
+import path from 'node:path'
+import { afterAll, beforeAll, describe, it } from 'vitest'
+import { TESTING_CREDENTIALS } from '../../vscode/src/testutils/testing-credentials'
+import { TestClient } from './TestClient'
+import { TestWorkspace } from './TestWorkspace'
+
+// Disabled because we don't need to run this test in CI on every PR.  We're
+// keeping the test around because it has useful infrastructure to debug memory
+// leaks.
+describe.skip('Memory Usage', () => {
+    const workspace = new TestWorkspace(path.join(__dirname, '__tests__', 'example-ts'))
+    const client = TestClient.create({
+        workspaceRootUri: workspace.rootUri,
+        name: 'memory-usage',
+        credentials: TESTING_CREDENTIALS.dotcom,
+    })
+
+    beforeAll(async () => {
+        await workspace.beforeAll()
+        await client.beforeAll()
+    })
+
+    afterAll(async () => {
+        await workspace.afterAll()
+        await client.afterAll()
+    })
+
+    it('selection', async () => {
+        const uri = workspace.file('src', 'animal.ts')
+        await client.openFile(uri)
+        const document = client.workspace.getDocument(uri)!
+        for (let i = 0; i < 5_000; i++) {
+            client.notify('textDocument/didChange', {
+                uri: document.uri.toString(),
+                selection: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 1, character: document.lineAt(1).text.length },
+                },
+            })
+        }
+        const { usage: usage1 } = await client.request('testing/memoryUsage', null)
+        console.log(usage1)
+        for (let i = 0; i < 40_000; i++) {
+            client.notify('textDocument/didChange', {
+                uri: document.uri.toString(),
+                selection: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 1, character: document.lineAt(1).text.length },
+                },
+            })
+            await client.request('testing/awaitPendingPromises', null)
+        }
+        await new Promise(resolve => setTimeout(resolve, 3_000))
+
+        const { usage: usage2 } = await client.request('testing/memoryUsage', null)
+        console.log(usage2)
+        console.log({
+            diffHeapUsaged: prettyPrintBytes(usage2.heapUsed - usage1.heapUsed),
+            diffExternal: prettyPrintBytes(usage2.external - usage1.external),
+        })
+    }, 20_000)
+})
+
+function prettyPrintBytes(bytes: number): string {
+    const units = ['B', 'KB', 'MB', 'GB', 'TB']
+    let unitIndex = 0
+
+    while (bytes >= 1024 && unitIndex < units.length - 1) {
+        bytes /= 1024
+        unitIndex++
+    }
+
+    return `${bytes.toFixed(2)} ${units[unitIndex]}`
+}

--- a/agent/src/panicWhenClientIsOutOfSync.test.ts
+++ b/agent/src/panicWhenClientIsOutOfSync.test.ts
@@ -21,7 +21,9 @@ describe('panicWhenClientIsOutOfSync', () => {
         mostRecentClientDocument: ProtocolTextDocument
     ): void {
         const documents = new AgentWorkspaceDocuments({ doPanic })
-        documents.loadAndUpdate(ProtocolTextDocumentWithUri.fromDocument(serverBeforeRequestDocument))
+        documents.loadDocumentWithChanges(
+            ProtocolTextDocumentWithUri.fromDocument(serverBeforeRequestDocument)
+        )
         panicWhenClientIsOutOfSync(
             documents.loadAndUpdateDocument(
                 ProtocolTextDocumentWithUri.fromDocument(mostRecentClientDocument)

--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -54,7 +54,7 @@ import type { ClientInfo, ExtensionConfiguration } from './protocol-alias'
 // Not using CODY_TESTING because it changes the URL endpoint we send requests
 // to and we want to send requests to sourcegraph.com because we record the HTTP
 // traffic.
-const isTesting = process.env.CODY_SHIM_TESTING === 'true'
+export const isTesting = process.env.CODY_SHIM_TESTING === 'true'
 
 export { AgentEventEmitter as EventEmitter } from '../../vscode/src/testutils/AgentEventEmitter'
 

--- a/vscode/src/jsonrpc/agent-protocol.ts
+++ b/vscode/src/jsonrpc/agent-protocol.ts
@@ -150,6 +150,8 @@ export type ClientRequests = {
     'testing/networkRequests': [null, { requests: NetworkRequest[] }]
     'testing/requestErrors': [null, { errors: NetworkRequest[] }]
     'testing/closestPostData': [{ url: string; postData: string }, { closestBody: string }]
+    'testing/memoryUsage': [null, { usage: MemoryUsage }]
+    'testing/awaitPendingPromises': [null, null]
 
     // Only used for testing purposes. This operation runs indefinitely unless
     // the client sends progress/cancel.
@@ -815,4 +817,13 @@ export interface GetFoldingRangeResult {
 export interface RemoteRepoFetchState {
     state: 'paused' | 'fetching' | 'errored' | 'complete'
     error?: CodyError | undefined | null
+}
+
+// Copy-pasted from @types/node
+export interface MemoryUsage {
+    rss: number
+    heapTotal: number
+    heapUsed: number
+    external: number
+    arrayBuffers: number
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -167,7 +167,7 @@ const register = async (
         PromptMixin.addCustom(newPromptMixin(config.chatPreInstruction))
     }
 
-    parseAllVisibleDocuments()
+    void parseAllVisibleDocuments()
 
     disposables.push(vscode.window.onDidChangeVisibleTextEditors(parseAllVisibleDocuments))
     disposables.push(vscode.workspace.onDidChangeTextDocument(updateParseTreeOnEdit))

--- a/vscode/src/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/tree-sitter/parse-tree-cache.ts
@@ -46,8 +46,6 @@ export async function parseDocument(document: TextDocument): Promise<void> {
         return
     }
 
-    console.log('boom')
-
     updateParseTreeCache(document, parser)
 }
 

--- a/vscode/src/tree-sitter/parse-tree-cache.ts
+++ b/vscode/src/tree-sitter/parse-tree-cache.ts
@@ -46,6 +46,8 @@ export async function parseDocument(document: TextDocument): Promise<void> {
         return
     }
 
+    console.log('boom')
+
     updateParseTreeCache(document, parser)
 }
 
@@ -114,8 +116,10 @@ export function asPoint(position: Pick<vscode.Position, 'line' | 'character'>): 
     return { row: position.line, column: position.character }
 }
 
-export function parseAllVisibleDocuments(): void {
+export function parseAllVisibleDocuments(): Promise<unknown> {
+    const promises: Promise<void>[] = []
     for (const editor of vscode.window.visibleTextEditors) {
-        void parseDocument(editor.document)
+        promises.push(parseDocument(editor.document))
     }
+    return Promise.all(promises)
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1587

Previously, the agent was firing the
`vscode.window.onDidChangeVisibleTextEditors` event on every `textDocument/didChange` event, including when we only updated the selection (no content changes). In VSC, this event only fires when you open a new file, change the actived file tab, or close a file. Now, the agent mirrors the VSC behavior by firing the event less frequently. This change doesn't actually fix the memory leak, it just makes it very difficult to reproduce because you need to open/close files thousands of times. Previously, it was easy to reproduce, you could just drag-select text with the mouse and fire thousands of events.


## Test plan

See new `memory.test.ts` file. This test suite can be skipped by default in CI because it's going to be difficult to maintain this as an automated test. However, we used this test file to reproduce the memory leak, and verified that it no longer reproduces after this fix.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
