### PR TITLE
Edit: preserve intent context

### DIFF
--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -5,451 +5,6 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: dc8be216269fcd82f7dcc12b2be5a112
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2598
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: document-code / v1
-          - name: traceparent
-            value: 00-06d29a9b5e68440d4a870c24604148e9-20a14d1cec3d13e0-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/TestClass.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }</SELECTEDCODE7662>
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-haiku-20240307
-            stopSequences:
-              - </CODE5711>
-              - public functionName() {
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: document-code
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
-      response:
-        bodySize: 2414
-        content:
-          mimeType: text/event-stream
-          size: 2414
-          text: >+
-            event: completion
-
-            data: {"completion":"/**\n * Logs a greeting message to the console if the shouldGreet property is true.\n */","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 28 May 2024 10:20:17 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "22"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-28T10:20:16.053Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 347b9435ce7582d47cbf5068362b6051
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2562
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: document-code / v1
-          - name: traceparent
-            value: 00-c607d32944847d507871dbf51255125d-e6c6e78d576d62d1-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/TestLogger.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }</SELECTEDCODE7662>
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-haiku-20240307
-            stopSequences:
-              - </CODE5711>
-              - function recordLog() {
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: document-code
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
-      response:
-        bodySize: 1037
-        content:
-          mimeType: text/event-stream
-          size: 1037
-          text: >+
-            event: completion
-
-            data: {"completion":"\n/**\n * Records a log message.\n */\n","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 28 May 2024 10:20:18 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "21"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-28T10:20:17.212Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 0c796620434faa4c24ed821525bd033c
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2544
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: document-code / v1
-          - name: traceparent
-            value: 00-38ae6c5f8d7e89fc02a15fc532f0a468-f1c32657ddb67604-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/example.test.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>const startTime = performance.now(/* CURSOR */)</SELECTEDCODE7662>
-
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-haiku-20240307
-            stopSequences:
-              - </CODE5711>
-              - const startTime = performance.now(/* CURSOR */)
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: document-code
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
-      response:
-        bodySize: 5165
-        content:
-          mimeType: text/event-stream
-          size: 5165
-          text: >+
-            event: completion
-
-            data: {"completion":"/**\n * Gets the current time in milliseconds since the DOM was loaded.\n * @returns {number} The time in milliseconds since the DOM was loaded.\n */","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Tue, 28 May 2024 10:20:19 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "19"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1405
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-28T10:20:18.349Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: 281086a3fa49ce7164441b752dad6975
       _order: 0
       cache: {}
@@ -737,6 +292,512 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-05-30T07:28:12.765Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 8a306f14a637d39fe8102df78e37c945
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2857
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: document-code / v1
+          - name: traceparent
+            value: 00-04a341531d89d9a5df4b958c286739d5-81962667692feb98-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: "Codebase context from file path src/TestClass.ts: Codebase context from
+                  file src/TestClass.ts:
+
+                  t foo = 42
+
+
+                  export class TestClass {
+
+                  \    constructor(private shouldGreet:
+                  boolean) {}
+
+
+                  \    "
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/TestClass.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }</SELECTEDCODE7662>
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-haiku-20240307
+            stopSequences:
+              - </CODE5711>
+              - public functionName() {
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: document-code
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
+      response:
+        bodySize: 3144
+        content:
+          mimeType: text/event-stream
+          size: 3144
+          text: >+
+            event: completion
+
+            data: {"completion":"/**\n * Logs the message 'Hello World!' to the console if the `shouldGreet` flag is true.\n */","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 03 Jun 2024 06:40:51 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-03T06:40:50.398Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 6f992ec32ed067e7ff4b66a789081379
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2827
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: document-code / v1
+          - name: traceparent
+            value: 00-20a668bb76ef51c60d1f12b6c3884f70-cc85c53cbd2630c9-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: "Codebase context from file path src/TestLogger.ts: Codebase context from
+                  file src/TestLogger.ts:
+
+                  o = 42
+
+                  export const TestLogger = {
+
+                  \    startLogging: () => {
+
+                  \        // Do some stuff
+
+
+                  \        "
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/TestLogger.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>function recordLog() {
+                              console.log(/* CURSOR */ 'Recording the log')
+                          }</SELECTEDCODE7662>
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-haiku-20240307
+            stopSequences:
+              - </CODE5711>
+              - function recordLog() {
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: document-code
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
+      response:
+        bodySize: 915
+        content:
+          mimeType: text/event-stream
+          size: 915
+          text: >+
+            event: completion
+
+            data: {"completion":"/**\n * Records a log message.\n */","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 03 Jun 2024 06:40:53 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-03T06:40:51.865Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: ee280acc70ef02924a1caa02d95637fc
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3098
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: document-code / v1
+          - name: traceparent
+            value: 00-ea8db51308607265118877e699c96d00-b737a7c6dca0ddad-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: "Codebase context from file path src/example.test.ts: Codebase context
+                  from file src/example.test.ts:
+
+                  \ expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+
+                  \    it('does 1', () => {
+
+                  \        expect(true).toBe(true)
+
+                  \    })
+
+
+                  \    it('does 2', () => {
+
+                  \        expect(true).toBe(true)
+
+                  \    })
+
+
+                  \    it('does something else', () => {
+
+                  \        // This line will error due to
+                  incorrect usage of `performance.now`
+
+                  \        "
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/example.test.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>const startTime = performance.now(/* CURSOR */)</SELECTEDCODE7662>
+
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-haiku-20240307
+            stopSequences:
+              - </CODE5711>
+              - const startTime = performance.now(/* CURSOR */)
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: document-code
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
+      response:
+        bodySize: 5686
+        content:
+          mimeType: text/event-stream
+          size: 5686
+          text: >+
+            event: completion
+
+            data: {"completion":"/**\n * Gets the current time in milliseconds.\n * This value can be used to measure elapsed time.\n * \n * @returns The current time in milliseconds.\n */","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 03 Jun 2024 06:40:54 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-03T06:40:53.106Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/edit_1541920145/recording.har.yaml
+++ b/agent/recordings/edit_1541920145/recording.har.yaml
@@ -153,11 +153,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 51f0c8d5ac3b8449a254b5b440d28bcb
+    - _id: 1909c976e8824195d44217c44b1851d5
       _order: 0
       cache: {}
       request:
-        bodySize: 2064
+        bodySize: 2307
         cookies: []
         headers:
           - name: content-type
@@ -170,7 +170,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-9e3de3063f4d6bf1bd5aec382b2e5f52-fff948d38d3908b3-01
+            value: 00-2f9574986ae9823103630e8c6d1a5409-da06396838473f1e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -205,6 +205,17 @@ log:
                   - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
 
                   - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >+
+                  Codebase context from file path src/ChatColumn.tsx: Codebase
+                  context from file src/ChatColumn.tsx:
+
+                  import { useEffect } from "react";
+
+                  import React = require("react");
+
+              - speaker: assistant
+                text: Ok.
               - speaker: human
                 text: >-
                   This is part of the file: src/ChatColumn.tsx
@@ -245,14 +256,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 18673
+        bodySize: 10356
         content:
           mimeType: text/event-stream
-          size: 18673
+          size: 10356
           text: >+
             event: completion
 
-            data: {"completion":"interface Message {\n  id: string;\n  text: string;\n  sender: 'user' | 'assistant';\n}\n\ninterface ChatColumnProps {\n  messages: Message[];\n  setChatID: (chatID: string) =\u003e void;\n  isLoading: boolean;\n}\n\nexport default function ChatColumn({\n  messages,\n  setChatID,\n  isLoading,\n}: ChatColumnProps) {","stopReason":"stop_sequence"}
+            data: {"completion":"export default function ChatColumn({\n\tmessages,\n\tsetChatID,\n\tisLoading,\n}: ChatColumnProps) {\ninterface ChatColumnProps {\n  messages: Message[];\n  setChatID: (id: string) =\u003e void;\n  isLoading: boolean;\n}","stopReason":"stop_sequence"}
 
 
             event: done
@@ -262,7 +273,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 27 May 2024 11:54:10 GMT
+            value: Mon, 03 Jun 2024 06:44:18 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -291,7 +302,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-27T11:54:08.267Z
+      startedDateTime: 2024-06-03T06:44:16.693Z
       time: 0
       timings:
         blocked: -1
@@ -301,11 +312,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 64caf07ff8d919b37c5ce88b548491bc
+    - _id: 24310be04faaebe4336c6508f077d736
       _order: 0
       cache: {}
       request:
-        bodySize: 2127
+        bodySize: 2803
         cookies: []
         headers:
           - name: content-type
@@ -318,7 +329,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-04e049d9c6486ea5014eab87be8094f3-c29a42facd70bd62-01
+            value: 00-134781e7f30d249ccbd49a5775c7fe9a-1bb5a14b960461f0-01
           - name: connection
             value: keep-alive
           - name: host
@@ -353,6 +364,28 @@ log:
                   - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
 
                   - Do not provide any additional commentary about the code you added. Only respond with the generated code.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/Heading.tsx: Below is the
+                  code from file path src/Heading.tsx. Review the code outside
+                  the XML tags to detect the functionality, formats, style,
+                  patterns, and logics in use. Then, use what you detect and
+                  reuse methods/libraries to complete and enclose completed code
+                  only inside XML tags precisely without duplicating existing
+                  implementations. Here is the code:
+
+                  <PRECEDINGCODE3493>import React = require("react");
+
+
+                  interface HeadingProps {
+                      text: string;
+                      level?: number;
+                  }
+
+
+                  </PRECEDINGCODE3493><CODE5711></CODE5711><FOLLOWINGCODE2472></FOLLOWINGCODE2472>
+              - speaker: assistant
+                text: Ok.
               - speaker: human
                 text: >-
                   The user is currently in the file: src/Heading.tsx
@@ -390,14 +423,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 10253
+        bodySize: 9561
         content:
           mimeType: text/event-stream
-          size: 10253
+          size: 9561
           text: >+
             event: completion
 
-            data: {"completion":"export const Heading: React.FC\u003cHeadingProps\u003e = ({ text, level = 1 }) =\u003e {\n    const HTag = `h${level}` as keyof JSX.IntrinsicElements;\n    return \u003cHTag\u003e{text}\u003c/HTag\u003e;\n};\n","stopReason":"stop_sequence"}
+            data: {"completion":"export const Heading: React.FC\u003cHeadingProps\u003e = ({ text, level = 1 }) =\u003e {\n    const Tag = `h${level}` as keyof JSX.IntrinsicElements;\n    return \u003cTag\u003e{text}\u003c/Tag\u003e;\n};","stopReason":"stop_sequence"}
 
 
             event: done
@@ -407,7 +440,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 27 May 2024 11:54:15 GMT
+            value: Mon, 03 Jun 2024 06:44:24 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -436,7 +469,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-27T11:54:12.584Z
+      startedDateTime: 2024-06-03T06:44:20.473Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -110,11 +110,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 01ca4864b06e9f4ea98e7b852d41ce90
+    - _id: 6f1970fd67cf4b74be4fd8cbcfd5517e
       _order: 0
       cache: {}
       request:
-        bodySize: 2627
+        bodySize: 3181
         cookies: []
         headers:
           - name: content-type
@@ -127,7 +127,7 @@ log:
           - name: user-agent
             value: enterpriseClient / v1
           - name: traceparent
-            value: 00-39a4712b5ef22a0a56522c628d4d690b-0543916a0d5b3bbe-01
+            value: 00-56a95a6d6c23d114b59bc91ee7b8987c-73031c7b67180e76-01
           - name: connection
             value: keep-alive
           - name: host
@@ -165,6 +165,41 @@ log:
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
+                text: "Codebase context from file path src/example.test.ts: Codebase context
+                  from file src/example.test.ts:
+
+                  \ expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+
+                  \    it('does 1', () => {
+
+                  \        expect(true).toBe(true)
+
+                  \    })
+
+
+                  \    it('does 2', () => {
+
+                  \        expect(true).toBe(true)
+
+                  \    })
+
+
+                  \    it('does something else', () => {
+
+                  \        // This line will error due to
+                  incorrect usage of `performance.now`
+
+                  \        "
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
                 text: >-
                   This is part of the file: src/example.test.ts
 
@@ -199,10 +234,10 @@ log:
             value: v1
         url: https://demo.sourcegraph.com/.api/completions/stream?client-name=enterpriseclient&client-version=v1
       response:
-        bodySize: 2307
+        bodySize: 1666
         content:
           mimeType: text/event-stream
-          size: 2307
+          size: 1666
           text: >+
             event: completion
 
@@ -226,92 +261,67 @@ log:
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp","stopReason":""}
+            data: {"completion":"/**\n * The starting","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp,","stopReason":""}
+            data: {"completion":"/**\n * The starting time","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in","stopReason":""}
+            data: {"completion":"/**\n * The starting time of","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in millis","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the operation","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds,","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the operation,","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the operation, in","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the operation, in millis","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the operation, in milliseconds","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this pe","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the operation, in milliseconds.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this perf","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the operation, in milliseconds.\n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this perf tr","stopReason":""}
+            data: {"completion":"/**\n * The starting time of the operation, in milliseconds.\n */","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this perf tracing","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this perf tracing starte","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this perf tracing started.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this perf tracing started.\n ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this perf tracing started.\n */","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"/**\n * The timestamp, in milliseconds, at which this perf tracing started.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * The starting time of the operation, in milliseconds.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -321,7 +331,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 30 May 2024 07:28:13 GMT
+            value: Mon, 03 Jun 2024 06:12:15 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -350,7 +360,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-30T07:28:10.826Z
+      startedDateTime: 2024-06-03T06:12:13.151Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -38,7 +38,7 @@ export class TestClass {
     constructor(private shouldGreet: boolean) {}
 
     /**
-     * Logs a greeting message to the console if the shouldGreet property is true.
+     * Logs the message 'Hello World!' to the console if the \`shouldGreet\` flag is true.
      */
     public functionName() {
         if (this.shouldGreet) {
@@ -66,8 +66,10 @@ describe('test block', () => {
     it('does something else', () => {
         // This line will error due to incorrect usage of \`performance.now\`
         /**
-         * Gets the current time in milliseconds since the DOM was loaded.
-         * @returns {number} The time in milliseconds since the DOM was loaded.
+         * Gets the current time in milliseconds.
+         * This value can be used to measure elapsed time.
+         * 
+         * @returns The current time in milliseconds.
          */
         const startTime = performance.now(/* CURSOR */)
     })

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -62,23 +62,16 @@ describe('Edit', () => {
           "import { useEffect } from "react";
           import React = require("react");
 
-          interface Message {
-            id: string;
-            text: string;
-            sender: 'user' | 'assistant';
-          }
-
+          export default function ChatColumn({
+          	messages,
+          	setChatID,
+          	isLoading,
+          }: ChatColumnProps) {
           interface ChatColumnProps {
             messages: Message[];
-            setChatID: (chatID: string) => void;
+            setChatID: (id: string) => void;
             isLoading: boolean;
           }
-
-          export default function ChatColumn({
-            messages,
-            setChatID,
-            isLoading,
-          }: ChatColumnProps) {
           	useEffect(() => {
           		if (!isLoading) {
           			setChatID(messages[0].chatID);
@@ -120,10 +113,9 @@ describe('Edit', () => {
           }
 
           export const Heading: React.FC<HeadingProps> = ({ text, level = 1 }) => {
-              const HTag = \`h\${level}\` as keyof JSX.IntrinsicElements;
-              return <HTag>{text}</HTag>;
+              const Tag = \`h\${level}\` as keyof JSX.IntrinsicElements;
+              return <Tag>{text}</Tag>;
           };
-
           "
         `,
             explainPollyError

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -977,7 +977,7 @@ describe('Agent', () => {
                   it('does something else', () => {
                       // This line will error due to incorrect usage of \`performance.now\`
                       /**
-                       * The timestamp, in milliseconds, at which this perf tracing started.
+                       * The starting time of the operation, in milliseconds.
                        */
                       const startTime = performance.now(/* CURSOR */)
                   })

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -18,6 +18,7 @@ import type { EditIntent } from '../types'
 import { truncatePromptString, truncatePromptStringStart } from '@sourcegraph/cody-shared'
 import { resolveContextItems } from '../../editor/utils/editor-context'
 import { PROMPT_TOPICS } from './constants'
+import { extractContextItemsFromContextMessages } from './utils'
 
 interface GetContextFromIntentOptions {
     intent: EditIntent
@@ -141,7 +142,7 @@ export const getContext = async ({
     userContextItems,
     editor,
     ...options
-}: GetContextOptions): Promise<(ContextItem | ContextMessage)[]> => {
+}: GetContextOptions): Promise<ContextItem[]> => {
     if (isAgentTesting) {
         // Need deterministic ordering of context files for the tests to pass
         // consistently across different file systems.
@@ -150,5 +151,5 @@ export const getContext = async ({
 
     const derivedContext = await getContextFromIntent({ editor, ...options })
     const userContext = await resolveContextItems(editor, userContextItems, options.selectedText)
-    return [...derivedContext, ...userContext]
+    return [...extractContextItemsFromContextMessages(derivedContext), ...userContext]
 }

--- a/vscode/src/edit/prompt/index.ts
+++ b/vscode/src/edit/prompt/index.ts
@@ -124,7 +124,7 @@ export const buildInteraction = async ({
     }
     promptBuilder.tryAddMessages(transcript.reverse())
 
-    const contextItemsAndMessages = await getContext({
+    const contextItems = await getContext({
         intent: task.intent,
         uri: task.fixupFile.uri,
         selectionRange: task.selectionRange,
@@ -134,7 +134,7 @@ export const buildInteraction = async ({
         precedingText,
         selectedText,
     })
-    await promptBuilder.tryAddContext('user', contextItemsAndMessages)
+    await promptBuilder.tryAddContext('user', contextItems)
 
     return {
         messages: promptBuilder.build(),

--- a/vscode/src/edit/prompt/utils.ts
+++ b/vscode/src/edit/prompt/utils.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode'
+
+import type { ContextItem, ContextMessage } from '@sourcegraph/cody-shared'
+
+type ExtractableContextMessage = Required<Pick<ContextMessage, 'file'>> & ContextMessage
+
+const contextMessageToContextItem = ({ text, file }: ExtractableContextMessage): ContextItem => {
+    return {
+        type: 'file',
+        content: text.toString(),
+        range: file.range
+            ? new vscode.Range(
+                  new vscode.Position(file.range.start.line, file.range.start.character),
+                  new vscode.Position(file.range.end.line, file.range.end.character)
+              )
+            : undefined,
+        repoName: file.repoName,
+        revision: file.revision,
+        source: file.source,
+        title: file.title,
+        uri: file.uri,
+    }
+}
+
+const contextMessageIsExtractable = (
+    contextMessage: ContextMessage
+): contextMessage is ExtractableContextMessage => {
+    return contextMessage.file !== undefined
+}
+
+/**
+ * Extract `ContextItems` from `ContextMessages` for interoperability
+ * between existing context mechanisms in the codebase.
+ *
+ * TODO: These types are ultimately very similar, we should refactor this so we
+ * can avoid maintaining both types.
+ */
+export const extractContextItemsFromContextMessages = (
+    contextMessages: ContextMessage[]
+): ContextItem[] => {
+    return contextMessages.filter(contextMessageIsExtractable).map(contextMessageToContextItem)
+}

--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ContextItem, ContextMessage, Message } from '@sourcegraph/cody-shared'
+import type { ContextItem, Message } from '@sourcegraph/cody-shared'
 import {
     type ChatMessage,
     ContextItemSource,
@@ -26,8 +26,7 @@ describe('PromptBuilder', () => {
             content: 'foobar',
             size: 100,
         }
-        const transcript: ContextMessage[] = [{ speaker: 'human', file, text: ps`` }]
-        expect(() => builder.tryAddContext('enhanced', transcript.reverse())).rejects.toThrowError()
+        expect(() => builder.tryAddContext('enhanced', [file])).rejects.toThrowError()
     })
 
     it('throws an error when trying to add User Context before chat input', () => {
@@ -39,8 +38,7 @@ describe('PromptBuilder', () => {
             content: 'foobar',
             size: 100,
         }
-        const transcript: ContextMessage[] = [{ speaker: 'human', file, text: ps`` }]
-        expect(() => builder.tryAddContext('user', transcript.reverse())).rejects.toThrowError()
+        expect(() => builder.tryAddContext('user', [file])).rejects.toThrowError()
     })
 
     describe('tryAddToPrefix', () => {
@@ -170,10 +168,6 @@ describe('PromptBuilder', () => {
             content: 'foo',
         }
 
-        function generateContextTranscript(contextItems: ContextItem[]): ContextMessage[] {
-            return contextItems.map(file => ({ speaker: 'human', file, text: ps`` }))
-        }
-
         it('should not allow context prompt to exceed context window', async () => {
             const builder = new PromptBuilder({ input: 10, output: 100 })
             builder.tryAddToPrefix(preamble)
@@ -208,13 +202,12 @@ describe('PromptBuilder', () => {
                 source: ContextItemSource.User,
             }
 
-            // Context should onlt be added once even when provided twice.
-            const contextTranscript = generateContextTranscript([file, file])
-            await builder.tryAddContext('user', contextTranscript.reverse())
+            // Context should only be added once even when provided twice.
+            await builder.tryAddContext('user', [file, file])
             expect(builder.contextItems.length).toBe(1)
         })
 
-        it('should not contains non-unique context (context with overlapping ranges)', async () => {
+        it('should not contain non-unique context (context with overlapping ranges)', async () => {
             const builder = new PromptBuilder({ input: 100, output: 100 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
@@ -225,19 +218,18 @@ describe('PromptBuilder', () => {
                 source: ContextItemSource.User,
             }
 
-            const outterRange: ContextItem = {
+            const outerRange: ContextItem = {
                 ...fileWithSameUri,
                 range: { start: { line: 0, character: 0 }, end: { line: 10, character: 1 } },
                 source: ContextItemSource.User,
             }
-            const contextTranscript = generateContextTranscript([innerRange, outterRange])
-            await builder.tryAddContext('user', contextTranscript.reverse())
+            await builder.tryAddContext('user', [innerRange, outerRange])
             expect(builder.contextItems.length).toBe(1)
-            expect(builder.contextItems).toStrictEqual([outterRange])
+            expect(builder.contextItems).toStrictEqual([outerRange])
         })
 
-        it('should not contains context that is too large', async () => {
-            const builder = new PromptBuilder({ input: 10, output: 10 })
+        it('should not contain context that is too large', async () => {
+            const builder = new PromptBuilder({ input: 50, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -247,7 +239,7 @@ describe('PromptBuilder', () => {
                 source: ContextItemSource.Embeddings,
             }
 
-            const outterRange: ContextItem = {
+            const outerRange: ContextItem = {
                 ...fileWithSameUri,
                 size: 100,
                 content: 'This is a file that exceeds the token limit',
@@ -256,17 +248,21 @@ describe('PromptBuilder', () => {
                 isTooLarge: true,
             }
 
-            const contextTranscript = generateContextTranscript([innerRange, outterRange, innerRange])
-            const { limitReached, ignored } = await builder.tryAddContext('enhanced', contextTranscript)
-            // Outter range should be ignored because it exceeds the token limit,
+            const { limitReached, ignored } = await builder.tryAddContext('enhanced', [
+                innerRange,
+                outerRange,
+                innerRange,
+            ])
+
+            // Outer range should be ignored because it exceeds the token limit,
             // and should not be added to the final context items list.
             expect(limitReached).toBeTruthy()
-            expect(ignored).toEqual([outterRange])
+            expect(ignored).toEqual([outerRange])
             expect(builder.contextItems).toStrictEqual([innerRange])
         })
 
         it('should remove context with overlapping ranges when full file is provided', async () => {
-            const builder = new PromptBuilder({ input: 10, output: 10 })
+            const builder = new PromptBuilder({ input: 50, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -284,14 +280,17 @@ describe('PromptBuilder', () => {
                 isTooLarge: true,
             }
 
-            const contextTranscript = generateContextTranscript([partialFile, fullFile, partialFile])
-            const { limitReached } = await builder.tryAddContext('user', contextTranscript)
+            const { limitReached } = await builder.tryAddContext('user', [
+                partialFile,
+                fullFile,
+                partialFile,
+            ])
             expect(limitReached).toBeFalsy()
             expect(builder.contextItems).toStrictEqual([fullFile])
         })
 
         it('should not remove user-added with overlapping ranges even when full file is provided', async () => {
-            const builder = new PromptBuilder({ input: 10, output: 10 })
+            const builder = new PromptBuilder({ input: 50, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -309,14 +308,17 @@ describe('PromptBuilder', () => {
                 isTooLarge: true,
             }
 
-            const contextTranscript = generateContextTranscript([selection, fullFile, selection])
-            const { limitReached } = await builder.tryAddContext('user', contextTranscript)
+            const { limitReached } = await builder.tryAddContext('user', [
+                selection,
+                fullFile,
+                selection,
+            ])
             expect(limitReached).toBeFalsy()
             expect(builder.contextItems).toStrictEqual([selection, fullFile])
         })
 
         it('should deduplicate context from different token usage types', async () => {
-            const builder = new PromptBuilder({ input: 10, output: 10 })
+            const builder = new PromptBuilder({ input: 50, output: 50 })
             builder.tryAddToPrefix(preamble)
             builder.tryAddMessages([...chatTranscript].reverse())
 
@@ -334,24 +336,51 @@ describe('PromptBuilder', () => {
                 isTooLarge: true,
             }
 
-            const userContext = generateContextTranscript([selection])
-            const user = await builder.tryAddContext('user', userContext)
+            const user = await builder.tryAddContext('user', [selection])
             expect(builder.contextItems).toStrictEqual([selection])
             expect(user.limitReached).toBeFalsy()
             expect(user.added).toStrictEqual([selection])
 
-            const historyContext = generateContextTranscript([fullFile])
-            const history = await builder.tryAddContext('history', historyContext)
+            const history = await builder.tryAddContext('history', [fullFile])
             expect(history.limitReached).toBeFalsy()
             expect(history.added).toStrictEqual([fullFile])
 
-            const enhancedContext = generateContextTranscript([selection, fullFile])
-            const enhanced = await builder.tryAddContext('enhanced', enhancedContext)
+            const enhanced = await builder.tryAddContext('enhanced', [selection, fullFile])
             expect(enhanced.limitReached).toBeFalsy()
             expect(enhanced.added).toStrictEqual([])
 
             // The final context items should only contain the selection and full file.
             expect(builder.contextItems).toStrictEqual([selection, fullFile])
+        })
+
+        it('preserves context items content', async () => {
+            const builder = new PromptBuilder({ input: 100, output: 100 })
+            builder.tryAddToPrefix(preamble)
+            builder.tryAddMessages([...chatTranscript].reverse())
+
+            const file: ContextItem = {
+                ...fileWithSameUri,
+                range: { start: { line: 0, character: 0 }, end: { line: 1, character: 1 } },
+                source: ContextItemSource.User,
+            }
+
+            // Context should only be added once even when provided twice.
+            await builder.tryAddContext('user', [file, file])
+            const promptContent = builder
+                .build()
+                .map(item => item.text)
+                .join('\n')
+
+            expect(builder.contextItems.length).toBe(1)
+            expect(promptContent).toMatchInlineSnapshot(`
+              "preamble
+              Codebase context from file foo/bar.go:
+              \`\`\`go
+              foo\`\`\`
+              Ok.
+              Hi!
+              Hi!"
+            `)
         })
     })
 })

--- a/vscode/src/prompt-builder/index.ts
+++ b/vscode/src/prompt-builder/index.ts
@@ -1,7 +1,6 @@
 import {
     type ChatMessage,
     type ContextItem,
-    type ContextMessage,
     type Message,
     type ModelContextWindow,
     TokenCounter,
@@ -20,6 +19,7 @@ interface PromptBuilderContextResult {
     added: ContextItem[]
 }
 
+const ASSISTANT_MESSAGE = { speaker: 'assistant', text: ps`Ok.` } as Message
 /**
  * PromptBuilder constructs a full prompt given a charLimit constraint.
  * The final prompt is constructed by concatenating the following fields:
@@ -42,12 +42,11 @@ export class PromptBuilder {
     }
 
     public build(): Message[] {
-        // Create context messages for each context item, where
-        // assistant messages come first because the transcript is in reversed order.
-        const assistantMessage = { speaker: 'assistant', text: ps`Ok.` } as Message
         for (const item of this.contextItems) {
+            // Create context messages for each context item, where
+            // assistant messages come first because the transcript is in reversed order.
             const contextMessage = renderContextItem(item)
-            const messagePair = contextMessage && [assistantMessage, contextMessage]
+            const messagePair = contextMessage && [ASSISTANT_MESSAGE, contextMessage]
             messagePair && this.reverseMessages.push(...messagePair)
         }
 
@@ -93,7 +92,7 @@ export class PromptBuilder {
 
     public async tryAddContext(
         type: ContextTokenUsageType | 'history',
-        contextMessages: (ContextItem | ContextMessage)[]
+        contextItems: ContextItem[]
     ): Promise<PromptBuilderContextResult> {
         // Turn-based context items that are used for UI display only.
         const result = {
@@ -104,65 +103,63 @@ export class PromptBuilder {
 
         // Create a new array to avoid modifying the original array,
         // then reverse it to process the newest context items first.
-        const reversedContextItems = contextMessages.slice().reverse()
+        const reversedContextItems = contextItems.slice().reverse()
 
         // Required by agent tests to ensure the context items are sorted correctly.
         sortContextItems(reversedContextItems as ContextItem[])
 
         for (const item of reversedContextItems) {
-            const newContextItem = contextItem(item)
             // Skip context items that are in the Cody ignore list
-            if (isCodyIgnoredFile(newContextItem.uri)) {
-                result.ignored.push(newContextItem)
+            if (isCodyIgnoredFile(item.uri) || (await contextFiltersProvider.isUriIgnored(item.uri))) {
+                result.ignored.push(item)
                 continue
             }
-            if (await contextFiltersProvider.isUriIgnored(newContextItem.uri)) {
-                result.ignored.push(newContextItem)
-                continue
-            }
+
             // Special-case remote context here. We can usually rely on the remote context to honor
             // any context filters but in case of client side overwrites, we want a file that is
             // ignored on a client to always be treated as ignored.
             if (
-                newContextItem.type === 'file' &&
-                (newContextItem.uri.scheme === 'https' || newContextItem.uri.scheme === 'http') &&
-                newContextItem.repoName &&
-                contextFiltersProvider.isRepoNameIgnored(newContextItem.repoName)
+                item.type === 'file' &&
+                (item.uri.scheme === 'https' || item.uri.scheme === 'http') &&
+                item.repoName &&
+                contextFiltersProvider.isRepoNameIgnored(item.repoName)
             ) {
-                result.ignored.push(newContextItem)
+                result.ignored.push(item)
                 continue
             }
 
-            const contextMessage = isContextItem(item) ? renderContextItem(item) : item
+            const contextMessage = renderContextItem(item)
             if (!contextMessage) {
                 continue
             }
 
             // Skip duplicated or invalid items before updating the token usage.
-            if (!isUniqueContextItem(newContextItem, this.contextItems)) {
+            if (!isUniqueContextItem(item, this.contextItems)) {
                 continue
             }
 
-            const messagePair = [{ speaker: 'assistant', text: ps`Ok.` } as Message, contextMessage]
-            const tokenType = getContextItemTokenUsageType(newContextItem)
-            const isWithinLimit = this.tokenCounter.updateUsage(tokenType, messagePair)
+            const tokenType = getContextItemTokenUsageType(item)
+            const isWithinLimit = this.tokenCounter.updateUsage(tokenType, [
+                ASSISTANT_MESSAGE,
+                contextMessage,
+            ])
 
             // Don't update context items from the past (history items) unless undefined.
-            if (type !== 'history' || newContextItem.isTooLarge === undefined) {
-                newContextItem.isTooLarge = !isWithinLimit
+            if (type !== 'history' || item.isTooLarge === undefined) {
+                item.isTooLarge = !isWithinLimit
             }
 
             // Skip item that would exceed token limit & add it to the ignored list.
             if (!isWithinLimit) {
-                newContextItem.content = undefined
-                result.ignored.push(newContextItem)
+                item.content = undefined
+                result.ignored.push(item)
                 result.limitReached = true
                 continue
             }
 
             // Add the new valid context item to the context list.
-            result.added.push(newContextItem) // for UI display.
-            this.contextItems.push(newContextItem) // for building context messages.
+            result.added.push(item) // for UI display.
+            this.contextItems.push(item) // for building context messages.
             // Update context items for the next iteration, removes items that are no longer unique.
             // TODO (bee) update token usage to reflect the removed context items.
             this.contextItems = getUniqueContextItems(this.contextItems)
@@ -171,12 +168,4 @@ export class PromptBuilder {
         result.added = this.contextItems.filter(c => result.added.includes(c))
         return result
     }
-}
-
-function isContextItem(value: ContextItem | ContextMessage): value is ContextItem {
-    return 'uri' in value && 'type' in value && !('speaker' in value)
-}
-
-function contextItem(value: ContextItem | ContextMessage): ContextItem {
-    return isContextItem(value) ? value : value.file
 }


### PR DESCRIPTION
- https://github.com/sourcegraph/cody/pull/3307 removed `extractContextItemsFromContextMessages` and replaced it with `isContextItem(value) ? value : value.file` which removes context items content from the final prompt. 

## Test plan

1. Updated and added unit tests
2. Tested locally by triggering the `doc` command on the function in the middle of the file. You should observe document prefix and suffix being added to the prompt in the Cody output channel.
