### PR TITLE
fix bug preventing vertically scrolling of long messages in the input

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -23,6 +23,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Fixed an issue where the test file name was incorrectly inserted with the unit test command. [pull/4262](https://github.com/sourcegraph/cody/pull/4262)
 - Chat: Fixed a long-standing bug where it was not possible to copy code from Cody's response before it was finished. [pull/4268](https://github.com/sourcegraph/cody/pull/4268)
 - Chat: Fixed a bug where list bullets or numbers were not shown in chat responses. [pull/4294](https://github.com/sourcegraph/cody/pull/4294)
+- Chat: Fixed a bug where long messages could not be scrolled vertically in the input. [pull/4313](https://github.com/sourcegraph/cody/pull/4313)
 
 ### Changed
 

--- a/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.story.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/HumanMessageCell.story.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { HumanMessageCell } from './HumanMessageCell'
-
+import { PromptString } from '@sourcegraph/cody-shared'
 import { VSCodeCell } from '../../../../storybook/VSCodeStoryDecorator'
 import { FIXTURE_TRANSCRIPT, FIXTURE_USER_ACCOUNT_INFO } from '../../../fixtures'
+import { HumanMessageCell } from './HumanMessageCell'
 
 const meta: Meta<typeof HumanMessageCell> = {
     title: 'ui/HumanMessageCell',
@@ -45,5 +45,26 @@ export const FollowupWithText: StoryObj<typeof meta> = {
     args: {
         message: FIXTURE_TRANSCRIPT.explainCode2[0],
         isFirstMessage: false,
+    },
+}
+
+export const Scrolling: StoryObj<typeof meta> = {
+    args: {
+        message: {
+            speaker: 'human',
+            text: PromptString.unsafe_fromUserQuery(
+                new Array(100)
+                    .fill(0)
+                    .map(
+                        (_, index) =>
+                            `Line ${index} ${
+                                index % 5 === 0
+                                    ? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                                    : ''
+                            }`
+                    )
+                    .join('\n')
+            ),
+        },
     },
 }

--- a/vscode/webviews/promptEditor/PromptEditor.module.css
+++ b/vscode/webviews/promptEditor/PromptEditor.module.css
@@ -6,7 +6,8 @@
 .editor {
     font: inherit;
     width: 100%;
-    overflow: hidden;
+    overflow: auto;
+    scrollbar-width: none;
 
     /* Don't allow the input box to become larger than the webview to avoid submit buttons going off the screen */
     max-height: 80vh; /* 80% of viewport height */

--- a/vscode/webviews/promptEditor/PromptEditor.story.tsx
+++ b/vscode/webviews/promptEditor/PromptEditor.story.tsx
@@ -2,7 +2,11 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { type FunctionComponent, useState } from 'react'
 import { ContextProvidersDecorator, VSCodeStandaloneComponent } from '../storybook/VSCodeStoryDecorator'
 import styles from './BaseEditor.story.module.css'
-import { PromptEditor, type SerializedPromptEditorState } from './PromptEditor'
+import {
+    PromptEditor,
+    type SerializedPromptEditorState,
+    serializedPromptEditorStateFromText,
+} from './PromptEditor'
 import { FILE_MENTION_EDITOR_STATE_FIXTURE } from './fixtures'
 
 const meta: Meta<typeof PromptEditor> = {
@@ -52,4 +56,36 @@ export const Interactive: StoryObj<typeof meta> = {
 export const WithInitialValue: StoryObj<typeof meta> = {
     render: props => <PromptEditorWithStateValue {...props} />,
     args: { initialEditorState: FILE_MENTION_EDITOR_STATE_FIXTURE },
+}
+
+export const VerticalScroll: StoryObj<typeof meta> = {
+    render: props => <PromptEditorWithStateValue {...props} />,
+    args: {
+        initialEditorState: serializedPromptEditorStateFromText(
+            new Array(80)
+                .fill(0)
+                .map((_, index) => {
+                    return `Line ${index}`
+                })
+                .join('\n')
+        ),
+    },
+}
+
+export const LongLines: StoryObj<typeof meta> = {
+    render: props => <PromptEditorWithStateValue {...props} />,
+    args: {
+        initialEditorState: serializedPromptEditorStateFromText(
+            new Array(80)
+                .fill(0)
+                .map((_, index) => {
+                    return `Line ${index}${
+                        index % 5 === 0
+                            ? 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                            : ''
+                    }`
+                })
+                .join('\n')
+        ),
+    },
 }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-1881/cody-for-vs-code-long-user-messages-cant-be-scrolled-using-a-mouse

HT @taras.yemets

## Test plan

CI, and try new storybook