### PR TITLE
Edit: fix @-mentions in the quick-pick menu

### DIFF
--- a/lib/shared/src/mentions/query.test.ts
+++ b/lib/shared/src/mentions/query.test.ts
@@ -87,17 +87,32 @@ describe('parseMentionQuery', () => {
 
 describe('scanForMentionTriggerInUserTextInput', () => {
     test('null if no @-mention is found', () =>
-        expect(scanForMentionTriggerInUserTextInput('Hello world')).toBeNull())
+        expect(
+            scanForMentionTriggerInUserTextInput({
+                textBeforeCursor: 'Hello world',
+                includeWhitespace: false,
+            })
+        ).toBeNull())
 
     test('@-mention file', () =>
-        expect(scanForMentionTriggerInUserTextInput('Hello @abc')).toEqual<MentionTrigger | null>({
+        expect(
+            scanForMentionTriggerInUserTextInput({
+                textBeforeCursor: 'Hello @abc',
+                includeWhitespace: false,
+            })
+        ).toEqual<MentionTrigger | null>({
             leadOffset: 6,
             matchingString: 'abc',
             replaceableString: '@abc',
         }))
 
     test('@-mention symbol', () =>
-        expect(scanForMentionTriggerInUserTextInput('Hello @#abc')).toEqual<MentionTrigger | null>({
+        expect(
+            scanForMentionTriggerInUserTextInput({
+                textBeforeCursor: 'Hello @#abc',
+                includeWhitespace: false,
+            })
+        ).toEqual<MentionTrigger | null>({
             leadOffset: 6,
             matchingString: '#abc',
             replaceableString: '@#abc',
@@ -105,7 +120,10 @@ describe('scanForMentionTriggerInUserTextInput', () => {
 
     test('@-mention URL', () =>
         expect(
-            scanForMentionTriggerInUserTextInput('Hello @https://example.com/p')
+            scanForMentionTriggerInUserTextInput({
+                textBeforeCursor: 'Hello @https://example.com/p',
+                includeWhitespace: false,
+            })
         ).toEqual<MentionTrigger | null>({
             leadOffset: 6,
             matchingString: 'https://example.com/p',
@@ -114,21 +132,36 @@ describe('scanForMentionTriggerInUserTextInput', () => {
 
     describe('special chars', () => {
         test('dotfile', () =>
-            expect(scanForMentionTriggerInUserTextInput('Hello @.abc')).toEqual<MentionTrigger | null>({
+            expect(
+                scanForMentionTriggerInUserTextInput({
+                    textBeforeCursor: 'Hello @.abc',
+                    includeWhitespace: false,
+                })
+            ).toEqual<MentionTrigger | null>({
                 leadOffset: 6,
                 matchingString: '.abc',
                 replaceableString: '@.abc',
             }))
 
         test('forward slash', () =>
-            expect(scanForMentionTriggerInUserTextInput('Hello @a/b')).toEqual<MentionTrigger | null>({
+            expect(
+                scanForMentionTriggerInUserTextInput({
+                    textBeforeCursor: 'Hello @a/b',
+                    includeWhitespace: false,
+                })
+            ).toEqual<MentionTrigger | null>({
                 leadOffset: 6,
                 matchingString: 'a/b',
                 replaceableString: '@a/b',
             }))
 
         test('backslash', () =>
-            expect(scanForMentionTriggerInUserTextInput('Hello @a\\b')).toEqual<MentionTrigger | null>({
+            expect(
+                scanForMentionTriggerInUserTextInput({
+                    textBeforeCursor: 'Hello @a\\b',
+                    includeWhitespace: false,
+                })
+            ).toEqual<MentionTrigger | null>({
                 leadOffset: 6,
                 matchingString: 'a\\b',
                 replaceableString: '@a\\b',
@@ -136,7 +169,10 @@ describe('scanForMentionTriggerInUserTextInput', () => {
 
         test('hyphen', () =>
             expect(
-                scanForMentionTriggerInUserTextInput('Hello @a-b.txt')
+                scanForMentionTriggerInUserTextInput({
+                    textBeforeCursor: 'Hello @a-b.txt',
+                    includeWhitespace: false,
+                })
             ).toEqual<MentionTrigger | null>({
                 leadOffset: 6,
                 matchingString: 'a-b.txt',
@@ -145,10 +181,28 @@ describe('scanForMentionTriggerInUserTextInput', () => {
     })
 
     test('with range', () => {
-        expect(scanForMentionTriggerInUserTextInput('a @b/c:12-34')).toEqual<MentionTrigger>({
+        expect(
+            scanForMentionTriggerInUserTextInput({
+                textBeforeCursor: 'a @b/c:12-34',
+                includeWhitespace: false,
+            })
+        ).toEqual<MentionTrigger>({
             leadOffset: 2,
             matchingString: 'b/c:12-34',
             replaceableString: '@b/c:12-34',
+        })
+    })
+
+    test('with spaces', () => {
+        expect(
+            scanForMentionTriggerInUserTextInput({
+                textBeforeCursor: 'Hello @google-docs Cody architecture ',
+                includeWhitespace: true,
+            })
+        ).toEqual<MentionTrigger>({
+            leadOffset: 6,
+            matchingString: 'google-docs Cody architecture ',
+            replaceableString: '@google-docs Cody architecture ',
         })
     })
 })

--- a/vscode/src/edit/input/get-input.ts
+++ b/vscode/src/edit/input/get-input.ts
@@ -323,7 +323,10 @@ export const getInput = async (
                     return
                 }
 
-                const mentionTrigger = scanForMentionTriggerInUserTextInput(value)
+                const mentionTrigger = scanForMentionTriggerInUserTextInput({
+                    textBeforeCursor: value,
+                    includeWhitespace: false,
+                })
                 const mentionQuery = mentionTrigger
                     ? parseMentionQuery(mentionTrigger.matchingString, null)
                     : undefined

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -65,6 +65,15 @@ const FLOATING_OPTIONS: UseFloatingOptions = {
     transform: false,
 }
 
+/**
+ * We allow whitespace for @-mentions in the Lexical editor because
+ * it has an explicit switch between modes and can render @-mentions
+ * as special nodes that can be detected in later edits.
+ *
+ * The Edit quick-pick menu uses a raw text input and lacks this functionality,
+ * so we rely on spaces to detect @-mentions and switch between @-item selection
+ * and regular text input.
+ */
 function scanForMentionTriggerInLexicalInput(text: string) {
     return scanForMentionTriggerInUserTextInput({ textBeforeCursor: text, includeWhitespace: true })
 }

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -65,6 +65,10 @@ const FLOATING_OPTIONS: UseFloatingOptions = {
     transform: false,
 }
 
+function scanForMentionTriggerInLexicalInput(text: string) {
+    return scanForMentionTriggerInUserTextInput({ textBeforeCursor: text, includeWhitespace: true })
+}
+
 export default function MentionsPlugin({
     userInfo,
 }: { userInfo?: UserAccountInfo }): JSX.Element | null {
@@ -207,7 +211,7 @@ export default function MentionsPlugin({
             onQueryChange={updateQuery}
             onSelectOption={onSelectOption}
             onClose={onClose}
-            triggerFn={scanForMentionTriggerInUserTextInput}
+            triggerFn={scanForMentionTriggerInLexicalInput}
             options={DUMMY_OPTIONS}
             anchorClassName={styles.resetAnchor}
             commandPriority={


### PR DESCRIPTION
- Fixes a regression introduced in https://github.com/sourcegraph/cody/pull/4307, which does not allow the use of @-mentions in the Edit code quick-pick menu.
- This PR changes the @-mentions regex to allow spaces in the chat input and disallow them in the quick-pick menu.

## Test plan

Updated unit tests and verified locally.
