### PR TITLE
VS Code: Add version bump scripts (#4442)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "update-agent-recordings": "pnpm build && CODY_KEEP_UNUSED_RECORDINGS=false CODY_RECORD_IF_MISSING=true vitest agent/src",
     "update-rewrite-recordings": "rm -rf recordings && CODY_RECORD_IF_MISSING=true vitest vscode/src/local-context/rewrite-keyword-query.test.ts",
     "openctx:link": "cd ../openctx pnpm -C lib/client link --global && pnpm -C lib/schema link --global && pnpm -C lib/protocol link --global && pnpm -C client/vscode-lib link --global && cd ../cody && pnpm link --global @openctx/client && pnpm link --global @openctx/schema &&  pnpm link --global @openctx/protocol && cd vscode && pnpm link --global @openctx/vscode-lib",
-    "openctx:unlink": "pnpm unlink --global @openctx/client && pnpm unlink --global @openctx/schema &&  pnpm unlink --global @openctx/protocol && cd vscode && pnpm unlink --global @openctx/vscode-lib"
+    "openctx:unlink": "pnpm unlink --global @openctx/client && pnpm unlink --global @openctx/schema &&  pnpm unlink --global @openctx/protocol && cd vscode && pnpm unlink --global @openctx/vscode-lib",
+    "vsce-version-bump": "pnpm -C vscode version-bump:minor"
   },
   "devDependencies": {
     "@biomejs/biome": "1.7.2",

--- a/vscode/CONTRIBUTING.md
+++ b/vscode/CONTRIBUTING.md
@@ -47,13 +47,16 @@ We also have some build-in UI to help during the development of autocomplete req
 
 To publish a new **major** release to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai) and [Open VSX Registry](https://open-vsx.org/extension/sourcegraph/cody-ai).
 
-1. Increment the `version` in [`package.json`](package.json) & [`CHANGELOG`](CHANGELOG.md).
-2. `pnpm update-agent-recordings` to update the version in agent recordings.
-3. Commit the version increment, e.g. `VS Code: Release 1.1.0`.
-4. `git tag vscode-v$(jq -r .version package.json)`
-5. `git push --tags`
-6. Wait for the [vscode-stable-release workflow](https://github.com/sourcegraph/cody/actions/workflows/vscode-stable-release.yml) run to finish.
-7. Update the [Release Notes](https://github.com/sourcegraph/cody/releases).
+1. `pnpm vsce-version-bump` to increment the version number for stable release
+
+- Increment the `version` in [`package.json`](package.json) & [`CHANGELOG`](CHANGELOG.md).
+- Commit the version increment, e.g. `VS Code: Release 1.1.0`.
+
+2. Open a PR with the version updated
+3. `git tag vscode-v$(jq -r .version package.json)`
+4. `git push --tags`
+5. Wait for the [vscode-stable-release workflow](https://github.com/sourcegraph/cody/actions/workflows/vscode-stable-release.yml) run to finish.
+6. Update the [Release Notes](https://github.com/sourcegraph/cody/releases).
 
 ### Release Checklist
 
@@ -61,13 +64,6 @@ Version Bump:
 
 - [x] [vscode/CHANGELOG.md](./CHANGELOG.md)
 - [x] [vscode/package.json](./package.json)
-- [x] Update agent recordings
-
-  ```
-  source agent/scripts/export-cody-http-recording-tokens.sh
-  src login
-  pnpm update-agent-recordings
-  ```
 
 ### Patch Release
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -40,7 +40,8 @@
     "vscode:prepublish": "pnpm -s run build",
     "vscode:uninstall": "node ./dist/post-uninstall.js",
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
-    "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts"
+    "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts",
+    "version-bump:minor": "RELEASE_TYPE=minor ts-node-transpile-only ./scripts/release-pr.ts"
   },
   "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -41,7 +41,7 @@
     "vscode:uninstall": "node ./dist/post-uninstall.js",
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts",
-    "version-bump:minor": "RELEASE_TYPE=minor ts-node-transpile-only ./scripts/release-pr.ts"
+    "version-bump:minor": "RELEASE_TYPE=minor ts-node-transpile-only ./scripts/version-bump.ts"
   },
   "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -41,7 +41,8 @@
     "vscode:uninstall": "node ./dist/post-uninstall.js",
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",
     "github-changelog": "ts-node-transpile-only ./scripts/github-changelog.ts",
-    "version-bump:minor": "RELEASE_TYPE=minor ts-node-transpile-only ./scripts/version-bump.ts"
+    "version-bump:minor": "RELEASE_TYPE=minor ts-node-transpile-only ./scripts/version-bump.ts",
+    "version-bump:dry-run": "RELEASE_TYPE=prerelease ts-node-transpile-only ./scripts/version-bump.ts"
   },
   "categories": ["Programming Languages", "Machine Learning", "Snippets", "Education"],
   "keywords": [

--- a/vscode/scripts/version-bump.ts
+++ b/vscode/scripts/version-bump.ts
@@ -1,0 +1,55 @@
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import semver from 'semver'
+
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+const changelogFile = fs.readFileSync('CHANGELOG.md', 'utf8')
+const releaseType = (process.env.RELEASE_TYPE || '').toLowerCase() as semver.ReleaseType
+
+try {
+    const currentVersion = packageJson.version
+
+    if (!['minor', 'patch'].includes(releaseType)) {
+        throw new Error(`Release type is invalid: ${releaseType}`)
+    }
+
+    console.log(`Current version: ${currentVersion}`)
+
+    // Increase minor version number by twice for minor release because ODD minor number is for pre-release
+    const isPatchRelease = releaseType === 'patch'
+    const nextVersion = isPatchRelease
+        ? semver.inc(currentVersion, releaseType)!
+        : semver.inc(semver.inc(currentVersion, releaseType)!, releaseType)!
+
+    if (!nextVersion) {
+        throw new Error('Version number is invalid.')
+    }
+
+    console.log(`Next version: ${nextVersion}`)
+
+    // Update version number in package.json
+    packageJson.version = nextVersion
+    fs.writeFileSync('package.json', JSON.stringify(packageJson, null, 2))
+
+    // Update version number in Changelog
+    const template = '## [Unreleased]\n\n### Added\n\n### Fixed\n\n### Changed\n\n## $VERSION'
+    const updatedChangelogFile = changelogFile.replace(
+        '## [Unreleased]',
+        template.replace('$VERSION', nextVersion)
+    )
+    fs.writeFileSync('CHANGELOG.md', updatedChangelogFile)
+
+    // Commit and push
+    execSync(
+        `git add . && git commit -m "VS Code: Release v${nextVersion}" && git push -u origin HEAD`,
+        {
+            stdio: 'inherit',
+        }
+    )
+
+    console.log(`Version bumped to ${nextVersion} successfully!`)
+} catch (error) {
+    // Revert changes if an error occurred
+    fs.writeFileSync('package.json', JSON.stringify(packageJson, null, 2))
+    fs.writeFileSync('CHANGELOG.md', changelogFile)
+}

--- a/vscode/src/uninstall/post-uninstall.ts
+++ b/vscode/src/uninstall/post-uninstall.ts
@@ -14,6 +14,11 @@ class StaticAuthStatusProvider implements AuthStatusProvider {
 }
 
 async function main() {
+    // Do not record telemetry events during testing
+    if (process.env.CODY_TESTING) {
+        return
+    }
+
     const uninstaller = readConfig()
     if (uninstaller) {
         const { config, extensionDetails, authStatus, anonymousUserID } = uninstaller


### PR DESCRIPTION
feat: add scripts to automatically bump the version and update the changelog
- Added a new script `vsce-version-bump` to the root `package.json` to bump the VS Code extension version.
- Added a new script `version-bump:minor` to the `vscode/package.json` to handle minor version bumps.
- Implements a `version-bump.ts` script that:
  - Increments the version number based on the `RELEASE_TYPE` environment variable
  - Updates the version in `package.json`
  - Updates the version in the `CHANGELOG.md` file
  - Commits and pushes the changes VS Code: Release v1.20.2
- Updated `vscode/CONTRIBUTING.md`


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

Try running `vsce-version-bump` and check `git log` to confirm `package.json` and `CHANGELOG.md` are updated correctly.