### PR TITLE
vscode: Relax provider search matching

### DIFF
--- a/vscode/webviews/mentions/mentionMenu/useMentionMenuData.ts
+++ b/vscode/webviews/mentions/mentionMenu/useMentionMenuData.ts
@@ -52,8 +52,16 @@ export function useMentionMenuData(
                     ? []
                     : providers.filter(
                           provider =>
-                              provider.id.toLowerCase().includes(queryLower) ||
-                              provider.title?.toLowerCase().includes(queryLower)
+                              provider.id.toLowerCase().includes(queryLower.trim()) ||
+                              provider.title?.toLowerCase().includes(queryLower.trim()) ||
+                              provider.id
+                                  .toLowerCase()
+                                  .replaceAll(' ', '')
+                                  .includes(queryLower.trim()) ||
+                              provider.title
+                                  ?.toLowerCase()
+                                  .replaceAll(' ', '')
+                                  .includes(queryLower.trim())
                       ),
             items: results
                 ?.slice(0, limit)


### PR DESCRIPTION
This PR makes it so that all of

- github
- " GitHub"
- issues
- githubissues
- "GitHub Issues"

match `GitHub Issues`.

Previously, any excessive spaces in the query would cause all providers to not match, and you always had to put in the space. Without requiring all the spaces (but still okay to put them in) it should feel a bit more like a fuzzy finder.

Test plan:

Tim!


## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
