### PR TITLE
Fix Sourcegraph Repositories Search Context Provider for enterprise

### DIFF
--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -8,7 +8,7 @@ const RemoteRepositorySearch: Provider & {
     providerUri: 'internal-remote-repository-search',
 
     meta() {
-        return { name: 'Sourcegraph Repositories', features: { mentions: true } }
+        return { name: 'Sourcegraph Repositories', mentions: {} }
     },
 
     async mentions({ query }) {


### PR DESCRIPTION
This updates the Sourcegraph Repositories search provider to use the updated OpenCtx protocol. Resolves the bug which causes the provider to be hidden on pre-release. 

## Test plan

tested manually