### PR TITLE
Document code: Add tree-sitter query for Rust

### DIFF
--- a/vscode/src/tree-sitter/queries.ts
+++ b/vscode/src/tree-sitter/queries.ts
@@ -4,6 +4,7 @@ import { javaQueries } from './queries/java'
 import { javascriptQueries } from './queries/javascript'
 import { kotlinQueries } from './queries/kotlin'
 import { pythonQueries } from './queries/python'
+import { rustQueries } from './queries/rust'
 
 export type QueryName =
     | 'singlelineTriggers'
@@ -47,4 +48,5 @@ export const languages: Partial<Record<SupportedLanguage, Record<QueryName, stri
     ...pythonQueries,
     ...javaQueries,
     ...kotlinQueries,
+    ...rustQueries,
 } as const

--- a/vscode/src/tree-sitter/queries/rust.ts
+++ b/vscode/src/tree-sitter/queries/rust.ts
@@ -1,0 +1,41 @@
+import dedent from 'dedent'
+
+import { SupportedLanguage } from '../grammars'
+import type { QueryName } from '../queries'
+
+const DOCUMENTABLE_NODES = dedent`
+    ; Function definitions
+    ;--------------------------------
+    (function_item
+        name: (identifier) @symbol.function) @range.function
+
+    ; Variables
+    ;--------------------------------
+    ((use_declaration) @symbol.identifier) @range.identifier
+
+    ; Types
+    ;--------------------------------
+    (struct_item
+        name: (type_identifier) @symbol.identifier) @range.identifier
+    (impl_item
+        type: (type_identifier) @symbol.identifier) @range.identifier
+    (enum_item
+        name: (type_identifier) @symbol.identifier) @range.identifier
+    (trait_item
+        name: (type_identifier) @symbol.identifier) @range.identifier
+`
+
+const ENCLOSING_FUNCTION_QUERY = dedent`
+    (function_item name: (identifier) @symbol.function) @range.function
+`
+
+export const rustQueries = {
+    [SupportedLanguage.rust]: {
+        singlelineTriggers: '',
+        intents: '',
+        documentableNodes: DOCUMENTABLE_NODES,
+        identifiers: '',
+        graphContextIdentifiers: '',
+        enclosingFunction: ENCLOSING_FUNCTION_QUERY,
+    },
+} satisfies Partial<Record<SupportedLanguage, Record<QueryName, string>>>

--- a/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
+++ b/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
@@ -100,4 +100,15 @@ describe('getDocumentableNode', () => {
             sourcesPath: 'test-data/documentable-node.kt',
         })
     })
