### PR TITLE
fix copy/insert/save code buttons in chat

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,7 +7,9 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 ### Fixed
-- Chat: The @-mentions for workspace repositories, which are added to the input box by default for new messages, now takes context filters into consideration and do not mention the excluded repos. [pull/4427](https://github.com/sourcegraph/cody/pull/4427)
+
+- Chat: The @-mentions for workspace repositories, which are added to the input box by default for new messages, now take context filters into consideration and do not mention the excluded repos. [pull/4427](https://github.com/sourcegraph/cody/pull/4427)
+- Chat: Fixed an issue where the buttons for copying and inserting code in assistant responses were not showing. [pull/4422](https://github.com/sourcegraph/cody/pull/4422)
 
 ### Changed
 

--- a/vscode/test/e2e/chat-messages.test.ts
+++ b/vscode/test/e2e/chat-messages.test.ts
@@ -1,0 +1,39 @@
+import { expect } from '@playwright/test'
+import { chatMessageRows, createEmptyChatPanel, sidebarSignin } from './common'
+import { test } from './helpers'
+
+test.use({ permissions: ['clipboard-read', 'clipboard-write'] })
+
+test('chat assistant response code buttons', async ({ page, sidebar, context, contextOptions }) => {
+    await sidebarSignin(page, sidebar)
+    const [chatPanel, chatInput] = await createEmptyChatPanel(page)
+    await chatInput.fill('show me a code snippet')
+    await chatInput.press('Enter')
+
+    const messageRows = chatMessageRows(chatPanel)
+    const assistantRow = messageRows.nth(1)
+    await expect(assistantRow).toContainText('Hello! Here is a code snippet:')
+    await expect(assistantRow).toContainText('def fib(n):')
+
+    const copyButton = assistantRow.getByRole('button', { name: 'Copy Code' })
+    const insertButton = assistantRow.getByRole('button', { name: 'Insert Code at Cursor' })
+    const saveToNewFileButton = assistantRow.getByRole('button', { name: 'Save Code to New File' })
+
+    expect(await copyButton.count()).toBe(1)
+    await expect(copyButton).toBeVisible()
+    await expect(insertButton).toBeVisible()
+    await expect(saveToNewFileButton).toBeVisible()
+
+    // When using Playwright for VS Code tests, the clipboard-read and clipboard-write permissions
+    // don't work, and attempting to read the clipboard from Playwright throws a DOMException. So,
+    // use this workaround instead.
+    const consoleLogPromise = page.waitForEvent('console', {
+        predicate: msg => msg.text().includes('Code: Copy to Clipboard'),
+        timeout: 5000,
+    })
+    await copyButton.click()
+    const consoleLogMessage = await consoleLogPromise
+    expect(await consoleLogMessage.args()[1].jsonValue()).toBe(
+        'def fib(n):\n  if n < 0:\n    return n\n  else:\n    return fib(n-1) + fib(n-2)\n'
+    )
+})

--- a/vscode/test/e2e/common.ts
+++ b/vscode/test/e2e/common.ts
@@ -68,6 +68,10 @@ export async function focusChatInputAtEnd(chatInput: Locator): Promise<void> {
     await chatInput.press('End')
 }
 
+export function chatMessageRows(chatPanel: FrameLocator): Locator {
+    return chatPanel.locator('[role="row"]')
+}
+
 /**
  * Gets the chat context cell. If {@link counts} is specified, then validates that the context
  * exactly matches the specified file and line counts.

--- a/vscode/webviews/chat/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent.module.css
@@ -1,4 +1,4 @@
-.container {
+.buttons-container {
     display: flex;
     align-items: center;
     border-style: solid;

--- a/vscode/webviews/chat/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent.tsx
@@ -35,7 +35,7 @@ function createButtons(
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
 ): HTMLElement {
     const container = document.createElement('div')
-    container.className = styles.container
+    container.className = styles.buttonsContainer
     if (!copyButtonOnSubmit) {
         return container
     }
@@ -118,6 +118,9 @@ function createCodeBlockActionButton(
             setTimeout(() => {
                 button.innerHTML = iconSvg
             }, 5000)
+
+            // Log for `chat assistant response code buttons` e2e test.
+            console.log('Code: Copy to Clipboard', text)
         })
     }
 
@@ -241,10 +244,20 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
 }) => {
     const rootRef = useRef<HTMLDivElement>(null)
 
+    // biome-ignore lint/correctness/useExhaustiveDependencies: needs to run when `displayMarkdown` changes or else the buttons won't show up.
     useEffect(() => {
-        const preElements = rootRef.current?.querySelectorAll('pre')
+        if (!rootRef.current) {
+            return
+        }
+
+        const preElements = rootRef.current.querySelectorAll('pre')
         if (!preElements?.length || !copyButtonOnSubmit) {
             return
+        }
+
+        const existingButtons = rootRef.current.querySelectorAll(`.${styles.buttonsContainer}`)
+        for (const existingButton of existingButtons) {
+            existingButton.remove()
         }
 
         for (const preElement of preElements) {
@@ -290,7 +303,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                 })
             }
         }
-    }, [copyButtonOnSubmit, insertButtonOnSubmit, guardrails])
+    }, [copyButtonOnSubmit, insertButtonOnSubmit, guardrails, displayMarkdown])
 
     usePreserveSelectionOnUpdate(rootRef, [displayMarkdown])
 

--- a/vscode/webviews/chat/fixtures.ts
+++ b/vscode/webviews/chat/fixtures.ts
@@ -102,7 +102,7 @@ export const FIXTURE_TRANSCRIPT: Record<
         },
         {
             speaker: 'assistant',
-            text: ps`This code is very cool.`,
+            text: ps`This code is very cool. Here is some more code:\n\n\n\`\`\`javascript\nfunction Symbol1() {\n  console.log('Hello, world!')\n}\n\`\`\`\n`,
         },
     ]),
     long: transcriptFixture([


### PR DESCRIPTION
These buttons were sometimes not showing on new messages due to the `useEffect` hook not having the right deps.

Fixes that issue and adds an e2e test to ensure the buttons show up and that the copy button copies the right text.

Fixes https://linear.app/sourcegraph/issue/CODY-2014/missing-copyinsert-buttons-on-code-snippets

## Test plan

CI + e2e