### PR TITLE
skip flaky test `Generate Unit Test > editCommands/test 1`

### DIFF
--- a/agent/src/generate-unit-test.test.ts
+++ b/agent/src/generate-unit-test.test.ts
@@ -7,7 +7,7 @@ import { TestClient } from './TestClient'
 import { TestWorkspace } from './TestWorkspace'
 import { trimEndOfLine } from './trimEndOfLine'
 
-describe('Generate Unit Test', () => {
+describe.skip('Generate Unit Test', () => {
     const workspace = new TestWorkspace(path.join(__dirname, '__tests__', 'generate-unit-test'))
     const client = TestClient.create({
         workspaceRootUri: workspace.rootUri,
@@ -25,7 +25,8 @@ describe('Generate Unit Test', () => {
         await client.afterAll()
     })
 
-    it('editCommands/test', async () => {
+    // TODO(sqs): Skip due to flakiness on CI: https://github.com/sourcegraph/cody/actions/runs/9377140919/job/25818213028#step:7:1017.
+    it.skip('editCommands/test', async () => {
         const uri = workspace.file('src', 'trickyLogic.ts')
         await client.openFile(uri)
         const id = await client.request('editCommands/test', null)


### PR DESCRIPTION
Skip due to flakiness on CI: https://github.com/sourcegraph/cody/actions/runs/9377140919/job/25818213028#step:7:1017.



## Test plan

CI