### PR TITLE
vscode: Fixup empty input detection

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ importers:
       '@lexical/react':
         specifier: ^0.15.0
         version: 0.15.0(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.15)
+      '@lexical/text':
+        specifier: ^0.15.0
+        version: 0.15.0
       '@mdi/js':
         specifier: ^7.2.96
         version: 7.2.96

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1396,6 +1396,7 @@
     "@lexical/code": "^0.15.0",
     "@lexical/html": "^0.15.0",
     "@lexical/react": "^0.15.0",
+    "@lexical/text": "^0.15.0",
     "@mdi/js": "^7.2.96",
     "@openctx/vscode-lib": "^0.0.8",
     "@opentelemetry/api": "^1.7.0",

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -231,7 +231,7 @@ describe('Transcript', () => {
     })
 
     test('focus', async () => {
-        const { container } = render(
+        const { container, rerender } = render(
             <Transcript
                 {...PROPS}
                 transcript={[
@@ -247,6 +247,15 @@ describe('Transcript', () => {
         )! as EditorHTMLElement
         expect(lastEditor).toHaveFocus()
         await typeInEditor(lastEditor, 'xyz')
+        rerender(
+            <Transcript
+                {...PROPS}
+                transcript={[
+                    { speaker: 'human', text: ps`Foo`, contextFiles: [] },
+                    { speaker: 'assistant', text: ps`Bar` },
+                ]}
+            />
+        )
         expectCells([{ message: 'Foo' }, { message: 'Bar' }, { message: 'xyz', canSubmit: true }])
     })
 })

--- a/vscode/webviews/promptEditor/PromptEditor.tsx
+++ b/vscode/webviews/promptEditor/PromptEditor.tsx
@@ -1,4 +1,5 @@
 import { $generateHtmlFromNodes } from '@lexical/html'
+import { $isRootTextContentEmpty } from '@lexical/text'
 import { type ChatMessage, type ContextItem, escapeHTML } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
 import {
@@ -139,7 +140,10 @@ export const PromptEditor: FunctionComponent<Props> = ({
                 }
                 return editorRef.current.getEditorState().read(() => {
                     const root = $getRoot()
-                    return root.getChildrenSize() === 0
+                    if (root.getChildrenSize() === 0) {
+                        return true
+                    }
+                    return $isRootTextContentEmpty(false, true)
                 })
             },
         }),


### PR DESCRIPTION
The current check wasn't exhaustive enough to detect "there is no input". It only checked that no nodes were created ever. But focusing it adds a paragraphNode that is then empty.

I found this pretty good answer on stackoverflow: https://stackoverflow.com/a/75498145 and there's a nice utility method in the @lexical/text package that can check for empty text content, _after_ trimming.

Test plan:

Can no longer submit empty inputs.