### PR TITLE
Autocomplete: Allow suffix to change/Fix for auto-inserted semi mode

### DIFF
--- a/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
+++ b/vscode/src/completions/get-inline-completions-tests/last-candidate.test.ts
@@ -236,6 +236,27 @@ describe('[getInlineCompletions] reuseLastCandidate', () => {
             source: InlineCompletionsResultSource.LastCandidate,
         }))
 
+    it('handles automatically-inserted semis', async () =>
+        // The user types `console.log()` and puts the cursor between brackets. Then they sees
+        // the ghost text `'hello world');` and save a TypeScript document with automatically
+        // inserted semis, changing the suffix to `);`. The completion should update the insert
+        // range to not show the semi twice.
+        expect(
+            await getInlineCompletions(
+                params('console.log(█);', [], {
+                    lastCandidate: lastCandidate(
+                        'console.log(█)',
+                        '"Hello from Vienna!");',
+                        undefined,
+                        range(0, 12, 0, 13)
+                    ),
+                })
+            )
+        ).toEqual<V>({
+            items: [{ insertText: '"Hello from Vienna!");', range: range(0, 12, 0, 14) }],
+            source: InlineCompletionsResultSource.LastCandidate,
+        }))
+
     describe('partial acceptance', () => {
         it('marks a completion as partially accepted when you type at least one word', async () => {
             const handleDidPartiallyAcceptCompletionItem = vitest.fn()


### PR DESCRIPTION
Closes #3410

When the same line suffix changes for the same candidate, we may want to check if the newly inserted suffix overlaps with the generation. This is useful for cases like JavaScript-formatter-inserts-semis-for-you as you can see from the video.

### Before

https://github.com/sourcegraph/cody/assets/458591/ea7cc8b0-f1ab-455f-8a36-9058fee5bbea

## Test plan

### After

https://github.com/sourcegraph/cody/assets/458591/d2eeabb0-88b1-4b6e-96cb-8790713b5256