### PR TITLE
Autocomplete: Remove multi-tenant llama code

### DIFF
--- a/lib/shared/src/experimentation/FeatureFlagProvider.ts
+++ b/lib/shared/src/experimentation/FeatureFlagProvider.ts
@@ -13,8 +13,6 @@ export enum FeatureFlag {
     // This flag is used to track the overall eligibility to use the StarCoder model. The `-hybrid`
     // suffix is no longer relevant
     CodyAutocompleteStarCoderHybrid = 'cody-autocomplete-default-starcoder-hybrid',
-    // Enable Llama Code 13b as the default model via Fireworks
-    CodyAutocompleteLlamaCode13B = 'cody-autocomplete-llama-code-13b',
     // Enable StarCoder2 7b and 15b as the default model via Fireworks
     CodyAutocompleteStarCoder2Hybrid = 'cody-autocomplete-starcoder2-hybrid',
     // Enable the FineTuned model as the default model via Fireworks

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1138,7 +1138,7 @@
         "cody.autocomplete.advanced.model": {
           "type": "string",
           "default": null,
-          "enum": [null, "starcoder-16b", "starcoder-7b", "llama-code-13b"],
+          "enum": [null, "starcoder-16b", "starcoder-7b"],
           "markdownDescription": "Overwrite the  model used for code autocompletion inference. This is only supported with the `fireworks` provider"
         },
         "cody.autocomplete.completeSuggestWidgetSelection": {

--- a/vscode/src/completions/providers/create-provider.test.ts
+++ b/vscode/src/completions/providers/create-provider.test.ts
@@ -235,8 +235,8 @@ describe('createProviderConfig', () => {
 
                 // fireworks
                 {
-                    codyLLMConfig: { provider: 'fireworks', completionModel: 'llama-code-13b' },
-                    expected: { provider: 'fireworks', model: 'llama-code-13b' },
+                    codyLLMConfig: { provider: 'fireworks', completionModel: 'starcoder-7b' },
+                    expected: { provider: 'fireworks', model: 'starcoder-7b' },
                 },
                 {
                     codyLLMConfig: { provider: 'fireworks' },
@@ -245,13 +245,16 @@ describe('createProviderConfig', () => {
 
                 // unknown-provider
                 {
-                    codyLLMConfig: { provider: 'unknown-provider', completionModel: 'llama-code-7b' },
+                    codyLLMConfig: {
+                        provider: 'unknown-provider',
+                        completionModel: 'superdupercoder-7b',
+                    },
                     expected: null,
                 },
 
                 // provider not defined (backward compat)
                 {
-                    codyLLMConfig: { provider: undefined, completionModel: 'llama-code-7b' },
+                    codyLLMConfig: { provider: undefined, completionModel: 'superdupercoder-7b' },
                     expected: { provider: 'anthropic', model: 'claude-instant-1.2' },
                 },
             ]

--- a/vscode/src/completions/providers/create-provider.ts
+++ b/vscode/src/completions/providers/create-provider.ts
@@ -208,16 +208,14 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
         return { provider: configuredProvider }
     }
 
-    const [starCoder2Hybrid, starCoderHybrid, llamaCode13B, claude3, finetunedFIMModelExperiment] =
-        await Promise.all([
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteLlamaCode13B),
-            featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
-            featureFlagProvider.evaluateFeatureFlag(
-                FeatureFlag.CodyAutocompleteFIMFineTunedModelBaseFeatureFlag
-            ),
-        ])
+    const [starCoder2Hybrid, starCoderHybrid, claude3, finetunedFIMModelExperiment] = await Promise.all([
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoder2Hybrid),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteStarCoderHybrid),
+        featureFlagProvider.evaluateFeatureFlag(FeatureFlag.CodyAutocompleteClaude3),
+        featureFlagProvider.evaluateFeatureFlag(
+            FeatureFlag.CodyAutocompleteFIMFineTunedModelBaseFeatureFlag
+        ),
+    ])
 
     // We run fine tuning experiment for VSC client only.
     // We disable for all agent clients like the JetBrains plugin.
@@ -228,10 +226,6 @@ async function resolveDefaultProviderFromVSCodeConfigOrFeatureFlags(
     if (!isFinetuningExperimentDisabled && finetunedFIMModelExperiment) {
         // The traffic in this feature flag is interpreted as a traffic allocated to the fine-tuned experiment.
         return resolveFinetunedModelProviderFromFeatureFlags()
-    }
-
-    if (llamaCode13B) {
-        return { provider: 'fireworks', model: 'llama-code-13b' }
     }
 
     if (starCoder2Hybrid) {


### PR DESCRIPTION
This deployment is not used and does no longer exist: https://sourcegraph.slack.com/archives/C0514L18QHG/p1715708673418439?thread_ts=1711144019.316819&cid=C0514L18QHG

## Test plan

- CI
