### PR TITLE
Unify Opt+L and Opt+K hotkeys, fix Opt+L inserting a char instead of opening chat

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -592,9 +592,9 @@
         "when": "!cody.activated"
       },
       {
-        "command": "cody.chat.tree.view.focus",
-        "key": "alt+f1",
-        "when": "cody.activated"
+        "command": "cody.chat.focus",
+        "key": "alt+l",
+        "when": "!cody.activated"
       },
       {
         "command": "cody.chat.panel.new",
@@ -604,12 +604,17 @@
       {
         "command": "cody.chat.panel.new",
         "key": "alt+l",
-        "when": "cody.activated && !editorHasSelection"
+        "when": "cody.activated"
+      },
+      {
+        "command": "cody.mention.selection",
+        "key": "alt+/",
+        "when": "cody.activated && editorTextFocus && editorHasSelection && cody.hasChatPanelsOpened"
       },
       {
         "command": "cody.mention.selection",
         "key": "alt+l",
-        "when": "cody.activated && !editorReadonly && editorTextFocus && editorHasSelection"
+        "when": "cody.activated && editorTextFocus && editorHasSelection && cody.hasChatPanelsOpened"
       },
       {
         "command": "cody.tutorial.chat",
@@ -758,6 +763,11 @@
           "command": "cody.chat.view.popOut",
           "when": "false",
           "_comment": "Hidden because it is only a wrapper around the workspace pop out command and would place any editor tab (not just Cody chat) in a new window."
+        },
+        {
+          "command": "cody.chat.panel.reset",
+          "when": "false",
+          "_comment": "Hidden because it only needs to be usable in the chat toolbar."
         }
       ],
       "editor/context": [
@@ -770,16 +780,16 @@
         {
           "command": "cody.mention.selection",
           "group": "0_cody",
-          "when": "cody.activated && !editorReadonly && editorHasSelection && cody.hasChatPanelsOpened"
+          "when": "cody.activated && editorHasSelection && cody.hasChatPanelsOpened"
         },
         {
           "command": "cody.mention.file",
           "group": "0_cody",
-          "when": "cody.activated && !editorReadonly && !editorHasSelection && cody.hasChatPanelsOpened"
+          "when": "cody.activated && !editorHasSelection && cody.hasChatPanelsOpened"
         },
         {
           "command": "cody.chat.panel.new",
-          "when": "cody.activated",
+          "when": "cody.activated && (!editorHasSelection || !cody.hasChatPanelsOpened)",
           "group": "ask"
         },
         {

--- a/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
+++ b/vscode/test/e2e/chat-keyboard-shortcuts.test.ts
@@ -1,0 +1,51 @@
+import { expect } from '@playwright/test'
+import {
+    chatMessageRows,
+    clickEditorTab,
+    getChatInputs,
+    getChatPanel,
+    openFileInEditorTab,
+    selectLineRangeInEditorTab,
+    sidebarSignin,
+} from './common'
+import { executeCommandInPalette, test } from './helpers'
+
+test('chat keyboard shortcuts', async ({ page, sidebar }) => {
+    await page.bringToFront()
+    await sidebarSignin(page, sidebar)
+
+    const chatPanel = getChatPanel(page)
+    const chatInput = getChatInputs(chatPanel).first()
+
+    // Alt+L with no selection opens a new chat (with file mention).
+    await openFileInEditorTab(page, 'buzz.ts')
+    await selectLineRangeInEditorTab(page, 3)
+    await page.keyboard.press('Alt+L')
+    await expect(chatInput).toHaveText('@buzz.ts ')
+
+    await executeCommandInPalette(page, 'View: Close Editor')
+
+    // Alt+L with a selection opens a new chat (with selection mention).
+    await openFileInEditorTab(page, 'buzz.ts')
+    await selectLineRangeInEditorTab(page, 3, 5)
+    await page.keyboard.press('Alt+L')
+    await expect(chatInput).toHaveText('@buzz.ts:3-5 ')
+
+    // Alt+L with an existing chat appends a selection mention.
+    await chatInput.press('x')
+    await clickEditorTab(page, 'buzz.ts')
+    await selectLineRangeInEditorTab(page, 7, 9)
+    await page.keyboard.press('Alt+L')
+    await expect(chatInput).toHaveText('@buzz.ts:3-5 x @buzz.ts:7-9 ')
+
+    // Alt+L in the chat (before sending) does nothing.
+    await chatInput.focus()
+    await chatInput.press('Alt+L')
+    await expect(chatInput).toHaveText('@buzz.ts:3-5 x @buzz.ts:7-9 ')
+
+    // Alt+L in the chat (after sending) opens a new chat.
+    await chatInput.press('Enter')
+    await expect(chatMessageRows(chatPanel).nth(2)).toHaveText(/hello from the assistant/)
+    await page.keyboard.press('Alt+L')
+    await expect(chatInput).toHaveText('@buzz.ts:7-9 ')
+})

--- a/vscode/test/e2e/initial-context.test.ts
+++ b/vscode/test/e2e/initial-context.test.ts
@@ -39,8 +39,6 @@ testWithGitRemote('initial context - file', async ({ page, sidebar, server }) =>
 
     await openFileInEditorTab(page, 'main.c')
 
-    await page.getByRole('tab', { name: /Cody*/ }).click()
-
     const [, lastChatInput] = await createEmptyChatPanel(page)
 
     await expect(chatInputMentions(lastChatInput)).toHaveText(['@host.example/user/myrepo', '@main.c'])


### PR DESCRIPTION
There are 2 hotkeys to open Cody chat: Opt+/ and Opt+L. In most places we document Opt+L. There are slight differences (Opt+L adds your selection, Opt+/ t) that do not merit having 2 different prominent keybindings.

We will standardize on Opt+L as the hotkey and as the single behavior. Opt+L also has the benefit of being similar to Opt+K, the edit hotkey. It makes Opt+/ an alias with the same behavior (for people with muscle memory).

Also fixes issues with Opt+L inserting a character instead of opening chat on macOS in some cases.

- Fixes https://github.com/sourcegraph/cody/issues/4215
- Fixes https://github.com/sourcegraph/cody/issues/4419
- Fixes https://github.com/sourcegraph/cody/issues/4178 (again)
- Fixes https://github.com/sourcegraph/cody/issues/4483
- Fixes https://github.com/sourcegraph/cody/issues/4194
- Fixes https://linear.app/sourcegraph/issue/CODY-1985/unify-optl-and-optk-hotkeys
- Fixes https://linear.app/sourcegraph/issue/CODY-1983/duplicate-optl-keybindings
- https://sourcegraph.slack.com/archives/C05MW2TMYAV/p1717152531711519

## Test plan

CI & e2e. Confirmed Opt+L in an editor with a selection does not input a character on macOS; it opens a chat window with the selection mentioned.