### PR TITLE
remove unneccessary windows check in ContextItemMentionNode test

### DIFF
--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.test.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.test.ts
@@ -1,4 +1,3 @@
-import { isWindows } from '@sourcegraph/cody-shared'
 import { describe, expect, test } from 'vitest'
 import { contextItemMentionNodeDisplayText } from './ContextItemMentionNode'
 

--- a/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.test.ts
+++ b/vscode/webviews/promptEditor/nodes/ContextItemMentionNode.test.ts
@@ -15,7 +15,7 @@ describe('contextItemMentionNodeDisplayText', () => {
                 uri: 'file:///a.go',
                 range: { start: { line: 1, character: 0 }, end: { line: 4, character: 0 } },
             })
-        ).toBe(`${isWindows() ? 'a.go' : 'a.go'}:2-4`))
+        ).toBe('a.go:2-4'))
 
     test('file range', () =>
         expect(
@@ -24,7 +24,7 @@ describe('contextItemMentionNodeDisplayText', () => {
                 uri: 'file:///a.go',
                 range: { start: { line: 1, character: 2 }, end: { line: 4, character: 4 } },
             })
-        ).toBe(`${isWindows() ? 'a.go' : 'a.go'}:2-5`))
+        ).toBe('a.go:2-5'))
 
     test('symbol', () =>
         expect(


### PR DESCRIPTION
The true and false branch are the same value.

Follow up from https://github.com/sourcegraph/cody/pull/4393 and https://github.com/sourcegraph/cody/pull/4394

Test Plan: CI