### PR TITLE
Exclude repos based on Context filters from default mention items

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Added
 
 ### Fixed
+- Chat: The @-mentions for workspace repositories, which are added to the input box by default for new messages, now takes context filters into consideration and do not mention the excluded repos. [pull/4427](https://github.com/sourcegraph/cody/pull/4427)
 
 ### Changed
 

--- a/vscode/src/chat/clientStateBroadcaster.ts
+++ b/vscode/src/chat/clientStateBroadcaster.ts
@@ -2,6 +2,7 @@ import {
     type ContextItem,
     ContextItemSource,
     type ContextItemTree,
+    contextFiltersProvider,
     isMultiLineRange,
 } from '@sourcegraph/cody-shared'
 import * as vscode from 'vscode'
@@ -38,6 +39,10 @@ export function startClientStateBroadcaster({
             // would return.
             const repos = remoteSearch.getRepos('all')
             for (const repo of repos) {
+                if (contextFiltersProvider.isRepoNameIgnored(repo.name)) {
+                    continue
+                }
+
                 items.push({
                     ...contextItemMentionFromOpenCtxItem(
                         createRemoteRepositoryMention({


### PR DESCRIPTION
By default, the input box for new messages contains @-mention chips for the repos opened in the workspace.

But it doesn't care if the repo is excluded based on Context Filters. 

This PR takes care of that. 

## Test plan

Loom: https://www.loom.com/share/3c7ff06d5b3d4128a1946bd492b4c486?sid=a53e2142-4ec6-4ea1-bdb4-28f5e59fe510