### PR TITLE
Document code: Add tree-sitter query for Kotlin

### DIFF
--- a/vscode/src/tree-sitter/queries.ts
+++ b/vscode/src/tree-sitter/queries.ts
@@ -2,6 +2,7 @@ import type { SupportedLanguage } from './grammars'
 import { goQueries } from './queries/go'
 import { javaQueries } from './queries/java'
 import { javascriptQueries } from './queries/javascript'
+import { kotlinQueries } from './queries/kotlin'
 import { pythonQueries } from './queries/python'
 
 export type QueryName =
@@ -45,4 +46,5 @@ export const languages: Partial<Record<SupportedLanguage, Record<QueryName, stri
     ...goQueries,
     ...pythonQueries,
     ...javaQueries,
+    ...kotlinQueries,
 } as const

--- a/vscode/src/tree-sitter/queries/kotlin.ts
+++ b/vscode/src/tree-sitter/queries/kotlin.ts
@@ -3,35 +3,21 @@ import dedent from 'dedent'
 import { SupportedLanguage } from '../grammars'
 import type { QueryName } from '../queries'
 
-const SINGLE_LINE_TRIGGERS = dedent`
-    (function_declaration (simple_identifier) @symbol.function) @trigger
-`
-
 const DOCUMENTABLE_NODES = dedent`
     ; Function definitions
     ;--------------------------------
-    (function_declaration (function_body) @symbol.function) @range.function
-    ((function_declaration (simple_identifier) @symbol.function)
-       (parameter (simple_identifier) @symbol.function)
-       (class_parameter (simple_identifier) @symbol.function)
-       (variable_declaration (simple_identifier) @symbol.function)) @range.function
+    (function_declaration (simple_identifier) @symbol.function) @range.function
 
-    ; Variables
-    ;--------------------------------
-    ((property_declaration) @symbol.identifier) @range.identifier
-    (variable_declaration
-        (simple_identifier) @symbol.identifier) @range.identifier
-
-    ; Types
+	; Variables
     ;--------------------------------
     (class_declaration
     	(type_identifier) @symbol.identifier) @range.identifier
-    ((type_alias) @symbol.function) @range.function
+   	(object_declaration
+    	(type_identifier) @symbol.identifier) @range.identifier
 
-    ; Comments
+    ; Types
     ;--------------------------------
-    (line_comment) @comment
-    (multiline_comment) @comment
+    ((type_alias) @symbol.identifier) @range.identifier
 `
 
 const ENCLOSING_FUNCTION_QUERY = dedent`
@@ -40,14 +26,11 @@ const ENCLOSING_FUNCTION_QUERY = dedent`
 
 export const kotlinQueries = {
     [SupportedLanguage.kotlin]: {
-        singlelineTriggers: SINGLE_LINE_TRIGGERS,
+        singlelineTriggers: '',
         intents: '',
         documentableNodes: DOCUMENTABLE_NODES,
         identifiers: '',
-        graphContextIdentifiers: dedent`
-            (call_expression (simple_identifier) @identifier)
-            (type_identifier (type_identifier) @identifier)
-        `,
+        graphContextIdentifiers: '',
         enclosingFunction: ENCLOSING_FUNCTION_QUERY,
     },
 } satisfies Partial<Record<SupportedLanguage, Record<QueryName, string>>>

--- a/vscode/src/tree-sitter/queries/kotlin.ts
+++ b/vscode/src/tree-sitter/queries/kotlin.ts
@@ -10,6 +10,7 @@ const SINGLE_LINE_TRIGGERS = dedent`
 const DOCUMENTABLE_NODES = dedent`
     ; Function definitions
     ;--------------------------------
