### PR TITLE
Chat: keep the editor query prefix on the @-mention provider selection

### DIFF
--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -78,6 +78,8 @@ function scanForMentionTriggerInLexicalInput(text: string) {
     return scanForMentionTriggerInUserTextInput({ textBeforeCursor: text, includeWhitespace: true })
 }
 
+export type setEditorQuery = (getNewQuery: (currentText: string) => string) => void
+
 export default function MentionsPlugin({
     userInfo,
 }: { userInfo?: UserAccountInfo }): JSX.Element | null {
@@ -105,14 +107,16 @@ export default function MentionsPlugin({
     })
 
     const setEditorQuery = useCallback(
-        (query: string): void => {
+        (getNewQuery: (currentText: string) => string): void => {
             if (editor) {
                 editor.update(() => {
                     const selection = $getSelection()
+
                     if (selection) {
                         const lastNode = selection.getNodes().at(-1)
                         if (lastNode) {
-                            const textNode = $createTextNode(`@${query}`)
+                            const currentText = lastNode.getTextContent()
+                            const textNode = $createTextNode(getNewQuery(currentText))
                             lastNode.replace(textNode)
                             textNode.selectEnd()
                         }
@@ -121,7 +125,7 @@ export default function MentionsPlugin({
             }
         },
         [editor]
-    )
+    ) satisfies setEditorQuery
 
     useEffect(() => {
         // Listen for changes to ContextItemMentionNode to update the token count.
@@ -139,6 +143,7 @@ export default function MentionsPlugin({
 
     const onSelectOption = useCallback(
         (selectedOption: MentionMenuOption, nodeToReplace: TextNode | null, closeMenu: () => void) => {
+            // console.log({ selectedOption, nodeToReplace })
             editor.update(() => {
                 const currentInputText = nodeToReplace?.__text
                 if (!currentInputText) {
@@ -240,7 +245,8 @@ export default function MentionsPlugin({
                     },
                 })
             }}
-            menuRenderFn={(anchorElementRef, { selectOptionAndCleanUp }) => {
+            menuRenderFn={(anchorElementRef, itemProps) => {
+                const { selectOptionAndCleanUp } = itemProps
                 anchorElementRef2.current = anchorElementRef.current ?? undefined
                 return (
                     anchorElementRef.current && (

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -143,7 +143,6 @@ export default function MentionsPlugin({
 
     const onSelectOption = useCallback(
         (selectedOption: MentionMenuOption, nodeToReplace: TextNode | null, closeMenu: () => void) => {
-            // console.log({ selectedOption, nodeToReplace })
             editor.update(() => {
                 const currentInputText = nodeToReplace?.__text
                 if (!currentInputText) {


### PR DESCRIPTION
- Keep the editor query prefix on the @-mention provider selection

## Test plan

1. Open a new chat with OpenCtx enabled.
2. Type a few words and then attempt to select an OpenCtx provider.
3. In the main branch, the chat input will be cleared upon provider selection. In this branch, it should only remove the text after @.
