### PR TITLE
bfg: include process.env when spawning cody-engine

### DIFF
--- a/vscode/src/graph/bfg/spawn-bfg.ts
+++ b/vscode/src/graph/bfg/spawn-bfg.ts
@@ -21,6 +21,7 @@ export async function spawnBfg(
     const child = child_process.spawn(codyrpc, {
         stdio: 'pipe',
         env: {
+            ...process.env,
             VERBOSE_DEBUG: `${isVerboseDebug}`,
             RUST_BACKTRACE: isVerboseDebug ? '1' : '0',
             // See bfg issue 138


### PR DESCRIPTION
We currently specify 3 environment variables when spawning cody-engine, but in the process of doing that we do not pass through environment variables defined in vscode.

This is normally fine, but for example in environments like NixOS (on linux) environment variable specified by the user are needed to run the cody-engine binary. This change updates the call site to include the normal process.env, but then override the variables we explicitly specify.

An alternative solution is that cody-engine should be statically compiled on linux.

Test Plan: After this change messages about not starting the cody-engine go away from my debug console. Previously I would get messages like this:

```
cannot execute /home/keegan/.config/Code/User/globalStorage/sourcegraph.cody-ai/cody-engine/cody-engine-5.4.3547-linux-x64: You are trying to run an unpatched binary on nixos, but you have not configured NIX_LD or NIX_LD_x86_64-linux. See https://github.com/Mic92/nix-ld for more details
```
