### PR TITLE
Jaccard Retriever: Reduce performance overhead

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Fixed
 
+- Performance: Reduced the performance overhead for certain types of context fetching, especially for larger files. This might have caused issues with slow autocomplete before. [pull/4446](https://github.com/sourcegraph/cody/pull/4446)
+
 ### Changed
 
 ## [1.20.1]

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -37,6 +37,7 @@
     "test:e2e:run": "playwright test",
     "test:integration": "tsc --build ./test/integration && pnpm run -s build:dev:desktop && node --inspect -r ts-node/register dist/tsc/test/integration/main.js",
     "test:unit": "vitest",
+    "bench": "vitest bench",
     "vscode:prepublish": "pnpm -s run build",
     "vscode:uninstall": "node ./dist/post-uninstall.js",
     "test:unit:tree-sitter-queries": "vitest ./src/tree-sitter/query-tests/*.test.ts",

--- a/vscode/src/completions/context/retrievers/jaccard-similarity/bestJaccardMatch.bench.ts
+++ b/vscode/src/completions/context/retrievers/jaccard-similarity/bestJaccardMatch.bench.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs'
+import { bench, describe } from 'vitest'
+import {
+    getWordOccurrences,
+    // getWordOccurrencesTokenizeAfterCount,
+    // getWordOccurrencesWithCache,
+} from './bestJaccardMatch'
+
+// This benchmarked some performance improvements to the `getWordOccurrences` function. Although the alternatives don't exist anymore I left the framework here in case there's future botltenecks that need a similar optimization round.
+describe.skip('sort', async () => {
+    const largeFile = await fs.promises.readFile(
+        'recordings/symf_3564355686/recording.har.yaml',
+        'utf-8'
+    )
+    const smallFile = await fs.promises.readFile('CHANGELOG.md', 'utf-8')
+
+    bench('getWordOccurrences', () => {
+        getWordOccurrences(smallFile)
+        getWordOccurrences(largeFile)
+    })
+
+    // bench('getWordOccurrencesTokenizeAfterCount', () => {
+    //     getWordOccurrencesTokenizeAfterCount(smallFile)
+    //     getWordOccurrencesTokenizeAfterCount(largeFile)
+    // })
+
+    // bench('getWordOccurrencesWithCache', () => {
+    //     getWordOccurrencesWithCache(smallFile)
+    //     getWordOccurrencesWithCache(largeFile)
+    // })
+})

--- a/vscode/vite.config.ts
+++ b/vscode/vite.config.ts
@@ -8,5 +8,8 @@ export default defineProjectWithDefaults(__dirname, {
         // Only use happy-dom for React component unit tests. Unit tests of plain JavaScript
         // functions don't need the DOM.
         environmentMatchGlobs: [['webviews/**/*.test.tsx', 'happy-dom']],
+        benchmark: {
+            include: ['{src,webviews}/**/*.bench.ts']
+        }
     },
 })


### PR DESCRIPTION
User reported high-cpu usage with Cody installed https://github.com/sourcegraph/cody/issues/4348. Their CPU profile revealed an average 4 seconds spent getting context for autocomplete with a large amount spent counting word occurrences. 

![CleanShot 2024-06-03 at 16 34 27](https://github.com/sourcegraph/cody/assets/3949285/b6d58e85-489a-4a7b-9677-a0539efed984)

Now instead of stemming each word individually we maintain a small cache which speeds up stemming by more than 7x (if cache cleared before every benchmark run. Can be much higher in real-world scenarios).

Fixes CODY-1928

## Test plan
- tested several options by writing a simple benchmark and picking the most performant alternative
![CleanShot 2024-06-03 at 16 30 07](https://github.com/sourcegraph/cody/assets/3949285/bf31e4ae-1b9c-4a6b-971f-9362644284fe)
- ran existing unit tests to ensure no altered behavior
