### PR TITLE
Apply context filters to Sourcegraph Repositories @-mention context p…

### DIFF
--- a/vscode/src/chat/context/chatContext.ts
+++ b/vscode/src/chat/context/chatContext.ts
@@ -70,6 +70,11 @@ export async function getChatContextItemsForMention(
                 (item): ContextItemOpenCtx => ({
                     type: 'openctx',
                     title: item.title,
+                    // HACK: The OpenCtx protocol does not support returning isIgnored
+                    // and it does not make sense to expect providers to return disabled
+                    // items. That is why we are using `item.data?.ignored`. We only need
+                    // this for our internal Sourcegraph Repositories provider.
+                    isIgnored: item.data?.isIgnored as boolean | undefined,
                     providerUri: item.providerUri,
                     uri: URI.parse(item.uri),
                     provider: 'openctx',

--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -1,4 +1,4 @@
-import { contextFiltersProvider, graphqlClient, isDefined, isError } from '@sourcegraph/cody-shared'
+import { contextFiltersProvider, graphqlClient, isError } from '@sourcegraph/cody-shared'
 
 import type { Item, Provider } from '@openctx/client'
 
@@ -21,19 +21,14 @@ const RemoteRepositorySearch: Provider & {
 
             const repositories = dataOrError.repositories.nodes
 
-            return repositories
-                .map(repo =>
-                    contextFiltersProvider.isRepoNameIgnored(repo.name)
-                        ? null
-                        : {
-                              uri: repo.url,
-                              title: repo.name,
-                              data: {
-                                  repoId: repo.id,
-                              },
-                          }
-                )
-                .filter(isDefined)
+            return repositories.map(repo => ({
+                uri: repo.url,
+                title: repo.name,
+                data: {
+                    repoId: repo.id,
+                    isIgnored: contextFiltersProvider.isRepoNameIgnored(repo.name),
+                },
+            }))
         } catch (error) {
             return []
         }

--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -1,6 +1,6 @@
-import { graphqlClient, isError } from '@sourcegraph/cody-shared'
+import { contextFiltersProvider, graphqlClient, isDefined, isError } from '@sourcegraph/cody-shared'
 
-import type { Item, Mention, Provider } from '@openctx/client'
+import type { Item, Provider } from '@openctx/client'
 
 const RemoteRepositorySearch: Provider & {
     providerUri: string
@@ -13,7 +13,7 @@ const RemoteRepositorySearch: Provider & {
 
     async mentions({ query }) {
         try {
-            const dataOrError = await graphqlClient.searchRepos(10, undefined, query)
+            const dataOrError = await graphqlClient.searchRepos(30, undefined, query)
 
             if (isError(dataOrError) || dataOrError === null) {
                 return []
@@ -21,16 +21,19 @@ const RemoteRepositorySearch: Provider & {
 
             const repositories = dataOrError.repositories.nodes
 
-            return repositories.map(
-                repo =>
-                    ({
-                        uri: repo.url,
-                        title: repo.name,
-                        data: {
-                            repoId: repo.id,
-                        },
-                    }) as Mention
-            )
+            return repositories
+                .map(repo =>
+                    contextFiltersProvider.isRepoNameIgnored(repo.name)
+                        ? null
+                        : {
+                              uri: repo.url,
+                              title: repo.name,
+                              data: {
+                                  repoId: repo.id,
+                              },
+                          }
+                )
+                .filter(isDefined)
         } catch (error) {
             return []
         }

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -63,13 +63,14 @@ export const MentionMenuContextItemContent: FunctionComponent<{
     query: MentionQuery
     item: ContextItem
 }> = ({ query, item }) => {
+    const isOpenCtx = item.type === 'openctx'
     const isFileType = item.type === 'file'
     const isSymbol = item.type === 'symbol'
     const icon = isSymbol ? (item.kind === 'class' ? 'symbol-structure' : 'symbol-method') : null
     const title = item.title ?? (isSymbol ? item.symbolName : displayPathBasename(item.uri))
     const description = getDescription(item, query)
 
-    const isIgnored = isFileType && item.isIgnored
+    const isIgnored = (isFileType || isOpenCtx) && item.isIgnored
     const isLargeFile = isFileType && item.isTooLarge
     let warning: string
     if (isIgnored) {


### PR DESCRIPTION
Issue: https://linear.app/sourcegraph/issue/CODY-1944/with-cody-context-filters-enabled-an-ignored-repo-should-not

This PR Integrates context filters with Sourcegraph Repositories @-mention context provider. 

No repo which is configured to be excluded from Cody using the context filters config present in site config should appear in the list while selecting a repo. 

Closes CODY-1944

## Test plan

Demo: https://www.loom.com/share/9ff608d9c4364bc5a03b0b030caa866f?sid=6c135b32-b1ed-42b9-8e2b-c99f79af2f10