### PR TITLE
commands: getContextFileFromUri treats empty ranges as full file

### DIFF
--- a/agent/recordings/customCommandsClient_509552979/recording.har.yaml
+++ b/agent/recordings/customCommandsClient_509552979/recording.har.yaml
@@ -5,11 +5,11 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
-    - _id: 6b16de44d8593d71e60f081f3b00edfd
+    - _id: 12e8efe3cf27710253140ac42d6a20d9
       _order: 0
       cache: {}
       request:
-        bodySize: 934
+        bodySize: 938
         cookies: []
         headers:
           - name: content-type
@@ -22,7 +22,7 @@ log:
           - name: user-agent
             value: customCommandsClient / v1
           - name: traceparent
-            value: 00-88ce13f1b073c5f44bc0c8e6535c2351-b12c0720295b9531-01
+            value: 00-470b8769b52a8b61829f00e140d714ee-6e41197a383fc5d7-01
           - name: connection
             value: keep-alive
           - name: host
@@ -39,7 +39,7 @@ log:
               - speaker: system
                 text: You are Cody, an AI coding assistant from Sourcegraph.
               - speaker: human
-                text: >-
+                text: >
                   Codebase context from file path src/example3.ts: export
                   function example(): string {
                       return 'example'
@@ -47,7 +47,7 @@ log:
               - speaker: assistant
                 text: Ok.
               - speaker: human
-                text: >-
+                text: >
                   Codebase context from file path src/example2.ts: export
                   function example(): string {
                       return 'example'
@@ -81,10 +81,10 @@ log:
             value: v1
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=customcommandsclient&client-version=v1
       response:
-        bodySize: 4004
+        bodySize: 4032
         content:
           mimeType: text/event-stream
-          size: 4004
+          size: 4032
           text: >+
             event: completion
 
@@ -98,7 +98,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Tue, 28 May 2024 11:58:22 GMT
+            value: Tue, 04 Jun 2024 10:17:18 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -127,7 +127,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-05-28T11:58:20.910Z
+      startedDateTime: 2024-06-04T10:17:16.975Z
       time: 0
       timings:
         blocked: -1

--- a/vscode/src/commands/context/file-path.ts
+++ b/vscode/src/commands/context/file-path.ts
@@ -20,12 +20,25 @@ export async function getContextFileFromUri(file: URI, range?: vscode.Range): Pr
                 return []
             }
 
+            const doc = await vscode.workspace.openTextDocument(file)
+
             // empty range can happen when user initiates action from right
             // click. Treat as wanting full document.
             range = range?.isEmpty ? undefined : range
 
-            const doc = await vscode.workspace.openTextDocument(file)
-            const content = doc?.getText(range).trim()
+            // if the range is the full file, remove our range specifier so it
+            // renders nicely in the UI
+            const fullRange = new vscode.Range(
+                0,
+                0,
+                doc.lineCount,
+                doc.lineAt(doc.lineCount - 1).text.length
+            )
+            if (range?.contains(fullRange)) {
+                range = undefined
+            }
+
+            const content = doc.getText(range).trim()
             if (!content) {
                 throw new Error('No file content')
             }

--- a/vscode/src/commands/context/file-path.ts
+++ b/vscode/src/commands/context/file-path.ts
@@ -38,8 +38,8 @@ export async function getContextFileFromUri(file: URI, range?: vscode.Range): Pr
                 range = undefined
             }
 
-            const content = doc.getText(range).trim()
-            if (!content) {
+            const content = doc.getText(range)
+            if (!content.trim()) {
                 throw new Error('No file content')
             }
             const size = TokenCounter.countTokens(content)

--- a/vscode/src/commands/context/file-path.ts
+++ b/vscode/src/commands/context/file-path.ts
@@ -20,13 +20,15 @@ export async function getContextFileFromUri(file: URI, range?: vscode.Range): Pr
                 return []
             }
 
+            // empty range can happen when user initiates action from right
+            // click. Treat as wanting full document.
+            range = range?.isEmpty ? undefined : range
+
             const doc = await vscode.workspace.openTextDocument(file)
             const content = doc?.getText(range).trim()
             if (!content) {
                 throw new Error('No file content')
             }
