### PR TITLE
only run guardrails when message is finished loading

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent.tsx
@@ -21,6 +21,7 @@ export interface CodeBlockActionsProps {
 
 interface ChatMessageContentProps {
     displayMarkdown: string
+    isMessageLoading: boolean
 
     copyButtonOnSubmit?: CodeBlockActionsProps['copyButtonOnSubmit']
     insertButtonOnSubmit?: CodeBlockActionsProps['insertButtonOnSubmit']
@@ -237,6 +238,7 @@ class GuardrailsStatusController {
  */
 export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps> = ({
     displayMarkdown,
+    isMessageLoading,
     copyButtonOnSubmit,
     insertButtonOnSubmit,
     guardrails,
@@ -269,27 +271,29 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                     container.classList.add(styles.attributionContainer)
                     buttons.append(container)
 
-                    const g = new GuardrailsStatusController(container)
-                    g.setPending()
+                    if (!isMessageLoading) {
+                        const g = new GuardrailsStatusController(container)
+                        g.setPending()
 
-                    guardrails
-                        .searchAttribution(preText)
-                        .then(attribution => {
-                            if (isError(attribution)) {
-                                g.setUnavailable(attribution)
-                            } else if (attribution.repositories.length === 0) {
-                                g.setSuccess()
-                            } else {
-                                g.setFailure(
-                                    attribution.repositories.map(r => r.name),
-                                    attribution.limitHit
-                                )
-                            }
-                        })
-                        .catch(error => {
-                            g.setUnavailable(error)
-                            return
-                        })
+                        guardrails
+                            .searchAttribution(preText)
+                            .then(attribution => {
+                                if (isError(attribution)) {
+                                    g.setUnavailable(attribution)
+                                } else if (attribution.repositories.length === 0) {
+                                    g.setSuccess()
+                                } else {
+                                    g.setFailure(
+                                        attribution.repositories.map(r => r.name),
+                                        attribution.limitHit
+                                    )
+                                }
+                            })
+                            .catch(error => {
+                                g.setUnavailable(error)
+                                return
+                            })
+                    }
                 }
 
                 // Insert the buttons after the pre using insertBefore() because there is no insertAfter()
@@ -303,7 +307,7 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
                 })
             }
         }
-    }, [copyButtonOnSubmit, insertButtonOnSubmit, guardrails, displayMarkdown])
+    }, [copyButtonOnSubmit, insertButtonOnSubmit, guardrails, displayMarkdown, isMessageLoading])
 
     usePreserveSelectionOnUpdate(rootRef, [displayMarkdown])
 

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -89,6 +89,7 @@ export const AssistantMessageCell: FunctionComponent<{
                     {displayMarkdown ? (
                         <ChatMessageContent
                             displayMarkdown={displayMarkdown}
+                            isMessageLoading={isLoading}
                             copyButtonOnSubmit={copyButtonOnSubmit}
                             insertButtonOnSubmit={insertButtonOnSubmit}
                             guardrails={guardrails}


### PR DESCRIPTION
This avoids many unnecessary guardrails requests while the message is still in progress.



## Test plan

CI, and set logpoint to ensure that the `isMessageLoading` check ensures it's only run at the end of the message being received.