### PR TITLE
Polly: fix bug where `'fs'` persister didn't pick up config

### DIFF
--- a/vscode/src/testutils/CodyPersister.ts
+++ b/vscode/src/testutils/CodyPersister.ts
@@ -60,7 +60,7 @@ export class CodyPersister extends FSPersister {
         this.api = new PollyYamlWriter(this.options.recordingsDir)
     }
     public static get id(): string {
-        return 'cody-fs'
+        return 'fs'
     }
 
     public async onFindRecording(recordingId: string): Promise<Har | null> {

--- a/vscode/src/testutils/polly.ts
+++ b/vscode/src/testutils/polly.ts
@@ -26,7 +26,7 @@ export function startPollyRecording(userOptions: PollyOptions): Polly {
         recordIfMissing: options.recordIfMissing ?? options.recordingMode === 'record',
         mode: options.recordingMode,
         adapters: ['node-http'],
-        persister: 'cody-fs',
+        persister: 'fs',
         recordFailedRequests: true,
         expiryStrategy: options.recordingExpiryStrategy,
         expiresIn: options.expiresIn,


### PR DESCRIPTION
The `recordingDirectory` setting was actually being ignored because our custom persister has the id `cody-fs` when the settings only allow the ID `cody`.


## Test plan

Green CI

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
