### PR TITLE
Fix: add experimental LSP context

### DIFF
--- a/lib/shared/src/configuration.ts
+++ b/lib/shared/src/configuration.ts
@@ -83,6 +83,11 @@ export interface Configuration {
     autocompleteExperimentalMultiModelCompletions?: MultimodelSingleModelConfig[]
 
     /**
+     * Experimental edit
+     */
+    editExperimentalGraphContext?: 'lsp-light' | null
+
+    /**
      * Hidden settings
      */
     isRunningInsideAgent?: boolean

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -28,7 +28,7 @@
     "build:dev:web": "concurrently \"pnpm run -s _build:esbuild:web --alias:@sourcegraph/cody-shared=@sourcegraph/cody-shared/src/index --alias:@sourcegraph/cody-shared/src=@sourcegraph/cody-shared/src\" \"pnpm run -s _build:webviews --mode development\"",
     "watch:build:dev:web": "concurrently \"pnpm run -s _build:esbuild:web --watch\" \"pnpm run -s _build:webviews --mode development --watch\"",
     "watch:build:dev:desktop": "concurrently \"pnpm run -s _build:esbuild:desktop --watch\" \"pnpm run -s _build:webviews --mode development --watch\"",
-    "_build:esbuild:desktop": "pnpm download-wasm && pnpm run -s _build:esbuild:node && pnpm run -s _build:esbuild:uninstall",
+    "_build:esbuild:desktop": "pnpm download-wasm && pnpm run -s _build:esbuild:uninstall && pnpm run -s _build:esbuild:node",
     "_build:esbuild:node": "esbuild ./src/extension.node.ts --bundle --outfile=dist/extension.node.js --external:vscode --external:typescript --format=cjs --platform=node --sourcemap",
     "_build:esbuild:web": "esbuild ./src/extension.web.ts --platform=browser --bundle --outfile=dist/extension.web.js --alias:path=path-browserify --external:typescript --alias:node:path=path-browserify --alias:node:os=os-browserify --external:vscode --external:node:fs/promises --define:process='{\"env\":{}}' --define:window=self --format=cjs --sourcemap",
     "_build:esbuild:uninstall": "esbuild ./src/uninstall/post-uninstall.ts --bundle --outfile=dist/post-uninstall.js --external:typescript --format=cjs --platform=node --sourcemap",

--- a/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
+++ b/vscode/src/completions/context/retrievers/bfg/bfg-retriever.ts
@@ -215,7 +215,10 @@ export class BfgRetriever implements ContextRetriever {
                     ...getLastNGraphContextIdentifiersFromDocument({
                         n: 10,
                         document,
-                        position,
+                        range: new vscode.Range(
+                            new vscode.Position(Math.max(position.line - 100), 0),
+                            position.translate({ characterDelta: 1 })
+                        ),
                     }),
                 ])
             )

