### PR TITLE
Document Code: Always expand to the start of a line as a fallback

### DIFF
--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -593,6 +593,150 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: 30808d8b947a72caa8db0a4470efeffc
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2440
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: document-code / v1
+          - name: traceparent
+            value: 00-643aa3246b4033feef165bc0a58d5243-1e53e483d76f4621-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/Hello.kt
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662></SELECTEDCODE7662>
+
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-haiku-20240307
+            stopSequences:
+              - </CODE5711>
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: document-code
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
+      response:
+        bodySize: 1607
+        content:
+          mimeType: text/event-stream
+          size: 1607
+          text: >+
+            event: completion
+
+            data: {"completion":"\n/**\n * Prints \"Hello, World!\" to the console.\n */\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Tue, 28 May 2024 09:29:15 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-28T09:29:13.744Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 12581f1c735a04aeb88af7a54cd007b2
       _order: 0
       cache: {}

--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -22,7 +22,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-ac67e5b4fcc3bad7ab9c77f64bcf7e39-1fa2dc912dec3c5b-01
+            value: 00-b722376b765597eced323e584ddde7ad-0f8fe4a85972f784-01
           - name: connection
             value: keep-alive
           - name: host
@@ -98,14 +98,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 8872
+        bodySize: 7732
         content:
           mimeType: text/event-stream
-          size: 8872
+          size: 7732
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Adds two numbers together and returns the result.\n *\n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two input numbers.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Adds two numbers and returns the result.\n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two input numbers.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -115,13 +115,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 08:39:09 GMT
+            value: Tue, 28 May 2024 10:20:15 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "23"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -139,12 +141,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1405
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T08:39:08.243Z
+      startedDateTime: 2024-05-28T10:20:14.666Z
       time: 0
       timings:
         blocked: -1
@@ -171,7 +173,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-f49f0f9bfe889143eabfb3c1a60c8f64-f6919574ad278d2e-01
+            value: 00-06d29a9b5e68440d4a870c24604148e9-20a14d1cec3d13e0-01
           - name: connection
             value: keep-alive
           - name: host
@@ -246,14 +248,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 3301
+        bodySize: 2414
         content:
           mimeType: text/event-stream
-          size: 3301
+          size: 2414
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Outputs a \"Hello World!\" message to the console if the `shouldGreet` property is truthy.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Logs a greeting message to the console if the shouldGreet property is true.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -263,13 +265,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 08:39:10 GMT
+            value: Tue, 28 May 2024 10:20:17 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "22"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -287,12 +291,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1405
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T08:39:09.846Z
+      startedDateTime: 2024-05-28T10:20:16.053Z
       time: 0
       timings:
         blocked: -1
@@ -319,7 +323,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-cb6475a0ec8e8829bcaca33659ee2213-7644c52d32311d95-01
+            value: 00-c607d32944847d507871dbf51255125d-e6c6e78d576d62d1-01
           - name: connection
             value: keep-alive
           - name: host
@@ -392,14 +396,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 915
+        bodySize: 1037
         content:
           mimeType: text/event-stream
-          size: 915
+          size: 1037
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Records a log message.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"\n/**\n * Records a log message.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -409,13 +413,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 08:39:12 GMT
+            value: Tue, 28 May 2024 10:20:18 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "21"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -433,12 +439,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1405
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T08:39:11.178Z
+      startedDateTime: 2024-05-28T10:20:17.212Z
       time: 0
       timings:
         blocked: -1
@@ -465,7 +471,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-9a0eba8eadb7e57a66d035bcbb755aa9-7703d879ed53b770-01
+            value: 00-38ae6c5f8d7e89fc02a15fc532f0a468-f1c32657ddb67604-01
           - name: connection
             value: keep-alive
           - name: host
@@ -537,14 +543,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 11286
+        bodySize: 5165
         content:
           mimeType: text/event-stream
-          size: 11286
+          size: 5165
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Returns the current high-resolution timestamp in milliseconds.\n * This value can be used to measure elapsed time with high precision.\n * The timestamp is relative to an arbitrary time in the past, and is not related to the current date and time.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Gets the current time in milliseconds since the DOM was loaded.\n * @returns {number} The time in milliseconds since the DOM was loaded.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -554,13 +560,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 08:39:13 GMT
+            value: Tue, 28 May 2024 10:20:19 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "19"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -578,12 +586,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1405
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T08:39:12.400Z
+      startedDateTime: 2024-05-28T10:20:18.349Z
       time: 0
       timings:
         blocked: -1
@@ -593,11 +601,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 30808d8b947a72caa8db0a4470efeffc
+    - _id: dcf90ca00af1ead9e388c2f20263943c
       _order: 0
       cache: {}
       request:
-        bodySize: 2440
+        bodySize: 2493
         cookies: []
         headers:
           - name: content-type
@@ -610,7 +618,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-643aa3246b4033feef165bc0a58d5243-1e53e483d76f4621-01
+            value: 00-1f8ae4faeb84cd19c626e8648c356543-035e89e285f950d5-01
           - name: connection
             value: keep-alive
           - name: host
@@ -652,7 +660,7 @@ log:
 
                   The user has the following code in their selection:
 
-                  <SELECTEDCODE7662></SELECTEDCODE7662>
+                  <SELECTEDCODE7662>class He/* CURSOR */llo {</SELECTEDCODE7662>
 
 
                   The user wants you to generate documentation for the selected code by following their instructions.
@@ -669,6 +677,7 @@ log:
             model: anthropic/claude-3-haiku-20240307
             stopSequences:
               - </CODE5711>
+              - class He/* CURSOR */llo {
             temperature: 0
             topK: -1
             topP: -1
@@ -681,14 +690,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 1607
+        bodySize: 964
         content:
           mimeType: text/event-stream
-          size: 1607
+          size: 964
           text: >+
             event: completion
 
-            data: {"completion":"\n/**\n * Prints \"Hello, World!\" to the console.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Represents a greeting object.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -698,13 +707,15 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 09:29:15 GMT
+            value: Tue, 28 May 2024 10:20:20 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
             value: chunked
           - name: connection
             value: keep-alive
+          - name: retry-after
+            value: "18"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -722,12 +733,12 @@ log:
             value: 1; mode=block
           - name: strict-transport-security
             value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
+        headersSize: 1405
         httpVersion: HTTP/1.1
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T09:29:13.744Z
+      startedDateTime: 2024-05-28T10:20:19.484Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -19,6 +19,18 @@ function recordLog() {
 "
 `;
 
+exports[`Document Code > commands/document (Kotlin class) 1`] = `
+"class He/**
+ * Prints "Hello, World!" to the console.
+ */
+/* CURSOR */llo {
+    fun greeting(): String {
+        return "Hello, world!"
+    }
+}
+"
+`;
+
 exports[`Document Code > commands/document (Method as part of a class) 1`] = `
 "const foo = 42
 

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -19,11 +19,11 @@ function recordLog() {
 "
 `;
 
-exports[`Document Code > commands/document (Kotlin class) 1`] = `
-"class He/**
- * Prints "Hello, World!" to the console.
+exports[`Document Code > commands/document (Kotlin class name) 1`] = `
+"/**
+ * Represents a greeting object.
  */
-/* CURSOR */llo {
+class He/* CURSOR */llo {
     fun greeting(): String {
         return "Hello, world!"
     }
@@ -38,7 +38,7 @@ export class TestClass {
     constructor(private shouldGreet: boolean) {}
 
         /**
-     * Outputs a "Hello World!" message to the console if the \`shouldGreet\` property is truthy.
+     * Logs a greeting message to the console if the shouldGreet property is true.
      */
 public functionName() {
         if (this.shouldGreet) {
@@ -66,36 +66,8 @@ describe('test block', () => {
     it('does something else', () => {
         // This line will error due to incorrect usage of \`performance.now\`
                 /**
-         * Returns the current high-resolution timestamp in milliseconds.
-         * This value can be used to measure elapsed time with high precision.
-         * The timestamp is relative to an arbitrary time in the past, and is not related to the current date and time.
-         */
-const startTime = performance.now(/* CURSOR */)
-    })
-})
-"
-`;
-
-exports[`Document Code > commands/document (no smart selection) 1`] = `
-"import { expect } from 'vitest'
-import { it } from 'vitest'
-import { describe } from 'vitest'
-
-describe('test block', () => {
-    it('does 1', () => {
-        expect(true).toBe(true)
-    })
-
-    it('does 2', () => {
-        expect(true).toBe(true)
-    })
-
-    it('does something else', () => {
-        // This line will error due to incorrect usage of \`performance.now\`
-                /**
-         * Returns the current high-resolution timestamp in milliseconds.
-         * This value can be used to measure elapsed time with high precision.
-         * The timestamp is relative to an arbitrary time in the past, and is not related to the current date and time.
+         * Gets the current time in milliseconds since the DOM was loaded.
+         * @returns {number} The time in milliseconds since the DOM was loaded.
          */
 const startTime = performance.now(/* CURSOR */)
     })
@@ -105,8 +77,7 @@ const startTime = performance.now(/* CURSOR */)
 
 exports[`Document Code > editCommands/document (basic function) 1`] = `
 "/**
- * Adds two numbers together and returns the result.
- *
+ * Adds two numbers and returns the result.
  * @param a - The first number to add.
  * @param b - The second number to add.
  * @returns The sum of the two input numbers.

--- a/agent/src/__tests__/document-code/src/Hello.kt
+++ b/agent/src/__tests__/document-code/src/Hello.kt
@@ -1,0 +1,5 @@
+class He/* CURSOR */llo {
+    fun greeting(): String {
+        return "Hello, world!"
+    }
+}

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1386,7 +1386,7 @@ export class Agent extends MessageHandler implements ExtensionClient {
         this.registerRequest(method, async (params, token) => {
             await this.authenticationPromise
             return callback(params, token).catch(err => {
-                console.error(err)
+                console.error(`Uncaught error from method '${method}'`, err)
                 throw err
             })
         })

--- a/agent/src/agent.ts
+++ b/agent/src/agent.ts
@@ -1385,7 +1385,10 @@ export class Agent extends MessageHandler implements ExtensionClient {
     ): void {
         this.registerRequest(method, async (params, token) => {
             await this.authenticationPromise
-            return callback(params, token)
+            return callback(params, token).catch(err => {
+                console.error(err)
+                throw err
+            })
         })
     }
 

--- a/agent/src/document-code.test.ts
+++ b/agent/src/document-code.test.ts
@@ -39,4 +39,18 @@ describe('Document Code', () => {
     it('commands/document (nested test case)', async () => {
         expect(await client.documentCode(workspace.file('src', 'example.test.ts'))).toMatchSnapshot()
     })
+
+    it.only('commands/document (Kotlin class name)', async () => {
+        expect(await client.documentCode(workspace.file('src', 'Hello.kt'))).toMatchInlineSnapshot(`
+          "class He/**
+           * Prints "Hello, World!" to the console.
+           */
+          /* CURSOR */llo {
+              fun greeting(): String {
+                  return "Hello, world!"
+              }
+          }
+          "
+        `)
+    })
 })

--- a/agent/src/document-code.test.ts
+++ b/agent/src/document-code.test.ts
@@ -40,17 +40,7 @@ describe('Document Code', () => {
         expect(await client.documentCode(workspace.file('src', 'example.test.ts'))).toMatchSnapshot()
     })
 
-    it.only('commands/document (Kotlin class name)', async () => {
-        expect(await client.documentCode(workspace.file('src', 'Hello.kt'))).toMatchInlineSnapshot(`
-          "class He/**
-           * Prints "Hello, World!" to the console.
-           */
-          /* CURSOR */llo {
-              fun greeting(): String {
-                  return "Hello, world!"
-              }
-          }
-          "
-        `)
+    it('commands/document (Kotlin class name)', async () => {
+        expect(await client.documentCode(workspace.file('src', 'Hello.kt'))).toMatchSnapshot()
     })
 })

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -28,6 +28,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed a bug where list bullets or numbers were not shown in chat responses. [pull/4294](https://github.com/sourcegraph/cody/pull/4294)
 - Chat: Fixed a bug where long messages could not be scrolled vertically in the input. [pull/4313](https://github.com/sourcegraph/cody/pull/4313)
 - Chat: Copying and pasting @-mentions in the chat input now works. [pull/4319](https://github.com/sourcegraph/cody/pull/4319)
+- Document Code: Fixed an issue where documentation would be incorrectly inserted in the middle of a line. [pull/4325](https://github.com/sourcegraph/cody/pull/4325)
 
 ### Changed
 

--- a/vscode/src/edit/utils/edit-selection.ts
+++ b/vscode/src/edit/utils/edit-selection.ts
@@ -66,9 +66,10 @@ export async function getEditSmartSelection(
  */
 export function getEditLineSelection(
     document: vscode.TextDocument,
-    selection: vscode.Range
+    selection: vscode.Range,
+    { forceExpand }: SmartSelectionOptions = {}
 ): vscode.Range {
-    if (selection.isEmpty) {
+    if (selection.isEmpty && !forceExpand) {
         // No selection to expand, do nothing
         return selection
     }


### PR DESCRIPTION
## Description

Fixes an issue where the "Document Code" command would incorrectly insert documentation at the cursor position: This occurred when the cursor was in the middle of some code, but we did not have a tree-sitter `documentableNode` or a folding range to expand to.

We now always fallback to the **line selection** and adjust the `insertionPoint` to be at the start of this line.

## Test plan

1. Place the cursor in the middle of some text (e.g. in a Markdown file)
2. Run "Document Code"
3. Expect that the inserted documentation is inserted in the line above the cursor

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
