### PR TITLE
vscode: Fixup empty section in command menu

### DIFF
--- a/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenu.tsx
@@ -179,6 +179,25 @@ export const MentionMenu: FunctionComponent<
 
     const heading = getItemsHeading(params.parentItem, mentionQuery)
 
+    const providers = data.providers
+        .filter(
+            provider =>
+                (provider.id !== RemoteRepositorySearch.providerUri &&
+                    provider.id !== RemoteFileProvider.providerUri) ||
+                !userInfo?.isDotComUser
+        )
+        .map(provider => (
+            // show remote repositories search provider only if the user is connected to a non-dotcom instance.
+            <CommandItem
+                key={commandRowValue(provider)}
+                value={commandRowValue(provider)}
+                onSelect={onProviderSelect}
+                className={styles.item}
+            >
+                <MentionMenuProviderItemContent provider={provider} />
+            </CommandItem>
+        ))
+
     return (
         <Command
             loop={true}
@@ -190,51 +209,27 @@ export const MentionMenu: FunctionComponent<
             ref={ref}
         >
             <CommandList>
-                {data.providers.length > 0 && (
-                    <CommandGroup>
-                        {data.providers
-                            .filter(
-                                provider =>
-                                    (provider.id !== RemoteRepositorySearch.providerUri &&
-                                        provider.id !== RemoteFileProvider.providerUri) ||
-                                    !userInfo?.isDotComUser
-                            )
-                            .map(provider => (
-                                // show remote repositories search provider  only if the user is connected to a non-dotcom instance.
-                                <CommandItem
-                                    key={commandRowValue(provider)}
-                                    value={commandRowValue(provider)}
-                                    onSelect={onProviderSelect}
-                                    className={styles.item}
-                                >
-                                    <MentionMenuProviderItemContent provider={provider} />
-                                </CommandItem>
-                            ))}
+                {providers.length > 0 && <CommandGroup>{providers}</CommandGroup>}
+
+                {(heading || (data.items && data.items.length > 0)) && (
+                    <CommandGroup heading={heading}>
+                        {heading && <CommandSeparator />}
+                        {data.items?.map(item => (
+                            <CommandItem
+                                key={commandRowValue(item)}
+                                value={commandRowValue(item)}
+                                disabled={item.isIgnored}
+                                onSelect={onCommandSelect}
+                                className={clsx(styles.item, styles.contextItem)}
+                            >
+                                <MentionMenuContextItemContent query={mentionQuery} item={item} />
+                            </CommandItem>
+                        ))}
                     </CommandGroup>
                 )}
 
-                <CommandGroup heading={heading}>
-                    {heading && params.parentItem && <CommandSeparator />}
-                    {data.items ? (
-                        data.items.length > 0 ? (
-                            data.items.map(item => (
-                                <CommandItem
-                                    key={commandRowValue(item)}
-                                    value={commandRowValue(item)}
-                                    disabled={item.isIgnored}
-                                    onSelect={onCommandSelect}
-                                    className={clsx(styles.item, styles.contextItem)}
-                                >
-                                    <MentionMenuContextItemContent query={mentionQuery} item={item} />
-                                </CommandItem>
-                            ))
-                        ) : (
-                            <CommandEmpty>{getEmptyLabel(params.parentItem, mentionQuery)}</CommandEmpty>
-                        )
-                    ) : (
-                        <CommandLoading>Loading...</CommandLoading>
-                    )}
-                </CommandGroup>
+                {data.items === undefined && <CommandLoading>Loading...</CommandLoading>}
+                <CommandEmpty>{getEmptyLabel(params.parentItem, mentionQuery)}</CommandEmpty>
             </CommandList>
         </Command>
     )


### PR DESCRIPTION
The command menu had an empty section at the end, because the emptyelement doesn't render when any providers are still shown. We thus created an empty CommandGroup.

This restructures it a bit to 
- always render the empty element and the loading element, as they won't show when there's any content
- to only render the second command group when there's actually gonna be entries in it

See the empty section at the end here:

![Screenshot 2024-05-30 at 12 15 03@2x](https://github.com/sourcegraph/cody/assets/19534377/7e3b2ddd-2365-4e90-a101-1becb001e3c1)


Test plan:

No more empty section at the end.
