### PR TITLE
Import OpenCtx Web provider and remove the old ones

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1305,9 +1305,7 @@
         "openctx.providers": {
           "type": "object",
           "markdownDescription": "OpenCtx providers configuration.",
-          "default": {
-            "https://openctx.org/npm/@openctx/provider-web": true
-          }
+          "default": {}
         },
         "cody.internal.unstable": {
           "order": 999,

--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -3,6 +3,7 @@ import type * as vscode from 'vscode'
 import { logDebug, outputChannel } from '../log'
 import RemoteFileProvider from './openctx/remoteFileSearch'
 import RemoteRepositorySearch from './openctx/remoteRepositorySearch'
+import WebProvider from './openctx/web'
 
 export function exposeOpenCtxClient(
     secrets: vscode.SecretStorage,
@@ -12,6 +13,11 @@ export function exposeOpenCtxClient(
     import('@openctx/vscode-lib')
         .then(({ createController }) => {
             const providers = [
+                {
+                    providerUri: WebProvider.providerUri,
+                    settings: true,
+                    provider: WebProvider,
+                },
                 {
                     providerUri: RemoteRepositorySearch.providerUri,
                     settings: true,

--- a/vscode/src/context/openctx/web.ts
+++ b/vscode/src/context/openctx/web.ts
@@ -1,0 +1,118 @@
+import type { ItemsParams, ItemsResult, Provider } from '@openctx/client'
+
+/**
+ * An OpenCtx provider that fetches the content of a URL and provides it as an item.
+ */
+const WebProvider: Provider & { providerUri: 'internal-web-provider' } = {
+    providerUri: 'internal-web-provider',
+
+    meta() {
+        return {
+            name: 'Web URLs',
+            mentions: {},
+        }
+    },
+
+    async mentions({ query }) {
+        const [item] = await fetchItem({ message: query }, 2000)
+        if (!item) {
+            return []
+        }
+
+        return [{ title: item.title, uri: item.url || '', data: { content: item.ai?.content } }]
+    },
+
+    async items(params) {
+        return fetchItem(params)
+    },
+}
+
+async function fetchItem(params: ItemsParams, timeoutMs?: number): Promise<ItemsResult> {
+    if (typeof params.mention?.data?.content === 'string') {
+        return [
+            {
+                ...params.mention,
+                url: params.mention.uri,
+                ui: { hover: { text: `Fetched from ${params.mention.uri}` } },
+                ai: { content: params.mention.data.content },
+            },
+        ]
+    }
+
+    const url = params.message || params.mention?.uri
+    if (!url) {
+        return []
+    }
+    try {
+        const content = await fetchContentForURLContextItem(
+            url,
+            timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined
+        )
+
+        if (content === null) {
+            return []
+        }
+        return [
+            {
+                url,
+                title: tryGetHTMLDocumentTitle(content) ?? url,
+                ui: { hover: { text: `Fetched from ${url}` } },
+                ai: { content: content },
+            },
+        ]
+    } catch (error) {
+        // Suppress errors because the user might be typing a URL that is not yet valid.
+        return []
+    }
+}
+
+async function fetchContentForURLContextItem(
+    urlStr: string,
+    signal?: AbortSignal
+): Promise<string | null> {
+    const url = new URL(urlStr)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return null
+    }
+    if (!/(localhost|\.\w{2,})$/.test(url.hostname)) {
+        return null
+    }
+
+    const resp = await fetch(urlStr, { signal })
+    if (!resp.ok) {
+        return null
+    }
+    const body = await resp.text()
+
+    // HACK(sqs): Rudimentarily strip HTML tags, script, and other unneeded elements from body using
+    // regexp. This is NOT intending to be a general-purpose HTML parser and is NOT sanitizing the
+    // value for security.
+    const bodyWithoutTags = body
+        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+        .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+        .replace(/<svg\b[^<]*(?:(?!<\/svg>)<[^<]*)*<\/svg>/gi, '')
+        .replace(/<!--.*?-->/gs, '')
+        .replace(/\s(?:class|style)=["'][^"']*["']/gi, '')
+        .replace(/\sdata-[\w-]+(=["'][^"']*["'])?/gi, '')
+
+    // TODO(sqs): Arbitrarily trim the response text to avoid overflowing the context window for the
+    // LLM. Ideally we would make the prompt builder prioritize this context item over other context
+    // because it is explicitly from the user.
+    const MAX_LENGTH = 14000
+    return bodyWithoutTags.length > MAX_LENGTH
+        ? `${bodyWithoutTags.slice(0, MAX_LENGTH)}... (web page content was truncated)`
+        : bodyWithoutTags
+}
+
+/**
+ * Try to get the title of an HTML document, using incomplete regexp parsing for simplicity (because
+ * this feature is experimental and we don't need robustness yet).
+ */
+function tryGetHTMLDocumentTitle(html: string): string | undefined {
+    return html
+        .match(/<title>(?<title>[^<]+)<\/title>/)
+        ?.groups?.title.replaceAll(/\s+/gm, ' ')
+        .trim()
+}
+
+export default WebProvider

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../../src/chat/context/constants'
 import RemoteFileProvider from '../../../src/context/openctx/remoteFileSearch'
 import RemoteRepositorySearch from '../../../src/context/openctx/remoteRepositorySearch'
+import WebProvider from '../../../src/context/openctx/web'
 import GithubLogo from '../../icons/providers/github.svg?react'
 import GoogleLogo from '../../icons/providers/google.svg?react'
 import JiraLogo from '../../icons/providers/jira.svg?react'
@@ -136,4 +137,5 @@ const iconForProvider: Record<
     'https://openctx.org/npm/@openctx/provider-sourcegraph-search': SourcegraphLogo,
     [RemoteRepositorySearch.providerUri]: SourcegraphLogo,
     [RemoteFileProvider.providerUri]: SourcegraphLogo,
+    [WebProvider.providerUri]: LinkIcon,
 }


### PR DESCRIPTION
As the OpenCtx Web provider was enabled by default on the pre-release, we can not just ship it that way and it doesn't belong to the vscode package and all the SOC2 compliance stuff....

This PR imports the Web provider from OpenCtx (as it is) and use it as internal providers similar to Remote Repo & File search providers. 

~This PR also removed the pre-openctx era providers namely github, sg search, URL fetcher. Still keeping the packages one as it has not been migrated to openctx yet and is used by "usage example" command.~

This PR also removes the default value of `openctx.providers` to include the web provider from npm package, because now it is included as an internal provider. 

Closes CODY-1945

## Test plan

Tested manually.