### PR TITLE
Add Sourcegraph File Context for Enterprise

### DIFF
--- a/lib/shared/src/mentions/api.ts
+++ b/lib/shared/src/mentions/api.ts
@@ -139,6 +139,7 @@ export async function openCtxMentionProviders(): Promise<ContextMentionProviderM
                 queryLabel: provider.name,
                 emptyLabel: 'No results found',
             }))
+            .sort((a, b) => (a.title > b.title ? 1 : -1))
     } catch (error) {
         logDebug('openctx', `Failed to fetch OpenCtx providers: ${error}`)
         return []

--- a/lib/shared/src/sourcegraph-api/graphql/client.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/client.ts
@@ -26,6 +26,8 @@ import {
     CURRENT_USER_ID_QUERY,
     CURRENT_USER_INFO_QUERY,
     EVALUATE_FEATURE_FLAG_QUERY,
+    FILE_CONTENTS_QUERY,
+    FILE_MATCH_SEARCH_QUERY,
     GET_FEATURE_FLAGS_QUERY,
     LOG_EVENT_MUTATION,
     LOG_EVENT_MUTATION_DEPRECATED,
@@ -162,6 +164,37 @@ export interface RepoSearchResponse {
             endCursor: string | null
         }
     }
+}
+export interface FileMatchSearchResponse {
+    search: {
+        results: {
+            results: {
+                __typename: string
+                repository: {
+                    name: string
+                }
+                file: {
+                    url: string
+                    path: string
+                    commit: {
+                        oid: string
+                    }
+                }
+            }[]
+        }
+    }
+}
+
+export interface FileContentsResponse {
+    repository: {
+        commit: {
+            file: {
+                path: string
+                url: string
+                content: string
+            } | null
+        } | null
+    } | null
 }
 
 interface RepositoryIdResponse {
@@ -603,6 +636,24 @@ export class SourcegraphGraphQLAPIClient {
             first,
             after: after || null,
             query,
+        }).then(response => extractDataOrError(response, data => data))
+    }
+
+    public async searchFileMatches(query?: string): Promise<FileMatchSearchResponse | Error> {
+        return this.fetchSourcegraphAPI<APIResponse<FileMatchSearchResponse>>(FILE_MATCH_SEARCH_QUERY, {
+            query,
+        }).then(response => extractDataOrError(response, data => data))
+    }
+
+    public async getFileContents(
+        repoName: string,
+        filePath: string,
+        rev?: string
+    ): Promise<FileContentsResponse | Error> {
+        return this.fetchSourcegraphAPI<APIResponse<FileContentsResponse>>(FILE_CONTENTS_QUERY, {
+            repoName,
+            filePath,
+            rev,
         }).then(response => extractDataOrError(response, data => data))
     }
 

--- a/lib/shared/src/sourcegraph-api/graphql/queries.ts
+++ b/lib/shared/src/sourcegraph-api/graphql/queries.ts
@@ -134,6 +134,41 @@ query RepositoriesSearch($first: Int!, $after: String, $query: String) {
     }
 }
 `
+export const FILE_CONTENTS_QUERY = `
+query FileContentsQuery($repoName: String!, $filePath: String!, $rev: String!) {
+    repository(name: $repoName){
+        commit(rev: $rev) {
+            file(path: $filePath) {
+                path
+                url
+                content
+            }
+        }
+    }
+}`
+
+export const FILE_MATCH_SEARCH_QUERY = `
+query FileMatchSearchQuery($query: String!) {
+  search(query: $query, version: V3, patternType: literal) {
+    results {
+      results {
+        __typename
+        ... on FileMatch {
+          repository {
+            name
+          }
+          file {
+            url
+            path
+            commit {
+                oid
+            }
+          }
+        }
+      }
+    }
+  }
+}`
 
 export const REPOSITORY_ID_QUERY = `
 query Repository($name: String!) {

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -1,6 +1,7 @@
 import { isDotCom, setOpenCtxClient } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
 import { logDebug, outputChannel } from '../log'
+import RemoteFileProvider from './openctx/remoteFileSearch'
 import RemoteRepositorySearch from './openctx/remoteRepositorySearch'
 
 export function exposeOpenCtxClient(
@@ -22,6 +23,11 @@ export function exposeOpenCtxClient(
                                   providerUri: RemoteRepositorySearch.providerUri,
                                   settings: true,
                                   provider: RemoteRepositorySearch,
+                              },
+                              {
+                                  providerUri: RemoteFileProvider.providerUri,
+                                  settings: true,
+                                  provider: RemoteFileProvider,
                               },
                           ],
                 }).controller.client

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -1,4 +1,4 @@
-import { isDotCom, setOpenCtxClient } from '@sourcegraph/cody-shared'
+import { type ConfigurationWithAccessToken, setOpenCtxClient } from '@sourcegraph/cody-shared'
 import type * as vscode from 'vscode'
 import { logDebug, outputChannel } from '../log'
 import RemoteFileProvider from './openctx/remoteFileSearch'
