### PR TITLE
support pasting @-mentions in chat input

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -26,6 +26,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed a long-standing bug where it was not possible to copy code from Cody's response before it was finished. [pull/4268](https://github.com/sourcegraph/cody/pull/4268)
 - Chat: Fixed a bug where list bullets or numbers were not shown in chat responses. [pull/4294](https://github.com/sourcegraph/cody/pull/4294)
 - Chat: Fixed a bug where long messages could not be scrolled vertically in the input. [pull/4313](https://github.com/sourcegraph/cody/pull/4313)
+- Chat: Copying and pasting @-mentions in the chat input now works. [pull/4319](https://github.com/sourcegraph/cody/pull/4319)
 
 ### Changed
 

--- a/vscode/webviews/promptEditor/BaseEditor.tsx
+++ b/vscode/webviews/promptEditor/BaseEditor.tsx
@@ -4,7 +4,7 @@ import { EditorRefPlugin } from '@lexical/react/LexicalEditorRefPlugin'
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary'
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
-import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin'
+import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
 import { clsx } from 'clsx'
 import { $getRoot, type EditorState, type LexicalEditor, type SerializedEditorState } from 'lexical'
 import { type FunctionComponent, type RefObject, useMemo } from 'react'
@@ -15,6 +15,7 @@ import MentionsPlugin from './plugins/atMentions/atMentions'
 import CodeHighlightPlugin from './plugins/codeHighlight'
 import { DisableEscapeKeyBlursPlugin } from './plugins/disableEscapeKeyBlurs'
 import { KeyboardEventPlugin, type KeyboardEventPluginProps } from './plugins/keyboardEvent'
+import { NoRichTextFormatShortcutsPlugin } from './plugins/noRichTextShortcuts'
 import { OnFocusChangePlugin } from './plugins/onFocus'
 
 interface Props extends KeyboardEventPluginProps {
@@ -63,7 +64,7 @@ export const BaseEditor: FunctionComponent<Props> = ({
         <div className={clsx(styles.editorShell, className)}>
             <div className={styles.editorContainer}>
                 <LexicalComposer initialConfig={initialConfig}>
-                    <PlainTextPlugin
+                    <RichTextPlugin
                         contentEditable={
                             <div className={styles.editorScroller}>
                                 <div className={styles.editor}>
@@ -80,6 +81,7 @@ export const BaseEditor: FunctionComponent<Props> = ({
                         placeholder={<div className={styles.placeholder}>{placeholder}</div>}
                         ErrorBoundary={LexicalErrorBoundary}
                     />
+                    <NoRichTextFormatShortcutsPlugin />
                     <HistoryPlugin />
                     <OnChangePlugin onChange={onChange} ignoreSelectionChange={true} />
                     <MentionsPlugin userInfo={userInfo} />

--- a/vscode/webviews/promptEditor/plugins/noRichTextShortcuts.tsx
+++ b/vscode/webviews/promptEditor/plugins/noRichTextShortcuts.tsx
@@ -1,0 +1,23 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { COMMAND_PRIORITY_CRITICAL, FORMAT_TEXT_COMMAND } from 'lexical'
+import { type FunctionComponent, useEffect } from 'react'
+
+/**
+ * Block rich text formatting shortcuts like Cmd+B/Ctrl+B (for bold). Pasting from rich text still
+ * (unintentionally) works; TODO(sqs): prevent that as well.
+ */
+export const NoRichTextFormatShortcutsPlugin: FunctionComponent = () => {
+    const [editor] = useLexicalComposerContext()
+
+    useEffect(() => {
+        return editor.registerCommand(
+            FORMAT_TEXT_COMMAND,
+            () => {
+                return true
+            },
+            COMMAND_PRIORITY_CRITICAL
+        )
+    }, [editor])
+
+    return null
+}


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-1892/fix-copy-and-paste-of-mentions-in-lexical-editor

Fixes https://linear.app/sourcegraph/issue/CODY-61/bug-copy-and-paste-removes-file-tokenization

Fixes https://linear.app/sourcegraph/issue/CODY-1779/-mentions-not-copyingpasting-properly


https://github.com/sourcegraph/cody/assets/1976/6b7aa431-c7f7-4970-9ca0-244b978a0d57



## Test plan

CI, and see video