### PR TITLE
Agent: implement more parts of the VS Code shim

### DIFF
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -61,6 +61,7 @@ export { AgentEventEmitter as EventEmitter } from '../../vscode/src/testutils/Ag
 export {
     CancellationTokenSource,
     CodeAction,
+    CodeActionTriggerKind,
     CodeActionKind,
     CodeLens,
     CommentMode,
@@ -75,6 +76,7 @@ export {
     FileType,
     InlineCompletionItem,
     InlineCompletionTriggerKind,
+    DiagnosticRelatedInformation,
     Location,
     MarkdownString,
     OverviewRulerLane,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -148,6 +148,12 @@ export enum ExtensionMode {
     Development = 2,
     Test = 3,
 }
+export class DiagnosticRelatedInformation {
+    constructor(
+        public readonly location: Location,
+        public readonly message: string
+    ) {}
+}
 export enum DiagnosticSeverity {
     Error = 0,
     Warning = 1,
@@ -210,16 +216,15 @@ export class CodeAction {
 }
 export class CodeActionKind {
     static readonly Empty = new CodeActionKind('Empty')
-    static readonly QuickFix = new CodeActionKind('')
-    static readonly Refactor = new CodeActionKind('')
-    static readonly RefactorExtract = new CodeActionKind('')
-    static readonly RefactorInline = new CodeActionKind('')
-    static readonly RefactorMove = new CodeActionKind('')
-    static readonly RefactorRewrite = new CodeActionKind('')
-    static readonly Source = new CodeActionKind('')
-    static readonly SourceOrganizeImports = new CodeActionKind('')
-
-    static readonly SourceFixAll = new CodeActionKind('')
+    static readonly QuickFix = new CodeActionKind('QuickFix')
+    static readonly Refactor = new CodeActionKind('Refactor')
+    static readonly RefactorExtract = new CodeActionKind('RefactorExtract')
+    static readonly RefactorInline = new CodeActionKind('RefactorInline')
+    static readonly RefactorMove = new CodeActionKind('RefactorMove')
+    static readonly RefactorRewrite = new CodeActionKind('RefactorRewrite')
+    static readonly Source = new CodeActionKind('Source')
+    static readonly SourceOrganizeImports = new CodeActionKind('SourceOrganizeImports')
+    static readonly SourceFixAll = new CodeActionKind('SourceFixAll')
 
     constructor(public readonly value: string) {}
 }
@@ -443,6 +448,10 @@ export class Selection extends Range {
     isReversed = false
 }
 
+export enum CodeActionTriggerKind {
+    Invoke = 1,
+    Automatic = 2,
+}
 export enum FoldingRangeKind {
     Comment = 1,
     Imports = 2,


### PR DESCRIPTION
These classes are missing in the VS Code shim. They will be needed in order to support Code Actions (for Fix command). Adding this as a separate low-risk PR.


## Test plan
Green CI.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