-            const endLine = Math.max(doc.lineCount - 1, 0)
-            range = range ?? new vscode.Range(0, 0, endLine, 0)
             const size = TokenCounter.countTokens(content)
 
             return [

--- a/vscode/src/prompt-builder/unique-context.test.ts
+++ b/vscode/src/prompt-builder/unique-context.test.ts
@@ -1,4 +1,4 @@
-import { type ContextItem, ContextItemSource } from '@sourcegraph/cody-shared'
+import { type ContextItem, ContextItemSource, type RangeData } from '@sourcegraph/cody-shared'
 import { describe, expect, it } from 'vitest'
 import { URI } from 'vscode-uri'
 import { getUniqueContextItems, isUniqueContextItem } from './unique-context'
@@ -308,55 +308,54 @@ describe('Unique Context Items', () => {
     })
 
     describe('isUniqueContextItem', () => {
-        const baseFile = {
-            type: 'file',
-            uri: URI.file('/foo/bar'),
-            content: 'foobar',
-        } as ContextItem
+        const contentLines = [...Array(20).keys()].map(i => `line ${i + 1}`)
+
+        /** returns the file with content respecting range */
+        const baseFile = (range?: RangeData): ContextItem => {
+            let content = contentLines.join('\n')
+            if (range) {
+                // sliceing below depends on character being 0
+                expect(range.start.character).toEqual(0)
+                expect(range.end.character).toEqual(0)
+                expect(range.end.line).toBeLessThanOrEqual(contentLines.length)
+                content = contentLines.slice(range.start.line, range.end.line).join('\n')
+            }
+            return {
+                type: 'file',
+                uri: URI.file('/foo/bar'),
+                content,
+                range,
+            }
+        }
 
         it('returns false when the new item is a duplicate with the same display path and range', () => {
-            const item = {
-                ...baseFile,
-                range: {
-                    start: { line: 0, character: 0 },
-                    end: { line: 5, character: 0 },
-                },
-            }
+            const item = baseFile({
+                start: { line: 0, character: 0 },
+                end: { line: 5, character: 0 },
+            })
 
             expect(isUniqueContextItem(item, [item])).toBeFalsy()
         })
 
         it('returns true when the new item has a different range (unique)', () => {
-            const item1: ContextItem = {
-                ...baseFile,
-                range: {
-                    start: { line: 0, character: 0 },
-                    end: { line: 10, character: 0 },
-                },
-            }
-            const item2: ContextItem = {
-                ...baseFile,
-                range: {
-                    start: { line: 11, character: 0 },
-                    end: { line: 20, character: 0 },
-                },
-            }
+            const item1: ContextItem = baseFile({
+                start: { line: 0, character: 0 },
+                end: { line: 10, character: 0 },
+            })
+            const item2: ContextItem = baseFile({
+                start: { line: 11, character: 0 },
+                end: { line: 20, character: 0 },
+            })
 
             expect(isUniqueContextItem(item2, [item1])).toBeTruthy()
         })
 
         it('returns true when the new item has no range and not duplicate', () => {
-            const item1: ContextItem = {
-                ...baseFile,
-                range: {
-                    start: { line: 0, character: 0 },
-                    end: { line: 10, character: 0 },
-                },
-            }
-            const item2: ContextItem = {
-                ...baseFile,
-                range: undefined,
-            }
+            const item1: ContextItem = baseFile({
+                start: { line: 0, character: 0 },
+                end: { line: 10, character: 0 },
+            })
+            const item2: ContextItem = baseFile(undefined)
 
             expect(isUniqueContextItem(item2, [item1])).toBeTruthy()
 
@@ -367,39 +366,27 @@ describe('Unique Context Items', () => {
         })
 
         it('returns false when the new item is a duplicate with a larger range', () => {
-            const inner: ContextItem = {
-                ...baseFile,
-                range: {
-                    start: { line: 0, character: 0 },
-                    end: { line: 5, character: 0 },
-                },
-            }
-            const outter: ContextItem = {
-                ...baseFile,
-                range: {
-                    start: { line: 0, character: 0 },
-                    end: { line: 10, character: 0 },
-                },
-            }
+            const inner: ContextItem = baseFile({
+                start: { line: 0, character: 0 },
+                end: { line: 5, character: 0 },
+            })
+            const outter: ContextItem = baseFile({
+                start: { line: 0, character: 0 },
+                end: { line: 10, character: 0 },
+            })
 
             expect(isUniqueContextItem(inner, [outter])).toBeFalsy()
         })
 
         it('returns false when the new item is a duplicate with a smaller range', () => {
-            const outter: ContextItem = {
-                ...baseFile,
-                range: {
-                    start: { line: 0, character: 0 },
-                    end: { line: 10, character: 0 },
-                },
-            }
-            const inner: ContextItem = {
-                ...baseFile,
-                range: {
-                    start: { line: 2, character: 0 },
-                    end: { line: 5, character: 0 },
-                },
-            }
+            const outter: ContextItem = baseFile({
+                start: { line: 0, character: 0 },
+                end: { line: 10, character: 0 },
+            })
+            const inner: ContextItem = baseFile({
+                start: { line: 2, character: 0 },
+                end: { line: 5, character: 0 },
+            })
 
             expect(isUniqueContextItem(inner, [outter])).toBeFalsy()
         })

--- a/vscode/src/prompt-builder/unique-context.test.ts
+++ b/vscode/src/prompt-builder/unique-context.test.ts
@@ -365,6 +365,16 @@ describe('Unique Context Items', () => {
             expect(isUniqueContextItem(item2, [item1, item2])).toBeFalsy()
         })
 
+        it('returns false when the new item has no range and an earlier item has whole file range', () => {
+            const item1: ContextItem = baseFile({
+                start: { line: 0, character: 0 },
+                end: { line: contentLines.length, character: 0 },
+            })
+            const item2: ContextItem = baseFile(undefined)
+
+            expect(isUniqueContextItem(item2, [item1])).toBeFalsy()
+        })
+
         it('returns false when the new item is a duplicate with a larger range', () => {
             const inner: ContextItem = baseFile({
                 start: { line: 0, character: 0 },
@@ -389,6 +399,23 @@ describe('Unique Context Items', () => {
             })
 
             expect(isUniqueContextItem(inner, [outter])).toBeFalsy()
+        })
+
+        it('returns false when the new item is a duplicate with a 2nd smaller range', () => {
+            const noOverlapFirst: ContextItem = baseFile({
+                start: { line: 11, character: 0 },
+                end: { line: 15, character: 0 },
+            })
+            const outer: ContextItem = baseFile({
+                start: { line: 0, character: 0 },
+                end: { line: 10, character: 0 },
+            })
+            const inner: ContextItem = baseFile({
+                start: { line: 2, character: 0 },
+                end: { line: 5, character: 0 },
+            })
+
+            expect(isUniqueContextItem(inner, [noOverlapFirst, outer])).toBeFalsy()
         })
     })
 })

--- a/vscode/src/prompt-builder/unique-context.ts
+++ b/vscode/src/prompt-builder/unique-context.ts
@@ -70,10 +70,18 @@ export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: Context
             // Duplicates if overlapping ranges on the same lines,
             // or if one range contains the other.
             if (item.range && itemToAddRange) {
-                return !(
+                if (
                     rangesOnSameLines(item.range, itemToAddRange) ||
                     rangeContainsLines(item.range, itemToAddRange)
-                )
+                ) {
+                    return false
+                }
+            }
+
+            // Duplicates if whole file (undefined range) and selection has the
+            // same content.
+            if (item.range && !itemToAddRange && equalContent(item, itemToAdd)) {
+                return false
             }
         }
     }
@@ -104,4 +112,11 @@ function rangesOnSameLines(range1: RangeData, range2: RangeData): boolean {
  */
 function isUserAddedItem(item: ContextItem): boolean {
     return getContextItemTokenUsageType(item) === 'user'
+}
+
+/**
+ * Checks if content is set and equal.
+ */
+function equalContent(item1: ContextItem, item2: ContextItem): boolean {
+    return !!item1.content && item1.content === item2.content
 }

--- a/vscode/src/prompt-builder/unique-context.ts
+++ b/vscode/src/prompt-builder/unique-context.ts
@@ -82,7 +82,7 @@ export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: Context
 
             // Duplicates if whole file (undefined range) and selection has the
             // same content.
-            if (!itemToAddRange && equalContent(item, itemToAdd)) {
+            if (!itemToAddRange && equalTrimmedContent(item, itemToAdd)) {
                 return false
             }
         }
@@ -119,6 +119,6 @@ function isUserAddedItem(item: ContextItem): boolean {
 /**
  * Checks if content is set and equal.
  */
-function equalContent(item1: ContextItem, item2: ContextItem): boolean {
-    return !!item1.content && item1.content === item2.content
+function equalTrimmedContent(item1: ContextItem, item2: ContextItem): boolean {
+    return !!item1.content && !!item2.content && item1.content.trim() === item2.content.trim()
 }

--- a/vscode/src/prompt-builder/unique-context.ts
+++ b/vscode/src/prompt-builder/unique-context.ts
@@ -57,8 +57,10 @@ export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: Context
     for (const item of uniqueItems) {
         // Check for existing items with the same display path
         if (getContextItemDisplayPath(item) === itemToAddDisplayPath) {
+            const itemRange = item.range
+
             // Assume context with no range contains full file content (unique)
-            if (item === itemToAdd || !item.range) {
+            if (item === itemToAdd || !itemRange) {
                 return false // Duplicate found.
             }
 
@@ -69,10 +71,10 @@ export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: Context
 
             // Duplicates if overlapping ranges on the same lines,
             // or if one range contains the other.
-            if (item.range && itemToAddRange) {
+            if (itemToAddRange) {
                 if (
-                    rangesOnSameLines(item.range, itemToAddRange) ||
-                    rangeContainsLines(item.range, itemToAddRange)
+                    rangesOnSameLines(itemRange, itemToAddRange) ||
+                    rangeContainsLines(itemRange, itemToAddRange)
                 ) {
                     return false
                 }
@@ -80,7 +82,7 @@ export function isUniqueContextItem(itemToAdd: ContextItem, uniqueItems: Context
 
             // Duplicates if whole file (undefined range) and selection has the
             // same content.
-            if (item.range && !itemToAddRange && equalContent(item, itemToAdd)) {
+            if (!itemToAddRange && equalContent(item, itemToAdd)) {
                 return false
             }
         }

--- a/vscode/test/e2e/command-custom.test.ts
+++ b/vscode/test/e2e/command-custom.test.ts
@@ -268,9 +268,9 @@ test.extend<ExpectedEvents>({
     // The files from the open tabs should be added as context
     await expectContextCellCounts(contextCell, { files: 2 })
     await contextCell.click()
-    await expect(chatContext.getByRole('link', { name: 'index.html:1-11' })).toBeVisible()
+    await expect(chatContext.getByRole('link', { name: 'index.html' })).toBeVisible()
     await expect(
-        chatContext.getByRole('link', { name: withPlatformSlashes('lib/batches/env/var.go:1') })
+        chatContext.getByRole('link', { name: withPlatformSlashes('lib/batches/env/var.go') })
     ).toBeVisible()
 })
 


### PR DESCRIPTION
"Add file to cody chat" command from a right click on a file would fail since we would have an empty range set. This treats any empty range as an indication the user wanted to add the whole file, which should plug the hole for other potential call sites on getContextFileFromUri.

Additionally if we do not have a range defined, we now do not set range on the returned ContextItem. This is so we render the file in chat as just the filename, rather than the filename with the range 1:lineCount.

Test Plan: Manually added and removed a file from chat. Then added the file via right click on the text area, right click on the explorer. Additionally tested that selecting text and right clicking correctly selected just the range.

Fixes https://linear.app/sourcegraph/issue/CODY-1996/add-file-to-cody-chat-is-broken
