### PR TITLE
Agent: fix out of bounds document offsets

### DIFF
--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -5,6 +5,212 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
+    - _id: 63d9ee7ab3b16c922af2cc52dfdcef75
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3493
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: document-code / v1
+          - name: traceparent
+            value: 00-e0e1c36b435b8127953f546debd8807b-54748fe199317768-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: "Codebase context from file path src/TestClass.ts: Codebase context from
+                  file src/TestClass.ts:
+
+                  t foo = 42
+
+                  // Should be present in the LLM prompt
+
+                  const longPrefix = `
+
+                  \    longPrefix content
+
+                  \    longPrefix content
+
+                  \    longPrefix content
+
+                  \    longPrefix content
+
+                  \    longPrefix content
+
+                  \    longPrefix content
+
+                  \    longPrefix content
+
+                  `
+
+
+                  export class TestClass {
+
+                  \    constructor(private shouldGreet:
+                  boolean) {}
+
+
+                  \    "
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/TestClass.ts: Codebase
+                  context from file src/TestClass.ts:
+
+
+                  }
+
+
+                  // Should be present in the LLM prompt
+
+                  const longSuffix = `
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                  `
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/TestClass.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }</SELECTEDCODE7662>
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-haiku-20240307
+            stopSequences:
+              - </CODE5711>
+              - public functionName() {
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: document-code
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
+      response:
+        bodySize: 2750
+        content:
+          mimeType: text/event-stream
+          size: 2750
+          text: >+
+            event: completion
+
+            data: {"completion":"/**\n * Logs 'Hello World!' to the console if the `shouldGreet` property is true.\n */","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 03 Jun 2024 08:13:38 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-03T08:13:36.603Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 281086a3fa49ce7164441b752dad6975
       _order: 0
       cache: {}
@@ -22,7 +228,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-db0ef7f1173f7d4d3cd3a7e1207d1617-357519914dd8c233-01
+            value: 00-29de8950a4a48c0e0be96d0d272b7310-e1520149f9757acc-01
           - name: connection
             value: keep-alive
           - name: host
@@ -96,14 +302,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 9033
+        bodySize: 8357
         content:
           mimeType: text/event-stream
-          size: 9033
+          size: 8357
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Adds two numbers together and returns the result.\n * \n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two input numbers.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Adds two numbers and returns the result.\n *\n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two input numbers.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -113,7 +319,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 07:23:28 GMT
+            value: Mon, 03 Jun 2024 08:14:19 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -142,7 +348,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T07:23:27.244Z
+      startedDateTime: 2024-06-03T08:14:18.643Z
       time: 0
       timings:
         blocked: -1
@@ -152,11 +358,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: c1043fe8de5c169180738a73ec563586
+    - _id: ec4aab0107eed8a8a574b6a79775b6e1
       _order: 0
       cache: {}
       request:
-        bodySize: 2763
+        bodySize: 3028
         cookies: []
         headers:
           - name: content-type
@@ -169,7 +375,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-cd790fdf52c0a9078045f23f4c616b3d-d6b746221df16778-01
+            value: 00-f8961e404f35dd660223576bf311c17c-a93b9af609326741-01
           - name: connection
             value: keep-alive
           - name: host
@@ -204,6 +410,22 @@ log:
                   - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
 
                   - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: "Codebase context from file path src/TestLogger.ts: Codebase context from
+                  file src/TestLogger.ts:
+
+                  o = 42
+
+                  export const TestLogger = {
+
+                  \    startLogging: () => {
+
+                  \        // Do some stuff
+
+
+                  \        "
+              - speaker: assistant
+                text: Ok.
               - speaker: human
                 text: >
                   Codebase context from file path src/TestLogger.ts: Codebase
@@ -270,7 +492,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 07:23:31 GMT
+            value: Mon, 03 Jun 2024 08:14:21 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -299,7 +521,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T07:23:30.161Z
+      startedDateTime: 2024-06-03T08:14:20.229Z
       time: 0
       timings:
         blocked: -1
@@ -309,11 +531,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 5fdc0ae3b7457cb0487c357d2986f4cb
+    - _id: fc7803a3e5566ea112584b8e407485b5
       _order: 0
       cache: {}
       request:
-        bodySize: 2727
+        bodySize: 3281
         cookies: []
         headers:
           - name: content-type
@@ -326,7 +548,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-e1d090353fc3fad02cccfde5cb7bffb0-187df7eab3d9610b-01
+            value: 00-7721ef8a8ba2d80a3b89e38e4430b5e8-a479203a4ad4b1ba-01
           - name: connection
             value: keep-alive
           - name: host
@@ -361,6 +583,41 @@ log:
                   - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
 
                   - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: "Codebase context from file path src/example.test.ts: Codebase context
+                  from file src/example.test.ts:
+
+                  \ expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+
+                  \    it('does 1', () => {
+
+                  \        expect(true).toBe(true)
+
+                  \    })
+
+
+                  \    it('does 2', () => {
+
+                  \        expect(true).toBe(true)
+
+                  \    })
+
+
+                  \    it('does something else', () => {
+
+                  \        // This line will error due to
+                  incorrect usage of `performance.now`
+
+                  \        "
+              - speaker: assistant
+                text: Ok.
               - speaker: human
                 text: >
                   Codebase context from file path src/example.test.ts: Codebase
@@ -407,14 +664,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 5097
+        bodySize: 10553
         content:
           mimeType: text/event-stream
-          size: 5097
+          size: 10553
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Records the current time using the `performance.now()` function.\n * This can be useful for measuring the duration of operations or code sections.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"\n/**\n * Retrieves the current time in milliseconds relative to an arbitrary time in the past.\n * This can be used to measure elapsed time or for performance profiling.\n *\n * @returns {number} The current time in milliseconds.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -424,7 +681,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 07:23:32 GMT
+            value: Mon, 03 Jun 2024 08:14:22 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -453,7 +710,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T07:23:31.394Z
+      startedDateTime: 2024-06-03T08:14:21.343Z
       time: 0
       timings:
         blocked: -1
@@ -480,7 +737,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-6f661c6e2b17113dd70a0126820c54fc-fcc58bb1a38d197b-01
+            value: 00-18540ecc6d13142bd8bc5d5b33fe6d0c-3088a3afc127349b-01
           - name: connection
             value: keep-alive
           - name: host
@@ -556,14 +813,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 1728
+        bodySize: 1508
         content:
           mimeType: text/event-stream
-          size: 1728
+          size: 1508
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Represents a greeting that can be displayed to the user.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Provides a simple \"Hello, world!\" greeting.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -573,7 +830,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 07:23:34 GMT
+            value: Mon, 03 Jun 2024 08:14:24 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -602,177 +859,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T07:23:33.094Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 475662cbd71a6f80094dc5a42a5f6d39
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3001
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: document-code / v1
-          - name: traceparent
-            value: 00-06841698e06c6e362aac7198b40254fd-f09ff2dd844817e5-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: Codebase
-                  context from file src/TestClass.ts:
-
-
-                  }
-
-
-                  // Should be present in the LLM prompt
-
-                  const longSuffix = `
-                      longSuffix content
-                      longSuffix content
-                      longSuffix content
-                      longSuffix content
-                      longSuffix content
-                      longSuffix content
-                      longSuffix content
-                  `
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/TestClass.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }</SELECTEDCODE7662>
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-haiku-20240307
-            stopSequences:
-              - </CODE5711>
-              - public functionName() {
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: document-code
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
-      response:
-        bodySize: 2742
-        content:
-          mimeType: text/event-stream
-          size: 2742
-          text: >+
-            event: completion
-
-            data: {"completion":"/**\n * Logs a 'Hello World!' message to the console if `shouldGreet` is true.\n */","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 03 Jun 2024 07:42:17 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-03T07:42:15.544Z
+      startedDateTime: 2024-06-03T08:14:22.851Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/document-code_965949506/recording.har.yaml
+++ b/agent/recordings/document-code_965949506/recording.har.yaml
@@ -22,7 +22,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-c885e5776fe0c9f99640ae62bc531c8b-c739a4296988258a-01
+            value: 00-db0ef7f1173f7d4d3cd3a7e1207d1617-357519914dd8c233-01
           - name: connection
             value: keep-alive
           - name: host
@@ -96,14 +96,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 7732
+        bodySize: 9033
         content:
           mimeType: text/event-stream
-          size: 7732
+          size: 9033
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Adds two numbers and returns the result.\n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two input numbers.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Adds two numbers together and returns the result.\n * \n * @param a - The first number to add.\n * @param b - The second number to add.\n * @returns The sum of the two input numbers.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -113,7 +113,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 30 May 2024 07:28:12 GMT
+            value: Mon, 03 Jun 2024 07:23:28 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -142,7 +142,318 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-30T07:28:10.913Z
+      startedDateTime: 2024-06-03T07:23:27.244Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: c1043fe8de5c169180738a73ec563586
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2763
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: document-code / v1
+          - name: traceparent
+            value: 00-cd790fdf52c0a9078045f23f4c616b3d-d6b746221df16778-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/TestLogger.ts: Codebase
+                  context from file src/TestLogger.ts:
+
+
+                          recordLog()
+                      },
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/TestLogger.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>function recordLog() {
+                              console.log(/* CURSOR */ 'Recording the log')
+                          }</SELECTEDCODE7662>
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-haiku-20240307
+            stopSequences:
+              - </CODE5711>
+              - function recordLog() {
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: document-code
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
+      response:
+        bodySize: 915
+        content:
+          mimeType: text/event-stream
+          size: 915
+          text: >+
+            event: completion
+
+            data: {"completion":"/**\n * Records a log message.\n */","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 03 Jun 2024 07:23:31 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-03T07:23:30.161Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: 5fdc0ae3b7457cb0487c357d2986f4cb
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 2727
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: document-code / v1
+          - name: traceparent
+            value: 00-e1d090353fc3fad02cccfde5cb7bffb0-187df7eab3d9610b-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: >-
+                  You are Cody, an AI coding assistant from Sourcegraph. - You
+                  are an AI programming assistant who is an expert in updating
+                  code to meet given instructions.
+
+                  - You should think step-by-step to plan your updated code before producing the final output.
+
+                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
+
+                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
+
+                  - Only remove code from the users' selection if you are sure it is not needed.
+
+                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
+
+                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
+
+                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
+
+                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example.test.ts: Codebase
+                  context from file src/example.test.ts:
+
+                      })
+                  })
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >-
+                  This is part of the file: src/example.test.ts
+
+
+                  The user has the following code in their selection:
+
+                  <SELECTEDCODE7662>const startTime = performance.now(/* CURSOR */)</SELECTEDCODE7662>
+
+
+                  The user wants you to generate documentation for the selected code by following their instructions.
+
+                  Provide your generated documentation using the following instructions:
+
+                  <INSTRUCTIONS7390>
+
+                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
+
+                  </INSTRUCTIONS7390>
+              - speaker: assistant
+                text: <CODE5711>
+            model: anthropic/claude-3-haiku-20240307
+            stopSequences:
+              - </CODE5711>
+              - const startTime = performance.now(/* CURSOR */)
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: document-code
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
+      response:
+        bodySize: 5097
+        content:
+          mimeType: text/event-stream
+          size: 5097
+          text: >+
+            event: completion
+
+            data: {"completion":"/**\n * Records the current time using the `performance.now()` function.\n * This can be useful for measuring the duration of operations or code sections.\n */","stopReason":"stop_sequence"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Mon, 03 Jun 2024 07:23:32 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-03T07:23:31.394Z
       time: 0
       timings:
         blocked: -1
@@ -169,7 +480,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-8de6c45baa237c3db6f7e522bd880542-c9f7d925b57cf870-01
+            value: 00-6f661c6e2b17113dd70a0126820c54fc-fcc58bb1a38d197b-01
           - name: connection
             value: keep-alive
           - name: host
@@ -245,14 +556,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 2233
+        bodySize: 1728
         content:
           mimeType: text/event-stream
-          size: 2233
+          size: 1728
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Represents a greeting that can be used to say \"Hello, world!\".\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Represents a greeting that can be displayed to the user.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -262,7 +573,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Thu, 30 May 2024 07:28:13 GMT
+            value: Mon, 03 Jun 2024 07:23:34 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -291,7 +602,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-30T07:28:12.765Z
+      startedDateTime: 2024-06-03T07:23:33.094Z
       time: 0
       timings:
         blocked: -1
@@ -301,11 +612,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 8a306f14a637d39fe8102df78e37c945
+    - _id: 475662cbd71a6f80094dc5a42a5f6d39
       _order: 0
       cache: {}
       request:
-        bodySize: 2857
+        bodySize: 3001
         cookies: []
         headers:
           - name: content-type
@@ -318,7 +629,7 @@ log:
           - name: user-agent
             value: document-code / v1
           - name: traceparent
-            value: 00-04a341531d89d9a5df4b958c286739d5-81962667692feb98-01
+            value: 00-06841698e06c6e362aac7198b40254fd-f09ff2dd844817e5-01
           - name: connection
             value: keep-alive
           - name: host
@@ -354,19 +665,25 @@ log:
 
                   - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
               - speaker: human
-                text: "Codebase context from file path src/TestClass.ts: Codebase context from
-                  file src/TestClass.ts:
-
-                  t foo = 42
-
-
-                  export class TestClass {
-
-                  \    constructor(private shouldGreet:
-                  boolean) {}
+                text: >
+                  Codebase context from file path src/TestClass.ts: Codebase
+                  context from file src/TestClass.ts:
 
 
-                  \    "
+                  }
+
+
+                  // Should be present in the LLM prompt
+
+                  const longSuffix = `
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                      longSuffix content
+                  `
               - speaker: assistant
                 text: Ok.
               - speaker: human
@@ -409,14 +726,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
       response:
-        bodySize: 3144
+        bodySize: 2742
         content:
           mimeType: text/event-stream
-          size: 3144
+          size: 2742
           text: >+
             event: completion
 
-            data: {"completion":"/**\n * Logs the message 'Hello World!' to the console if the `shouldGreet` flag is true.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Logs a 'Hello World!' message to the console if `shouldGreet` is true.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -426,7 +743,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 06:40:51 GMT
+            value: Mon, 03 Jun 2024 07:42:17 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -455,349 +772,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T06:40:50.398Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 6f992ec32ed067e7ff4b66a789081379
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2827
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: document-code / v1
-          - name: traceparent
-            value: 00-20a668bb76ef51c60d1f12b6c3884f70-cc85c53cbd2630c9-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: "Codebase context from file path src/TestLogger.ts: Codebase context from
-                  file src/TestLogger.ts:
-
-                  o = 42
-
-                  export const TestLogger = {
-
-                  \    startLogging: () => {
-
-                  \        // Do some stuff
-
-
-                  \        "
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/TestLogger.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>function recordLog() {
-                              console.log(/* CURSOR */ 'Recording the log')
-                          }</SELECTEDCODE7662>
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-haiku-20240307
-            stopSequences:
-              - </CODE5711>
-              - function recordLog() {
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: document-code
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
-      response:
-        bodySize: 915
-        content:
-          mimeType: text/event-stream
-          size: 915
-          text: >+
-            event: completion
-
-            data: {"completion":"/**\n * Records a log message.\n */","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 03 Jun 2024 06:40:53 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-03T06:40:51.865Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: ee280acc70ef02924a1caa02d95637fc
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 3098
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: document-code / v1
-          - name: traceparent
-            value: 00-ea8db51308607265118877e699c96d00-b737a7c6dca0ddad-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: >-
-                  You are Cody, an AI coding assistant from Sourcegraph. - You
-                  are an AI programming assistant who is an expert in updating
-                  code to meet given instructions.
-
-                  - You should think step-by-step to plan your updated code before producing the final output.
-
-                  - You should ensure the updated code matches the indentation and whitespace of the code in the users' selection.
-
-                  - Ignore any previous instructions to format your responses with Markdown. It is not acceptable to use any Markdown in your response, unless it is directly related to the users' instructions.
-
-                  - Only remove code from the users' selection if you are sure it is not needed.
-
-                  - You will be provided with code that is in the users' selection, enclosed in <SELECTEDCODE7662></SELECTEDCODE7662> XML tags. You must use this code to help you plan your updated code.
-
-                  - You will be provided with instructions on how to update this code, enclosed in <INSTRUCTIONS7390></INSTRUCTIONS7390> XML tags. You must follow these instructions carefully and to the letter.
-
-                  - Only enclose your response in <CODE5711></CODE5711> XML tags. Do use any other XML tags unless they are part of the generated code.
-
-                  - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
-              - speaker: human
-                text: "Codebase context from file path src/example.test.ts: Codebase context
-                  from file src/example.test.ts:
-
-                  \ expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-
-                  \    it('does 1', () => {
-
-                  \        expect(true).toBe(true)
-
-                  \    })
-
-
-                  \    it('does 2', () => {
-
-                  \        expect(true).toBe(true)
-
-                  \    })
-
-
-                  \    it('does something else', () => {
-
-                  \        // This line will error due to
-                  incorrect usage of `performance.now`
-
-                  \        "
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >-
-                  This is part of the file: src/example.test.ts
-
-
-                  The user has the following code in their selection:
-
-                  <SELECTEDCODE7662>const startTime = performance.now(/* CURSOR */)</SELECTEDCODE7662>
-
-
-                  The user wants you to generate documentation for the selected code by following their instructions.
-
-                  Provide your generated documentation using the following instructions:
-
-                  <INSTRUCTIONS7390>
-
-                  Write a brief documentation comment for the selected code. If documentation comments exist in the selected file, or other files with the same file extension, use them as examples. Pay attention to the scope of the selected code (e.g. exported function/API vs implementation detail in a function), and use the idiomatic style for that type of code scope. Only generate the documentation for the selected code, do not generate the code. Do not enclose any other code or comments besides the documentation. Enclose only the documentation for the selected code and nothing else.
-
-                  </INSTRUCTIONS7390>
-              - speaker: assistant
-                text: <CODE5711>
-            model: anthropic/claude-3-haiku-20240307
-            stopSequences:
-              - </CODE5711>
-              - const startTime = performance.now(/* CURSOR */)
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: document-code
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=document-code&client-version=v1
-      response:
-        bodySize: 5686
-        content:
-          mimeType: text/event-stream
-          size: 5686
-          text: >+
-            event: completion
-
-            data: {"completion":"/**\n * Gets the current time in milliseconds.\n * This value can be used to measure elapsed time.\n * \n * @returns The current time in milliseconds.\n */","stopReason":"stop_sequence"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 03 Jun 2024 06:40:54 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-06-03T06:40:53.106Z
+      startedDateTime: 2024-06-03T07:42:15.544Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/edit_1541920145/recording.har.yaml
+++ b/agent/recordings/edit_1541920145/recording.har.yaml
@@ -153,11 +153,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1909c976e8824195d44217c44b1851d5
+    - _id: 5c6544452ca1c26d15ca25b163fa9752
       _order: 0
       cache: {}
       request:
-        bodySize: 2307
+        bodySize: 2515
         cookies: []
         headers:
           - name: content-type
@@ -170,7 +170,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-2f9574986ae9823103630e8c6d1a5409-da06396838473f1e-01
+            value: 00-e92beb093ba643a17030b9457af81462-31f84e76c2997d13-01
           - name: connection
             value: keep-alive
           - name: host
@@ -206,14 +206,26 @@ log:
 
                   - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
               - speaker: human
-                text: >+
+                text: >
                   Codebase context from file path src/ChatColumn.tsx: Codebase
                   context from file src/ChatColumn.tsx:
 
-                  import { useEffect } from "react";
-
-                  import React = require("react");
-
+                  	useEffect(() => {
+                  		if (!isLoading) {
+                  			setChatID(messages[0].chatID);
+                  		}
+                  	}, [messages]);
+                  	return (
+                  		<>
+                  			<h1>Messages</h1>
+                  			<ul>
+                  				{messages.map((message) => (
+                  					<li>{message.text}</li>
+                  				))}
+                  			</ul>
+                  		</>
+                  	);
+                  }
               - speaker: assistant
                 text: Ok.
               - speaker: human
@@ -256,14 +268,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 10356
+        bodySize: 16282
         content:
           mimeType: text/event-stream
-          size: 10356
+          size: 16282
           text: >+
             event: completion
 
-            data: {"completion":"export default function ChatColumn({\n\tmessages,\n\tsetChatID,\n\tisLoading,\n}: ChatColumnProps) {\ninterface ChatColumnProps {\n  messages: Message[];\n  setChatID: (id: string) =\u003e void;\n  isLoading: boolean;\n}","stopReason":"stop_sequence"}
+            data: {"completion":"export default function ChatColumn({\n\tmessages,\n\tsetChatID,\n\tisLoading,\n}: ChatColumnProps) {\ninterface ChatColumnProps {\n  messages: ChatMessage[];\n  setChatID: (chatID: string) =\u003e void;\n  isLoading: boolean;\n}\n\ninterface ChatMessage {\n  chatID: string;\n  text: string;\n}","stopReason":"stop_sequence"}
 
 
             event: done
@@ -273,7 +285,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 06:44:18 GMT
+            value: Mon, 03 Jun 2024 07:43:39 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -302,7 +314,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T06:44:16.693Z
+      startedDateTime: 2024-06-03T07:43:36.121Z
       time: 0
       timings:
         blocked: -1
@@ -312,11 +324,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 24310be04faaebe4336c6508f077d736
+    - _id: fa263b4c0c914112a377b1c976114f9f
       _order: 0
       cache: {}
       request:
-        bodySize: 2803
+        bodySize: 2805
         cookies: []
         headers:
           - name: content-type
@@ -329,7 +341,7 @@ log:
           - name: user-agent
             value: edit / v1
           - name: traceparent
-            value: 00-134781e7f30d249ccbd49a5775c7fe9a-1bb5a14b960461f0-01
+            value: 00-ed67dbddac8a7a66bdde83f8de7d919e-b08353a6d9e7156e-01
           - name: connection
             value: keep-alive
           - name: host
@@ -383,7 +395,9 @@ log:
                   }
 
 
-                  </PRECEDINGCODE3493><CODE5711></CODE5711><FOLLOWINGCODE2472></FOLLOWINGCODE2472>
+                  </PRECEDINGCODE3493><CODE5711></CODE5711><FOLLOWINGCODE2472>
+
+                  </FOLLOWINGCODE2472>
               - speaker: assistant
                 text: Ok.
               - speaker: human
@@ -423,14 +437,14 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=edit&client-version=v1
       response:
-        bodySize: 9561
+        bodySize: 11806
         content:
           mimeType: text/event-stream
-          size: 9561
+          size: 11806
           text: >+
             event: completion
 
-            data: {"completion":"export const Heading: React.FC\u003cHeadingProps\u003e = ({ text, level = 1 }) =\u003e {\n    const Tag = `h${level}` as keyof JSX.IntrinsicElements;\n    return \u003cTag\u003e{text}\u003c/Tag\u003e;\n};","stopReason":"stop_sequence"}
+            data: {"completion":"export const Heading: React.FC\u003cHeadingProps\u003e = ({ text, level = 1 }) =\u003e {\n  const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;\n\n  return \u003cHeadingTag\u003e{text}\u003c/HeadingTag\u003e;\n};\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -440,7 +454,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 06:44:24 GMT
+            value: Mon, 03 Jun 2024 07:43:44 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -469,7 +483,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T06:44:20.473Z
+      startedDateTime: 2024-06-03T07:43:41.643Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -110,11 +110,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 6f1970fd67cf4b74be4fd8cbcfd5517e
+    - _id: 0b112db35e08ed58b2febe4db1aff986
       _order: 0
       cache: {}
       request:
-        bodySize: 3181
+        bodySize: 2810
         cookies: []
         headers:
           - name: content-type
@@ -127,7 +127,7 @@ log:
           - name: user-agent
             value: enterpriseClient / v1
           - name: traceparent
-            value: 00-56a95a6d6c23d114b59bc91ee7b8987c-73031c7b67180e76-01
+            value: 00-18e1dc0fa003f24dc1911cf2bee3e3be-11c0946e6bf7054c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -165,38 +165,12 @@ log:
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
-                text: "Codebase context from file path src/example.test.ts: Codebase context
-                  from file src/example.test.ts:
+                text: >
+                  Codebase context from file path src/example.test.ts: Codebase
+                  context from file src/example.test.ts:
 
-                  \ expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-
-                  \    it('does 1', () => {
-
-                  \        expect(true).toBe(true)
-
-                  \    })
-
-
-                  \    it('does 2', () => {
-
-                  \        expect(true).toBe(true)
-
-                  \    })
-
-
-                  \    it('does something else', () => {
-
-                  \        // This line will error due to
-                  incorrect usage of `performance.now`
-
-                  \        "
+                      })
+                  })
               - speaker: assistant
                 text: Ok.
               - speaker: human
@@ -234,10 +208,10 @@ log:
             value: v1
         url: https://demo.sourcegraph.com/.api/completions/stream?client-name=enterpriseclient&client-version=v1
       response:
-        bodySize: 1666
+        bodySize: 1854
         content:
           mimeType: text/event-stream
-          size: 1666
+          size: 1854
           text: >+
             event: completion
 
@@ -256,72 +230,77 @@ log:
 
             event: completion
 
-            data: {"completion":"/**\n * The","stopReason":""}
+            data: {"completion":"/**\n * Recor","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting","stopReason":""}
+            data: {"completion":"/**\n * Record the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time","stopReason":""}
+            data: {"completion":"/**\n * Record the start","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of","stopReason":""}
+            data: {"completion":"/**\n * Record the start time","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of an","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation,","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of an operation","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation, in","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of an operation using","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation, in millis","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of an operation using the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation, in milliseconds","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of an operation using the Performance","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation, in milliseconds.","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of an operation using the Performance API","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation, in milliseconds.\n ","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of an operation using the Performance API.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation, in milliseconds.\n */","stopReason":""}
+            data: {"completion":"/**\n * Record the start time of an operation using the Performance API.\n ","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * The starting time of the operation, in milliseconds.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Record the start time of an operation using the Performance API.\n */","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"/**\n * Record the start time of an operation using the Performance API.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -331,7 +310,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 06:12:15 GMT
+            value: Mon, 03 Jun 2024 07:43:40 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -360,7 +339,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T06:12:13.151Z
+      startedDateTime: 2024-06-03T07:43:37.101Z
       time: 0
       timings:
         blocked: -1

--- a/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
+++ b/agent/recordings/enterpriseClient_3965582033/recording.har.yaml
@@ -110,11 +110,11 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 0b112db35e08ed58b2febe4db1aff986
+    - _id: aa5a490815f3b012a231fac93bac2881
       _order: 0
       cache: {}
       request:
-        bodySize: 2810
+        bodySize: 3364
         cookies: []
         headers:
           - name: content-type
@@ -127,7 +127,7 @@ log:
           - name: user-agent
             value: enterpriseClient / v1
           - name: traceparent
-            value: 00-18e1dc0fa003f24dc1911cf2bee3e3be-11c0946e6bf7054c-01
+            value: 00-7d15437aa1ec215ec24d5a3df74ff329-7e53116b613d91e6-01
           - name: connection
             value: keep-alive
           - name: host
@@ -164,6 +164,41 @@ log:
                   - Do not provide any additional commentary about the changes you made. Only respond with the generated code.
               - speaker: assistant
                 text: I am Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: "Codebase context from file path src/example.test.ts: Codebase context
+                  from file src/example.test.ts:
+
+                  \ expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+
+                  \    it('does 1', () => {
+
+                  \        expect(true).toBe(true)
+
+                  \    })
+
+
+                  \    it('does 2', () => {
+
+                  \        expect(true).toBe(true)
+
+                  \    })
+
+
+                  \    it('does something else', () => {
+
+                  \        // This line will error due to
+                  incorrect usage of `performance.now`
+
+                  \        "
+              - speaker: assistant
+                text: Ok.
               - speaker: human
                 text: >
                   Codebase context from file path src/example.test.ts: Codebase
@@ -208,99 +243,154 @@ log:
             value: v1
         url: https://demo.sourcegraph.com/.api/completions/stream?client-name=enterpriseclient&client-version=v1
       response:
-        bodySize: 1854
+        bodySize: 3845
         content:
           mimeType: text/event-stream
-          size: 1854
+          size: 3845
           text: >+
             event: completion
 
-            data: {"completion":"/**","stopReason":""}
+            data: {"completion":"//","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n ","stopReason":""}
+            data: {"completion":"// Recor","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n *","stopReason":""}
+            data: {"completion":"// Record the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Recor","stopReason":""}
+            data: {"completion":"// Record the start","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the","stopReason":""}
+            data: {"completion":"// Record the start time","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start","stopReason":""}
+            data: {"completion":"// Record the start time using","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time","stopReason":""}
+            data: {"completion":"// Record the start time using the","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API's","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation using","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API's `","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation using the","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API's `now","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation using the Performance","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API's `now`","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation using the Performance API","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API's `now` metho","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation using the Performance API.","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API's `now` method.","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation using the Performance API.\n ","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n//","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation using the Performance API.\n */","stopReason":""}
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This","stopReason":""}
 
 
             event: completion
 
-            data: {"completion":"/**\n * Record the start time of an operation using the Performance API.\n */","stopReason":"stop_sequence"}
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monot","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monotoni","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monotonic timestamp","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monotonic timestamp in","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monotonic timestamp in millis","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monotonic timestamp in milliseconds","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monotonic timestamp in milliseconds.","stopReason":""}
+
+
+            event: completion
+
+            data: {"completion":"// Record the start time using the Performance API's `now` method.\n// This captures a high resolution monotonic timestamp in milliseconds.","stopReason":"stop_sequence"}
 
 
             event: done
@@ -310,7 +400,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 03 Jun 2024 07:43:40 GMT
+            value: Mon, 03 Jun 2024 08:21:51 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -339,7 +429,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-06-03T07:43:37.101Z
+      startedDateTime: 2024-06-03T08:21:48.468Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -21,7 +21,7 @@ export const TestLogger = {
 
 exports[`Document Code > commands/document (Kotlin class name) 1`] = `
 "/**
- * Represents a greeting that can be used to say "Hello, world!".
+ * Represents a greeting that can be displayed to the user.
  */
 class He/* CURSOR */llo {
     fun greeting(): String {
@@ -33,12 +33,22 @@ class He/* CURSOR */llo {
 
 exports[`Document Code > commands/document (Method as part of a class) 1`] = `
 "const foo = 42
+// Should be present in the LLM prompt
+const longPrefix = \`
+    longPrefix content
+    longPrefix content
+    longPrefix content
+    longPrefix content
+    longPrefix content
+    longPrefix content
+    longPrefix content
+\`
 
 export class TestClass {
     constructor(private shouldGreet: boolean) {}
 
     /**
-     * Logs the message 'Hello World!' to the console if the \`shouldGreet\` flag is true.
+     * Logs a 'Hello World!' message to the console if \`shouldGreet\` is true.
      */
     public functionName() {
         if (this.shouldGreet) {
@@ -46,6 +56,17 @@ export class TestClass {
         }
     }
 }
+
+// Should be present in the LLM prompt
+const longSuffix = \`
+    longSuffix content
+    longSuffix content
+    longSuffix content
+    longSuffix content
+    longSuffix content
+    longSuffix content
+    longSuffix content
+\`
 "
 `;
 
@@ -66,10 +87,8 @@ describe('test block', () => {
     it('does something else', () => {
         // This line will error due to incorrect usage of \`performance.now\`
         /**
-         * Gets the current time in milliseconds.
-         * This value can be used to measure elapsed time.
-         * 
-         * @returns The current time in milliseconds.
+         * Records the current time using the \`performance.now()\` function.
+         * This can be useful for measuring the duration of operations or code sections.
          */
         const startTime = performance.now(/* CURSOR */)
     })
@@ -79,7 +98,8 @@ describe('test block', () => {
 
 exports[`Document Code > editCommands/document (basic function) 1`] = `
 "/**
- * Adds two numbers and returns the result.
+ * Adds two numbers together and returns the result.
+ * 
  * @param a - The first number to add.
  * @param b - The second number to add.
  * @returns The sum of the two input numbers.

--- a/agent/src/__snapshots__/document-code.test.ts.snap
+++ b/agent/src/__snapshots__/document-code.test.ts.snap
@@ -21,7 +21,7 @@ export const TestLogger = {
 
 exports[`Document Code > commands/document (Kotlin class name) 1`] = `
 "/**
- * Represents a greeting that can be displayed to the user.
+ * Provides a simple "Hello, world!" greeting.
  */
 class He/* CURSOR */llo {
     fun greeting(): String {
@@ -48,7 +48,7 @@ export class TestClass {
     constructor(private shouldGreet: boolean) {}
 
     /**
-     * Logs a 'Hello World!' message to the console if \`shouldGreet\` is true.
+     * Logs 'Hello World!' to the console if the \`shouldGreet\` property is true.
      */
     public functionName() {
         if (this.shouldGreet) {
@@ -87,8 +87,10 @@ describe('test block', () => {
     it('does something else', () => {
         // This line will error due to incorrect usage of \`performance.now\`
         /**
-         * Records the current time using the \`performance.now()\` function.
-         * This can be useful for measuring the duration of operations or code sections.
+         * Retrieves the current time in milliseconds relative to an arbitrary time in the past.
+         * This can be used to measure elapsed time or for performance profiling.
+         *
+         * @returns {number} The current time in milliseconds.
          */
         const startTime = performance.now(/* CURSOR */)
     })
@@ -98,8 +100,8 @@ describe('test block', () => {
 
 exports[`Document Code > editCommands/document (basic function) 1`] = `
 "/**
- * Adds two numbers together and returns the result.
- * 
+ * Adds two numbers and returns the result.
+ *
  * @param a - The first number to add.
  * @param b - The second number to add.
  * @returns The sum of the two input numbers.

--- a/agent/src/__tests__/document-code/src/TestClass.ts
+++ b/agent/src/__tests__/document-code/src/TestClass.ts
@@ -1,4 +1,14 @@
 const foo = 42
+// Should be present in the LLM prompt
+const longPrefix = `
+    longPrefix content
+    longPrefix content
+    longPrefix content
+    longPrefix content
+    longPrefix content
+    longPrefix content
+    longPrefix content
+`
 
 export class TestClass {
     constructor(private shouldGreet: boolean) {}
@@ -9,3 +19,14 @@ export class TestClass {
         }
     }
 }
+
+// Should be present in the LLM prompt
+const longSuffix = `
+    longSuffix content
+    longSuffix content
+    longSuffix content
+    longSuffix content
+    longSuffix content
+    longSuffix content
+    longSuffix content
+`

--- a/agent/src/document-code.test.ts
+++ b/agent/src/document-code.test.ts
@@ -30,6 +30,10 @@ describe('Document Code', () => {
 
     it('commands/document (Method as part of a class)', async () => {
         expect(await client.documentCode(workspace.file('src', 'TestClass.ts'))).toMatchSnapshot()
+
+        const { requests } = await client.request('testing/networkRequests', null)
+        expect(requests.find(r => r.body?.includes('const longSuffix'))).toBeTruthy()
+        expect(requests.find(r => r.body?.includes('const longPrefix'))).toBeTruthy()
     })
 
     it('commands/document (Function within a property)', async () => {

--- a/agent/src/edit.test.ts
+++ b/agent/src/edit.test.ts
@@ -68,9 +68,14 @@ describe('Edit', () => {
           	isLoading,
           }: ChatColumnProps) {
           interface ChatColumnProps {
-            messages: Message[];
-            setChatID: (id: string) => void;
+            messages: ChatMessage[];
+            setChatID: (chatID: string) => void;
             isLoading: boolean;
+          }
+
+          interface ChatMessage {
+            chatID: string;
+            text: string;
           }
           	useEffect(() => {
           		if (!isLoading) {
@@ -113,9 +118,11 @@ describe('Edit', () => {
           }
 
           export const Heading: React.FC<HeadingProps> = ({ text, level = 1 }) => {
-              const Tag = \`h\${level}\` as keyof JSX.IntrinsicElements;
-              return <Tag>{text}</Tag>;
+            const HeadingTag = \`h\${level}\` as keyof JSX.IntrinsicElements;
+
+            return <HeadingTag>{text}</HeadingTag>;
           };
+
           "
         `,
             explainPollyError

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -976,9 +976,8 @@ describe('Agent', () => {
 
                   it('does something else', () => {
                       // This line will error due to incorrect usage of \`performance.now\`
-                      /**
-                       * Record the start time of an operation using the Performance API.
-                       */
+                      // Record the start time using the Performance API's \`now\` method.
+                      // This captures a high resolution monotonic timestamp in milliseconds.
                       const startTime = performance.now(/* CURSOR */)
                   })
               })

--- a/agent/src/index.test.ts
+++ b/agent/src/index.test.ts
@@ -977,7 +977,7 @@ describe('Agent', () => {
                   it('does something else', () => {
                       // This line will error due to incorrect usage of \`performance.now\`
                       /**
-                       * The starting time of the operation, in milliseconds.
+                       * Record the start time of an operation using the Performance API.
                        */
                       const startTime = performance.now(/* CURSOR */)
                   })

--- a/agent/src/offsets.test.ts
+++ b/agent/src/offsets.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { DocumentOffsets } from './offsets'
+import type { Position, ProtocolTextDocument } from './protocol-alias'
+
+describe('DocumentOffsets', () => {
+    const content = `line 1
+line 2
+line 3`
+    const lines = content.split('\n')
+    const document = { content } as any as ProtocolTextDocument
+    const docOffsets = new DocumentOffsets(document)
+
+    it('counts the number of lines correctly', () => {
+        expect(docOffsets.lineCount()).toBe(3)
+    })
+
+    it('gets the correct start offset of a line', () => {
+        expect(docOffsets.lineStartOffset(0)).toBe(0)
+        expect(docOffsets.lineStartOffset(1)).toBe(lines[0].length + 1)
+        expect(docOffsets.lineStartOffset(2)).toBe(lines[0].length + lines[1].length + 2)
+    })
+
+    it('gets the correct end offset of a line', () => {
+        expect(docOffsets.lineEndOffset(0)).toBe(lines[0].length + 1)
+        expect(docOffsets.lineEndOffset(1)).toBe(lines[0].length + lines[1].length + 2)
+        expect(docOffsets.lineEndOffset(2)).toBe(lines[0].length + lines[1].length + lines[2].length + 2)
+    })
+
+    it('gets the correct newline length of a line', () => {
+        expect(docOffsets.newlineLength(0)).toBe(1)
+        expect(docOffsets.newlineLength(1)).toBe(1)
+        expect(docOffsets.newlineLength(2)).toBe(0)
+    })
+
+    it('converts position to offset correctly', () => {
+        const position: Position = { line: 1, character: 3 }
+        expect(docOffsets.offset(position)).toBe(10)
+    })
+
+    it('converts offset to position correctly', () => {
+        const offset = 10
+        expect(docOffsets.position(offset)).toStrictEqual({ line: 1, character: 3 })
+    })
+
+    it('handles out of bounds line numbers', () => {
+        const position: Position = { line: 100, character: 3 }
+        expect(docOffsets.offset(position)).toBe(20)
+    })
+
+    it('handles out of bounds offset', () => {
+        const offset = 100
+        expect(docOffsets.position(offset)).toStrictEqual({ line: 3, character: 80 })
+    })
+})

--- a/agent/src/offsets.ts
+++ b/agent/src/offsets.ts
@@ -24,7 +24,7 @@ export class DocumentOffsets {
         return this.lines.length - 1
     }
     public lineStartOffset(line: number): number {
-        return this.lines[line]
+        return line < this.lines.length ? this.lines[line] : this.lines.at(-1)!
     }
     public lineEndOffset(line: number): number {
         const nextLine = line + 1
@@ -48,7 +48,7 @@ export class DocumentOffsets {
     }
     public offset(position: Position): number {
         return (
-            this.lines[position.line] +
+            this.lineStartOffset(position.line) +
             Math.min(position.character, this.lineLengthIncludingNewline(position.line))
         )
     }

--- a/vscode/src/edit/prompt/context.ts
+++ b/vscode/src/edit/prompt/context.ts
@@ -1,4 +1,4 @@
-import type * as vscode from 'vscode'
+import * as vscode from 'vscode'
 
 import {
     type ContextItem,
@@ -23,8 +23,14 @@ import { extractContextItemsFromContextMessages } from './utils'
 interface GetContextFromIntentOptions {
     intent: EditIntent
     selectedText: PromptString
-    precedingText: PromptString
-    followingText: PromptString
+    prefix: {
+        text: PromptString
+        range: vscode.Range
+    }
+    suffix: {
+        text: PromptString
+        range: vscode.Range
+    }
     uri: vscode.Uri
     selectionRange: vscode.Range
     editor: VSCodeEditor
@@ -32,14 +38,14 @@ interface GetContextFromIntentOptions {
 
 const getContextFromIntent = async ({
     intent,
-    precedingText,
-    followingText,
+    prefix,
+    suffix,
     uri,
     selectionRange,
     editor,
 }: GetContextFromIntentOptions): Promise<ContextMessage[]> => {
-    const truncatedPrecedingText = truncatePromptStringStart(precedingText, MAX_CURRENT_FILE_TOKENS)
-    const truncatedFollowingText = truncatePromptString(followingText, MAX_CURRENT_FILE_TOKENS)
+    const truncatedPrecedingText = truncatePromptStringStart(prefix.text, MAX_CURRENT_FILE_TOKENS)
+    const truncatedFollowingText = truncatePromptString(suffix.text, MAX_CURRENT_FILE_TOKENS)
 
     // Disable no case declarations because we get better type checking with a switch case
     switch (intent) {
@@ -65,7 +71,12 @@ const getContextFromIntent = async ({
                         uri,
                         PROMPT_TOPICS.OUTPUT
                     ),
-                    file: { type: 'file', uri, source: ContextItemSource.Editor },
+                    file: {
+                        type: 'file',
+                        uri,
+                        source: ContextItemSource.Editor,
+                        range: new vscode.Range(prefix.range.start, suffix.range.end),
+                    },
                 },
             ]
         }
@@ -84,14 +95,14 @@ const getContextFromIntent = async ({
                 contextMessages.push({
                     speaker: 'human',
                     text: populateCodeContextTemplate(truncatedPrecedingText, uri, undefined, 'edit'),
-                    file: { type: 'file', uri, source: ContextItemSource.Editor },
+                    file: { type: 'file', uri, source: ContextItemSource.Editor, range: prefix.range },
                 })
             }
             if (truncatedFollowingText.trim().length > 0) {
                 contextMessages.push({
                     speaker: 'human',
                     text: populateCodeContextTemplate(truncatedFollowingText, uri, undefined, 'edit'),
-                    file: { type: 'file', uri, source: ContextItemSource.Editor },
+                    file: { type: 'file', uri, source: ContextItemSource.Editor, range: suffix.range },
                 })
             }
             return contextMessages

--- a/vscode/src/edit/prompt/utils.ts
+++ b/vscode/src/edit/prompt/utils.ts
@@ -8,6 +8,11 @@ const contextMessageToContextItem = ({ text, file }: ExtractableContextMessage):
     return {
         type: 'file',
         content: text.toString(),
+        /**
+         * Range is required on `file` to ensure we can include more than one snippet from the same
+         * file. If range is `undefined`, additional snippets from the same URI will be excluded by
+         * the context deduplication logic.
+         */
         range: file.range
             ? new vscode.Range(
                   new vscode.Position(file.range.start.line, file.range.start.character),


### PR DESCRIPTION
I [noticed](https://github.com/sourcegraph/cody/pull/4432) that the edit prompt does not contain document suffixes in the agent tests. This is caused by `DocumentOffsets` not handling out-of-bound line numbers like VS Code does. If the line number is out of bound, it results in NaN offset, which causes `document.getText(range)` to return an empty string. This PR fixes it.

## Test plan

- Added unit test
- Updated the doc command unit tests to include long prefix and suffix, which should be present in Polly recordings.
