### PR TITLE
Chat: Don't append @ when "Add context" is pressed multiple times

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Chat: Don't append @ when "Add context" is pressed multiple times. [pull/4439](https://github.com/sourcegraph/cody/pull/4439)
+
 ### Changed
 
 ## [1.20.1]

--- a/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
+++ b/vscode/webviews/chat/cells/messageCell/assistant/AssistantMessageCell.tsx
@@ -171,7 +171,11 @@ export function makeHumanMessageInfo(
         },
         hasExplicitMentions: Boolean(contextItems.some(item => item.source === ContextItemSource.User)),
         appendAtMention: () => {
-            humanEditorRef.current?.appendText('@', true)
+            if (humanEditorRef.current?.getSerializedValue().text.trim().endsWith('@')) {
+                humanEditorRef.current?.setFocus(true, { moveCursorToEnd: true })
+            } else {
+                humanEditorRef.current?.appendText('@', true)
+            }
         },
     }
 }


### PR DESCRIPTION
Don't append unnecessary @'s if you press the "Add context..." button in chat multiple times. Instead, this change just refocuses the input at the relevant location.

## Test plan

- CI (could not find any relevant test to update/add to)
