### PR TITLE
Chat: Fix contrast and colors of send button

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 - Chat: The @-mentions for workspace repositories, which are added to the input box by default for new messages, now takes context filters into consideration and do not mention the excluded repos. [pull/4427](https://github.com/sourcegraph/cody/pull/4427)
+- Chat: Fixed the contrast and colors of send button. [pull/4436](https://github.com/sourcegraph/cody/pull/4436)
 
 ### Changed
 

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.module.css
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.module.css
@@ -1,32 +1,50 @@
-.button circle {
-    stroke: transparent;
-    fill: var(--vscode-button-background);
+.button {
+    border: 1px solid var(--vscode-button-border, transparent);
+    background-color: var(--vscode-button-background);
+    cursor: pointer;
+    border-radius: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
-.button[disabled] circle {
-    fill: color-mix(in srgb, var(--vscode-button-foreground) 15%, transparent);
+.button svg {
+    transform: translateX(1px);
+}
+
+.button:hover, .button:focus-visible {
+    background-color: var(--vscode-button-hoverBackground);
+}
+
+.button:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 2px;
 }
 
 .button path {
-    stroke: transparent;
     fill: var(--vscode-button-foreground);
 }
 
-.button[disabled] path {
-    fill: color-mix(in srgb, var(--vscode-button-foreground) 30%, transparent);
+.button[disabled] {
+    cursor: default;
+    border-color: transparent;
+    background-color: var(--vscode-disabledForeground);
+    opacity: 0.5;
 }
 
-/* todo(tim): We need a tailwind high-contrast: modifier, then we don't need this */
-body[data-vscode-theme-kind='vscode-high-contrast'] .button circle {
-    stroke: var(--vscode-button-border);
-    fill: transparent;
+/* For high contrast dark we make a few aesthetic tweaks, such as changing the button border color instead of an outline */
+body[data-vscode-theme-kind="vscode-high-contrast"] .button:focus-visible {
+    outline: none;
+    border-color: var(--vscode-focusBorder);
 }
 
-body[data-vscode-theme-kind='vscode-high-contrast'] .button path {
-    stroke: transparent;
-    fill: currentColor;
-}
+body[data-vscode-theme-kind="vscode-high-contrast"], body[data-vscode-theme-kind="vscode-high-contrast-light"] {
+    .button[disabled] {
+        background-color: transparent;
+        border-color: var(--vscode-disabledForeground);
 
-body[data-vscode-theme-kind='vscode-high-contrast'] .button[disabled] path {
-    fill: var(--vscode-button-border);
+        path {
+            fill: var(--vscode-disabledForeground);
+        }
+    }
 }

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/SubmitButton.tsx
@@ -30,9 +30,8 @@ export const SubmitButton: FunctionComponent<{
             disabled={disabled ? true : undefined}
         >
             {/* biome-ignore lint/a11y/noSvgWithoutTitle: */}
-            <svg width="20" height="20" viewBox="0 0 20 20">
-                <circle cx="10" cy="10" r="9.5" />
-                <path d="M8.25 6L14.25 10L8.25 14V6Z" strokeLinecap="round" strokeLinejoin="round" />
+            <svg width="8" height="10" viewBox="0 0 8 10">
+                <path d="M1.25 1L7.25 5L1.25 9V1Z" stroke-linecap="round" stroke-linejoin="round" />
             </svg>
         </button>
     )

--- a/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.module.css
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/toolbar/Toolbar.module.css
@@ -1,13 +1,7 @@
 .container {
     display: flex;
     align-items: center;
-    overflow-y: hidden;
-    overflow-x: auto;
-    scrollbar-width: none;
-
-    margin: 0;
-    margin-left: -4px; /* make leftmost toolbar icon flush with text */
-    padding: 0;
+    margin: 0 0 0 -3px; /* make leftmost toolbar icon flush with text */
 }
 
 .spacer {

--- a/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
+++ b/vscode/webviews/storybook/VSCodeStoryDecorator.tsx
@@ -37,7 +37,7 @@ export enum Theme {
 export const themeClassnames = {
     [Theme.DarkPlus]: 'vscode-dark',
     [Theme.DarkModern]: 'vscode-dark',
-    [Theme.DarkHighContrast]: 'vscode-high-contrast-dark',
+    [Theme.DarkHighContrast]: 'vscode-high-contrast',
     [Theme.LightPlus]: 'vscode-light',
     [Theme.LightModern]: 'vscode-light',
     [Theme.LightHighContrast]: 'vscode-high-contrast-light',


### PR DESCRIPTION
Fixes the send button styles, including hover, focus and high contrast modes:

https://github.com/sourcegraph/cody/assets/153/44e7a62e-1478-400e-8a9d-c9b46cbe919e

Also fixes the Storybook theme selector to apply the correct class name for the High Contrast Dark theme.

## Test plan

- CI