### PR TITLE
Edit: Fix incorrect prompt used for enterprise chat models

### DIFF
--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -5,562 +5,6 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 617e920073ef94d831dcdb5bf3df9d23
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2919
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
-          - name: user-agent
-            value: enterpriseClient / v1
-          - name: host
-            value: demo.sourcegraph.com
-        headersSize: 312
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: human
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/example.test.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-
-                  </SELECTEDCODE7662>
-
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-haiku-20240307
-            stopSequences:
-              - </CODE5711>
-              - describe('test block', () => {
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: client-name
-            value: enterpriseclient
-          - name: client-version
-            value: v1
-        url: https://demo.sourcegraph.com/.api/completions/stream?client-name=enterpriseclient&client-version=v1
-      response:
-        bodySize: 18454
-        content:
-          mimeType: text/event-stream
-          size: 18454
-          text: >+
-            event: completion
-
-            data: {"completion":"/**","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\":","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Ver","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\":","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Ver","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n *","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * -","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\":","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `performance","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `performance.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `performance.now","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `performance.now`","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `performance.now`\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `performance.now`\n */","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `performance.now`\n */\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * Test block for example functionality\n *\n * This test block contains three test cases:\n * - \"does 1\": Verifies that true is equal to true\n * - \"does 2\": Verifies that true is equal to true\n * - \"does something else\": Currently incomplete test case that will error due to incorrect usage of `performance.now`\n */\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 07 May 2024 01:12:06 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
-              Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1214
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-07T01:12:03.072Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: c9c2a56f40f6c55243e807a2cc11f436
       _order: 0
       cache: {}
@@ -657,6 +101,351 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-05-17T22:37:21.548Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 5d852bc2b95b53f276258d1b27315ad4
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2918
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_b20717265e7ab1d132874d8ff0be053ab9c1dacccec8dce0bbba76888b6a0a69
+          - name: user-agent
+            value: enterpriseClient / v1
+          - name: traceparent
+            value: 00-8f14491f144983eef12922d40451c3c2-1c81a8f0cef9505a-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: demo.sourcegraph.com
+        headersSize: 406
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: human
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: assistant
+                text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/example.test.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>describe('test block', () => {
+                      it('does 1', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does 2', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does something else', () => {
+                          // This line will error due to incorrect usage of `performance.now`
+                          const startTime = performance.now(/* CURSOR */)
+                      })
+                  })
+
+                  </SELECTEDCODE7662>
+
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-opus-20240229
+            stopSequences:
+              - </CODE5711>
+              - describe('test block', () => {
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: client-name
+            value: enterpriseclient
+          - name: client-version
+            value: v1
+        url: https://demo.sourcegraph.com/.api/completions/stream?client-name=enterpriseclient&client-version=v1
+      response:
+        bodySize: 4857
+        content:
+          mimeType: text/event-stream
+          size: 4857
+          text: >+
+            event: completion
+
+            data: {"completion":"/**","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n *","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n * -","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n * - does","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n * - does something","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n * - does something else","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n * - does something else\n ","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n * - does something else\n */","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n * - does something else\n */\n","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Test block for example tests\n *\n * Contains tests for:\n * - does 1\n * - does 2\n * - does something else\n */\n","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 29 May 2024 16:25:31 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Accept-Encoding, Authorization, Cookie, Authorization, X-Requested-With,
+              Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1214
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-05-29T16:25:29.358Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -940,34 +940,34 @@ describe('Agent', () => {
             const obtained = await demoEnterpriseClient.documentCode(uri)
             expect(obtained).toMatchInlineSnapshot(
                 `
-                  "import { expect } from 'vitest'
-                  import { it } from 'vitest'
-                  import { describe } from 'vitest'
+              "import { expect } from 'vitest'
+              import { it } from 'vitest'
+              import { describe } from 'vitest'
 
-                  /**
-                   * Test block for example functionality
-                   *
-                   * This test block contains three test cases:
-                   * - "does 1": Verifies that true is equal to true
-                   * - "does 2": Verifies that true is equal to true
-                   * - "does something else": Currently incomplete test case that will error due to incorrect usage of \`performance.now\`
-                   */
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of \`performance.now\`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
+              /**
+               * Test block for example tests
+               *
+               * Contains tests for:
+               * - does 1
+               * - does 2
+               * - does something else
+               */
+              describe('test block', () => {
+                  it('does 1', () => {
+                      expect(true).toBe(true)
                   })
-                  "
-                `
+
+                  it('does 2', () => {
+                      expect(true).toBe(true)
+                  })
+
+                  it('does something else', () => {
+                      // This line will error due to incorrect usage of \`performance.now\`
+                      const startTime = performance.now(/* CURSOR */)
+                  })
+              })
+              "
+            `
             )
         })
 

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -2,6 +2,10 @@
 
 export { ModelProvider } from './models'
 export {
+    type EditModel,
+    type EditProvider,
+    type ChatModel,
+    type ChatProvider,
     ModelUsage,
     type ModelContextWindow,
 } from './models/types'

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -2,10 +2,6 @@
 
 export { ModelProvider } from './models'
 export {
-    type ChatModel,
-    type ChatProvider,
-    type EditModel,
-    type EditProvider,
     ModelUsage,
     type ModelContextWindow,
 } from './models/types'

--- a/lib/shared/src/index.ts
+++ b/lib/shared/src/index.ts
@@ -3,7 +3,9 @@
 export { ModelProvider } from './models'
 export {
     type ChatModel,
+    type ChatProvider,
     type EditModel,
+    type EditProvider,
     ModelUsage,
     type ModelContextWindow,
 } from './models/types'

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -10,7 +10,7 @@ import { ModelUsage } from './types'
 import { ModelUIGroup } from './utils'
 
 // The models must first be added to the custom chat models list in https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/completions/httpapi/chat.go?L48-51
-export const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
+export const DEFAULT_DOT_COM_MODELS = [
     // The order listed here is the order shown to users. Put the default LLM first.
     {
         title: 'Claude 3 Sonnet',

--- a/lib/shared/src/models/dotcom.ts
+++ b/lib/shared/src/models/dotcom.ts
@@ -10,7 +10,7 @@ import { ModelUsage } from './types'
 import { ModelUIGroup } from './utils'
 
 // The models must first be added to the custom chat models list in https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/completions/httpapi/chat.go?L48-51
-const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
+export const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
     // The order listed here is the order shown to users. Put the default LLM first.
     {
         title: 'Claude 3 Sonnet',
@@ -148,7 +148,7 @@ const DEFAULT_DOT_COM_MODELS: ModelProvider[] = [
         contextWindow: { input: CHAT_INPUT_TOKEN_BUDGET, output: CHAT_OUTPUT_TOKEN_BUDGET },
         deprecated: true,
     },
-]
+] as const satisfies ModelProvider[]
 
 /**
  * Returns an array of ModelProviders representing the default models for DotCom.

--- a/lib/shared/src/models/types.ts
+++ b/lib/shared/src/models/types.ts
@@ -27,6 +27,18 @@ export type EditModel =
     | (string & {})
 
 /**
+ * Available providers for Edit.
+ * This is either:
+ * - one of the availble options (dotcom)
+ * - an unknown `string` (enterprise)
+ */
+export type EditProvider =
+    | {
+          [K in keyof Models]: HasUsage<Models[K], ModelUsage.Edit>
+      }[keyof Models]['provider']
+    | (string & {})
+
+/**
  * Available models for Chat.
  * This is either:
  * - one of the availble options (dotcom)
@@ -36,6 +48,18 @@ export type ChatModel =
     | {
           [K in keyof Models]: HasUsage<Models[K], ModelUsage.Chat>
       }[keyof Models]['model']
+    | (string & {})
+
+/**
+ * Available providers for Chat.
+ * This is either:
+ * - one of the availble options (dotcom)
+ * - an unknown `string` (enterprise)
+ */
+export type ChatProvider =
+    | {
+          [K in keyof Models]: HasUsage<Models[K], ModelUsage.Chat>
+      }[keyof Models]['provider']
     | (string & {})
 
 export interface ModelContextWindow {

--- a/lib/shared/src/models/types.ts
+++ b/lib/shared/src/models/types.ts
@@ -1,4 +1,4 @@
-import type { ModelProvider } from '.'
+import type { DEFAULT_DOT_COM_MODELS } from './dotcom'
 
 export enum ModelUsage {
     Chat = 'chat',
@@ -12,7 +12,7 @@ type HasUsage<T, I> = T extends { usage: readonly ModelUsage[] }
         : never
     : never
 
-type Models = typeof ModelProvider
+type Models = typeof DEFAULT_DOT_COM_MODELS
 
 /**
  * Available models for Edit.
@@ -51,7 +51,7 @@ export type ChatModel =
     | (string & {})
 
 /**
- * Available providers for Chat.
+ * Available models for Chat.
  * This is either:
  * - one of the availble options (dotcom)
  * - an unknown `string` (enterprise)

--- a/lib/shared/src/models/types.ts
+++ b/lib/shared/src/models/types.ts
@@ -51,7 +51,7 @@ export type ChatModel =
     | (string & {})
 
 /**
- * Available models for Chat.
+ * Available providers for Chat.
  * This is either:
  * - one of the availble options (dotcom)
  * - an unknown `string` (enterprise)

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -29,6 +29,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Fixed a bug where long messages could not be scrolled vertically in the input. [pull/4313](https://github.com/sourcegraph/cody/pull/4313)
 - Chat: Copying and pasting @-mentions in the chat input now works. [pull/4319](https://github.com/sourcegraph/cody/pull/4319)
 - Document Code: Fixed an issue where documentation would be incorrectly inserted in the middle of a line. [pull/4325](https://github.com/sourcegraph/cody/pull/4325)
+- Edit: Fixed an issue where an invalid prompt would be used, resulting in an error in certain enterprise configurations. [pull/4350](https://github.com/sourcegraph/cody/pull/4350)
 
 ### Changed
 

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -24,10 +24,15 @@ import { openai } from './models/openai'
 import type { EditLLMInteraction, GetLLMInteractionOptions, LLMInteraction } from './type'
 
 const INTERACTION_MODELS: Record<EditModel, EditLLMInteraction> = {
+    'anthropic/claude-2.0': claude,
+    'anthropic/claude-2.1': claude,
+    'anthropic/claude-instant-1.2': claude,
     'anthropic/claude-3-opus-20240229': claude,
     'anthropic/claude-3-sonnet-20240229': claude,
     'anthropic/claude-3-haiku-20240307': claude,
     'openai/gpt-3.5-turbo': openai,
+    'openai/gpt-4-turbo': openai,
+    'openai/gpt-4o': openai,
 } as const
 
 const getInteractionArgsFromIntent = (

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -5,10 +5,12 @@ import {
     type ChatMessage,
     type CompletionParameters,
     type EditModel,
+    type EditProvider,
     type Message,
     ModelProvider,
     PromptString,
     TokenCounter,
+    getModelInfo,
     getSimplePreamble,
     ps,
 } from '@sourcegraph/cody-shared'
@@ -23,16 +25,9 @@ import { claude } from './models/claude'
 import { openai } from './models/openai'
 import type { EditLLMInteraction, GetLLMInteractionOptions, LLMInteraction } from './type'
 
-const INTERACTION_MODELS: Record<EditModel, EditLLMInteraction> = {
-    'anthropic/claude-2.0': claude,
-    'anthropic/claude-2.1': claude,
-    'anthropic/claude-instant-1.2': claude,
-    'anthropic/claude-3-opus-20240229': claude,
-    'anthropic/claude-3-sonnet-20240229': claude,
-    'anthropic/claude-3-haiku-20240307': claude,
-    'openai/gpt-3.5-turbo': openai,
-    'openai/gpt-4-turbo': openai,
-    'openai/gpt-4o': openai,
+const INTERACTION_PROVIDERS: Record<EditProvider, EditLLMInteraction> = {
+    Anthropic: claude,
+    OpenAI: openai,
 } as const
 
 const getInteractionArgsFromIntent = (
@@ -40,8 +35,9 @@ const getInteractionArgsFromIntent = (
     model: EditModel,
     options: GetLLMInteractionOptions
 ): LLMInteraction => {
-    // Default to the generic Claude prompt if the model is unknown
-    const interaction = INTERACTION_MODELS[model] || claude
+    const { provider } = getModelInfo(model)
+    // Default to the generic Claude prompt if the provider is unknown
+    const interaction = INTERACTION_PROVIDERS[provider] || claude
     switch (intent) {
         case 'add':
             return interaction.getAdd(options)

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -28,7 +28,6 @@ const INTERACTION_MODELS: Record<EditModel, EditLLMInteraction> = {
     'anthropic/claude-3-sonnet-20240229': claude,
     'anthropic/claude-3-haiku-20240307': claude,
     'openai/gpt-3.5-turbo': openai,
-    'openai/gpt-4-turbo': openai,
 } as const
 
 const getInteractionArgsFromIntent = (

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -5,33 +5,13 @@ export function getEditModelsForUser(authStatus: AuthStatus): ModelProvider[] {
     return ModelProvider.getProviders(ModelUsage.Edit, !authStatus.userCanUpgrade)
 }
 
-/**
- * Gets the overriden model for enterprise users.
- * The only primary change here is that we override to use `fastChatModel`
- * for the "Document" command
- */
-export function getOverridenEnterpriseModelForIntent(
-    intent: EditIntent,
-    currentModel: EditModel,
-    authStatus: AuthStatus
-): EditModel {
-    const model = authStatus.configOverwrites?.chatModel || currentModel
-    const fastModel = authStatus.configOverwrites?.fastChatModel || currentModel
-
-    if (intent === 'doc') {
-        return fastModel
-    }
-
-    return model
-}
-
 export function getOverridenModelForIntent(
     intent: EditIntent,
     currentModel: EditModel,
     authStatus: AuthStatus
 ): EditModel {
     if (!authStatus.isDotCom) {
-        return getOverridenEnterpriseModelForIntent(intent, currentModel, authStatus)
+        return authStatus.configOverwrites?.chatModel || currentModel
     }
 
     switch (intent) {

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -11,7 +11,9 @@ export function getOverridenModelForIntent(
     authStatus: AuthStatus
 ): EditModel {
     if (!authStatus.isDotCom) {
-        return authStatus.configOverwrites?.chatModel || currentModel
+        // We do not want to override the model if the user is connected to an enterprise instance.
+        // We cannot assume what models will be available here.
+        return currentModel
     }
 
     switch (intent) {

--- a/vscode/src/edit/utils/edit-models.ts
+++ b/vscode/src/edit/utils/edit-models.ts
@@ -1,11 +1,57 @@
-import { type AuthStatus, type EditModel, ModelProvider, ModelUsage } from '@sourcegraph/cody-shared'
+import {
+    type AuthStatus,
+    type EditModel,
+    type EditProvider,
+    ModelProvider,
+    ModelUsage,
+} from '@sourcegraph/cody-shared'
 import type { EditIntent } from '../types'
 
 export function getEditModelsForUser(authStatus: AuthStatus): ModelProvider[] {
     return ModelProvider.getProviders(ModelUsage.Edit, !authStatus.userCanUpgrade)
 }
 
-export function getOverridenModelForIntent(intent: EditIntent, currentModel: EditModel): EditModel {
+export interface EditLLMConfig {
+    model: EditModel
+    provider: EditProvider
+}
+
+/**
+ * Gets the overriden model for enterprise users.
+ * The only primary change here is that we override to use `fastChatModel`
+ * for the "Document" command
+ */
+export function getOverridenEnterpriseModelForIntent(
+    intent: EditIntent,
+    currentModel: EditModel,
+    currentProvider: EditProvider,
+    authStatus: AuthStatus
+): EditLLMConfig {
+    const provider = authStatus.configOverwrites?.provider || currentProvider
+
+    if (intent === 'doc') {
+        return {
+            model: authStatus.configOverwrites?.fastChatModel || currentModel,
+            provider,
+        }
+    }
+
+    return {
+        model: authStatus.configOverwrites?.chatModel || currentModel,
+        provider,
+    }
+}
+
+export function getOverridenLLMConfigForIntent(
+    intent: EditIntent,
+    currentModel: EditModel,
+    currentProvider: EditProvider,
+    authStatus: AuthStatus
+): EditLLMConfig {
+    if (!authStatus.isDotCom) {
+        return getOverridenEnterpriseModelForIntent(intent, currentModel, currentProvider, authStatus)
+    }
+
     switch (intent) {
         case 'fix':
             // Fix is a case where we want to ensure that users do not end up with a broken edit model.
@@ -13,14 +59,23 @@ export function getOverridenModelForIntent(intent: EditIntent, currentModel: Edi
             // TODO: Make the model usage more visible to users outside of the normal edit flow. This means
             // we could let the user provide any model they want for `fix`.
             // Issue: https://github.com/sourcegraph/cody/issues/3512
-            return 'anthropic/claude-3-sonnet-20240229'
+            return {
+                model: 'anthropic/claude-3-sonnet-20240229',
+                provider: 'Anthropic',
+            }
         case 'doc':
             // Doc is a case where we can sacrifice LLM performnace for improved latency and get comparable results.
-            return 'anthropic/claude-3-haiku-20240307'
+            return {
+                model: 'anthropic/claude-3-haiku-20240307',
+                provider: 'Anthropic',
+            }
         case 'test':
         case 'add':
         case 'edit':
             // Support all model usage for add and edit intents.
-            return currentModel
+            return {
+                model: currentModel,
+                provider: currentProvider,
+            }
     }
 }

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode'
 import {
     type ContextItem,
     type EditModel,
-    EditProvider,
     type EventSource,
     type PromptString,
     displayPathBasename,
@@ -23,7 +22,7 @@ import { PersistenceTracker } from '../common/persistence-tracker'
 import { lines } from '../completions/text-processing'
 import { sleep } from '../completions/utils'
 import { getInput } from '../edit/input/get-input'
-import { getOverridenLLMConfigForIntent } from '../edit/utils/edit-models'
+import { getOverridenModelForIntent } from '../edit/utils/edit-models'
 import type { ExtensionClient } from '../extension-client'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import type { AuthProvider } from '../services/AuthProvider'
@@ -339,14 +338,13 @@ export class FixupController
         intent: EditIntent,
         mode: EditMode,
         model: EditModel,
-        provider: EditProvider,
         source?: EventSource,
         destinationFile?: vscode.Uri,
         insertionPoint?: vscode.Position,
         telemetryMetadata?: FixupTelemetryMetadata
     ): Promise<FixupTask> {
         const authStatus = this.authProvider.getAuthStatus()
-        const llmConfig = getOverridenLLMConfigForIntent(intent, model, provider, authStatus)
+        const overridenModel = getOverridenModelForIntent(intent, model, authStatus)
         const fixupFile = this.files.forUri(document.uri)
         const task = new FixupTask(
             fixupFile,
@@ -355,8 +353,7 @@ export class FixupController
             intent,
             selectionRange,
             mode,
-            llmConfig.model,
-            llmConfig.provider,
+            overridenModel,
             source,
             destinationFile,
             insertionPoint,

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode'
 import {
     type ContextItem,
     type EditModel,
-    type EditProvider,
     type EventSource,
     type PromptString,
     ps,
@@ -74,7 +73,6 @@ export class FixupTask {
         /* The mode indicates how code should be inserted */
         public readonly mode: EditMode,
         public readonly model: EditModel,
-        public readonly provider: EditProvider,
         /* the source of the instruction, e.g. 'code-action', 'doc', etc */
         public source?: EventSource,
         /* The file to write the edit to. If not provided, the edit will be applied to the fixupFile. */

--- a/vscode/src/non-stop/FixupTask.ts
+++ b/vscode/src/non-stop/FixupTask.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode'
 import {
     type ContextItem,
     type EditModel,
+    type EditProvider,
     type EventSource,
     type PromptString,
     ps,
@@ -10,7 +11,6 @@ import {
 
 import type { EditIntent, EditMode } from '../edit/types'
 
-import { getOverridenModelForIntent } from '../edit/utils/edit-models'
 import type { FixupFile } from './FixupFile'
 import type { Diff } from './diff'
 import { CodyTaskState } from './utils'
@@ -74,6 +74,7 @@ export class FixupTask {
         /* The mode indicates how code should be inserted */
         public readonly mode: EditMode,
         public readonly model: EditModel,
+        public readonly provider: EditProvider,
         /* the source of the instruction, e.g. 'code-action', 'doc', etc */
         public source?: EventSource,
         /* The file to write the edit to. If not provided, the edit will be applied to the fixupFile. */
@@ -84,7 +85,6 @@ export class FixupTask {
         this.id = Date.now().toString(36).replaceAll(/\d+/g, '')
         this.instruction = instruction.replace(/^\/(edit|fix)/, ps``).trim()
         this.originalRange = selectionRange
-        this.model = getOverridenModelForIntent(this.intent, this.model)
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes an issue where an enterprise instance would have `chatModel` set to something non-claude specific.

We would still override the model, which resulted in weird bugs

Also improves the type safety again, as this seemed to have regressed

## Test plan

1. Connect to an enterprise instance with the `chatModel` set to an OpenAI model
2. Run an edit command
3. Check that it works as expected

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
