### PR TITLE
Agent: return more details in JSON-RPC error responses

### DIFF
--- a/agent/src/cli/jsonrpc.ts
+++ b/agent/src/cli/jsonrpc.ts
@@ -115,7 +115,9 @@ export const jsonrpcCommand = new Command('jsonrpc')
         const networkRequests: Request[] = []
         const requestErrors: PollyRequestError[] = []
         let polly: Polly | undefined
-        if (options.recordingDirectory) {
+        if (options.recordingMode === 'passthrough') {
+            // Do nothing. We don't want Polly to interfere with `fetch` at all.
+        } else if (options.recordingDirectory) {
             if (options.recordingMode === undefined) {
                 console.error('CODY_RECORDING_MODE is required when CODY_RECORDING_DIRECTORY is set.')
                 process.exit(1)

--- a/vscode/src/jsonrpc/CodyJsonRpcErrorCode.ts
+++ b/vscode/src/jsonrpc/CodyJsonRpcErrorCode.ts
@@ -1,0 +1,9 @@
+export enum CodyJsonRpcErrorCode {
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InternalError = -32603,
+    RequestCanceled = -32604,
+    RateLimitError = -32000,
+}


### PR DESCRIPTION
The PR #3807 introduced a regression in how we deal with rate limits. Before that PR, we returned a dedicated JSON-RPC error code on rate limit errors, and this code was no longer returning after the PR. This PR recovers the original logic and integrates it with the new vscode-jsonrpc bindings.


## Test plan

Not tested yet.

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
