### PR TITLE
Document Code: Exclude local variables from getDocumentableNode in Java

### DIFF
--- a/vscode/src/tree-sitter/queries/java.ts
+++ b/vscode/src/tree-sitter/queries/java.ts
@@ -20,11 +20,6 @@ const DOCUMENTABLE_NODES = dedent`
     ;--------------------------------
     (class_declaration
         name: (_) @symbol.identifier) @range.identifier
-    (variable_declarator
-        name: (identifier) @symbol.identifier) @range.identifier
-    (field_declaration
-        (variable_declarator
-            name: (identifier) @symbol.identifier) @range.identifier)
 
     ; Type Identifiers
     ;--------------------------------

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.java
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.java
@@ -19,14 +19,14 @@
 // ------------------------------------
 
   class Test {
+//^ start range.identifier[1]
       public int age;
-//               ^^^ symbol.identifier[1], range.identifier[1]
 //                █
   }
+//^ end range.identifier[1]
 
 // Nodes types:
-// symbol.identifier[1]: identifier
-// range.identifier[1]: variable_declarator
+// range.identifier[1]: class_declaration
 
 // ------------------------------------
 
@@ -184,16 +184,16 @@
 // ------------------------------------
 
   public enum Planet {
+//^ start range.identifier[1]
       EARTH(5.976e+24, 6.37814e6);
       private final double mass;
-//                         ^^^^ symbol.identifier[1], range.identifier[1]
 //                          █
       private final double radius;
   }
+//^ end range.identifier[1]
 
 // Nodes types:
-// symbol.identifier[1]: identifier
-// range.identifier[1]: variable_declarator
+// range.identifier[1]: enum_declaration
 
 // ------------------------------------
 


### PR DESCRIPTION
## Description

Excludes local variables from the `getDocumentableNode` query in Java. This means we'll generally expand to the nearest function/method/class declaration/interface declaration

## Test plan

Unit tests

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