--- a/vscode/src/completions/context/retrievers/graph/identifiers.ts
+++ b/vscode/src/completions/context/retrievers/graph/identifiers.ts
@@ -10,7 +10,7 @@ import { lines } from '../../../text-processing'
 interface GetLastNGraphContextIdentifiersFromDocumentParams {
     n: number
     document: vscode.TextDocument
-    position: vscode.Position
+    range: vscode.Range
 }
 
 interface SymbolRequest {
@@ -24,17 +24,11 @@ interface SymbolRequest {
 export function getLastNGraphContextIdentifiersFromDocument(
     params: GetLastNGraphContextIdentifiersFromDocumentParams
 ): SymbolRequest[] {
-    const { document, position, n } = params
+    const { document, range, n } = params
 
     const queryPoints = {
-        startPoint: asPoint({
-            line: Math.max(position.line - 100, 0),
-            character: 0,
-        }),
-        endPoint: asPoint({
-            line: position.line,
-            character: position.character + 1,
-        }),
+        startPoint: asPoint(range.start),
+        endPoint: asPoint(range.end),
     }
 
     const symbolRequests = execQueryWrapper({

--- a/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.test.ts
+++ b/vscode/src/completions/context/retrievers/lsp-light/lsp-light-retriever.test.ts
@@ -129,7 +129,7 @@ describe('LspLightRetriever', () => {
     it('preloads the results when navigating to a line', async () => {
         await onDidChangeTextEditorSelection({
             textEditor: { document: testDocuments.document1 },
-            selections: [{ active: { line: 3, character: 0 } }],
+            selections: [{ active: new Position(3, 0) }],
         })
 
         // Preloading is debounced so we need to advance the timer manually
@@ -172,7 +172,7 @@ describe('LspLightRetriever', () => {
 
         await onDidChangeTextEditorSelection({
             textEditor: { document: testDocuments.document1 },
-            selections: [{ active: { line: 1, character: 0 } }],
+            selections: [{ active: new Position(1, 0) }],
         })
         await vi.advanceTimersToNextTimerAsync()
 
@@ -196,7 +196,7 @@ describe('LspLightRetriever', () => {
         getSymbolContextSnippets.mockImplementation(() => Promise.resolve([]))
         await onDidChangeTextEditorSelection({
             textEditor: { document: testDocuments.document1 },
-            selections: [{ active: { line: 2, character: 0 } }],
+            selections: [{ active: new Position(2, 0) }],
         })
         await vi.advanceTimersToNextTimerAsync()
 

--- a/vscode/src/configuration.test.ts
+++ b/vscode/src/configuration.test.ts
@@ -110,6 +110,8 @@ describe('getConfiguration', () => {
                         return ''
                     case 'cody.experimental.minion.anthropicKey':
                         return undefined
+                    case 'cody.edit.experimental.graphContext':
+                        return undefined
                     default:
                         throw new Error(`unexpected key: ${key}`)
                 }
@@ -165,6 +167,7 @@ describe('getConfiguration', () => {
                 multiline: undefined,
                 singleline: undefined,
             },
+            editExperimentalGraphContext: undefined,
             testingModelConfig: undefined,
             experimentalChatContextRanker: false,
         } satisfies Configuration)

--- a/vscode/src/configuration.ts
+++ b/vscode/src/configuration.ts
@@ -88,6 +88,11 @@ export function getConfiguration(
         null
     )
 
+    const editExperimentalGraphContext: 'lsp-light' | null = getHiddenSetting(
+        'edit.experimental.graphContext',
+        null
+    )
+
     function hasValidLocalEmbeddingsConfig(): boolean {
         return (
             [
@@ -136,6 +141,7 @@ export function getConfiguration(
         internalUnstable: getHiddenSetting('internal.unstable', isTesting),
 
         autocompleteExperimentalGraphContext,
+        editExperimentalGraphContext,
         experimentalSimpleChatContext: getHiddenSetting('experimental.simpleChatContext', true),
         experimentalSymfContext: getHiddenSetting('experimental.symfContext', true),
         experimentalCommitMessage: getHiddenSetting('experimental.commitMessage', true),

--- a/vscode/src/edit/manager.ts
+++ b/vscode/src/edit/manager.ts
@@ -122,7 +122,7 @@ export class EditManager implements vscode.Disposable {
         }
 
         // Set default edit configuration, if not provided
-        // It is possible that these values may be overriden later, e.g. if the user changes them in the edit input.
+        // It is possible that these values may be overridden later, e.g. if the user changes them in the edit input.
         const range = getEditLineSelection(document, proposedRange)
         const mode = configuration.mode || DEFAULT_EDIT_MODE
         const model = configuration.model || editModel.get(this.options.authProvider, this.models)

--- a/vscode/src/non-stop/FixupController.ts
+++ b/vscode/src/non-stop/FixupController.ts
@@ -22,7 +22,7 @@ import { PersistenceTracker } from '../common/persistence-tracker'
 import { lines } from '../completions/text-processing'
 import { sleep } from '../completions/utils'
 import { getInput } from '../edit/input/get-input'
-import { getOverridenModelForIntent } from '../edit/utils/edit-models'
+import { getOverridenModelForIntent as getOverriddenModelForIntent } from '../edit/utils/edit-models'
 import type { ExtensionClient } from '../extension-client'
 import { isRunningInsideAgent } from '../jsonrpc/isRunningInsideAgent'
 import type { AuthProvider } from '../services/AuthProvider'
@@ -344,7 +344,7 @@ export class FixupController
         telemetryMetadata?: FixupTelemetryMetadata
     ): Promise<FixupTask> {
         const authStatus = this.authProvider.getAuthStatus()
-        const overridenModel = getOverridenModelForIntent(intent, model, authStatus)
+        const overriddenModel = getOverriddenModelForIntent(intent, model, authStatus)
         const fixupFile = this.files.forUri(document.uri)
         const task = new FixupTask(
             fixupFile,
@@ -353,7 +353,7 @@ export class FixupController
             intent,
             selectionRange,
             mode,
-            overridenModel,
+            overriddenModel,
             source,
             destinationFile,
             insertionPoint,

--- a/vscode/src/testutils/mocks.ts
+++ b/vscode/src/testutils/mocks.ts
@@ -870,6 +870,7 @@ export const DEFAULT_VSCODE_SETTINGS = {
         multiline: undefined,
         singleline: undefined,
     },
+    editExperimentalGraphContext: null,
     testingModelConfig: undefined,
     experimentalChatContextRanker: false,
 } satisfies Configuration


### PR DESCRIPTION
- Adds experimental LSP context support to the Fix command. For now, it's meant to be used for internal testing and benchmarking. 
- Part of https://github.com/sourcegraph/cody-issues/issues/204

Fixes CODY-1556
https://github.com/sourcegraph/cody/assets/3846380/36459393-1165-4b46-9624-97be6b409e8d

## Test plan

1. Add `"cody.edit.experimental.graphContext": "lsp-light"` to your VS Code settings.
2. Trigger the fix command on an object declaration with the type declared in a separate file.


