### PR TITLE
chore(dev): fix broken link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 
 ## Test plan
 
-<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->
+<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->


### PR DESCRIPTION
Spotted a broken link. Ideally this shouldn't be pointing at the legacy docs, but that's still better that a 404. I'll update this once I've ported this stuff to Notion. 

## Test plan

<!-- Required. See https://sourcegraph.com/docs/dev/background-information/testing_principles. -->

n/a, just updating PR template. 