### PR TITLE
Fix: Use withPlatformSlashes helper to format file path in unit test

### DIFF
--- a/vscode/src/prompt-builder/index.test.ts
+++ b/vscode/src/prompt-builder/index.test.ts
@@ -8,6 +8,7 @@ import {
     ps,
 } from '@sourcegraph/cody-shared'
 import { URI } from 'vscode-uri'
+import { withPlatformSlashes } from '../../test/e2e/helpers'
 import { PromptBuilder } from './index'
 
 describe('PromptBuilder', () => {
@@ -372,9 +373,10 @@ describe('PromptBuilder', () => {
                 .join('\n')
 
             expect(builder.contextItems.length).toBe(1)
+            const filePath = withPlatformSlashes('foo/bar.go')
             expect(promptContent).toMatchInlineSnapshot(`
               "preamble
-              Codebase context from file foo/bar.go:
+              Codebase context from file ${filePath}:
               \`\`\`go
               foo\`\`\`
               Ok.


### PR DESCRIPTION
The test-unit (windows, 20) is currently failing on main. This is because a new unit test added in https://github.com/sourcegraph/cody/pull/4432 is currently failing in CI because of the file path showing up in snippet is not platform specified:

![image](https://github.com/sourcegraph/cody/assets/68532117/2d7f26ee-7ec2-4ee2-9370-94c8796ca332)


This PR resolve it with the following changes:
- Adds the `withPlatformSlashes` helper function to format file paths with the correct platform-specific slashes in the prompt content
- Updates the test case to use the new helper function when asserting the prompt content


## Test plan

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->

The `test-unit (windows, 20)` should show up as green after this change.