### PR TITLE
removing the default "codebase context from file <file_path>" line for openctx providers

### DIFF
--- a/vscode/src/prompt-builder/utils.ts
+++ b/vscode/src/prompt-builder/utils.ts
@@ -43,7 +43,9 @@ export function renderContextItem(contextItem: ContextItem): ContextMessage | nu
             messageText = content
             break
         default:
-            messageText = populateCodeContextTemplate(content, uri, repoName)
+            if (contextItem.type === 'openctx') messageText = content
+            else messageText = populateCodeContextTemplate(content, uri, repoName)
+
             break
     }
 


### PR DESCRIPTION
## Context
By default the context from the openctx providers are appended with the line "Codebase context from file" which is the default template. Adding a check for the openctx providers and only adding the content from the openctx providers.


## Test plan
Manually checked
1. Added a debugger point in the local code to ensure openctx line does not have the default line.

<img width="1218" alt="image" src="https://github.com/sourcegraph/cody/assets/20701220/55be6225-f045-4d81-b20e-a86472b6195e">
 
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
