### PR TITLE
Agent: get tests green again

### DIFF
--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -976,10 +976,10 @@ describe('Agent', () => {
 
                   it('does something else', () => {
                       // This line will error due to incorrect usage of \`performance.now\`
-                              /**
+                      /**
                        * The timestamp, in milliseconds, at which this perf tracing started.
                        */
-              const startTime = performance.now(/* CURSOR */)
+                      const startTime = performance.now(/* CURSOR */)
                   })
               })
               "


### PR DESCRIPTION
Had to update the snapshot. Didn't re-record


## Test plan
Green CI.
<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
