### PR TITLE
CI: increase timeout for Fix integration test

### DIFF
--- a/agent/src/fix.test.ts
+++ b/agent/src/fix.test.ts
@@ -50,5 +50,5 @@ describe.skipIf(isWindows())('Fix', () => {
           }
           "
         `)
-    }, 10_000)
+    }, 20_000)
 })


### PR DESCRIPTION
This test typechecking with `tsc` so it may take more than 10s to run in CI where 1) we have less powerful machines and 2) we're running a very large number of tests in parallel. On my local computer, this test takes ~340ms to run per vitest output.


## Test plan
Green CI, no flaky failure.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
