### PR TITLE
Do not use Number.MAX_SAFE_INTEGER in agent protocol

### DIFF
--- a/vscode/src/editor/utils/index.ts
+++ b/vscode/src/editor/utils/index.ts
@@ -42,7 +42,7 @@ export async function getSmartSelection(
         // Regardless of the columns provided, we want to ensure the edit spans the full range of characters
         // on the start and end lines. This helps improve the reliability of the output.
         const adjustedStartColumn = document.lineAt(startPosition.row).firstNonWhitespaceCharacterIndex
-        const adjustedEndColumn = Number.MAX_SAFE_INTEGER
+        const adjustedEndColumn = document.lineAt(startPosition.row).range.end.character
         return new vscode.Selection(
             startPosition.row,
             adjustedStartColumn,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1623

## Test plan

1. Open `sourcegraph/cody`
2. Open `agent/src/index.test.ts`
3. Put cursor in some nested code. I used line with `accessToken: 'REDACTED_0ba08837494d00e3943c46999589eb29a210ba8063f084fff511c8e4d1503909',`
4. Try to run any edit command

It should fail before my fix and pass after.