### PR TITLE
Document code: Add tree-sitter query for Java

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Added @-mention remote repositories search provider for enterprise. [pull/4311](https://github.com/sourcegraph/cody/pull/4311)
 - Chat: Editor selection is now included in all chats by default. []()
 - Chat: Assistant responses now have a "Try again with different context" line at the bottom with ways you can improve the context used to generate the response. [pull/4317](https://github.com/sourcegraph/cody/pull/4317)
+- Document Code: Added additional Java support for range expansion. [pull/4353](https://github.com/sourcegraph/cody/pull/4353)
 
 ### Fixed
 

--- a/vscode/src/tree-sitter/queries.ts
+++ b/vscode/src/tree-sitter/queries.ts
@@ -1,5 +1,6 @@
 import type { SupportedLanguage } from './grammars'
 import { goQueries } from './queries/go'
+import { javaQueries } from './queries/java'
 import { javascriptQueries } from './queries/javascript'
 import { pythonQueries } from './queries/python'
 
@@ -43,4 +44,5 @@ export const languages: Partial<Record<SupportedLanguage, Record<QueryName, stri
     ...javascriptQueries,
     ...goQueries,
     ...pythonQueries,
+    ...javaQueries,
 } as const

--- a/vscode/src/tree-sitter/queries/java.ts
+++ b/vscode/src/tree-sitter/queries/java.ts
@@ -7,10 +7,19 @@ const DOCUMENTABLE_NODES = dedent`
     ;--------------------------------
     (method_declaration
         name: (identifier) @symbol.function) @range.function
+    (enum_body_declarations
+        (method_declaration
+            name: (identifier) @symbol.function) @range.function)
     (constructor_declaration
         name: (identifier) @symbol.function) @range.function
+    (enum_body_declarations
+        (constructor_declaration
+            name: (identifier) @symbol.function) @range.function)
     (record_declaration
         name: (identifier) @symbol.function) @range.function
+    (enum_body_declarations
+        (record_declaration
+            name: (identifier) @symbol.function) @range.function)
 
     ; Variables
     ;--------------------------------
@@ -18,6 +27,9 @@ const DOCUMENTABLE_NODES = dedent`
         name: (_) @symbol.identifier) @range.identifier
     (variable_declarator
         name: (identifier) @symbol.identifier) @range.identifier
+    (field_declaration
+        (variable_declarator
+            name: (identifier) @symbol.identifier) @range.identifier)
 
     ; Type Identifiers
     ;--------------------------------
@@ -25,6 +37,10 @@ const DOCUMENTABLE_NODES = dedent`
         name: (identifier) @symbol.identifier) @range.identifier
     (enum_declaration
         name: (identifier) @symbol.identifier) @range.identifier
+    (enum_declaration
+        (enum_body
+            (enum_constant
+                name: (identifier) @symbol.identifier) @range.identifier))
 `
 
 export const javaQueries = {

--- a/vscode/src/tree-sitter/queries/java.ts
+++ b/vscode/src/tree-sitter/queries/java.ts
@@ -1,0 +1,39 @@
+import dedent from 'dedent'
+import { SupportedLanguage } from '../grammars'
+import type { QueryName } from '../queries'
+
+const DOCUMENTABLE_NODES = dedent`
+    ; Functions
+    ;--------------------------------
+    (method_declaration
+        name: (identifier) @symbol.function) @range.function
+    (constructor_declaration
+        name: (identifier) @symbol.function) @range.function
+    (record_declaration
+        name: (identifier) @symbol.function) @range.function
+
+    ; Variables
+    ;--------------------------------
+    (class_declaration
+        name: (_) @symbol.identifier) @range.identifier
+    (variable_declarator
+        name: (identifier) @symbol.identifier) @range.identifier
+
+    ; Type Identifiers
+    ;--------------------------------
+    (interface_declaration
+        name: (identifier) @symbol.identifier) @range.identifier
+    (enum_declaration
+        name: (identifier) @symbol.identifier) @range.identifier
+`
+
+export const javaQueries = {
+    [SupportedLanguage.java]: {
+        documentableNodes: DOCUMENTABLE_NODES,
+        singlelineTriggers: '',
+        intents: '',
+        identifiers: '',
+        graphContextIdentifiers: '',
+        enclosingFunction: '',
+    },
+} satisfies Partial<Record<SupportedLanguage, Record<QueryName, string>>>

--- a/vscode/src/tree-sitter/queries/java.ts
+++ b/vscode/src/tree-sitter/queries/java.ts
@@ -15,11 +15,6 @@ const DOCUMENTABLE_NODES = dedent`
     (enum_body_declarations
         (constructor_declaration
             name: (identifier) @symbol.function) @range.function)
-    (record_declaration
-        name: (identifier) @symbol.function) @range.function
-    (enum_body_declarations
-        (record_declaration
-            name: (identifier) @symbol.function) @range.function)
 
     ; Variables
     ;--------------------------------
@@ -41,6 +36,11 @@ const DOCUMENTABLE_NODES = dedent`
         (enum_body
             (enum_constant
                 name: (identifier) @symbol.identifier) @range.identifier))
+    (record_declaration
+        name: (identifier) @symbol.function) @range.function
+    (enum_body_declarations
+        (record_declaration
+            name: (identifier) @symbol.function) @range.function)
 `
 
 export const javaQueries = {

--- a/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
+++ b/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
@@ -78,4 +78,15 @@ describe('getDocumentableNode', () => {
             sourcesPath: 'test-data/documentable-node.go',
         })
     })
+
+    it('java', async () => {
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.java)
+
+        await annotateAndMatchSnapshot({
+            parser,
+            language,
+            captures: queryWrapper(queries.getDocumentableNode),
+            sourcesPath: 'test-data/documentable-node.java',
+        })
+    })
 })

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.java
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.java
@@ -74,3 +74,75 @@ public enum Day {
     FRIDAY,
     SATURDAY
 }
+
+// ------------------------------------
+
+public enum Month {
+    JANUARY,
+//     |
+    FEBRUARY,
+    MARCH,
+    APRIL,
+    MAY,
+    JUNE,
+    JULY,
+    AUGUST,
+    SEPTEMBER,
+    OCTOBER,
+    NOVEMBER,
+    DECEMBER
+}
+
+// ------------------------------------
+
+public enum Planet {
+    EARTH(5.976e+24, 6.37814e6);
+//            |
+    private final double mass;
+    private final double radius;
+}
+
+// ------------------------------------
+
+public enum Planet {
+    EARTH(5.976e+24, 6.37814e6);
+    private final double mass;
+//                        |
+    private final double radius;
+}
+
+// ------------------------------------
+
+public enum Planet {
+    EARTH(5.976e+24, 6.37814e6);
+    private final double mass;
+    private final double radius;
+
+    Planet(double mass, double radius) {
+//             |
+        this.mass = mass;
+        this.radius = radius;
+    }
+}
+
+// ------------------------------------
+
+public enum Planet {
+    EARTH(5.976e+24, 6.37814e6);
+    private final double mass;
+    private final double radius;
+
+    public double surfaceGravity() {
+//                     |
+        return 6.67300E-11 * mass / (radius * radius);
+    }
+}
+
+// ------------------------------------
+
+public enum Planet {
+    EARTH(5.976e+24, 6.37814e6);
+    public static class InnerClass {
+//                       |
+    }
+}

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.java
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.java
@@ -1,0 +1,76 @@
+class Test {
+//      |
+}
+
+// ------------------------------------
+
+class Test {
+    public int age;
+//              |
+}
+
+// ------------------------------------
+
+class Test {
+    public Hello() {
+//           |
+    }
+}
+
+// ------------------------------------
+
+class Test {
+    public Hello() {
+//     |
+    }
+}
+
+// ------------------------------------
+
+class Test {
+    public Hello() {
+        System.out.println("Hi!");
+//           |
+    }
+}
+
+// ------------------------------------
+
+class Test {
+    public Test() {
+//           |
+    }
+}
+
+// ------------------------------------
+
+public record Point(int x, int y) {
+//              |
+}
+
+// ------------------------------------
+
+public interface Shape {
+//                  |
+    double calculateArea();
+}
+
+// ------------------------------------
+
+public interface Shape {
+    double calculateArea();
+    //         |
+}
+
+// ------------------------------------
+
+public enum Day {
+//           |
+    SUNDAY,
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY
+}

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.java
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.java
@@ -1,0 +1,147 @@
+// 
+// | - query start position in the source file.
+// █ – query start position in the annotated file.
+// ^ – characters matching the last query result.
+//
+// ------------------------------------
+
+  class Test {
+//^ start range.identifier[1]
+//      ^^^^ symbol.identifier[1]
+//        █
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// symbol.identifier[1]: identifier
+// range.identifier[1]: class_declaration
+
+// ------------------------------------
+
+  class Test {
+      public int age;
+//               ^^^ symbol.identifier[1], range.identifier[1]
+//                █
+  }
+
+// Nodes types:
+// symbol.identifier[1]: identifier
+// range.identifier[1]: variable_declarator
+
+// ------------------------------------
+
+  class Test {
+      public Hello() {
+//    ^ start range.function[1]
+//           ^^^^^ symbol.function[1]
+//             █
+      }
+//    ^ end range.function[1]
+  }
+
+// Nodes types:
+// symbol.function[1]: identifier
+// range.function[1]: constructor_declaration
+
+// ------------------------------------
+
+  class Test {
+      public Hello() {
+//    ^ start range.function[1]
+//       █
+      }
+//    ^ end range.function[1]
+  }
+
+// Nodes types:
+// range.function[1]: constructor_declaration
+
+// ------------------------------------
+
+  class Test {
+      public Hello() {
+//    ^ start range.function[1]
+          System.out.println("Hi!");
+//             █
+      }
+//    ^ end range.function[1]
+  }
+
+// Nodes types:
+// range.function[1]: constructor_declaration
+
+// ------------------------------------
+
+  class Test {
+      public Test() {
+//    ^ start range.function[1]
+//           ^^^^ symbol.function[1]
+//             █
+      }
+//    ^ end range.function[1]
+  }
+
+// Nodes types:
+// symbol.function[1]: identifier
+// range.function[1]: constructor_declaration
+
+// ------------------------------------
+
+  public record Point(int x, int y) {
+//^ start range.function[1]
+//              ^^^^^ symbol.function[1]
+//                █
+  }
+//^ end range.function[1]
+
+// Nodes types:
+// symbol.function[1]: identifier
+// range.function[1]: record_declaration
+
+// ------------------------------------
+
+  public interface Shape {
+//^ start range.identifier[1]
+//                 ^^^^^ symbol.identifier[1]
+//                    █
+      double calculateArea();
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// symbol.identifier[1]: identifier
+// range.identifier[1]: interface_declaration
+
+// ------------------------------------
+
+  public interface Shape {
+      double calculateArea();
+//    ^^^^^^^^^^^^^^^^^^^^^^^ range.function[1]
+//           ^^^^^^^^^^^^^ symbol.function[1]
+//               █
+  }
+
+// Nodes types:
+// symbol.function[1]: identifier
+// range.function[1]: method_declaration
+
+// ------------------------------------
+
+  public enum Day {
+//^ start range.identifier[1]
+//            ^^^ symbol.identifier[1]
+//             █
+      SUNDAY,
+      MONDAY,
+      TUESDAY,
+      WEDNESDAY,
+      THURSDAY,
+      FRIDAY,
+      SATURDAY
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// symbol.identifier[1]: identifier
+// range.identifier[1]: enum_declaration
+

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.java
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.java
@@ -145,3 +145,108 @@
 // symbol.identifier[1]: identifier
 // range.identifier[1]: enum_declaration
 
+// ------------------------------------
+
+  public enum Month {
+      JANUARY,
+//    ^^^^^^^ symbol.identifier[1], range.identifier[1]
+//       █
+      FEBRUARY,
+      MARCH,
+      APRIL,
+      MAY,
+      JUNE,
+      JULY,
+      AUGUST,
+      SEPTEMBER,
+      OCTOBER,
+      NOVEMBER,
+      DECEMBER
+  }
+
+// Nodes types:
+// symbol.identifier[1]: identifier
+// range.identifier[1]: enum_constant
+
+// ------------------------------------
+
+  public enum Planet {
+      EARTH(5.976e+24, 6.37814e6);
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ range.identifier[1]
+//              █
+      private final double mass;
+      private final double radius;
+  }
+
+// Nodes types:
+// range.identifier[1]: enum_constant
+
+// ------------------------------------
+
+  public enum Planet {
+      EARTH(5.976e+24, 6.37814e6);
+      private final double mass;
+//                         ^^^^ symbol.identifier[1], range.identifier[1]
+//                          █
+      private final double radius;
+  }
+
+// Nodes types:
+// symbol.identifier[1]: identifier
+// range.identifier[1]: variable_declarator
+
+// ------------------------------------
+
+  public enum Planet {
+      EARTH(5.976e+24, 6.37814e6);
+      private final double mass;
+      private final double radius;
+
+      Planet(double mass, double radius) {
+//    ^ start range.function[1]
+//               █
+          this.mass = mass;
+          this.radius = radius;
+      }
+//    ^ end range.function[1]
+  }
+
+// Nodes types:
+// range.function[1]: constructor_declaration
+
+// ------------------------------------
+
+  public enum Planet {
+      EARTH(5.976e+24, 6.37814e6);
+      private final double mass;
+      private final double radius;
+
+      public double surfaceGravity() {
+//    ^ start range.function[1]
+//                  ^^^^^^^^^^^^^^ symbol.function[1]
+//                       █
+          return 6.67300E-11 * mass / (radius * radius);
+      }
+//    ^ end range.function[1]
+  }
+
+// Nodes types:
+// symbol.function[1]: identifier
+// range.function[1]: method_declaration
+
+// ------------------------------------
+
+  public enum Planet {
+      EARTH(5.976e+24, 6.37814e6);
+      public static class InnerClass {
+//    ^ start range.identifier[1]
+//                        ^^^^^^^^^^ symbol.identifier[1]
+//                         █
+      }
+//    ^ end range.identifier[1]
+  }
+
+// Nodes types:
+// symbol.identifier[1]: identifier
+// range.identifier[1]: class_declaration
+


### PR DESCRIPTION

<img width="565" alt="image" src="https://github.com/sourcegraph/cody/assets/9516420/8e2bf9d4-0889-41d8-b3e5-6d222324ac4b">

## Description

This PR adds tree-sitter support for `getDocumentableNode` in Java.

This means we get:
- Improved range expansion
- Code actions appearing automatically against documentable nodes
- Ghost text appearing above documentable nodes (assuming there is no containing documentable node)

## Test plan

1. Open Java code
2. Move cursor to a position on a documentable node, e.g. a method name
3. Document code, expect documentation is generated correctly (above the method)
4. Move cursor to a position within a documentable node, e.g. within a method
5. Document code, expect documentation is generated correctly (above the method)

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
