### PR TITLE
vscode: remove Rename Chat functionality

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -52,6 +52,10 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Added @-mention provider icons. [pull/4336](https://github.com/sourcegraph/cody/pull/4336)
 - Chat: New chats now start with @-mentions of your current repository and file. Use @-mentions to include other context. Enterprise users can @-mention remote repositories to chat across multiple repositories. [pull/4364](https://github.com/sourcegraph/cody/pull/4364)
 
+### Removed
+
+- Chat: The `Rename Chat` functionality.
+
 ## [1.18.2]
 
 ### Added

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -462,14 +462,6 @@
         "icon": "$(layout-sidebar-left)"
       },
       {
-        "command": "cody.chat.history.edit",
-        "category": "Cody",
-        "title": "Rename Chat",
-        "group": "Cody",
-        "icon": "$(edit)",
-        "enablement": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory && viewItem == cody.chats"
-      },
-      {
         "command": "cody.chat.history.clear",
         "category": "Cody",
         "title": "Delete All Chats",
@@ -903,11 +895,6 @@
         }
       ],
       "view/item/context": [
-        {
-          "command": "cody.chat.history.edit",
-          "when": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory && viewItem == cody.chats",
-          "group": "inline@1"
-        },
         {
           "command": "cody.chat.history.delete",
           "when": "view == cody.chat.tree.view && cody.activated && cody.hasChatHistory && viewItem == cody.chats",

--- a/vscode/src/chat/chat-view/ChatManager.ts
+++ b/vscode/src/chat/chat-view/ChatManager.ts
@@ -79,9 +79,6 @@ export class ChatManager implements vscode.Disposable {
             vscode.commands.registerCommand('cody.chat.history.export', () => this.exportHistory()),
             vscode.commands.registerCommand('cody.chat.history.clear', () => this.clearHistory()),
             vscode.commands.registerCommand('cody.chat.history.delete', item => this.clearHistory(item)),
-            vscode.commands.registerCommand('cody.chat.history.edit', item =>
-                this.editChatHistory(item)
-            ),
             vscode.commands.registerCommand('cody.chat.panel.new', () => this.createNewWebviewPanel()),
             vscode.commands.registerCommand('cody.chat.panel.restore', (id, chat) =>
                 this.restorePanel(id, chat)
@@ -154,14 +151,6 @@ export class ChatManager implements vscode.Disposable {
 
         const provider = await this.chatPanelsManager.getActiveChatPanel()
         await provider.handleGetUserEditorContext(uri)
-    }
-
-    private async editChatHistory(treeItem?: vscode.TreeItem): Promise<void> {
-        const chatID = treeItem?.id
-        const chatLabel = treeItem?.label as vscode.TreeItemLabel
-        if (chatID) {
-            await this.chatPanelsManager.editChatHistory(chatID, chatLabel.label)
-        }
     }
 
     private async clearHistory(treeItem?: vscode.TreeItem): Promise<void> {

--- a/vscode/src/chat/chat-view/ChatPanelsManager.ts
+++ b/vscode/src/chat/chat-view/ChatPanelsManager.ts
@@ -274,30 +274,6 @@ export class ChatPanelsManager implements vscode.Disposable {
         await this.treeViewProvider.updateTree(this.options.authProvider.getAuthStatus())
     }
 
-    public async editChatHistory(chatID: string, label: string): Promise<void> {
-        await vscode.window
-            .showInputBox({
-                prompt: 'Enter new chat name',
-                value: label,
-            })
-            .then(async title => {
-                const authProvider = this.options.authProvider
-                const authStatus = authProvider.getAuthStatus()
-
-                const history = chatHistory.getChat(authStatus, chatID)
-                if (title && history) {
-                    history.chatTitle = title
-                    await chatHistory.saveChat(authStatus, history)
-                    await this.updateTreeViewHistory()
-                    const chatIDUTC = new Date(chatID).toUTCString()
-                    const provider =
-                        this.panelProviders.find(p => p.sessionID === chatID) ||
-                        this.panelProviders.find(p => p.sessionID === chatIDUTC)
-                    provider?.setChatTitle(title)
-                }
-            })
-    }
-
     public async clearHistory(chatID?: string): Promise<void> {
         const authProvider = this.options.authProvider
         const authStatus = authProvider.getAuthStatus()

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -1419,16 +1419,6 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
     // #region other public accessors and mutators
     // =======================================================================
 
-    public setChatTitle(title: string): void {
-        const isDefaultChatTitle = title === 'New Chat'
-        // Skip storing default chat title
-        if (!isDefaultChatTitle) {
-            this.chatModel.setCustomChatTitle(title)
-        }
-
-        this.postChatTitle()
-    }
-
     // Convenience function for tests
     public getViewTranscript(): readonly ChatMessage[] {
         return this.chatModel.getMessages().map(prepareChatMessage)


### PR DESCRIPTION
Being ruthless with this feature. We will be moving chat history to the backend, synchronizing it, etc. Being able to rename chats will add complexity. We can always add it back once we do all that.

Test Plan: CI. Ran manually and the edit title button was gone.

More context at https://sourcegraph.slack.com/archives/C0748TDGT29/p1717162754194119?thread_ts=1717160259.281599&cid=C0748TDGT29