### PR TITLE
Autocomplete: Add feature flag to extend context language pool

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -44,6 +44,9 @@ export enum FeatureFlag {
     CodyAutocompleteSmartThrottle = 'cody-autocomplete-smart-throttle',
     // When activated, reduces the debounce time to 25ms (from 75ms).
     CodyAutocompleteReducedDebounce = 'cody-autocomplete-reduced-debounce',
+    // When enabled, it will extend the number of languages considered for context (e.g. React files
+    // will be able to use CSS files as context).
+    CodyAutocompleteContextExtendLanguagePool = 'cody-autocomplete-context-extend-language-pool',
 
     // use-ssc-for-cody-subscription is a feature flag that enables the use of SSC as the source of truth for Cody subscription data.
     UseSscForCodySubscription = 'use-ssc-for-cody-subscription',

--- a/vscode/src/completions/completion-provider-config.ts
+++ b/vscode/src/completions/completion-provider-config.ts
@@ -17,6 +17,7 @@ class CompletionProviderConfig {
         FeatureFlag.CodyAutocompleteTracing,
         FeatureFlag.CodyAutocompleteSmartThrottle,
         FeatureFlag.CodyAutocompleteReducedDebounce,
+        FeatureFlag.CodyAutocompleteContextExtendLanguagePool,
     ] as const
 
     private get config() {

--- a/vscode/src/completions/context/utils.test.ts
+++ b/vscode/src/completions/context/utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { shouldBeUsedAsContext } from './utils'
+
+describe('shouldBeUsedAsContext', () => {
+    describe('without extended language pool', () => {
+        it('returns true for the same language', () => {
+            expect(shouldBeUsedAsContext(false, 'erlang', 'erlang')).toBe(true)
+        })
+
+        it('allows js as context for jsx and vice versa', () => {
+            expect(shouldBeUsedAsContext(false, 'javascript', 'javascriptreact')).toBe(true)
+            expect(shouldBeUsedAsContext(false, 'javascriptreact', 'javascript')).toBe(true)
+        })
+
+        it('allows ts as context for tsx and vice versa', () => {
+            expect(shouldBeUsedAsContext(false, 'typescript', 'typescriptreact')).toBe(true)
+            expect(shouldBeUsedAsContext(false, 'typescriptreact', 'typescript')).toBe(true)
+        })
+    })
+
+    describe('with extended language pool', () => {
+        it('allows css files as context for template languages', () => {
+            expect(shouldBeUsedAsContext(true, 'typescriptreact', 'scss')).toBe(true)
+            expect(shouldBeUsedAsContext(true, 'javascriptreact', 'less')).toBe(true)
+            expect(shouldBeUsedAsContext(true, 'handlebars', 'css')).toBe(true)
+        })
+
+        it('allows template languages to be used as context for css files', () => {
+            expect(shouldBeUsedAsContext(true, 'scss', 'typescriptreact')).toBe(true)
+            expect(shouldBeUsedAsContext(true, 'less', 'javascriptreact')).toBe(true)
+            expect(shouldBeUsedAsContext(true, 'css', 'handlebars')).toBe(true)
+        })
+    })
+})

--- a/vscode/src/completions/context/utils.ts
+++ b/vscode/src/completions/context/utils.ts
@@ -1,19 +1,50 @@
+const typeScriptFamily = new Set(['typescript', 'typescriptreact'])
+const javaScriptFamily = new Set(['javascript', 'javascriptreact'])
+const cssFamily = new Set(['css', 'less', 'scss'])
+const htmlFamily = new Set([
+    'typescriptreact',
+    'javascriptreact',
+    'html',
+    'handlebars',
+    'vue-html',
+    'razor',
+    'php',
+    'haml',
+    // This omits vue and svelte as these languages usually do not
+    // import CSS modules but define them in the same file instead.
+])
+
 /**
- * Returns the base language id for the given language id. This is used to determine which language
- * IDs can be included as context for a given language ID.
- *
- * TODO(beyang): handle JavaScript <-> TypeScript and verify this works for C header files omit
- * files of other languages
+ * Returns true if the given language ID should be used as context for the base
+ * language id.
  */
-export function baseLanguageId(languageId: string): string {
-    switch (languageId) {
-        case 'typescript':
-        case 'typescriptreact':
-            return 'typescript'
-        case 'javascript':
-        case 'javascriptreact':
-            return 'javascript'
-        default:
-            return languageId
+export function shouldBeUsedAsContext(
+    enableExtendedLanguagePool: boolean,
+    baseLanguageId: string,
+    languageId: string
+): boolean {
+    if (baseLanguageId === languageId) {
+        return true
     }
+
+    if (typeScriptFamily.has(baseLanguageId) && typeScriptFamily.has(languageId)) {
+        return true
+    }
+    if (javaScriptFamily.has(baseLanguageId) && javaScriptFamily.has(languageId)) {
+        return true
+    }
+
+    if (!enableExtendedLanguagePool) {
+        // Allow template languages to use css files as context (in the hope
+        // that this allows filling class names more effectively)
+        if (htmlFamily.has(baseLanguageId) && cssFamily.has(languageId)) {
+            return true
+        }
+        // Allow css files to use template languages
+        if (cssFamily.has(baseLanguageId) && htmlFamily.has(languageId)) {
+            return true
+        }
+    }
+
+    return false
 }


### PR DESCRIPTION
Closes #3407

@valerybugakov: Is this an A/B test that you think we can run? 🙂 

## Test plan

<img width="1405" alt="Screenshot 2024-06-03 at 16 47 59" src="https://github.com/sourcegraph/cody/assets/458591/51b87024-c902-4402-9c47-43cd061ecfb2">




<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
