### PR TITLE
Add Icons to Mention chips and update chip labels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,14 +25,14 @@
     "source.organizeImports.biome": "explicit"
   },
   "editor.insertSpaces": true,
-  "cSpell.words": [
-    "Supercompletion",
-    "Supercompletions"
-  ],
+  "cSpell.words": ["Supercompletion", "Supercompletions"],
   "[typescript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
+  "[css]": {
+    "editor.defaultFormatter": "stylelint.vscode-stylelint"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,9 @@ importers:
       lru-cache:
         specifier: ^10.0.0
         version: 10.0.0
+      lucide:
+        specifier: ^0.381.0
+        version: 0.381.0
       lucide-react:
         specifier: ^0.378.0
         version: 0.378.0(react@18.2.0)
@@ -10839,6 +10842,10 @@ packages:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
+    dev: false
+
+  /lucide@0.381.0:
+    resolution: {integrity: sha512-+RPg88RMmB+7EcusALa0EcedUY9xuw/6bGNeuf5t02dSx5DiJVl39Sc7XuOOU+zcZDvFKTRUaZv+ijRIjlb0PQ==}
     dev: false
 
   /lz-string@1.5.0:

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -42,7 +42,12 @@
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
-  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
+  "categories": [
+    "Programming Languages",
+    "Machine Learning",
+    "Snippets",
+    "Education"
+  ],
   "keywords": [
     "ai",
     "openai",
@@ -95,7 +100,11 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
+  "activationEvents": [
+    "onLanguage",
+    "onStartupFinished",
+    "onWebviewPanel:cody.chatPanel"
+  ],
   "contributes": {
     "walkthroughs": [
       {
@@ -704,13 +713,17 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["next"],
+        "args": [
+          "next"
+        ],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": ["previous"],
+        "args": [
+          "previous"
+        ],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       }
@@ -1018,12 +1031,20 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
+          "examples": [
+            "https://github.com/sourcegraph/cody",
+            "ssh://git@github.com/sourcegraph/cody"
+          ]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": ["embeddings", "keyword", "blended", "none"],
+          "enum": [
+            "embeddings",
+            "keyword",
+            "blended",
+            "none"
+          ],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -1081,13 +1102,17 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": ["Answer all my questions in Spanish."]
+          "examples": [
+            "Answer all my questions in Spanish."
+          ]
         },
         "cody.edit.preInstruction": {
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": ["Write all unit tests with Jest instead of detected framework."]
+          "examples": [
+            "Write all unit tests with Jest instead of detected framework."
+          ]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1152,8 +1177,14 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": ["all", "off"],
-          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
+          "enum": [
+            "all",
+            "off"
+          ],
+          "enumDescriptions": [
+            "Sends usage data and errors.",
+            "Disables all extension telemetry."
+          ],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
@@ -1181,7 +1212,12 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [null, "starcoder-16b", "starcoder-7b", "llama-code-13b"],
+          "enum": [
+            null,
+            "starcoder-16b",
+            "starcoder-7b",
+            "llama-code-13b"
+          ],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1201,7 +1237,10 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": ["lsp", "indentation-based"],
+          "enum": [
+            "lsp",
+            "indentation-based"
+          ],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1222,7 +1261,13 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [null, "bfg", "bfg-mixed", "tsc", "tsc-mixed"],
+          "enum": [
+            null,
+            "bfg",
+            "bfg-mixed",
+            "tsc",
+            "tsc-mixed"
+          ],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {
@@ -1440,6 +1485,7 @@
     "lodash": "^4.17.21",
     "lowlight": "^3.1.0",
     "lru-cache": "^10.0.0",
+    "lucide": "^0.381.0",
     "lucide-react": "^0.378.0",
     "mac-ca": "^2.0.3",
     "marked": "^4.0.16",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -42,12 +42,7 @@
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
   },
-  "categories": [
-    "Programming Languages",
-    "Machine Learning",
-    "Snippets",
-    "Education"
-  ],
+  "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [
     "ai",
     "openai",
@@ -100,11 +95,7 @@
   },
   "main": "./dist/extension.node.js",
   "browser": "./dist/extension.web.js",
-  "activationEvents": [
-    "onLanguage",
-    "onStartupFinished",
-    "onWebviewPanel:cody.chatPanel"
-  ],
+  "activationEvents": ["onLanguage", "onStartupFinished", "onWebviewPanel:cody.chatPanel"],
   "contributes": {
     "walkthroughs": [
       {
@@ -713,17 +704,13 @@
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "next"
-        ],
+        "args": ["next"],
         "key": "shift+ctrl+down",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       },
       {
         "command": "cody.supercompletion.jumpTo",
-        "args": [
-          "previous"
-        ],
+        "args": ["previous"],
         "key": "shift+ctrl+up",
         "when": "cody.activated && !editorReadonly && cody.hasActionableSupercompletion"
       }
@@ -1031,20 +1018,12 @@
           "order": 2,
           "type": "string",
           "markdownDescription": "A Git repository URL to use instead of allowing Cody to infer the Git repository from the workspace.",
-          "examples": [
-            "https://github.com/sourcegraph/cody",
-            "ssh://git@github.com/sourcegraph/cody"
-          ]
+          "examples": ["https://github.com/sourcegraph/cody", "ssh://git@github.com/sourcegraph/cody"]
         },
         "cody.useContext": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "embeddings",
-            "keyword",
-            "blended",
-            "none"
-          ],
+          "enum": ["embeddings", "keyword", "blended", "none"],
           "default": "blended",
           "markdownDescription": "Controls which context providers Cody uses for chat, commands and inline edits. Use 'blended' for best results. For debugging other context sources, 'embeddings' will use an embeddings-based index if available. 'keyword' will use a search-based index. 'none' will not use embeddings or search-based indexes."
         },
@@ -1102,17 +1081,13 @@
           "order": 6,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the start of all chat messages (e.g. \"Answer all my questions in Spanish.\")",
-          "examples": [
-            "Answer all my questions in Spanish."
-          ]
+          "examples": ["Answer all my questions in Spanish."]
         },
         "cody.edit.preInstruction": {
           "order": 7,
           "type": "string",
           "markdownDescription": "A custom instruction to be included at the end of all instructions for edit commands (e.g. \"Write all unit tests with Jest instead of detected framework.\")",
-          "examples": [
-            "Write all unit tests with Jest instead of detected framework."
-          ]
+          "examples": ["Write all unit tests with Jest instead of detected framework."]
         },
         "cody.codeActions.enabled": {
           "order": 11,
@@ -1177,14 +1152,8 @@
         "cody.telemetry.level": {
           "order": 99,
           "type": "string",
-          "enum": [
-            "all",
-            "off"
-          ],
-          "enumDescriptions": [
-            "Sends usage data and errors.",
-            "Disables all extension telemetry."
-          ],
+          "enum": ["all", "off"],
+          "enumDescriptions": ["Sends usage data and errors.", "Disables all extension telemetry."],
           "markdownDescription": "Controls the telemetry about Cody usage and errors. See [Cody usage and privacy notice](https://about.sourcegraph.com/terms/cody-notice).",
           "default": "all"
         },
@@ -1212,12 +1181,7 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "starcoder-16b",
-            "starcoder-7b",
-            "llama-code-13b"
-          ],
+          "enum": [null, "starcoder-16b", "starcoder-7b", "llama-code-13b"],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {
@@ -1237,10 +1201,7 @@
         },
         "cody.experimental.foldingRanges": {
           "type": "string",
-          "enum": [
-            "lsp",
-            "indentation-based"
-          ],
+          "enum": ["lsp", "indentation-based"],
           "enumDescriptions": [
             "Use folding ranges that are enabled by default in VS Code, and are usually powered by LSP",
             "Use custom implementation of folding ranges that is indentation based. This is the implementation that is used by other Cody clients like the JetBrains plugin"
@@ -1261,13 +1222,7 @@
         "cody.autocomplete.experimental.graphContext": {
           "type": "string",
           "default": null,
-          "enum": [
-            null,
-            "bfg",
-            "bfg-mixed",
-            "tsc",
-            "tsc-mixed"
-          ],
+          "enum": [null, "bfg", "bfg-mixed", "tsc", "tsc-mixed"],
           "markdownDescription": "Use the code graph to retrieve context for autocomplete requests."
         },
         "cody.autocomplete.experimental.fireworksOptions": {

--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -24,6 +24,9 @@ const RemoteRepositorySearch: Provider & {
             return repositories.map(repo => ({
                 uri: repo.url,
                 title: repo.name,
+                // By default we show <title> <uri> in the mentions menu.
+                // As repo.url and repo.name are almost same, we do not want to show the uri.
+                // So that is why we are setting the description to " " string.
                 description: ' ',
                 data: {
                     repoId: repo.id,

--- a/vscode/src/context/openctx/remoteRepositorySearch.ts
+++ b/vscode/src/context/openctx/remoteRepositorySearch.ts
@@ -8,7 +8,7 @@ const RemoteRepositorySearch: Provider & {
     providerUri: 'internal-remote-repository-search',
 
     meta() {
-        return { name: 'Sourcegraph Repositories', mentions: {} }
+        return { name: 'Remote Repositories', mentions: {} }
     },
 
     async mentions({ query }) {
@@ -24,6 +24,7 @@ const RemoteRepositorySearch: Provider & {
             return repositories.map(repo => ({
                 uri: repo.url,
                 title: repo.name,
+                description: ' ',
                 data: {
                     repoId: repo.id,
                     isIgnored: contextFiltersProvider.isRepoNameIgnored(repo.name),

--- a/vscode/test/e2e/chat-atFile.test.ts
+++ b/vscode/test/e2e/chat-atFile.test.ts
@@ -78,14 +78,14 @@ test.extend<ExpectedEvents>({
     // Forward slashes
     await chatInput.fill('@lib/batches/env')
     await expect(
-        chatPanelFrame.getByRole('option', { name: withPlatformSlashes('var.go lib/batches/env') })
+        chatPanelFrame.getByRole('option', { name: withPlatformSlashes('var.go') })
     ).toBeVisible()
 
     // Backslashes
     if (isWindows()) {
         await chatInput.fill('@lib\\batches\\env')
         await expect(
-            chatPanelFrame.getByRole('option', { name: withPlatformSlashes('var.go lib/batches/env') })
+            chatPanelFrame.getByRole('option', { name: withPlatformSlashes('var.go') })
         ).toBeVisible()
     }
 
@@ -99,14 +99,13 @@ test.extend<ExpectedEvents>({
     // Searching and clicking
     await chatInput.fill('Explain @mj')
     await chatPanelFrame.getByRole('option', { name: 'Main.java' }).click()
-    await expect(chatInput).toHaveText('Explain @Main.java ')
-    await expect(chatInput.getByText('@Main.java')).toHaveClass(/context-item-mention-node/)
+    await expect(chatInput).toHaveText('Explain Main.java ')
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
-    await expect(chatPanelFrame.getByText('Explain @Main.java')).toBeVisible()
+    await expect(chatPanelFrame.getByText('Explain Main.java')).toBeVisible()
     const contextCell = getContextCell(chatPanelFrame)
     await expect(contextCell).toHaveCount(1)
-    await expect(chatInput).not.toHaveText('Explain @Main.java ')
+    await expect(chatInput).not.toHaveText('Explain Main.java ')
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).not.toBeVisible()
 
     // Keyboard nav through context files
@@ -116,7 +115,7 @@ test.extend<ExpectedEvents>({
     ).toBeVisible()
     await chatInput.press('Tab')
     await chatInput.press('Tab')
-    await expect(chatInput).toHaveText(withPlatformSlashes('Explain @lib/batches/env/var.go '))
+    await expect(chatInput).toHaveText(withPlatformSlashes('Explain var.go '))
     await chatInput.focus()
     await chatInput.pressSequentially('and ')
     await chatInput.pressSequentially('@vgo', { delay: 10 })
@@ -129,21 +128,13 @@ test.extend<ExpectedEvents>({
     await chatInput.press('ArrowDown') // second item again
     await expect(chatPanelFrame.getByRole('option', { selected: true })).toHaveText(/visualize\.go/)
     await chatInput.press('Tab')
-    await expect(chatInput).toHaveText(
-        withPlatformSlashes(
-            'Explain @lib/batches/env/var.go and @lib/codeintel/tools/lsif-visualize/visualize.go '
-        )
-    )
+    await expect(chatInput).toHaveText(withPlatformSlashes('Explain var.go and visualize.go '))
 
     // Send the message and check it was included
     await chatInput.press('Enter')
     await expect(chatInput).toBeEmpty()
     await expect(
-        chatPanelFrame.getByText(
-            withPlatformSlashes(
-                'Explain @lib/batches/env/var.go and @lib/codeintel/tools/lsif-visualize/visualize.go'
-            )
-        )
+        chatPanelFrame.getByText(withPlatformSlashes('Explain var.go and visualize.go'))
     ).toBeVisible()
 
     // Ensure explicitly @-included context shows up as enhanced context
@@ -156,14 +147,14 @@ test.extend<ExpectedEvents>({
     await chatInput.pressSequentially('@Main.java', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.press('Tab')
-    await expect(chatInput).toHaveText('@Main.java ')
+    await expect(chatInput).toHaveText('Main.java ')
 
     // Check pressing tab after typing a partial filename but where that complete
     // filename already exists earlier in the input.
     // https://github.com/sourcegraph/cody/issues/2243
     await chatInput.pressSequentially('and @Main.ja', { delay: 10 })
     await chatInput.press('Tab')
-    await expect(chatInput).toHaveText('@Main.java and @Main.java ')
+    await expect(chatInput).toHaveText('Main.java and Main.java ')
 
     // Support @-file in mid-sentence
     await chatInput.focus()
@@ -178,16 +169,16 @@ test.extend<ExpectedEvents>({
     await chatInput.pressSequentially('@Main', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'Main.java' })).toBeVisible()
     await chatInput.press('Tab')
-    await expect(chatInput).toHaveText('Explain the @Main.java file')
+    await expect(chatInput).toHaveText('Explain the Main.java file')
     // Confirm the cursor is at the end of the newly added file name with space
     await page.keyboard.press('!')
     await page.keyboard.press('Delete')
-    await expect(chatInput).toHaveText('Explain the @Main.java !file')
+    await expect(chatInput).toHaveText('Explain the Main.java !file')
 
     //  "ArrowLeft" / "ArrowRight" keys alter the query input for @-mentions.
     const noMatches = atMentionMenuItem(chatPanelFrame, 'No files found')
     await chatInput.pressSequentially(' @abcdefg')
-    await expect(chatInput).toHaveText('Explain the @Main.java ! @abcdefgfile')
+    await expect(chatInput).toHaveText('Explain the Main.java ! @abcdefgfile')
     await noMatches.hover()
     await expect(noMatches).toBeVisible()
     await chatInput.press('ArrowLeft')
@@ -195,7 +186,7 @@ test.extend<ExpectedEvents>({
     await chatInput.press('ArrowRight')
     await expect(noMatches).toBeVisible()
     await chatInput.press('$')
-    await expect(chatInput).toHaveText('Explain the @Main.java ! @abcdefg$file')
+    await expect(chatInput).toHaveText('Explain the Main.java ! @abcdefg$file')
     await expect(noMatches).not.toBeVisible()
     // Selection close on submit
     await chatInput.press('Enter')
@@ -255,26 +246,24 @@ test.extend<ExpectedEvents>({
     // Send a message with an @-mention.
     await firstChatInput.fill('Explain @mj')
     await chatPanelFrame.getByRole('option', { name: 'Main.java' }).click()
-    await expect(firstChatInput).toHaveText('Explain @Main.java ')
-    await expect(firstChatInput.getByText('@Main.java')).toHaveClass(/context-item-mention-node/)
+    await expect(firstChatInput).toHaveText('Explain Main.java ')
     await firstChatInput.press('Enter')
     const contextCell = getContextCell(chatPanelFrame)
     await expectContextCellCounts(contextCell, { files: 1 })
 
     // Edit the just-sent message and resend it. Confirm it is sent with the right context items.
-    await expect(firstChatInput).toHaveText('Explain @Main.java ')
+    await expect(firstChatInput).toHaveText('Explain Main.java ')
     await firstChatInput.press('Meta+Enter')
     await expectContextCellCounts(contextCell, { files: 1 })
 
     // Edit it again, add a new @-mention, and resend.
-    await expect(firstChatInput).toHaveText('Explain @Main.java ')
+    await expect(firstChatInput).toHaveText('Explain Main.java ')
     await focusChatInputAtEnd(firstChatInput)
     await firstChatInput.pressSequentially('and @index.ht')
     await chatPanelFrame.getByRole('option', { name: 'index.html' }).click()
-    await expect(firstChatInput).toHaveText('Explain @Main.java and @index.html')
-    await expect(firstChatInput.getByText('@index.html')).toHaveClass(/context-item-mention-node/)
+    await expect(firstChatInput).toHaveText('Explain Main.java and index.html')
     await firstChatInput.press('Enter')
-    await expect(firstChatInput).toHaveText('Explain @Main.java and @index.html')
+    await expect(firstChatInput).toHaveText('Explain Main.java and index.html')
     await expectContextCellCounts(contextCell, { files: 2 })
 })
 
@@ -312,7 +301,7 @@ test.extend<ExpectedEvents>({
     await chatInput.fill('@buzz.ts:2-4')
     await expect(chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'buzz.ts Lines 2-4' }).click()
-    await expect(chatInput).toHaveText('@buzz.ts:2-4 ')
+    await expect(chatInput).toHaveText('buzz.ts:2-4 ')
     // Submit the message
     await chatInput.press('Enter')
 
@@ -388,7 +377,7 @@ test.extend<ExpectedEvents>({
     await chatInput.pressSequentially('fizzb', { delay: 10 })
     await expect(chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' })).toBeVisible()
     await chatPanelFrame.getByRole('option', { name: 'fizzbuzz()' }).click()
-    await expect(chatInput).toHaveText('@buzz.ts:1-15#fizzbuzz() ')
+    await expect(chatInput).toHaveText('fizzbuzz()')
 
     // Submit the message
     await chatInput.press('Enter')
@@ -436,7 +425,7 @@ test.extend<ExpectedEvents>({
     // Verify the chat input has the selected code as an @-mention item
     const chatFrame = page.frameLocator('iframe.webview').last().frameLocator('iframe')
     const chatInput = chatFrame.getByRole('textbox', { name: 'Chat message' })
-    await expect(chatInput).toHaveText('@buzz.ts:2-13 ')
+    await expect(chatInput).toHaveText('buzz.ts:2-13 ')
 
     // Repeat the above steps to add another code selection as an @-mention item.
     // The chat input should have the new code selections appended as @-mention items
@@ -448,7 +437,7 @@ test.extend<ExpectedEvents>({
     await expect(commandPaletteInputBox).toBeVisible()
     await commandPaletteInputBox.fill('>Add Selection to Cody Chat')
     await page.locator('a').filter({ hasText: 'Add Selection to Cody Chat' }).click()
-    await expect(chatInput).toHaveText('@buzz.ts:2-13 @buzz.ts:4-6 ')
+    await expect(chatInput).toHaveText('buzz.ts:2-13 buzz.ts:4-6 ')
 })
 
 async function openMentionsForProvider(

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -16,7 +16,8 @@ import { clsx } from 'clsx'
 import {
     ArrowRightIcon,
     DatabaseIcon,
-    FileTextIcon,
+    FileIcon,
+    FolderGitIcon,
     LibraryBigIcon,
     LinkIcon,
     PackageIcon,
@@ -116,7 +117,7 @@ export const iconForProvider: Record<
         strokeWidth?: string | number
     }>
 > = {
-    [FILE_CONTEXT_MENTION_PROVIDER.id]: FileTextIcon,
+    [FILE_CONTEXT_MENTION_PROVIDER.id]: FileIcon,
     [SYMBOL_CONTEXT_MENTION_PROVIDER.id]: SquareFunctionIcon,
     'src-search': SourcegraphLogo,
     [URL_CONTEXT_MENTION_PROVIDER.id]: LinkIcon,
@@ -136,7 +137,7 @@ export const iconForProvider: Record<
     'https://openctx.org/npm/@openctx/provider-hello-world': SmileIcon,
     'https://openctx.org/npm/@openctx/provider-devdocs': LibraryBigIcon,
     'https://openctx.org/npm/@openctx/provider-sourcegraph-search': SourcegraphLogo,
-    [RemoteRepositorySearch.providerUri]: SourcegraphLogo,
-    [RemoteFileProvider.providerUri]: SourcegraphLogo,
+    [RemoteRepositorySearch.providerUri]: FolderGitIcon,
+    [RemoteFileProvider.providerUri]: FileIcon,
     [WebProvider.providerUri]: LinkIcon,
 }

--- a/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
+++ b/vscode/webviews/mentions/mentionMenu/MentionMenuItem.tsx
@@ -109,7 +109,7 @@ export const MentionMenuProviderItemContent: FunctionComponent<{
     )
 }
 
-const iconForProvider: Record<
+export const iconForProvider: Record<
     string,
     React.ComponentType<{
         size?: string | number

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
@@ -10,9 +10,11 @@
         display: inline-block;
         xvertical-align: -1px;
         xmargin: 0 2px;
-        width: 11px;
-        height: 11px;
+        width: 13px;
+        height: 13px;
         xuser-select2: none;
+        filter: invert(23%) sepia(34%) saturate(4949%) hue-rotate(195deg) brightness(98%) contrast(101%);;
+        margin-right: 0.25rem;
     }
 }
 

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
@@ -3,18 +3,16 @@
     background-color: color-mix(in lch, var(--vscode-textLink-foreground) 10%, transparent);
     border-radius: 2px;
     white-space: normal;
-    margin-right: 3px;
-
+    padding: 0 1px;
+    display: inline-block;
 
     .icon {
         display: inline-block;
-        xvertical-align: -1px;
-        xmargin: 0 2px;
         width: 13px;
         height: 13px;
-        xuser-select2: none;
-        filter: invert(23%) sepia(34%) saturate(4949%) hue-rotate(195deg) brightness(98%) contrast(101%);;
-        margin-right: 0.25rem;
+        margin-right: -2px;
+        transform: translateY(-1px);
+        opacity: 0.8;
     }
 }
 

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.module.css
@@ -3,6 +3,17 @@
     background-color: color-mix(in lch, var(--vscode-textLink-foreground) 10%, transparent);
     border-radius: 2px;
     white-space: normal;
+    margin-right: 3px;
+
+
+    .icon {
+        display: inline-block;
+        xvertical-align: -1px;
+        xmargin: 0 2px;
+        width: 11px;
+        height: 11px;
+        xuser-select2: none;
+    }
 }
 
 body[data-vscode-theme-kind='vscode-high-contrast-light'] .context-item-mention-node {

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.test.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.test.ts
@@ -5,7 +5,7 @@ import { contextItemMentionNodeDisplayText } from './ContextItemMentionNode'
 describe('contextItemMentionNodeDisplayText', () => {
     test('file', () =>
         expect(contextItemMentionNodeDisplayText({ type: 'file', uri: 'file:///foo/bar.ts' })).toBe(
-            isWindows() ? '@\\foo\\bar.ts' : '@foo/bar.ts'
+            isWindows() ? '\\bar.ts' : 'bar.ts'
         ))
 
     test('file range of full end line', () =>
@@ -15,7 +15,7 @@ describe('contextItemMentionNodeDisplayText', () => {
                 uri: 'file:///a.go',
                 range: { start: { line: 1, character: 0 }, end: { line: 4, character: 0 } },
             })
-        ).toBe(`${isWindows() ? '@\\a.go' : '@a.go'}:2-4`))
+        ).toBe(`${isWindows() ? '\\a.go' : 'a.go'}:2-4`))
 
     test('file range', () =>
         expect(
@@ -24,7 +24,7 @@ describe('contextItemMentionNodeDisplayText', () => {
                 uri: 'file:///a.go',
                 range: { start: { line: 1, character: 2 }, end: { line: 4, character: 4 } },
             })
-        ).toBe(`${isWindows() ? '@\\a.go' : '@a.go'}:2-5`))
+        ).toBe(`${isWindows() ? '\\a.go' : 'a.go'}:2-5`))
 
     test('symbol', () =>
         expect(
@@ -35,5 +35,5 @@ describe('contextItemMentionNodeDisplayText', () => {
                 symbolName: 'MySymbol',
                 kind: 'function',
             })
-        ).toBe(`@${isWindows() ? '\\foo\\bar.ts' : 'foo/bar.ts'}:2-4#MySymbol`))
+        ).toBe('MySymbol'))
 })

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -24,6 +24,7 @@ import {
 } from 'lexical'
 import { BookMarked, File, SquareCode, createElement } from 'lucide'
 import { URI } from 'vscode-uri'
+import { iconForProvider } from '../../mentions/mentionMenu/MentionMenuItem'
 import styles from './ContextItemMentionNode.module.css'
 
 export const MENTION_CLASS_NAME = styles.contextItemMentionNode
@@ -205,12 +206,6 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
             }
             return `${decodeURIComponent(displayPath(URI.parse(contextItem.uri)))}${rangeText}`
 
-        case 'repository':
-            return contextItem.title ?? 'unknown repository'
-
-        case 'tree':
-            return contextItem.title ?? 'unknown tree'
-
         case 'symbol':
             return `@${displayPath(URI.parse(contextItem.uri))}${rangeText}#${contextItem.symbolName}`
 
@@ -266,8 +261,12 @@ const CONTEXT_ITEM_ICONS: Partial<
     file: File,
     symbol: SquareCode,
 }
-function mentionIconForContextItem(contextItem: SerializedContextItem): SVGElement | null {
-    const icon = CONTEXT_ITEM_ICONS[contextItem.type]
+function mentionIconForContextItem(contextItem: SerializedContextItem): HTMLImageElement | null {
+    const icon =
+        iconForProvider[
+            contextItem.provider || (contextItem as { providerUri: string }).providerUri || ''
+        ]
+
     if (!icon) {
         return null
     }
@@ -276,5 +275,6 @@ function mentionIconForContextItem(contextItem: SerializedContextItem): SVGEleme
     const imgEl = document.createElement('img')
     imgEl.classList.add(styles.icon)
     imgEl.setAttribute('src', `data:image/svg+xml,${iconEl.outerHTML}`)
+
     return imgEl
 }

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -134,12 +134,8 @@ export class ContextItemMentionNode extends TextNode {
     createDOM(config: EditorConfig): HTMLElement {
         const dom = document.createElement('span')
         const inner = super.createDOM(config)
-        // dom.innerText = '\u200B' // zero-width space
-        // dom.innerHTML = `<img src="https://slack.org/media/sqs.jpg" width=11 height=11 style="display:inline"/>`
         dom.appendChild(inner)
         dom.className = ContextItemMentionNode.CLASS_NAMES
-
-        //inner.innerHTML = '\u200B' + inner.innerHTML
 
         const icon = mentionIconForContextItem(this.contextItem)
         if (icon) {

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -207,7 +207,7 @@ export function contextItemMentionNodeDisplayText(contextItem: SerializedContext
             return `${decodeURIComponent(displayPathBasename(URI.parse(contextItem.uri)))}${rangeText}`
 
         case 'symbol':
-            return `${contextItem.symbolName}`
+            return contextItem.symbolName
 
         case 'package':
             return `@${contextItem.ecosystem}:${contextItem.name}`

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.ts
@@ -134,6 +134,7 @@ export class ContextItemMentionNode extends TextNode {
     createDOM(config: EditorConfig): HTMLElement {
         const dom = document.createElement('span')
         const inner = super.createDOM(config)
+        inner.innerText = ' ' + inner.innerText
         dom.appendChild(inner)
         dom.className = ContextItemMentionNode.CLASS_NAMES
 
@@ -262,7 +263,7 @@ const CONTEXT_ITEM_ICONS: Partial<Record<string, Icon>> = {
     [RemoteFileProvider.providerUri]: File,
     [WebProvider.providerUri]: Link,
 }
-function mentionIconForContextItem(contextItem: SerializedContextItem): HTMLImageElement | null {
+function mentionIconForContextItem(contextItem: SerializedContextItem): SVGElement | null {
     let icon: Icon | null | undefined = null
 
     icon =
@@ -274,11 +275,10 @@ function mentionIconForContextItem(contextItem: SerializedContextItem): HTMLImag
         return null
     }
 
-    const iconEl = createElement(icon)
-
-    const imgEl = document.createElement('img')
-    imgEl.classList.add(styles.icon)
-    imgEl.setAttribute('src', `data:image/svg+xml,${iconEl.outerHTML}`)
-
-    return imgEl
+    const svgEl = createElement(icon)
+    svgEl.classList.add(styles.icon)
+    svgEl.setAttribute('stroke', 'currentColor')
+    svgEl.setAttribute('width', '13px')
+    svgEl.setAttribute('height', '13px')
+    return svgEl
 }


### PR DESCRIPTION
This PR:

1. Adds icons to all the mention chips enabled by default namely Files, Symbols, Remote Repositories & Web URL. 
2. Renames Sourcegraph Repositories to Remote Repositories.
3. Updates the label for Symbol mention chips to only show symbol name and not the whole file path as well. 
4. Updates the level for File mention chips to only show file base path.


This PR doesn't update icons for all the other experimental openctx providers yet which are not enabled by default. For all the other providers there is a default DocumentIcon set. 

![CleanShot 2024-05-30 at 23 50 18@2x](https://github.com/sourcegraph/cody/assets/22571395/4a3b3e1d-831a-42ca-a557-0a2c26292daf)

Closes CODY-1946

## Test plan

Manually tested