### PR TITLE
Correct error message when the chat/new request fails to authenticate to the Sourcegraph API

### DIFF
--- a/vscode/src/models/index.ts
+++ b/vscode/src/models/index.ts
@@ -10,6 +10,11 @@ async function setModel(modelID: EditModel, storageKey: string) {
 
 function getModel<T extends string>(authProvider: AuthProvider, models: Model[], storageKey: string): T {
     const authStatus = authProvider.getAuthStatus()
+
+    if (!authStatus.authenticated) {
+        throw new Error('You are not authenticated')
+    }
+
     // Free user can only use the default model
     if (authStatus.isDotCom && authStatus.userCanUpgrade) {
         return models[0].model as T


### PR DESCRIPTION
This change is related to https://github.com/sourcegraph/jetbrains/issues/1498.

Previously, users received a misleading error message when the problem actually was caused by an expired authentication token. 

## Test plan

Try to start a new chat after your token has expired. The stack trace should say "You are not authenticated".

Verified manually that the behaviour of VS Code is not affected.
