### PR TITLE
vscode: Make keybinding for new chat separate keycaps

### DIFF
--- a/vscode/webviews/chat/components/WelcomeMessage.tsx
+++ b/vscode/webviews/chat/components/WelcomeMessage.tsx
@@ -93,8 +93,12 @@ export const WelcomeMessage: FunctionComponent = () => {
                     <MenuExample>Add to Cody Chat</MenuExample>
                 </FeatureRow>
                 <FeatureRow icon={NewChatIcon}>
-                    Start a new chat using <Kbd>{isMacOS() ? '⌥' : 'Alt'}+/</Kbd> or the{' '}
-                    <CodyIcon character="H" /> button in the top right of any file
+                    Start a new chat using{' '}
+                    <Kbd>
+                        {isMacOS() ? '⌥' : 'Alt'}
+                        <span className="tw-ml-1">/</span>
+                    </Kbd>{' '}
+                    or the <CodyIcon character="H" /> button in the top right of any file
                 </FeatureRow>
                 <FeatureRow icon={SettingsIcon}>
                     Customize chat settings with the{' '}


### PR DESCRIPTION
This reads nicer IMO, it properly indicates which two buttons you're supposed to press.

Before: 
![image](https://github.com/sourcegraph/cody/assets/19534377/92cec976-fb82-48bd-86be-e6307a33d1b1)

After: 
![Screenshot 2024-05-30 at 14 03 52@2x](https://github.com/sourcegraph/cody/assets/19534377/591b6b1c-70ed-4d51-80f9-78fc812da2ad)

Test plan: Visual inspection.
