### PR TITLE
Document code: Add tree-sitter query for PHP

### DIFF
--- a/vscode/src/tree-sitter/queries.ts
+++ b/vscode/src/tree-sitter/queries.ts
@@ -3,6 +3,7 @@ import { goQueries } from './queries/go'
 import { javaQueries } from './queries/java'
 import { javascriptQueries } from './queries/javascript'
 import { kotlinQueries } from './queries/kotlin'
+import { phpQueries } from './queries/php'
 import { pythonQueries } from './queries/python'
 
 export type QueryName =
@@ -47,4 +48,5 @@ export const languages: Partial<Record<SupportedLanguage, Record<QueryName, stri
     ...pythonQueries,
     ...javaQueries,
     ...kotlinQueries,
+    ...phpQueries,
 } as const

--- a/vscode/src/tree-sitter/queries/php.ts
+++ b/vscode/src/tree-sitter/queries/php.ts
@@ -1,0 +1,46 @@
+import dedent from 'dedent'
+
+import { SupportedLanguage } from '../grammars'
+import type { QueryName } from '../queries'
+
+const DOCUMENTABLE_NODES = dedent`
+    ; Function definitions
+    ;--------------------------------
+    (function_definition
+        name: (name) @symbol.function) @range.function
+    (method_declaration
+        name: (name) @symbol.function) @range.function
+    (function_call_expression
+        function: [(qualified_name (name)) (name)] @symbol.function) @range.function
+    (function_call_expression
+        (name) @symbol.function) @range.function
+    (class_declaration
+        name: (name) @symbol.function) @range.function
+
+
+	; Variables
+    ;--------------------------------
+    ((variable_name) @symbol.identifier) @range.identifier
+    ((class_interface_clause) @symbol.identifier) @range.identifier
+
+    ; Types
+    ;--------------------------------
+    (primitive_type) @symbol.function
+    (interface_declaration
+        name: (name) @symbol.function) @range.function
+`
+
+const ENCLOSING_FUNCTION_QUERY = dedent`
+    (function_definition name: (name) @symbol.function) @range.function
+`
+
+export const phpQueries = {
+    [SupportedLanguage.php]: {
+        singlelineTriggers: '',
+        intents: '',
+        documentableNodes: DOCUMENTABLE_NODES,
+        identifiers: '',
+        graphContextIdentifiers: '',
+        enclosingFunction: ENCLOSING_FUNCTION_QUERY,
+    },
+} satisfies Partial<Record<SupportedLanguage, Record<QueryName, string>>>

