### PR TITLE
fix: remove isFirstMessage check for adding userContextFromSelection

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -184,10 +184,10 @@ export const HumanMessageEditor: FunctionComponent<{
             return
         }
         const editor = editorRef.current
-        if (editor && isFirstMessage) {
-            editorRef.current?.addContextItemAsToken(userContextFromSelection)
+        if (editor) {
+            editor?.addContextItemAsToken(userContextFromSelection)
         }
-    }, [userContextFromSelection, isFirstMessage])
+    }, [userContextFromSelection])
 
     const focusEditor = useCallback(() => editorRef.current?.setFocus(true), [])
 


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody/issues/4321

Remove isFirstMessage check for adding user Context from selection via  `Add selection to Cody Chat`. 

Currently `isFirstMessage` blocks users from adding selection to Cody chat if the message is not the first message.

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

1. Start Cody in debug mode from this branch
2. Start new chat and send Cody a question
3. Select some code in your editor
4. Right click in your selected code and select `Add selection to Cody Chat`
5. Verify the selected code is added as @-mention context in your chat window

![image](https://github.com/sourcegraph/cody/assets/68532117/79c97f40-7b28-45b6-8ecc-ed4e85fd48c9)

Before this change, users are not able to `Add selection to Cody Chat` in non-new chat