### PR TITLE
vscode: Rename context files to context items

### DIFF
--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -86,7 +86,7 @@ export async function expectContextCellCounts(
     const summary = contextCell.locator('summary', { hasText: 'Context' })
     await expect(summary).toHaveAttribute(
         'title',
-        `${counts.files} file${counts.files === 1 ? '' : 's'}`,
+        `${counts.files} item${counts.files === 1 ? '' : 's'}`,
         { timeout: counts.timeout }
     )
 }

--- a/vscode/webviews/chat/Transcript.test.tsx
+++ b/vscode/webviews/chat/Transcript.test.tsx
@@ -301,7 +301,7 @@ function expectCells(expectedCells: CellMatcher[]): void {
             expect(cell).toHaveAttribute('data-testid', 'context')
             if (expectedCell.context.files !== undefined) {
                 expect(cell.querySelector('summary')).toHaveAccessibleDescription(
-                    `${expectedCell.context.files} file`
+                    `${expectedCell.context.files} item`
                 )
             } else if (expectedCell.context.loading) {
                 expect(cell.querySelector('[role="status"]')).toHaveAttribute('aria-busy')

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -89,7 +89,7 @@ export const Transcript: React.FunctionComponent<{
                 (message.contextFiles && message.contextFiles.length > 0) || isLastMessage ? (
                     <ContextCell
                         key={`${messageIndexInTranscript}-context`}
-                        contextFiles={message.contextFiles}
+                        contextItems={message.contextFiles}
                         model={nextAssistantMessage?.model}
                     />
                 ) : null,

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof ContextCell>
 
 export const Default: Story = {
     args: {
-        contextFiles: [
+        contextItems: [
             { type: 'file', uri: URI.file('/foo/bar.go') },
             { type: 'file', uri: URI.file('/foo/qux.go') },
             { type: 'file', uri: URI.file('/this/is/a/very/very/very/very/long/file/path.ts') },

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -1,4 +1,5 @@
 import type { ContextItem, ModelProvider } from '@sourcegraph/cody-shared'
+import { pluralize } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
 import { BrainIcon } from 'lucide-react'
 import type React from 'react'
@@ -16,30 +17,30 @@ import styles from './ContextCell.module.css'
  * A component displaying the context for a human message.
  */
 export const ContextCell: React.FunctionComponent<{
-    contextFiles: ContextItem[] | undefined
+    contextItems: ContextItem[] | undefined
     model?: ModelProvider['model']
     className?: string
 
     /** For use in storybooks only. */
     __storybook__initialOpen?: boolean
-}> = ({ contextFiles, model, className, __storybook__initialOpen }) => {
+}> = ({ contextItems, model, className, __storybook__initialOpen }) => {
     const usedContext = []
     const excludedAtContext = []
-    if (contextFiles) {
-        for (const f of contextFiles) {
-            if (f.isTooLarge || f.isIgnored) {
-                excludedAtContext.push(f)
+    if (contextItems) {
+        for (const item of contextItems) {
+            if (item.isTooLarge || item.isIgnored) {
+                excludedAtContext.push(item)
             } else {
-                usedContext.push(f)
+                usedContext.push(item)
             }
         }
     }
 
-    const fileCount = new Set(usedContext.map(file => file.uri.toString())).size
-    let fileCountLabel = `${fileCount} file${fileCount > 1 ? 's' : ''}`
+    const itemCount = new Set(usedContext.map(file => file.uri.toString())).size
+    let contextItemCountLabel = `${itemCount} ${pluralize('item', itemCount)}`
     if (excludedAtContext.length) {
         const excludedAtUnit = excludedAtContext.length === 1 ? 'mention' : 'mentions'
-        fileCountLabel = `${fileCountLabel} — ${excludedAtContext.length} ${excludedAtUnit} excluded`
+        contextItemCountLabel = `${contextItemCountLabel} — ${excludedAtContext.length} ${excludedAtUnit} excluded`
     }
 
     function logContextOpening() {
@@ -47,13 +48,13 @@ export const ContextCell: React.FunctionComponent<{
             command: 'event',
             eventName: 'CodyVSCodeExtension:chat:context:opened',
             properties: {
-                fileCount,
+                fileCount: itemCount,
                 excludedAtContext: excludedAtContext.length,
             },
         })
     }
 
-    return contextFiles === undefined || contextFiles.length !== 0 ? (
+    return contextItems === undefined || contextItems.length !== 0 ? (
         <Cell
             style="context"
             gutterIcon={
@@ -66,7 +67,7 @@ export const ContextCell: React.FunctionComponent<{
             contentClassName="tw-flex tw-flex-col tw-gap-4"
             data-testid="context"
         >
-            {contextFiles === undefined ? (
+            {contextItems === undefined ? (
                 <LoadingDots />
             ) : (
                 <details className={styles.details} open={__storybook__initialOpen}>
@@ -74,14 +75,14 @@ export const ContextCell: React.FunctionComponent<{
                         className={styles.summary}
                         onClick={logContextOpening}
                         onKeyUp={logContextOpening}
-                        title={fileCountLabel}
+                        title={contextItemCountLabel}
                     >
                         <h4 className={styles.heading}>
-                            Context <span className={styles.stats}>&mdash; {fileCountLabel}</span>
+                            Context <span className={styles.stats}>&mdash; {contextItemCountLabel}</span>
                         </h4>
                     </summary>
                     <ul className={styles.list}>
-                        {contextFiles?.map((item, i) => (
+                        {contextItems?.map((item, i) => (
                             // biome-ignore lint/suspicious/noArrayIndexKey: stable order
                             <li key={i}>
                                 <FileLink


### PR DESCRIPTION
In preparation for more context sources, we're renaming them to items. This PR also does a little cleanup of the variable names within the ContextCell component.

Closes CODY-1891

https://uploads.linear.app/15b96a4d-ffc0-481a-ba9c-9d840020f7bc/d7743f63-6b06-4ef6-a365-dd73d5a4e56c/d8227344-1a42-44be-8059-380d19eb4240

Test plan:

Screenshot.