--- a/vscode/src/tree-sitter/query-sdk.test.ts
+++ b/vscode/src/tree-sitter/query-sdk.test.ts
@@ -17,6 +17,7 @@ describe('getDocumentQuerySDK', () => {
         { languageId: SupportedLanguage.typescriptreact },
         { languageId: SupportedLanguage.go },
         { languageId: SupportedLanguage.python },
+        { languageId: SupportedLanguage.php },
     ])('returns valid SDK for $languageId', async ({ languageId }) => {
         const nonInitializedSDK = getDocumentQuerySDK(languageId)
         expect(nonInitializedSDK).toBeNull()
@@ -32,7 +33,6 @@ describe('getDocumentQuerySDK', () => {
         { languageId: SupportedLanguage.csharp },
         { languageId: SupportedLanguage.cpp },
         { languageId: SupportedLanguage.csharp },
-        { languageId: SupportedLanguage.php },
     ])('returns null for $languageId because queries are not defined', async ({ languageId }) => {
         const nonInitializedSDK = getDocumentQuerySDK(languageId)
         expect(nonInitializedSDK).toBeNull()

--- a/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
+++ b/vscode/src/tree-sitter/query-tests/documentable-nodes.test.ts
@@ -100,4 +100,15 @@ describe('getDocumentableNode', () => {
             sourcesPath: 'test-data/documentable-node.kt',
         })
     })
+
+    it('php', async () => {
+        const { language, parser, queries } = await initTreeSitterSDK(SupportedLanguage.php)
+
+        await annotateAndMatchSnapshot({
+            parser,
+            language,
+            captures: queryWrapper(queries.getDocumentableNode),
+            sourcesPath: 'test-data/documentable-node.php',
+        })
+    })
 })

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.php
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.php
@@ -1,0 +1,85 @@
+<?php
+class Creature {
+    //  |
+}
+?>
+
+// ------------------------------------
+
+<?php
+class Animal {
+    public $name;
+    //  |
+    public $type;
+}
+?>
+
+// ------------------------------------
+
+<?php
+interface Stringer {
+    //  |
+    public function string();
+}
+?>
+
+// ------------------------------------
+
+<?php
+interface Stringer {
+    public function string();
+    //  |
+}
+?>
+
+// ------------------------------------
+
+<?php
+class key {
+    //  |
+}
+?>
+
+// ------------------------------------
+<?php
+$person = new class {
+    //  |
+};
+?>
+
+// ------------------------------------
+
+$shortDeclaration = 4;
+//  |
+
+// ------------------------------------
+
+<?php
+const $name = "Tom";
+//  |
+?>
+
+// ------------------------------------
+
+<?php
+function nestedVar() {
+    $y = 4;
+    //  |
+}
+?>
+
+// ------------------------------------
+
+<?php
+function greet() {
+    //  |
+}
+?>
+// ------------------------------------
+
+<?php
+public function DisplayName() {
+    //  |
+    return $this->firstName . " " . $this->lastName;
+}
+?>

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.php
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.php
@@ -1,0 +1,136 @@
+// 
+// | - query start position in the source file.
+// █ – query start position in the annotated file.
+// ^ – characters matching the last query result.
+//
+// ------------------------------------
+
+  <?php
+  class Creature {
+//^ start range.function[1]
+//      ^^^^^^^^ symbol.function[1]
+//        █
+  }
+//^ end range.function[1]
+  ?>
+
+// Nodes types:
+// symbol.function[1]: name
+// range.function[1]: class_declaration
+
+// ------------------------------------
+
+  <?php
+  class Animal {
+      public $name;
+//           ^^^^^ range.identifier[1]
+//        █
+      public $type;
+  }
+  ?>
+
+// Nodes types:
+// range.identifier[1]: variable_name
+
+// ------------------------------------
+
+  <?php
+  interface Stringer {
+//^ start range.function[1]
+//        █
+      public function string();
+  }
+//^ end range.function[1]
+  ?>
+
+// Nodes types:
+// range.function[1]: interface_declaration
+
+// ------------------------------------
+
+  <?php
+  interface Stringer {
+      public function string();
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^ range.function[1]
+//        █
+  }
+  ?>
+
+// Nodes types:
+// range.function[1]: method_declaration
+
+// ------------------------------------
+
+  <?php
+  class key {
+//^ start range.function[1]
+//      ^^^ symbol.function[1]
+//        █
+  }
+//^ end range.function[1]
+  ?>
+
+// Nodes types:
+// symbol.function[1]: name
+// range.function[1]: class_declaration
+
+// ------------------------------------
+<?php
+$person = new class {
+    //  |
+};
+?>
+
+// ------------------------------------
+
+$shortDeclaration = 4;
+//  |
+
+// ------------------------------------
+
+<?php
+const $name = "Tom";
+//  |
+?>
+
+// ------------------------------------
+
+  <?php
+  function nestedVar() {
+//^ start range.function[1]
+      $y = 4;
+//        █
+  }
+//^ end range.function[1]
+  ?>
+
+// Nodes types:
+// range.function[1]: function_definition
+
+// ------------------------------------
+
+  <?php
+  function greet() {
+//^ start range.function[1]
+//        █
+  }
+//^ end range.function[1]
+  ?>
+
+// Nodes types:
+// range.function[1]: function_definition
+
+// ------------------------------------
+
+  <?php
+  public function DisplayName() {
+//       ^ start range.function[1]
+//        █
+      return $this->firstName . " " . $this->lastName;
+  }
+//^ end range.function[1]
+  ?>
+
+// Nodes types:
+// range.function[1]: function_definition
+


### PR DESCRIPTION
Copied from https://github.com/sourcegraph/cody/pull/4355

This PR adds tree-sitter support for getDocumentableNode in PHP.

This means we get:

- Improved range expansion
- Code actions appearing automatically against documentable nodes
- Ghost text appearing above documentable nodes (assuming there is no containing documentable node)

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

- Open PHP code
- Move cursor to a position on a documentable node, e.g. a method name
- Document code, expect documentation is generated correctly (above the method)
- Move cursor to a position within a documentable node, e.g. within a method
- Document code, expect documentation is generated correctly (above the method)