### PR TITLE
Document Code: improve tree-sitter query for c++

### DIFF
--- a/vscode/src/tree-sitter/queries/cpp.ts
+++ b/vscode/src/tree-sitter/queries/cpp.ts
@@ -11,28 +11,24 @@ const DOCUMENTABLE_NODES = dedent`
         declarator: (function_declarator)
         body: (compound_statement) @symbol.function) @range.function
 
-    ; Class definitions
-    ;--------------------------------
-    (class_specifier
-        name: (type_identifier)
-        body: (_)) @range.class
-    (struct_specifier
-        name: (type_identifier)
-        body: (_)) @range.struct
-    (declaration
-        type: (union_specifier
-            name: (type_identifier) @symbol.union)) @range.union
-
-    ; Variables
-    ;--------------------------------
-    (declaration) @symbol.identifier @range.identifier
-
     ; Types
     ;--------------------------------
+    (template_declaration
+        (struct_specifier
+            name: (template_type) @symbol.identifier)) @range.identifier
     (type_definition
         type: (struct_specifier) @symbol.identifier) @range.identifier
     (enum_specifier
         name: (type_identifier) @symbol.identifier) @range.identifier
+
+    ; Class definitions
+    ;--------------------------------
+    (class_specifier
+        name: (type_identifier) @symbol.identifier
+        body: (_)) @range.identifier
+    (struct_specifier
+        name: (type_identifier) @symbol.identifier
+        body: (_)) @range.identifier
 `
 
 const ENCLOSING_FUNCTION_QUERY = dedent`

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.cpp
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.cpp
@@ -106,16 +106,6 @@ void return_statement()
 
 // ------------------------------------
 
-return_statement('value');
-//       |
-
-// ------------------------------------
-
-char *user_name = "Tom";
-//  |
-
-// ------------------------------------
-
 enum Level
 {
     //  |
@@ -123,3 +113,40 @@ enum Level
     MEDIUM,
     HIGH
 };
+
+// ------------------------------------
+
+template <typename T> struct SampleStruct {
+  template <typename ParseContext>
+    auto parse(ParseContext &ctx) {
+        // |
+        return ctx.begin();
+    }
+
+      void foo() {
+    }
+};
+
+// ------------------------------------
+
+#define TEST(name) void test_##name()
+
+TEST(twoSum)
+{
+    int target = 9;
+    int returnSize[2];
+    int expected[] = {0, 1};
+    // |
+};
+
+// ------------------------------------
+
+// Variable should not be detected as documentable.
+int nums[] = {2, 7, 11, 15};
+//       |
+
+// ------------------------------------
+
+// Variable should not be detected as documentable.
+char *user_name = "Tom";
+//  |

--- a/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.cpp
+++ b/vscode/src/tree-sitter/query-tests/test-data/documentable-node.snap.cpp
@@ -178,21 +178,6 @@
 
 // ------------------------------------
 
-return_statement('value');
-//       |
-
-// ------------------------------------
-
-  char *user_name = "Tom";
-//^^^^^^^^^^^^^^^^^^^^^^^^ symbol.identifier[1], range.identifier[1]
-//    █
-
-// Nodes types:
-// symbol.identifier[1]: declaration
-// range.identifier[1]: declaration
-
-// ------------------------------------
-
   enum Level
 //^ start range.identifier[1]
   {
@@ -206,3 +191,44 @@ return_statement('value');
 // Nodes types:
 // range.identifier[1]: enum_specifier
 
+// ------------------------------------
+
+  template <typename T> struct SampleStruct {
+//                      ^ start range.identifier[1]
+    template <typename ParseContext>
+      auto parse(ParseContext &ctx) {
+//           █
+          return ctx.begin();
+      }
+
+        void foo() {
+      }
+  };
+//^ end range.identifier[1]
+
+// Nodes types:
+// range.identifier[1]: struct_specifier
+
+// ------------------------------------
+
+#define TEST(name) void test_##name()
+
+TEST(twoSum)
+{
+    int target = 9;
+    int returnSize[2];
+    int expected[] = {0, 1};
+    // |
+};
+
+// ------------------------------------
+
+// Variable should not be detected as documentable.
+int nums[] = {2, 7, 11, 15};
+//       |
+
+// ------------------------------------
+
+// Variable should not be detected as documentable.
+char *user_name = "Tom";
+//  |


### PR DESCRIPTION
- Add support for template declarations and struct specializations
- Refine class and struct definitions to better capture symbol and range information
- Remove unused variable and union declaration rules

## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Updated test to cover template declaration.

Confirm https://github.com/sourcegraph/jetbrains/issues/1728 is fixed:

![image](https://github.com/sourcegraph/cody/assets/68532117/7b49fcc3-66c3-4033-8a8c-334965fc69a3)

- Open https://github.com/fmtlib/fmt/blob/master/test/format-test.cc#L2410
- Put cursor somewhere inside template <> struct formatter<convertible_to_cstring> template method.
- Run Document Code

https://github.com/sourcegraph/cody/assets/68532117/296d3188-9f43-4b59-8c3a-c4e11a292c19