+
+    it('rust', async () => {
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.rust)
+
+        await annotateAndMatchSnapshot({
+            parser,
+            language,
+            captures: queryWrapper(queries.getDocumentableNode),
+            sourcesPath: 'test-data/documentable-node.rs',
+        })
+    })
 })

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.rs
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.rs
@@ -1,0 +1,99 @@
+// fn main() {
+
+struct Creature {
+    //      |
+}
+
+// ------------------------------------
+
+struct Animal {
+    name: String,
+    //      |
+    type: String
+}
+
+// ------------------------------------
+
+struct User {
+    name: String,
+    first_name: String,
+    last_name: String,
+    //      |
+    email: String
+}
+
+// ------------------------------------
+
+trait Stringer {
+    //      |
+    fn string(&self) -> String;
+}
+
+// ------------------------------------
+
+trait SuperStringer: Stringer {
+    //      |
+}
+
+// ------------------------------------
+
+type Key = i32;
+//      |
+
+// ------------------------------------
+
+let person = (
+    //      |
+);
+
+// ------------------------------------
+
+let short_declaration = 4;
+//      |
+
+// ------------------------------------
+
+const NAME: &str = "Tom";
+//      |
+
+// ------------------------------------
+
+fn nested_var() {
+    let y = 4;
+    //      |
+}
+
+// ------------------------------------
+
+fn greet() {
+//      |
+}
+
+// ------------------------------------
+
+fn get_display_name(u: &User) -> String {
+    let mut name = String::new();
+    //      |
+    name.push_str(&u.first_name);
+    name.push_str(" ");
+    name.push_str(&u.last_name);
+    name
+}
+
+// ------------------------------------
+
+use mycrate::{
+    //      |
+    math::{add, subtract},
+    io::{read_file, write_file},
+    ui::{create_button, create_menu}
+};
+
+// ------------------------------------
+
+impl Stringer for Person {
+    fn string(&self) -> String {
+        //      |
+      format!("{} ({} years old)", self.name, self.age)
+    }
+  }

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.rs
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.rs
@@ -1,0 +1,166 @@
+// 
+// | - query start position in the source file.
+// █ – query start position in the annotated file.
+// ^ – characters matching the last query result.
+//
+// ------------------------------------
+
+// fn main() {
+
+  struct Creature {
+//^ start range.identifier[1]
+//       ^^^^^^^^ symbol.identifier[1]
+//            █
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// symbol.identifier[1]: type_identifier
+// range.identifier[1]: struct_item
+
+// ------------------------------------
+
+  struct Animal {
+//^ start range.identifier[1]
+      name: String,
+//            █
+      type: String
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: struct_item
+
+// ------------------------------------
+
+  struct User {
+//^ start range.identifier[1]
+      name: String,
+      first_name: String,
+      last_name: String,
+//            █
+      email: String
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: struct_item
+
+// ------------------------------------
+
+  trait Stringer {
+//^ start range.identifier[1]
+//      ^^^^^^^^ symbol.identifier[1]
+//            █
+      fn string(&self) -> String;
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// symbol.identifier[1]: type_identifier
+// range.identifier[1]: trait_item
+
+// ------------------------------------
+
+  trait SuperStringer: Stringer {
+//^ start range.identifier[1]
+//      ^^^^^^^^^^^^^ symbol.identifier[1]
+//            █
+  }
+//^ end range.identifier[1]
+
+// Nodes types:
+// symbol.identifier[1]: type_identifier
+// range.identifier[1]: trait_item
+
+// ------------------------------------
+
+type Key = i32;
+//      |
+
+// ------------------------------------
+
+let person = (
+    //      |
+);
+
+// ------------------------------------
+
+let short_declaration = 4;
+//      |
+
+// ------------------------------------
+
+const NAME: &str = "Tom";
+//      |
+
+// ------------------------------------
+
+  fn nested_var() {
+//^ start range.function[1]
+      let y = 4;
+//            █
+  }
+//^ end range.function[1]
+
+// Nodes types:
+// range.function[1]: function_item
+
+// ------------------------------------
+
+  fn greet() {
+//^ start range.function[1]
+//   ^^^^^ symbol.function[1]
+//        █
+  }
+//^ end range.function[1]
+
+// Nodes types:
+// symbol.function[1]: identifier
+// range.function[1]: function_item
+
+// ------------------------------------
+
+  fn get_display_name(u: &User) -> String {
+//^ start range.function[1]
+      let mut name = String::new();
+//            █
+      name.push_str(&u.first_name);
+      name.push_str(" ");
+      name.push_str(&u.last_name);
+      name
+  }
+//^ end range.function[1]
+
+// Nodes types:
+// range.function[1]: function_item
+
+// ------------------------------------
+
+  use mycrate::{
+//^ start symbol.identifier[1], range.identifier[1]
+//            █
+      math::{add, subtract},
+      io::{read_file, write_file},
+      ui::{create_button, create_menu}
+  };
+// ^ end symbol.identifier[1], range.identifier[1]
+
+// Nodes types:
+// symbol.identifier[1]: use_declaration
+// range.identifier[1]: use_declaration
+
+// ------------------------------------
+
+  impl Stringer for Person {
+      fn string(&self) -> String {
+//    ^ start range.function[1]
+//                █
+        format!("{} ({} years old)", self.name, self.age)
+      }
+//    ^ end range.function[1]
+    }
+
+// Nodes types:
+// range.function[1]: function_item
+


### PR DESCRIPTION
Copied from https://github.com/sourcegraph/cody/pull/4355

This PR adds tree-sitter support for getDocumentableNode in Rust.

This means we get:

- Improved range expansion
- Code actions appearing automatically against documentable nodes
- Ghost text appearing above documentable nodes (assuming there is no containing documentable node)

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Open Rust code
- Move cursor to a position on a documentable node, e.g. a method name
- Document code, expect documentation is generated correctly (above the method)
- Move cursor to a position within a documentable node, e.g. within a method
- Document code, expect documentation is generated correctly (above the method)