### PR TITLE
vscode: do not show "Rename Chat" in command pallette

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -467,7 +467,7 @@
         "title": "Rename Chat",
         "group": "Cody",
         "icon": "$(edit)",
-        "enablement": "cody.activated && cody.hasChatHistory"
+        "enablement": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory && viewItem == cody.chats"
       },
       {
         "command": "cody.chat.history.clear",


### PR DESCRIPTION
This command only works when directly clicked on a chat item in the history. So we use the same enablement condition as when it is shown there.

Test Plan: tested renaming chat still works and that it doesn't appear in command pallette