### PR TITLE
vscode: Fix item count

### DIFF
--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -24,8 +24,8 @@ export const ContextCell: React.FunctionComponent<{
     /** For use in storybooks only. */
     __storybook__initialOpen?: boolean
 }> = ({ contextItems, model, className, __storybook__initialOpen }) => {
-    const usedContext = []
-    const excludedAtContext = []
+    const usedContext: ContextItem[] = []
+    const excludedAtContext: ContextItem[] = []
     if (contextItems) {
         for (const item of contextItems) {
             if (item.isTooLarge || item.isIgnored) {
@@ -36,7 +36,7 @@ export const ContextCell: React.FunctionComponent<{
         }
     }
 
-    const itemCount = new Set(usedContext.map(file => file.uri.toString())).size
+    const itemCount = usedContext.length
     let contextItemCountLabel = `${itemCount} ${pluralize('item', itemCount)}`
     if (excludedAtContext.length) {
         const excludedAtUnit = excludedAtContext.length === 1 ? 'mention' : 'mentions'
@@ -48,7 +48,7 @@ export const ContextCell: React.FunctionComponent<{
             command: 'event',
             eventName: 'CodyVSCodeExtension:chat:context:opened',
             properties: {
-                fileCount: itemCount,
+                fileCount: new Set(usedContext.map(file => file.uri.toString())).size,
                 excludedAtContext: excludedAtContext.length,
             },
         })


### PR DESCRIPTION
When we switched the wording from files to items, this number made even less sense than before.

I think this was always a bit confusing as there are often more list items than there are files (because we include multiple chunks) but with the term items this just fell apart completely.

So now we no longer count the unique number of file URIs, but instead just the number of rendered items. For telemetry, I kept it the same for now, as I am scared of skewing any metrics.

Test plan:

Verified locally that the number is now matching the number of list items.