### PR TITLE
Edit: Fix indentation handling for text insertions

### DIFF
--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -6,10 +6,10 @@ export const TestLogger = {
     startLogging: () => {
         // Do some stuff
 
-                /**
+        /**
          * Records a log message.
          */
-function recordLog() {
+        function recordLog() {
             console.log(/* CURSOR */ 'Recording the log')
         }
 
@@ -37,10 +37,10 @@ exports[`Document Code > commands/document (Method as part of a class) 1`] = `
 export class TestClass {
     constructor(private shouldGreet: boolean) {}
 
-        /**
+    /**
      * Logs a greeting message to the console if the shouldGreet property is true.
      */
-public functionName() {
+    public functionName() {
         if (this.shouldGreet) {
             console.log(/* CURSOR */ 'Hello World!')
         }
@@ -65,11 +65,11 @@ describe('test block', () => {
 
     it('does something else', () => {
         // This line will error due to incorrect usage of \`performance.now\`
-                /**
+        /**
          * Gets the current time in milliseconds since the DOM was loaded.
          * @returns {number} The time in milliseconds since the DOM was loaded.
          */
-const startTime = performance.now(/* CURSOR */)
+        const startTime = performance.now(/* CURSOR */)
     })
 })
 "

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -785,14 +785,17 @@ export class FixupController
             return false
         }
 
-        // add correct indentation based on first non empty character index
+        // Get the index of the first non-whitespace character on the line where the insertion point is.
         const nonEmptyStartIndex = document.lineAt(insertionPoint.line).firstNonWhitespaceCharacterIndex
-        // add indentation to each line
+        // Split the text into lines and prepend each line with spaces to match the indentation level
+        // of the line where the insertion point is.
         const textLines = text.split('\n').map(line => ' '.repeat(nonEmptyStartIndex) + line)
-        // join text with new lines, and then remove everything after the last new line if it only contains white spaces
-        const replacementText = textLines.join('\n').replace(/[\t ]+$/, '')
+        // Join the lines back into a single string with newline characters
+        // Remove any leading whitespace from the first line, as we are inserting at the insertionPoint
+        // Keep any trailing whitespace on the last line to preserve the original indentation.
+        const replacementText = textLines.join('\n').trimStart()
 
-        // Insert updated text at selection range
+        // Insert the updated text at the specified insertionPoint.
         if (edit instanceof vscode.WorkspaceEdit) {
             edit.insert(document.uri, insertionPoint, replacementText)
             return vscode.workspace.applyEdit(edit)


### PR DESCRIPTION
CLOSE: https://github.com/sourcegraph/jetbrains/issues/1696

This PR fixes the indentation misalignment for text insertions.

## Issues

Current Process:

1. Get the index of the first non-whitespace character on the line where the insertion point is
2. Split the text into lines and prepend each line with spaces to match the indentation level of the line where the insertion point is
3. Keep the leading whitespace <-`ROOT-CAUSE`
4. Remove trailing whitespace on the last line <- `ROOT-CAUSE`
5.  Insert the updated text at the specified insertionPoint

Since we are already inserting at the "correct" insertion point, the indentation prepended for the first line should be ignored. Or else, we will be inserting the indentation again at the insertion point, causing the issue described in https://github.com/sourcegraph/jetbrains/issues/1696. This issue also affect VS Code users who do not have formatted configured. 

## Changes

Updated Process:

- Get the index of the first non-whitespace character on the line where the insertion point is
- Split the text into lines and prepend each line with spaces to match the indentation level of the line where the insertion point is
- `Remove any leading whitespace from the first line, as we are inserting at the insertionPoint`
- `Keep any trailing whitespace on the last line to preserve the original indentation`
- Insert the updated text at the specified insertionPoint

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

Check agent test diff to confirm this change fixed the same issues for agent tests:

```diff
 FAIL  |agent| src/document-code.test.ts > Document Code > commands/document (Method as part of a class)
Error: Snapshot `Document Code > commands/document (Method as part of a class) 1` mismatched

- Expected
+ Received

@@ -1,14 +1,14 @@
  "const foo = 42

  export class TestClass {
      constructor(private shouldGreet: boolean) {}

-         /**
+     /**
       * Logs a greeting message to the console if the shouldGreet property is true.
       */
- public functionName() {
+     public functionName() {
          if (this.shouldGreet) {
              console.log(/* CURSOR */ 'Hello World!')
          }
      }
  }
```

```diff
- Expected
+ Received

@@ -1,14 +1,14 @@
  "const foo = 42

  export class TestClass {
      constructor(private shouldGreet: boolean) {}

-         /**
+     /**
       * Logs a greeting message to the console if the shouldGreet property is true.
       */
- public functionName() {
+     public functionName() {
          if (this.shouldGreet) {
              console.log(/* CURSOR */ 'Hello World!')
          }
      }
  }
```

### JetBrains

- Start JetBrains with tha latest commit from this branch
- Open the sourcegraph/jetbrains repository
- Open [src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCancelOrUndoAction.kt?L7-11](https://sourcegraph.com/github.com/sourcegraph/jetbrains/-/blob/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCancelOrUndoAction.kt?L7-11), and then remove the doc string at the top
- After removing the doc string in your editor, place your cursor at the end of line 20
- Execute the Doc command
- Verify the indentation is showing up correctly:

![image](https://github.com/sourcegraph/cody/assets/68532117/94d85b24-fb26-4abb-9a1a-10ad16cc9c26)

- Try highlighting the whole code block to confirm the indentation still show up correctly

![image](https://github.com/sourcegraph/cody/assets/68532117/d38db12d-b4e3-41b7-badb-0b3284977ca3)


#### Before:

![image](https://github.com/sourcegraph/cody/assets/68532117/e3e516dc-29da-4c2a-9331-013f0f57a040)

### VS Code

- Start Cody from this branch in debug mode
- Open the sourcegraph/jetbrains repository
- Ensure the Edit commands (test, doc, edit) are still working as expected

https://github.com/sourcegraph/cody/assets/68532117/a1c1b30f-d84c-48b2-854b-d78e96fa64b3
