### PR TITLE
Document Code: move tests to separate workspace

### DIFF
--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -64,6 +64,33 @@ const startTime = performance.now(/* CURSOR */)
 "
 `;
 
+exports[`Document Code > commands/document (no smart selection) 1`] = `
+"import { expect } from 'vitest'
+import { it } from 'vitest'
+import { describe } from 'vitest'
+
+describe('test block', () => {
+    it('does 1', () => {
+        expect(true).toBe(true)
+    })
+
+    it('does 2', () => {
+        expect(true).toBe(true)
+    })
+
+    it('does something else', () => {
+        // This line will error due to incorrect usage of \`performance.now\`
+                /**
+         * Returns the current high-resolution timestamp in milliseconds.
+         * This value can be used to measure elapsed time with high precision.
+         * The timestamp is relative to an arbitrary time in the past, and is not related to the current date and time.
+         */
+const startTime = performance.now(/* CURSOR */)
+    })
+})
+"
+`;
+
 exports[`Document Code > editCommands/document (basic function) 1`] = `
 "/**
  * Adds two numbers together and returns the result.

--- a/agent/src/__tests__/document-code/src/TestClass.ts
+++ b/agent/src/__tests__/document-code/src/TestClass.ts
@@ -1,0 +1,11 @@
+const foo = 42
+
+export class TestClass {
+    constructor(private shouldGreet: boolean) {}
+
+    public functionName() {
+        if (this.shouldGreet) {
+            console.log(/* CURSOR */ 'Hello World!')
+        }
+    }
+}

--- a/agent/src/__tests__/document-code/src/TestLogger.ts
+++ b/agent/src/__tests__/document-code/src/TestLogger.ts
@@ -1,0 +1,12 @@
+const foo = 42
+export const TestLogger = {
+    startLogging: () => {
+        // Do some stuff
+
+        function recordLog() {
+            console.log(/* CURSOR */ 'Recording the log')
+        }
+
+        recordLog()
+    },
+}

--- a/agent/src/__tests__/document-code/src/example.test.ts
+++ b/agent/src/__tests__/document-code/src/example.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'vitest'
+import { it } from 'vitest'
+import { describe } from 'vitest'
+
+describe('test block', () => {
+    it('does 1', () => {
+        expect(true).toBe(true)
+    })
+
+    it('does 2', () => {
+        expect(true).toBe(true)
+    })
+
+    it('does something else', () => {
+        // This line will error due to incorrect usage of `performance.now`
+        const startTime = performance.now(/* CURSOR */)
+    })
+})

--- a/agent/src/__tests__/document-code/src/sum.ts
+++ b/agent/src/__tests__/document-code/src/sum.ts
@@ -1,0 +1,3 @@
+export function sum(a: number, b: number): number {
+    /* CURSOR */
+}

--- a/agent/src/document-code.test.ts
+++ b/agent/src/document-code.test.ts
@@ -6,7 +6,7 @@ import { TestClient } from './TestClient'
 import { TestWorkspace } from './TestWorkspace'
 
 describe('Document Code', () => {
-    const workspace = new TestWorkspace(path.join(__dirname, '__tests__', 'example-ts'))
+    const workspace = new TestWorkspace(path.join(__dirname, '__tests__', 'document-code'))
     const client = TestClient.create({
         workspaceRootUri: workspace.rootUri,
         name: 'document-code',


### PR DESCRIPTION
Previously, the document code tests ran in the monolithic `example-ts` workspace. This was problematic because when you added a new "Document Code" test to example-ts, then it would invalidate the HTTP recordings for unrelated tests in the `index.test.ts` file, because they use enhanced symf context that would pull in the newly added files. Now, we run the test with an isolated `document-code` workspace so that we can add tests without introducing big unrelated diffs in `index.test.ts`.


## Test plan

Green CI
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
