### PR TITLE
scroll to prompt editor after sending context items to chat

### DIFF
--- a/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
+++ b/vscode/webviews/chat/cells/messageCell/human/editor/HumanMessageEditor.tsx
@@ -185,7 +185,7 @@ export const HumanMessageEditor: FunctionComponent<{
                 const editor = editorRef.current
                 if (editor) {
                     editor.addMentions(addContextItemsToLastHumanInput)
-                    editor.setFocus(true)
+                    editor.setFocus(true, { scrollTo: true })
                 }
             },
             [isSent]

--- a/vscode/webviews/promptEditor/PromptEditor.tsx
+++ b/vscode/webviews/promptEditor/PromptEditor.tsx
@@ -46,7 +46,7 @@ interface Props extends KeyboardEventPluginProps {
 
 export interface PromptEditorRefAPI {
     getSerializedValue(): SerializedPromptEditorValue
-    setFocus(focus: boolean, options?: { moveCursorToEnd?: boolean }): void
+    setFocus(focus: boolean, options?: { moveCursorToEnd?: boolean; scrollTo?: boolean }): void
     appendText(text: string, ensureWhitespaceBefore?: boolean): void
     addMentions(items: ContextItem[]): void
     setInitialContextMentions(items: ContextItem[]): void
@@ -81,7 +81,7 @@ export const PromptEditor: FunctionComponent<Props> = ({
                 }
                 return toSerializedPromptEditorValue(editorRef.current)
             },
-            setFocus(focus, { moveCursorToEnd } = {}): void {
+            setFocus(focus, { moveCursorToEnd, scrollTo } = {}): void {
                 const editor = editorRef.current
                 if (editor) {
                     if (focus) {
@@ -105,14 +105,14 @@ export const PromptEditor: FunctionComponent<Props> = ({
                                 // Ensure element is focused in case the editor is empty. Copied
                                 // from LexicalAutoFocusPlugin.
                                 const doFocus = () =>
-                                    editor.getRootElement()?.focus({ preventScroll: true })
+                                    editor.getRootElement()?.focus({ preventScroll: !scrollTo })
                                 doFocus()
 
                                 // HACK(sqs): Needed in VS Code webviews to actually get it to focus
                                 // on initial load, for some reason.
                                 setTimeout(doFocus)
                             },
-                            { tag: 'skip-scroll-into-view' }
+                            !scrollTo ? { tag: 'skip-scroll-into-view' } : undefined
                         )
                     } else {
                         editor.blur()


### PR DESCRIPTION
When adding a file to the prompt via the menu it was unclear if anything happened if the prompt editor was out of view. We now ensure that after we give focus to the editor we scroll to it.


## Test plan

With a long message ensuring the follow-up prompt was out of view, I added a file to the context via right click.

https://github.com/sourcegraph/cody/assets/187831/62bbadfc-ff43-4166-8009-99407a2847a0