+    (function_declaration (function_body) @symbol.function) @range.function
     ((function_declaration (simple_identifier) @symbol.function)
        (parameter (simple_identifier) @symbol.function)
        (class_parameter (simple_identifier) @symbol.function)
@@ -17,8 +18,7 @@ const DOCUMENTABLE_NODES = dedent`
 
     ; Variables
     ;--------------------------------
-    (property_declaration
-        (simple_identifier) @symbol.identifier) @range.identifier
+    ((property_declaration) @symbol.identifier) @range.identifier
     (variable_declaration
         (simple_identifier) @symbol.identifier) @range.identifier
 
@@ -26,11 +26,12 @@ const DOCUMENTABLE_NODES = dedent`
     ;--------------------------------
     (class_declaration
     	(type_identifier) @symbol.identifier) @range.identifier
+    ((type_alias) @symbol.function) @range.function
 
     ; Comments
     ;--------------------------------
     (line_comment) @comment
-    (block_comment) @comment
+    (multiline_comment) @comment
 `
 
 const ENCLOSING_FUNCTION_QUERY = dedent`

--- a/vscode/src/tree-sitter/queries/kotlin.ts
+++ b/vscode/src/tree-sitter/queries/kotlin.ts
@@ -1,0 +1,55 @@
+import dedent from 'dedent'
+
+import { SupportedLanguage } from '../grammars'
+import type { QueryName } from '../queries'
+
+const SINGLE_LINE_TRIGGERS = dedent`
+    (function_declaration (simple_identifier) @symbol.function) @trigger
+`
+
+const DOCUMENTABLE_NODES = dedent`
+    ; Function definitions
+    ;--------------------------------
+    (function_declaration (simple_identifier) @symbol.function) @range.function
+    ((function_declaration (simple_identifier) @symbol.function)
+       (parameter (simple_identifier) @symbol.function)
+       (class_parameter (simple_identifier) @symbol.function)
+       (variable_declaration (simple_identifier) @symbol.function)) @range.function
+
+    ; Variables
+    ;--------------------------------
+    (property_declaration
+        (simple_identifier) @symbol.identifier) @range.identifier
+    (variable_declaration
+        (simple_identifier) @symbol.identifier) @range.identifier
+
+    ; Types
+    ;--------------------------------
+    (class_declaration
+        name: (simple_identifier) @symbol.identifier) @range.identifier
+    (enum_class_declaration
+        name: (simple_identifier) @symbol.identifier) @range.identifier
+
+    ; Comments
+    ;--------------------------------
+    (line_comment) @comment
+    (block_comment) @comment
+`
+
+const ENCLOSING_FUNCTION_QUERY = dedent`
+    (function_declaration (simple_identifier) @symbol.function) @range.function
+`
+
+export const kotlinQueries = {
+    [SupportedLanguage.kotlin]: {
+        singlelineTriggers: SINGLE_LINE_TRIGGERS,
+        intents: '',
+        documentableNodes: DOCUMENTABLE_NODES,
+        identifiers: '',
+        graphContextIdentifiers: dedent`
+            (call_expression (simple_identifier) @identifier)
+            (type_identifier (type_identifier) @identifier)
+        `,
+        enclosingFunction: ENCLOSING_FUNCTION_QUERY,
+    },
+} satisfies Partial<Record<SupportedLanguage, Record<QueryName, string>>>

--- a/vscode/src/tree-sitter/queries/kotlin.ts
+++ b/vscode/src/tree-sitter/queries/kotlin.ts
@@ -10,7 +10,6 @@ const SINGLE_LINE_TRIGGERS = dedent`
 const DOCUMENTABLE_NODES = dedent`
     ; Function definitions
     ;--------------------------------
-    (function_declaration (simple_identifier) @symbol.function) @range.function
     ((function_declaration (simple_identifier) @symbol.function)
        (parameter (simple_identifier) @symbol.function)
        (class_parameter (simple_identifier) @symbol.function)
@@ -26,9 +25,7 @@ const DOCUMENTABLE_NODES = dedent`
     ; Types
     ;--------------------------------
     (class_declaration
-        name: (simple_identifier) @symbol.identifier) @range.identifier
-    (enum_class_declaration
-        name: (simple_identifier) @symbol.identifier) @range.identifier
+    	(type_identifier) @symbol.identifier) @range.identifier
 
     ; Comments
     ;--------------------------------

--- a/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
+++ b/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
@@ -89,4 +89,15 @@ describe('getDocumentableNode', () => {
             sourcesPath: 'test-data/documentable-node.java',
         })
     })
+
+    it('kotlin', async () => {
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.kotlin)
+
+        await annotateAndMatchSnapshot({
+            parser,
+            language,
+            captures: queryWrapper(queries.getDocumentableNode),
+            sourcesPath: 'test-data/documentable-node.kt',
+        })
+    })
 })

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.kt
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.kt
@@ -1,0 +1,86 @@
+package main
+
+class Creature {
+    //  |
+}
+
+// ------------------------------------
+
+data class Animal(
+        val name: String,
+        //      |
+        val type: String
+)
+
+// ------------------------------------
+
+data class User(
+        val name: String,
+        val firstName: String,
+        val lastName: String,
+        //      |
+        val email: String
+)
+
+// ------------------------------------
+
+interface Stringer {
+    //  |
+    fun string(): String
+}
+
+// ------------------------------------
+
+interface SuperStringer {
+    fun string(): String
+    //  |
+}
+
+// ------------------------------------
+
+typealias Key = Int
+//  |
+
+// ------------------------------------
+
+val person =
+        object {
+            //  |
+        }
+
+// ------------------------------------
+
+val people =
+        object {
+            //  |
+        }
+
+// ------------------------------------
+
+val shortDeclaration = 4
+//      |
+
+// ------------------------------------
+
+const val name = "Tom"
+//      |
+
+// ------------------------------------
+
+fun nestedVar() {
+    val y = 4
+    //  |
+}
+
+// ------------------------------------
+
+fun greet() {
+    //  |
+}
+
+// ------------------------------------
+
+fun getDisplayName(u: User): String {
+    //           |
+    return u.firstName + " " + u.lastName
+}

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.kt
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.kt
@@ -25,7 +25,7 @@ data class User(
 // ------------------------------------
 
 interface Stringer {
-    //  |
+    //     |
     fun string(): String
 }
 

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.kt
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.kt
@@ -1,0 +1,162 @@
+// 
+// | - query start position in the source file.
+// █ – query start position in the annotated file.
+// ^ – characters matching the last query result.
+//
+// ------------------------------------
+
+  package main
+
+  class Creature {
+//^ start range.identifier[1]
+//      ^^^^^^^^ symbol.identifier[1]
+//        █
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// symbol.identifier[1]: type_identifier
+// range.identifier[1]: class_declaration
+
+// ------------------------------------
+
+  data class Animal(
+//^ start range.identifier[1]
+          val name: String,
+//                █
+          val type: String
+  )
+//^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: class_declaration
+
+// ------------------------------------
+
+  data class User(
+//^ start range.identifier[1]
+          val name: String,
+          val firstName: String,
+          val lastName: String,
+//                █
+          val email: String
+  )
+//^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: class_declaration
+
+// ------------------------------------
+
+  interface Stringer {
+//^ start range.identifier[1]
+//        █
+      fun string(): String
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: class_declaration
+
+// ------------------------------------
+
+  interface SuperStringer {
+//^ start range.identifier[1]
+      fun string(): String
+//        █
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: class_declaration
+
+// ------------------------------------
+
+  typealias Key = Int
+//^^^^^^^^^^^^^^^^^^^ symbol.function[1], range.function[1]
+//    █
+
+// Nodes types:
+// symbol.function[1]: type_alias
+// range.function[1]: type_alias
+
+// ------------------------------------
+
+  val person =
+//^ start range.identifier[1]
+          object {
+//                █
+          }
+//        ^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: property_declaration
+
+// ------------------------------------
+
+  val people =
+//^ start range.identifier[1]
+          object {
+//                █
+          }
+//        ^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: property_declaration
+
+// ------------------------------------
+
+  val shortDeclaration = 4
+//    ^^^^^^^^^^^^^^^^ symbol.identifier[1], range.identifier[1]
+//        █
+
+// Nodes types:
+// symbol.identifier[1]: simple_identifier
+// range.identifier[1]: variable_declaration
+
+// ------------------------------------
+
+  const val name = "Tom"
+//^^^^^^^^^^^^^^^^^^^^^^ symbol.identifier[1]
+//          ^^^^ range.identifier[1]
+//        █
+
+// Nodes types:
+// symbol.identifier[1]: property_declaration
+// range.identifier[1]: variable_declaration
+
+// ------------------------------------
+
+  fun nestedVar() {
+      val y = 4
+//        ^ symbol.identifier[1], range.identifier[1]
+//        █
+  }
+
+// Nodes types:
+// symbol.identifier[1]: simple_identifier
+// range.identifier[1]: variable_declaration
+
+// ------------------------------------
+
+  fun greet() {
+//^ start range.function[1]
+//        █
+  }
+//^ end range.function[1]
+
+// Nodes types:
+// range.function[1]: function_declaration
+
+// ------------------------------------
+
+  fun getDisplayName(u: User): String {
+//^ start range.function[1]
+//                 █
+      return u.firstName + " " + u.lastName
+  }
+//^ end range.function[1]
+
+// Nodes types:
+// range.function[1]: function_declaration
+

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.kt
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.kt
@@ -50,97 +50,68 @@
 
   interface Stringer {
 //^ start range.identifier[1]
-//        █
+//          ^^^^^^^^ symbol.identifier[1]
+//           █
       fun string(): String
   }
 //^ end range.identifier[1]
 
 // Nodes types:
+// symbol.identifier[1]: type_identifier
 // range.identifier[1]: class_declaration
 
 // ------------------------------------
 
   interface SuperStringer {
-//^ start range.identifier[1]
       fun string(): String
+//    ^^^^^^^^^^^^^^^^^^^^ range.function[1]
+//        ^^^^^^ symbol.function[1]
 //        █
   }
-//^ end range.identifier[1]
 
 // Nodes types:
-// range.identifier[1]: class_declaration
+// symbol.function[1]: simple_identifier
+// range.function[1]: function_declaration
 
 // ------------------------------------
 
   typealias Key = Int
-//^^^^^^^^^^^^^^^^^^^ symbol.function[1], range.function[1]
+//^^^^^^^^^^^^^^^^^^^ symbol.identifier[1], range.identifier[1]
 //    █
 
 // Nodes types:
-// symbol.function[1]: type_alias
-// range.function[1]: type_alias
+// symbol.identifier[1]: type_alias
+// range.identifier[1]: type_alias
 
 // ------------------------------------
 
-  val person =
-//^ start range.identifier[1]
-          object {
-//                █
-          }
-//        ^ end range.identifier[1]
-
-// Nodes types:
-// range.identifier[1]: property_declaration
+val person =
+        object {
+            //  |
+        }
 
 // ------------------------------------
 
-  val people =
-//^ start range.identifier[1]
-          object {
-//                █
-          }
-//        ^ end range.identifier[1]
-
-// Nodes types:
-// range.identifier[1]: property_declaration
+val people =
+        object {
+            //  |
+        }
 
 // ------------------------------------
 
-  val shortDeclaration = 4
-//    ^^^^^^^^^^^^^^^^ symbol.identifier[1], range.identifier[1]
-//        █
-
-// Nodes types:
-// symbol.identifier[1]: simple_identifier
-// range.identifier[1]: variable_declaration
+val shortDeclaration = 4
+//      |
 
 // ------------------------------------
 
-  const val name = "Tom"
-//^^^^^^^^^^^^^^^^^^^^^^ symbol.identifier[1]
-//          ^^^^ range.identifier[1]
-//        █
-
-// Nodes types:
-// symbol.identifier[1]: property_declaration
-// range.identifier[1]: variable_declaration
+const val name = "Tom"
+//      |
 
 // ------------------------------------
 
   fun nestedVar() {
-      val y = 4
-//        ^ symbol.identifier[1], range.identifier[1]
-//        █
-  }
-
-// Nodes types:
-// symbol.identifier[1]: simple_identifier
-// range.identifier[1]: variable_declaration
-
-// ------------------------------------
-
-  fun greet() {
 //^ start range.function[1]
+      val y = 4
 //        █
   }
 //^ end range.function[1]
@@ -150,13 +121,28 @@
 
 // ------------------------------------
 
+  fun greet() {
+//^ start range.function[1]
+//    ^^^^^ symbol.function[1]
+//        █
+  }
+//^ end range.function[1]
+
+// Nodes types:
+// symbol.function[1]: simple_identifier
+// range.function[1]: function_declaration
+
+// ------------------------------------
+
   fun getDisplayName(u: User): String {
 //^ start range.function[1]
+//    ^^^^^^^^^^^^^^ symbol.function[1]
 //                 █
       return u.firstName + " " + u.lastName
   }
 //^ end range.function[1]
 
 // Nodes types:
+// symbol.function[1]: simple_identifier
 // range.function[1]: function_declaration
 


### PR DESCRIPTION
Description

This PR adds tree-sitter support for getDocumentableNode in Kotlin.

This means we get:

- Improved range expansion
- Code actions appearing automatically against documentable nodes
- Ghost text appearing above documentable nodes (assuming there is no containing documentable node)


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Copied from https://github.com/sourcegraph/cody/pull/4353

- Open Kotlin code
- Move cursor to a position on a documentable node, e.g. a method name
- Document code, expect documentation is generated correctly (above the method)
- Move cursor to a position within a documentable node, e.g. within a method
- Document code, expect documentation is generated correctly (above the method)