### PR TITLE
Update BFG version

### DIFF
--- a/vscode/src/graph/bfg/download-bfg.ts
+++ b/vscode/src/graph/bfg/download-bfg.ts
@@ -13,7 +13,7 @@ import { captureException } from '../../services/sentry/sentry'
 
 // Available releases: https://github.com/sourcegraph/bfg/releases
 // Do not include 'v' in this string.
-const defaultBfgVersion = '5.3.16802'
+const defaultBfgVersion = '5.4.3547'
 
 // We use this Promise to only have one downloadBfg running at once.
 let serializeBfgDownload: Promise<string | null> = Promise.resolve(null)


### PR DESCRIPTION
Updates version of BFG to include https://github.com/sourcegraph/bfg-private/pull/187.

Closes AI-60.

## Test plan

- tested locally
- e2e tests