@@ -6,30 +6,33 @@ import RemoteRepositorySearch from './openctx/remoteRepositorySearch'
 
 export function exposeOpenCtxClient(
     secrets: vscode.SecretStorage,
-    config: { serverEndpoint: string }
+    config: ConfigurationWithAccessToken
 ): void {
     logDebug('openctx', 'OpenCtx is enabled in Cody')
     import('@openctx/vscode-lib')
         .then(({ createController }) => {
+            const providers = [
+                {
+                    providerUri: RemoteRepositorySearch.providerUri,
+                    settings: true,
+                    provider: RemoteRepositorySearch,
+                },
+            ]
+
+            if (config.experimentalNoodle) {
+                providers.push({
+                    providerUri: RemoteFileProvider.providerUri,
+                    settings: true,
+                    provider: RemoteFileProvider,
+                })
+            }
+
             setOpenCtxClient(
                 createController({
                     outputChannel,
                     secrets,
                     features: {},
-                    providers: isDotCom(config.serverEndpoint)
-                        ? []
-                        : [
-                              {
-                                  providerUri: RemoteRepositorySearch.providerUri,
-                                  settings: true,
-                                  provider: RemoteRepositorySearch,
-                              },
-                              {
-                                  providerUri: RemoteFileProvider.providerUri,
-                                  settings: true,
-                                  provider: RemoteFileProvider,
-                              },
-                          ],
+                    providers,
                 }).controller.client
             )
         })

--- a/vscode/src/context/openctx/remoteFileSearch.ts
+++ b/vscode/src/context/openctx/remoteFileSearch.ts
@@ -1,0 +1,112 @@
+import type { Item, Mention, Provider } from '@openctx/client'
+import { graphqlClient, isDefined, isError } from '@sourcegraph/cody-shared'
+
+const RemoteFileProvider: Provider & { providerUri: string } = {
+    providerUri: 'internal-remote-file-search',
+
+    meta() {
+        return {
+            name: 'Sourcegraph Files',
+            mentions: {},
+        }
+    },
+
+    async mentions({ query }) {
+        const [repoName, filePath] = query?.split(':') || []
+
+        if (!query?.includes(':') || !repoName.trim()) {
+            return await getRepoMentions(query?.trim())
+        }
+
+        return await getFileMentions(repoName, filePath.trim())
+    },
+
+    async items({ mention }) {
+        if (!mention?.data?.repoName || !mention?.data?.filePath) {
+            return []
+        }
+
+        return await getFileItem(
+            mention.data.repoName as string,
+            mention.data.filePath as string,
+            mention.data.rev as string
+        )
+    },
+}
+
+export async function getRepoMentions(query?: string): Promise<Mention[]> {
+    const dataOrError = await graphqlClient.searchRepos(10, undefined, query)
+
+    if (isError(dataOrError) || dataOrError === null) {
+        return []
+    }
+
+    const repositories = dataOrError.repositories.nodes
+
+    return repositories.map(repo => ({
+        uri: repo.url,
+        title: repo.name,
+        description: ' ',
+        data: {
+            repoName: repo.name,
+        },
+    }))
+}
+
+export async function getFileMentions(repoName: string, filePath?: string): Promise<Mention[]> {
+    const query = `repo:${repoName} type:file count:10` + (filePath ? ` file:${filePath}` : '')
+
+    const dataOrError = await graphqlClient.searchFileMatches(query)
+
+    if (isError(dataOrError) || dataOrError === null) {
+        return []
+    }
+
+    return dataOrError.search.results.results
+        .map(result => {
+            if (result.__typename !== 'FileMatch') {
+                return null
+            }
+
+            const url = `${graphqlClient.endpoint.replace(/\/$/, '')}${result.file.url}`
+
+            return {
+                uri: url,
+                title: result.file.path,
+                description: result.repository.name,
+                data: {
+                    mentionLabel: `${result.repository.name}:${result.file.path}`,
+                    repoName: result.repository.name,
+                    rev: result.file.commit.oid,
+                    filePath: result.file.path,
+                },
+            } satisfies Mention
+        })
+        .filter(isDefined)
+}
+export async function getFileItem(repoName: string, filePath: string, rev = 'HEAD'): Promise<Item[]> {
+    const dataOrError = await graphqlClient.getFileContents(repoName, filePath, rev)
+
+    if (isError(dataOrError)) {
+        return []
+    }
+
+    const file = dataOrError?.repository?.commit?.file
+    if (!file) {
+        return []
+    }
+
+    const url = `${graphqlClient.endpoint.replace(/\/$/, '')}${file.url}`
+
+    return [
+        {
+            url,
+            title: `${repoName}/${file.path}`,
+            ai: {
+                content: file.content,
+            },
+        },
+    ] satisfies Item[]
+}
+
+export default RemoteFileProvider

--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -12,10 +12,6 @@ const RemoteRepositorySearch: Provider & {
     },
 
     async mentions({ query }) {
-        if (query && query.length < 3) {
-            return []
-        }
-
         try {
             const dataOrError = await graphqlClient.searchRepos(10, undefined, query)
 

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
@@ -124,7 +124,7 @@ export const MentionMenu: FunctionComponent<
     )
 
     const onCommandSelect = useCallback(
-        async (value: string): Promise<void> => {
+        (value: string): void => {
             const item = data.items?.find(item => commandRowValue(item) === value)
             if (!item) {
                 throw new Error(`No item found with value ${value}`)
@@ -145,12 +145,11 @@ export const MentionMenu: FunctionComponent<
                     // Do not set the selected item as mention if it is repo item from the remote file search provider.
                     // Rather keep the provider in place and update the query with repo name so that the provider can
                     // start showing the files instead.
-                    const meta = await RemoteFileProvider.meta({}, {})
 
                     updateMentionMenuParams({
                         parentItem: {
                             id: RemoteFileProvider.providerUri,
-                            title: meta.name,
+                            title: 'Sourcegraph Files',
                             queryLabel: 'Enter file path to search.',
                             emptyLabel: `No files found in ${openCtxItem.mention.data.repoName} repository`,
                         },

--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
@@ -1,6 +1,7 @@
 import type { MenuRenderFn } from '@lexical/react/LexicalTypeaheadMenuPlugin'
 import {
     type ContextItem,
+    type ContextItemOpenCtx,
     type ContextMentionProviderMetadata,
     FILE_CONTEXT_MENTION_PROVIDER,
     type MentionQuery,
@@ -13,6 +14,7 @@ import {
     FILE_RANGE_TOOLTIP_LABEL,
     NO_SYMBOL_MATCHES_HELP_LABEL,
 } from '../../../src/chat/context/constants'
+import RemoteFileProvider from '../../../src/context/openctx/remoteFileSearch'
 import RemoteRepositorySearch from '../../../src/context/openctx/remoteRepositorySearch'
 import type { UserAccountInfo } from '../../Chat'
 import {
@@ -122,14 +124,46 @@ export const MentionMenu: FunctionComponent<
     )
 
     const onCommandSelect = useCallback(
-        (value: string): void => {
+        async (value: string): Promise<void> => {
             const item = data.items?.find(item => commandRowValue(item) === value)
             if (!item) {
                 throw new Error(`No item found with value ${value}`)
             }
+
+            // HACK: The OpenCtx interface do not support building multi-step selection for mentions.
+            // For the remote file search provider, we first need the user to search for the repo from the list and then
+            // put in the query to search for files. Below we are doing a hack to not set the repo item as a mention
+            // but instead keep the same provider selected and put the full repo name in the query. The provider will then
+            // return files instead of repos if the repo name is in the query.
+            if (item.provider === 'openctx') {
+                const openCtxItem = item as ContextItemOpenCtx
+                if (
+                    openCtxItem.providerUri === RemoteFileProvider.providerUri &&
+                    openCtxItem.mention?.data?.repoName &&
+                    !openCtxItem.mention?.data?.filePath
+                ) {
+                    // Do not set the selected item as mention if it is repo item from the remote file search provider.
+                    // Rather keep the provider in place and update the query with repo name so that the provider can
+                    // start showing the files instead.
+                    const meta = await RemoteFileProvider.meta({}, {})
+
+                    updateMentionMenuParams({
+                        parentItem: {
+                            id: RemoteFileProvider.providerUri,
+                            title: meta.name,
+                            queryLabel: 'Enter file path to search.',
+                            emptyLabel: `No files found in ${openCtxItem.mention.data.repoName} repository`,
+                        },
+                    })
+                    setEditorQuery(`${openCtxItem.mention?.data?.repoName}:`)
+                    setValue(null)
+                    return
+                }
+            }
+
             selectOptionAndCleanUp(createMentionMenuOption(item))
         },
-        [data.items, selectOptionAndCleanUp]
+        [data.items, selectOptionAndCleanUp, setEditorQuery, updateMentionMenuParams]
     )
 
     // We use `cmdk` Command as a controlled component, so we need to supply its `value`. We track
@@ -162,8 +196,9 @@ export const MentionMenu: FunctionComponent<
                         {data.providers
                             .filter(
                                 provider =>
-                                    provider.id !== RemoteRepositorySearch.providerUri ||
-                                    (userInfo && !userInfo.isDotComUser)
+                                    (provider.id !== RemoteRepositorySearch.providerUri &&
+                                        provider.id !== RemoteFileProvider.providerUri) ||
+                                    !userInfo?.isDotComUser
                             )
                             .map(provider => (
                                 // show remote repositories search provider  only if the user is connected to a non-dotcom instance.

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -28,6 +28,7 @@ import {
     IGNORED_FILE_WARNING_LABEL,
     LARGE_FILE_WARNING_LABEL,
 } from '../../../src/chat/context/constants'
+import RemoteFileProvider from '../../../src/context/openctx/remoteFileSearch'
 import RemoteRepositorySearch from '../../../src/context/openctx/remoteRepositorySearch'
 import GithubLogo from '../../icons/providers/github.svg?react'
 import GoogleLogo from '../../icons/providers/google.svg?react'
@@ -134,4 +135,5 @@ const iconForProvider: Record<
     'https://openctx.org/npm/@openctx/provider-devdocs': LibraryBigIcon,
     'https://openctx.org/npm/@openctx/provider-sourcegraph-search': SourcegraphLogo,
     [RemoteRepositorySearch.providerUri]: SourcegraphLogo,
+    [RemoteFileProvider.providerUri]: SourcegraphLogo,
 }

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -205,7 +205,7 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
         case 'github_issue':
             return `@github:issue:${contextItem.owner}/${contextItem.repoName}/${contextItem.issueNumber}`
         case 'openctx':
-            return `@${contextItem.title}`
+            return `@${contextItem.mention?.data?.mentionLabel || contextItem.title}`
     }
     // @ts-ignore
     throw new Error(`unrecognized context item type ${contextItem.type}`)


### PR DESCRIPTION
Similar to the Sourcegraph Repositories context provider, this PR adds a Sourcegraph Files provider. Which only loads under the `config.experimental.noodle` config flag right now.

But this is not as clean as the previous provider. Searching for files on Sourcegraph without first selecting a repo is not a great experience because a global file search based on file path won't get the desired results. Imagine searching for client.js, there will be 100s of those. 

The OpenCtx protocol does not provide a way to do a two-step selection for multiple items and we do not modify the protocol to introduce the complexity. 

So, in this PR, we are doing a HACK to pull this off. Given this is an internal Cody provider, this should be fine. 

Here is what it does:

1. The provider separates the repoName from filePath based on `:`. So `[repoName, filePath] = query.split(':')`. If any repo or filePath contains `:` in them, it is fine that the search will not work for them, and IMHO, it should not; who even puts a `:` in file names?
2. Anyways, the user does not have to manually put in the full repo name. Whatever query they type first, we consider it to query the repos and show them repos in the list. 
3. When the user selects a repo from the list, we put the full name of that repo in the query and append a `:`, so now the provider will start showing them files in the list. On this selection, we do not set the repo item as mention yet and keep the provider selected.
4. Now they can simply write a query to search files and then select it. Now we will set the file item as mention and reset the mention menu state. 

## Test plan

Manually tested. 

Demo: https://www.loom.com/share/725597bf6a4a4e17bb7124b460f124fb?sid=9b9ba412-67fb-4c98-b480-56095ce8a6c8