### PR TITLE
fix "Try again with different context:" failure due to telemetryRecorder misuse

### DIFF
--- a/lib/shared/src/telemetry-v2/singleton.ts
+++ b/lib/shared/src/telemetry-v2/singleton.ts
@@ -19,6 +19,8 @@ export let telemetryRecorderProvider: TelemetryRecorderProvider | undefined
  *
  * The default recorder throws an error if it is used before initialization
  * via createOrUpdateTelemetryRecorderProvider.
+ *
+ * DO NOT USE from webviews. Use the {@link useTelemetryRecorder} hook instead.
  */
 export let telemetryRecorder: TelemetryRecorder = new NoOpTelemetryRecorderProvider().getRecorder([
     new CallbackTelemetryProcessor(() => {

--- a/vscode/webviews/App.tsx
+++ b/vscode/webviews/App.tsx
@@ -30,7 +30,11 @@ import {
 import { WithContextProviders } from './mentions/providers'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 import { updateDisplayPathEnvInfoForWebview } from './utils/displayPathEnvInfo'
-import { createWebviewTelemetryRecorder, createWebviewTelemetryService } from './utils/telemetry'
+import {
+    TelemetryRecorderContext,
+    createWebviewTelemetryRecorder,
+    createWebviewTelemetryService,
+} from './utils/telemetry'
 
 export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vscodeAPI }) => {
     const [config, setConfig] = useState<(LocalEnv & ConfigurationSubsetForWebview) | null>(null)
@@ -231,12 +235,12 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     if (authStatus.showNetworkError) {
         return (
             <div className={styles.outerContainer}>
-                <ConnectionIssuesPage
-                    configuredEndpoint={authStatus.endpoint}
-                    telemetryService={telemetryService}
-                    telemetryRecorder={telemetryRecorder}
-                    vscodeAPI={vscodeAPI}
-                />
+                <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+                    <ConnectionIssuesPage
+                        configuredEndpoint={authStatus.endpoint}
+                        vscodeAPI={vscodeAPI}
+                    />
+                </TelemetryRecorderContext.Provider>
             </div>
         )
     }
@@ -244,13 +248,14 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
     if (view === 'login' || !authStatus.isLoggedIn || !userAccountInfo) {
         return (
             <div className={styles.outerContainer}>
-                <LoginSimplified
-                    simplifiedLoginRedirect={loginRedirect}
-                    telemetryService={telemetryService}
-                    telemetryRecorder={telemetryRecorder}
-                    uiKindIsWeb={config?.uiKindIsWeb}
-                    vscodeAPI={vscodeAPI}
-                />
+                <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+                    <LoginSimplified
+                        simplifiedLoginRedirect={loginRedirect}
+                        telemetryService={telemetryService}
+                        uiKindIsWeb={config?.uiKindIsWeb}
+                        vscodeAPI={vscodeAPI}
+                    />
+                </TelemetryRecorderContext.Provider>
             </div>
         )
     }
@@ -271,18 +276,19 @@ export const App: React.FunctionComponent<{ vscodeAPI: VSCodeWrapper }> = ({ vsc
                     <EnhancedContextContext.Provider value={enhancedContextStatus}>
                         <ChatModelContextProvider value={chatModelContext}>
                             <WithContextProviders>
-                                <Chat
-                                    chatEnabled={chatEnabled}
-                                    userInfo={userAccountInfo}
-                                    messageInProgress={messageInProgress}
-                                    transcript={transcript}
-                                    vscodeAPI={vscodeAPI}
-                                    telemetryService={telemetryService}
-                                    telemetryRecorder={telemetryRecorder}
-                                    isTranscriptError={isTranscriptError}
-                                    guardrails={attributionEnabled ? guardrails : undefined}
-                                    userContextFromSelection={userContextFromSelection}
-                                />
+                                <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+                                    <Chat
+                                        chatEnabled={chatEnabled}
+                                        userInfo={userAccountInfo}
+                                        messageInProgress={messageInProgress}
+                                        transcript={transcript}
+                                        vscodeAPI={vscodeAPI}
+                                        telemetryService={telemetryService}
+                                        isTranscriptError={isTranscriptError}
+                                        guardrails={attributionEnabled ? guardrails : undefined}
+                                        userContextFromSelection={userContextFromSelection}
+                                    />
+                                </TelemetryRecorderContext.Provider>
                             </WithContextProviders>
                         </ChatModelContextProvider>
                     </EnhancedContextContext.Provider>

--- a/vscode/webviews/AppWrapper.tsx
+++ b/vscode/webviews/AppWrapper.tsx
@@ -1,5 +1,7 @@
+import type { TelemetryRecorder } from '@sourcegraph/cody-shared'
 import type { FunctionComponent, ReactNode } from 'react'
 import { TooltipProvider } from './components/shadcn/ui/tooltip'
+import { TelemetryRecorderContext } from './utils/telemetry'
 
 export const AppWrapper: FunctionComponent<{ children: ReactNode }> = ({ children }) => {
     return (
@@ -7,4 +9,18 @@ export const AppWrapper: FunctionComponent<{ children: ReactNode }> = ({ childre
             {children}
         </TooltipProvider>
     )
+}
+
+/**
+ * For use in tests only.
+ */
+export const TestAppWrapper: FunctionComponent<{ children: ReactNode }> = ({ children }) => (
+    <AppWrapper>
+        <TelemetryRecorderContext.Provider value={NOOP_TELEMETRY_RECORDER}>
+            {children}
+        </TelemetryRecorderContext.Provider>
+    </AppWrapper>
+)
+const NOOP_TELEMETRY_RECORDER: TelemetryRecorder = {
+    recordEvent: () => {},
 }

--- a/vscode/webviews/Chat.story.tsx
+++ b/vscode/webviews/Chat.story.tsx
@@ -25,7 +25,6 @@ const meta: Meta<typeof Chat> = {
             onMessage: () => () => {},
         },
         telemetryService: null as any,
-        telemetryRecorder: null as any,
         isTranscriptError: false,
         userContextFromSelection: [],
     } satisfies React.ComponentProps<typeof Chat>,

--- a/vscode/webviews/Chat.tsx
+++ b/vscode/webviews/Chat.tsx
@@ -7,7 +7,6 @@ import type {
     ChatMessage,
     ContextItem,
     Guardrails,
-    TelemetryRecorder,
     TelemetryService,
 } from '@sourcegraph/cody-shared'
 import { Transcript, focusLastHumanMessageEditor } from './chat/Transcript'
@@ -17,6 +16,7 @@ import { truncateTextStart } from '@sourcegraph/cody-shared/src/prompt/truncatio
 import { CHAT_INPUT_TOKEN_BUDGET } from '@sourcegraph/cody-shared/src/token/constants'
 import styles from './Chat.module.css'
 import { ScrollDown } from './components/ScrollDown'
+import { useTelemetryRecorder } from './utils/telemetry'
 
 interface ChatboxProps {
     chatEnabled: boolean
@@ -24,7 +24,6 @@ interface ChatboxProps {
     transcript: ChatMessage[]
     vscodeAPI: Pick<VSCodeWrapper, 'postMessage' | 'onMessage'>
     telemetryService: TelemetryService
-    telemetryRecorder: TelemetryRecorder
     isTranscriptError: boolean
     userInfo: UserAccountInfo
     guardrails?: Guardrails
@@ -36,13 +35,15 @@ export const Chat: React.FunctionComponent<React.PropsWithChildren<ChatboxProps>
     transcript,
     vscodeAPI,
     telemetryService,
-    telemetryRecorder,
+
     isTranscriptError,
     chatEnabled = true,
     userInfo,
     guardrails,
     userContextFromSelection,
 }) => {
+    const telemetryRecorder = useTelemetryRecorder()
+
     const feedbackButtonsOnSubmit = useCallback(
         (text: string) => {
             const eventData = {

--- a/vscode/webviews/OnboardingExperiment.story.tsx
+++ b/vscode/webviews/OnboardingExperiment.story.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { NOOP_TELEMETRY_SERVICE, noOpTelemetryRecorder } from '@sourcegraph/cody-shared'
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/cody-shared'
 
 import { LoginSimplified } from './OnboardingExperiment'
 import { VSCodeSidebar } from './storybook/VSCodeStoryDecorator'
@@ -26,7 +26,6 @@ export const Login: StoryObj<typeof LoginSimplified> = {
         <LoginSimplified
             simplifiedLoginRedirect={() => {}}
             telemetryService={NOOP_TELEMETRY_SERVICE}
-            telemetryRecorder={noOpTelemetryRecorder}
             uiKindIsWeb={false}
             vscodeAPI={vscodeAPI}
         />
@@ -38,7 +37,6 @@ export const LoginWeb: StoryObj<typeof LoginSimplified> = {
         <LoginSimplified
             simplifiedLoginRedirect={() => {}}
             telemetryService={NOOP_TELEMETRY_SERVICE}
-            telemetryRecorder={noOpTelemetryRecorder}
             uiKindIsWeb={true}
             vscodeAPI={vscodeAPI}
         />

--- a/vscode/webviews/OnboardingExperiment.tsx
+++ b/vscode/webviews/OnboardingExperiment.tsx
@@ -11,11 +11,11 @@ import signInLogoGoogle from './sign-in-logo-google.svg'
 import type { VSCodeWrapper } from './utils/VSCodeApi'
 
 import styles from './OnboardingExperiment.module.css'
+import { useTelemetryRecorder } from './utils/telemetry'
 
 interface LoginProps {
     simplifiedLoginRedirect: (method: AuthMethod) => void
     telemetryService: TelemetryService
-    telemetryRecorder: TelemetryRecorder
     uiKindIsWeb: boolean
     vscodeAPI: VSCodeWrapper
 }
@@ -26,7 +26,8 @@ const WebLogin: React.FunctionComponent<
         telemetryRecorder: TelemetryRecorder
         vscodeAPI: VSCodeWrapper
     }>
-> = ({ telemetryService, telemetryRecorder, vscodeAPI }) => {
+> = ({ telemetryService, vscodeAPI }) => {
+    const telemetryRecorder = useTelemetryRecorder()
     return (
         <ol>
             <li>
@@ -64,10 +65,10 @@ const WebLogin: React.FunctionComponent<
 export const LoginSimplified: React.FunctionComponent<React.PropsWithoutRef<LoginProps>> = ({
     simplifiedLoginRedirect,
     telemetryService,
-    telemetryRecorder,
     uiKindIsWeb,
     vscodeAPI,
 }) => {
+    const telemetryRecorder = useTelemetryRecorder()
     const otherSignInClick = (): void => {
         telemetryService.log('CodyVSCodeExtension:auth:clickOtherSignInOptions')
         vscodeAPI.postMessage({ command: 'auth', authKind: 'signin' })

--- a/vscode/webviews/Troubleshooting/ConnectionIssuesPage.tsx
+++ b/vscode/webviews/Troubleshooting/ConnectionIssuesPage.tsx
@@ -1,6 +1,4 @@
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
-
-import type { TelemetryRecorder, TelemetryService } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
 import { useCallback, useState } from 'react'
 import type { VSCodeWrapper } from '../utils/VSCodeApi'
@@ -8,8 +6,6 @@ import styles from './ConnectionIssuesPage.module.css'
 
 export const ConnectionIssuesPage: React.FunctionComponent<
     React.PropsWithoutRef<{
-        telemetryService: TelemetryService
-        telemetryRecorder: TelemetryRecorder
         vscodeAPI: VSCodeWrapper
         configuredEndpoint: string | undefined | null
     }>

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render as render_, screen } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { type Assertion, describe, expect, test, vi } from 'vitest'
 import { URI } from 'vscode-uri'
-import { AppWrapper } from '../AppWrapper'
+import { TestAppWrapper } from '../AppWrapper'
 import { Transcript } from './Transcript'
 import { FIXTURE_USER_ACCOUNT_INFO } from './fixtures'
 
@@ -26,7 +26,7 @@ vi.mock('../utils/VSCodeApi', () => ({
 }))
 
 function render(element: JSX.Element): ReturnType<typeof render_> {
-    return render_(element, { wrapper: AppWrapper })
+    return render_(element, { wrapper: TestAppWrapper })
 }
 
 describe('Transcript', () => {

--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import { type Assertion, type Mock, describe, expect, test, vi } from 'vitest'
-import { AppWrapper } from '../../../../../AppWrapper'
+import { TestAppWrapper } from '../../../../../AppWrapper'
 import { serializedPromptEditorStateFromText } from '../../../../../promptEditor/PromptEditor'
 import { FILE_MENTION_EDITOR_STATE_FIXTURE } from '../../../../../promptEditor/fixtures'
 import { FIXTURE_USER_ACCOUNT_INFO } from '../../../../fixtures'
@@ -210,7 +210,7 @@ function renderWithMocks(props: Partial<ComponentProps<typeof HumanMessageEditor
     }
 
     const { container } = render(<HumanMessageEditor {...DEFAULT_PROPS} {...props} />, {
-        wrapper: AppWrapper,
+        wrapper: TestAppWrapper,
     })
     return {
         container,

--- a/vscode/webviews/utils/telemetry.ts
+++ b/vscode/webviews/utils/telemetry.ts
@@ -1,5 +1,6 @@
 import type { TelemetryRecorder, TelemetryService } from '@sourcegraph/cody-shared'
 
+import { createContext, useContext } from 'react'
 import type { WebviewRecordEventParameters } from '../../src/chat/protocol'
 import type { VSCodeWrapper } from './VSCodeApi'
 
@@ -19,7 +20,9 @@ export function createWebviewTelemetryService(vscodeAPI: VSCodeWrapper): Telemet
 /**
  * Create a new {@link TelemetryRecorder} for use in the VS Code webviews for V2 telemetry.
  */
-export function createWebviewTelemetryRecorder(vscodeAPI: VSCodeWrapper): TelemetryRecorder {
+export function createWebviewTelemetryRecorder(
+    vscodeAPI: Pick<VSCodeWrapper, 'postMessage'>
+): TelemetryRecorder {
     return {
         recordEvent(feature, action, parameters) {
             vscodeAPI.postMessage({
@@ -31,4 +34,14 @@ export function createWebviewTelemetryRecorder(vscodeAPI: VSCodeWrapper): Teleme
             })
         },
     }
+}
+
+export const TelemetryRecorderContext = createContext<TelemetryRecorder | null>(null)
+
+export function useTelemetryRecorder(): TelemetryRecorder {
+    const telemetryRecorder = useContext(TelemetryRecorderContext)
+    if (!telemetryRecorder) {
+        throw new Error('no telemetryRecorder')
+    }
+    return telemetryRecorder
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../vscode/webviews/chat/models/chatModelContext'
 import { type VSCodeWrapper, setVSCodeWrapper } from '../../vscode/webviews/utils/VSCodeApi'
 import {
+    TelemetryRecorderContext,
     createWebviewTelemetryRecorder,
     createWebviewTelemetryService,
 } from '../../vscode/webviews/utils/telemetry'
@@ -180,17 +181,18 @@ export const App: FunctionComponent = () => {
             <p>Error: {client.message}</p>
         ) : (
             <ChatModelContextProvider value={chatModelContext}>
-                <Chat
-                    chatEnabled={true}
-                    userInfo={userAccountInfo}
-                    messageInProgress={messageInProgress}
-                    transcript={transcript}
-                    vscodeAPI={vscodeAPI}
-                    telemetryService={telemetryService}
-                    telemetryRecorder={telemetryRecorder}
-                    isTranscriptError={isTranscriptError}
-                    userContextFromSelection={[]}
-                />
+                <TelemetryRecorderContext.Provider value={telemetryRecorder}>
+                    <Chat
+                        chatEnabled={true}
+                        userInfo={userAccountInfo}
+                        messageInProgress={messageInProgress}
+                        transcript={transcript}
+                        vscodeAPI={vscodeAPI}
+                        telemetryService={telemetryService}
+                        isTranscriptError={isTranscriptError}
+                        userContextFromSelection={[]}
+                    />
+                </TelemetryRecorderContext.Provider>
             </ChatModelContextProvider>
         )
     ) : (


### PR DESCRIPTION
Instead of requiring this `telemetryRecorder` to be passed down via props, which is messy, it's now stored in React context.



## Test plan

CI