### PR TITLE
CI: make tests more stable on Windows

### DIFF
--- a/agent/src/TestWorkspace.ts
+++ b/agent/src/TestWorkspace.ts
@@ -29,9 +29,17 @@ export class TestWorkspace {
     }
 
     public async afterAll(): Promise<void> {
-        await fspromises.rm(this.rootPath, {
-            recursive: true,
-            force: true,
-        })
+        try {
+            await fspromises.rm(this.rootPath, {
+                recursive: true,
+                force: true,
+                maxRetries: 5,
+            })
+        } catch (error) {
+            console.error(
+                `Ignoring error in afterAll hook while recursively deleting the directory '${this.rootPath}'`,
+                error
+            )
+        }
     }
 }


### PR DESCRIPTION
Previously, the CI could fail in the `afterAll` hook for agent integration tests because `fs.rm` would crash on Windows. An example error message:

```
 FAIL  |agent| src/document-code.test.ts > Document Code
Error: EBUSY: resource busy or locked, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\cody-vscode-shim-testqDezWe\src'
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: { errno: -4082, code: 'EBUSY', syscall: 'rmdir', path: 'C:\Users\RUNNER~1\AppData\Local\Temp\cody-vscode-shim-testqDezWe\src' }
```

In this PR, we change the `fs.rm` logic to

- Retry deleting files.
- Log the error if it still fails to delete. This is not a fatal error for the tests.


## Test plan

Green CI, no flaky failures related to `fs.rm`
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
