### PR TITLE
chat: do not auto add selection context if source is chat

### DIFF
--- a/agent/recordings/defaultClient_631904893/recording.har.yaml
+++ b/agent/recordings/defaultClient_631904893/recording.har.yaml
@@ -762,153 +762,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: 1668a2afd7ba6791b44c46a9aaea04cc
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1183
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-cab982e42876ca0abc5622bd04492720-97f01a5028735602-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >-
-                  Codebase context from file src/squirrel.ts:
-
-                  ```typescript
-
-                  /**
-                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
-                   * It is related to the implementation of precise code navigation in Sourcegraph.
-                   */
-                  export interface Squirrel {}
-
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/animal.ts:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from @src/animal.ts:1-6:
-                  ```
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Write a class Dog that implements the Animal interface in my workspace.
-                  Show the code only, no explanation needed.
-            model: anthropic/claude-3-sonnet-20240229
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 11260
-        content:
-          mimeType: text/event-stream
-          size: 11260
-          text: >+
-            event: completion
-
-            data: {"completion":"```typescript\nclass Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 27 May 2024 11:54:29 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1299
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-27T11:54:27.883Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: fe008c5affb1f0e459786ed6dda1b083
       _order: 0
       cache: {}
@@ -1033,322 +886,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-05-27T11:54:32.544Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: f627f84bef553c2970b80bb5218446ce
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1455
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-4df8b46032003bcbb9bc078cffcceae8-4f90a82f0043149d-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/TestClass.ts:
-                  ```typescript
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/multiple-selections.ts:
-                  ```typescript
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-                  /* SELECTION_2_START */
-                  function anotherFunction() {}
-                  /* SELECTION_2_END */
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/animal.ts:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from @src/multiple-selections.ts:7-8:
-                  ```
-
-                  function anotherFunction() {}
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
-            model: anthropic/claude-3-sonnet-20240229
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 367
-        content:
-          mimeType: text/event-stream
-          size: 367
-          text: |+
-            event: completion
-            data: {"completion":"anotherFunction","stopReason":"end_turn"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 27 May 2024 11:54:50 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "591"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-27T11:54:49.134Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 80746d9e31bdca041aab743e776dec9e
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 1460
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-37f5092213af016bf11535aa9d76c0ff-44a37fc16ba49e16-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/TestClass.ts:
-                  ```typescript
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/multiple-selections.ts:
-                  ```typescript
-                  function outer() {
-                      /* SELECTION_START */
-                      return function inner() {}
-                      /* SELECTION_END */
-                  }
-
-                  /* SELECTION_2_START */
-                  function anotherFunction() {}
-                  /* SELECTION_2_END */
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  Codebase context from file src/animal.ts:
-                  ```typescript
-                  /* SELECTION_START */
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  /* SELECTION_END */
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from @src/multiple-selections.ts:2-4:
-                  ```
-
-                      return function inner() {}
-                      ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: What is the name of the function that I have selected? Only answer with
-                  the name of the function, nothing else
-            model: anthropic/claude-3-sonnet-20240229
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 158
-        content:
-          mimeType: text/event-stream
-          size: 158
-          text: |+
-            event: completion
-            data: {"completion":"inner","stopReason":"end_turn"}
-
-            event: done
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 27 May 2024 11:54:53 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "588"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-27T11:54:52.318Z
       time: 0
       timings:
         blocked: -1
@@ -1491,191 +1028,6 @@ log:
         send: 0
         ssl: -1
         wait: 0
-    - _id: ca9db2a2d35f28f09eee89118ab57160
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 2823
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-90af16414990c696b7cc08dd4ab86569-2d6e3e037ed21a06-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 415
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            maxTokensToSample: 4000
-            messages:
-              - speaker: system
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/TestClass.ts: const foo =
-                  42
-
-
-                  export class TestClass {
-                      constructor(private shouldGreet: boolean) {}
-
-                      public functionName() {
-                          if (this.shouldGreet) {
-                              console.log(/* CURSOR */ 'Hello World!')
-                          }
-                      }
-                  }
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: >
-                  Codebase context from file path src/example.test.ts: import {
-                  expect } from 'vitest'
-
-                  import { it } from 'vitest'
-
-                  import { describe } from 'vitest'
-
-
-                  describe('test block', () => {
-                      it('does 1', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does 2', () => {
-                          expect(true).toBe(true)
-                      })
-
-                      it('does something else', () => {
-                          // This line will error due to incorrect usage of `performance.now`
-                          const startTime = performance.now(/* CURSOR */)
-                      })
-                  })
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: |-
-                  My selected code from @src/animal.ts:1-6:
-                  ```
-
-                  export interface Animal {
-                      name: string
-                      makeAnimalSound(): string
-                      isMammal: boolean
-                  }
-                  ```
-              - speaker: assistant
-                text: Ok.
-              - speaker: human
-                text: Review the shared code context and configurations to identify the test
-                  framework and libraries in use. Then, generate a suite of
-                  multiple unit tests for the functions in <selected> using the
-                  detected test framework and libraries. Be sure to import the
-                  function being tested. Follow the same patterns as any shared
-                  context. Only add packages, imports, dependencies, and
-                  assertions if they are used in the shared code. Pay attention
-                  to the file path of each shared context to see if test for
-                  <selected> already exists. If one exists, focus on generating
-                  new unit tests for uncovered cases. If none are detected,
-                  import common unit test libraries for {languageName}. Focus on
-                  validating key functionality with simple and complete
-                  assertions. Only include mocks if one is detected in the
-                  shared code. Before writing the tests, identify which test
-                  libraries and frameworks to import, e.g. 'No new imports
-                  needed - using existing libs' or 'Importing test framework
-                  that matches shared context usage' or 'Importing the defined
-                  framework', etc. Then briefly summarize test coverage and any
-                  limitations. At the end, enclose the full completed code for
-                  the new unit tests, including all necessary imports, in a
-                  single markdown codeblock. No fragments or TODO. The new tests
-                  should validate expected functionality and cover edge cases
-                  for <selected> with all required imports, including importing
-                  the function being tested. Do not repeat existing tests.
-            model: anthropic/claude-3-sonnet-20240229
-            temperature: 0
-            topK: -1
-            topP: -1
-        queryString:
-          - name: api-version
-            value: "1"
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 636659
-        content:
-          mimeType: text/event-stream
-          size: 636659
-          text: >+
-            event: completion
-
-            data: {"completion":"To generate unit tests for the `Animal` interface, we can use the Vitest framework, which is already being used in the provided code context (`src/example.test.ts`).\n\nNo new imports are needed - using existing libs.\n\nThe test suite should cover the following aspects of the `Animal` interface:\n\n1. Validate the properties (`name` and `isMammal`) with different input values.\n2. Test the `makeAnimalSound` method with different implementations of the `Animal` interface.\n\nHere's a possible test suite:\n\n```typescript\nimport { describe, it, expect } from 'vitest'\n\n// Import the implementations of the Animal interface\nimport { Dog, Cat } from './animals'\n\ndescribe('Animal', () =\u003e {\n  describe('Dog', () =\u003e {\n    const dog = new Dog('Buddy', true)\n\n    it('should have the correct name', () =\u003e {\n      expect(dog.name).toBe('Buddy')\n    })\n\n    it('should be a mammal', () =\u003e {\n      expect(dog.isMammal).toBe(true)\n    })\n\n    it('should make the correct sound', () =\u003e {\n      expect(dog.makeAnimalSound()).toBe('Woof!')\n    })\n  })\n\n  describe('Cat', () =\u003e {\n    const cat = new Cat('Missy', true)\n\n    it('should have the correct name', () =\u003e {\n      expect(cat.name).toBe('Missy')\n    })\n\n    it('should be a mammal', () =\u003e {\n      expect(cat.isMammal).toBe(true)\n    })\n\n    it('should make the correct sound', () =\u003e {\n      expect(cat.makeAnimalSound()).toBe('Meow!')\n    })\n  })\n})\n```\n\nThis test suite covers the basic functionality of the `Animal` interface by testing the properties and the `makeAnimalSound` method with two different implementations (`Dog` and `Cat`). It validates the expected behavior with assertions using the `expect` function from Vitest.\n\nNote: The implementations of `Dog` and `Cat` classes are not provided in the shared code context, so I've assumed their existence for the purpose of this example. You may need to adjust the import statements and class instantiation based on your actual implementation.\n\nThe test coverage is reasonably comprehensive, but it may not cover all edge cases or complex scenarios. Additionally, if there are any dependencies or mocks required for the `Animal` interface or its implementations, those would need to be set up in the test suite as well.","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 27 May 2024 11:55:04 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "578"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-27T11:55:02.689Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
     - _id: ad4d12b86c3f16e562cdecb23a262d4e
       _order: 0
       cache: {}
@@ -1805,6 +1157,341 @@ log:
         send: 0
         ssl: -1
         wait: 0
+    - _id: bc5fcddc3eb7bcc9bd6f89a3a5473c55
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 961
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-bf3e29873958a72e53e96bab873623db-c1da42115d035c92-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >-
+                  Codebase context from file src/squirrel.ts:
+
+                  ```typescript
+
+                  /**
+                   * Squirrel is an interface that mocks something completely unrelated to squirrels.
+                   * It is related to the implementation of precise code navigation in Sourcegraph.
+                   */
+                  export interface Squirrel {}
+
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  Codebase context from file src/animal.ts:
+                  ```typescript
+                  /* SELECTION_START */
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  /* SELECTION_END */
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Write a class Dog that implements the Animal interface in my workspace.
+                  Show the code only, no explanation needed.
+            model: anthropic/claude-3-sonnet-20240229
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 11260
+        content:
+          mimeType: text/event-stream
+          size: 11260
+          text: >+
+            event: completion
+
+            data: {"completion":"```typescript\nclass Dog implements Animal {\n    name: string;\n    isMammal: boolean = true;\n\n    constructor(name: string) {\n        this.name = name;\n    }\n\n    makeAnimalSound(): string {\n        return \"Woof!\";\n    }\n}\n```","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 05 Jun 2024 15:16:32 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-05T15:16:31.066Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: ce4376723f632bb377407fac15cdda8b
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 3177
+        cookies: []
+        headers:
+          - name: content-type
+            value: application/json
+          - name: accept-encoding
+            value: gzip;q=0
+          - name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - name: user-agent
+            value: defaultClient / v1
+          - name: traceparent
+            value: 00-019e2ecff0220986e0f2fe222a214075-4932633d0417757d-01
+          - name: connection
+            value: keep-alive
+          - name: host
+            value: sourcegraph.com
+        headersSize: 415
+        httpVersion: HTTP/1.1
+        method: POST
+        postData:
+          mimeType: application/json
+          params: []
+          textJSON:
+            maxTokensToSample: 4000
+            messages:
+              - speaker: system
+                text: You are Cody, an AI coding assistant from Sourcegraph.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/TestLogger.ts: const foo =
+                  42
+
+                  export const TestLogger = {
+                      startLogging: () => {
+                          // Do some stuff
+
+                          function recordLog() {
+                              console.log(/* CURSOR */ 'Recording the log')
+                          }
+
+                          recordLog()
+                      },
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/TestClass.ts: const foo =
+                  42
+
+
+                  export class TestClass {
+                      constructor(private shouldGreet: boolean) {}
+
+                      public functionName() {
+                          if (this.shouldGreet) {
+                              console.log(/* CURSOR */ 'Hello World!')
+                          }
+                      }
+                  }
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: >
+                  Codebase context from file path src/example.test.ts: import {
+                  expect } from 'vitest'
+
+                  import { it } from 'vitest'
+
+                  import { describe } from 'vitest'
+
+
+                  describe('test block', () => {
+                      it('does 1', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does 2', () => {
+                          expect(true).toBe(true)
+                      })
+
+                      it('does something else', () => {
+                          // This line will error due to incorrect usage of `performance.now`
+                          const startTime = performance.now(/* CURSOR */)
+                      })
+                  })
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: |-
+                  My selected code from @src/animal.ts:1-6:
+                  ```
+
+                  export interface Animal {
+                      name: string
+                      makeAnimalSound(): string
+                      isMammal: boolean
+                  }
+                  ```
+              - speaker: assistant
+                text: Ok.
+              - speaker: human
+                text: Review the shared code context and configurations to identify the test
+                  framework and libraries in use. Then, generate a suite of
+                  multiple unit tests for the functions in <selected> using the
+                  detected test framework and libraries. Be sure to import the
+                  function being tested. Follow the same patterns as any shared
+                  context. Only add packages, imports, dependencies, and
+                  assertions if they are used in the shared code. Pay attention
+                  to the file path of each shared context to see if test for
+                  <selected> already exists. If one exists, focus on generating
+                  new unit tests for uncovered cases. If none are detected,
+                  import common unit test libraries for {languageName}. Focus on
+                  validating key functionality with simple and complete
+                  assertions. Only include mocks if one is detected in the
+                  shared code. Before writing the tests, identify which test
+                  libraries and frameworks to import, e.g. 'No new imports
+                  needed - using existing libs' or 'Importing test framework
+                  that matches shared context usage' or 'Importing the defined
+                  framework', etc. Then briefly summarize test coverage and any
+                  limitations. At the end, enclose the full completed code for
+                  the new unit tests, including all necessary imports, in a
+                  single markdown codeblock. No fragments or TODO. The new tests
+                  should validate expected functionality and cover edge cases
+                  for <selected> with all required imports, including importing
+                  the function being tested. Do not repeat existing tests.
+            model: anthropic/claude-3-sonnet-20240229
+            temperature: 0
+            topK: -1
+            topP: -1
+        queryString:
+          - name: api-version
+            value: "1"
+          - name: client-name
+            value: defaultclient
+          - name: client-version
+            value: v1
+        url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=defaultclient&client-version=v1
+      response:
+        bodySize: 574048
+        content:
+          mimeType: text/event-stream
+          size: 574048
+          text: >+
+            event: completion
+
+            data: {"completion":"Based on the shared code context from `src/example.test.ts`, the test framework and libraries being used are Vitest and the built-in assertion library from Vitest.\n\nTo test the `Animal` interface, we can create a mock implementation of the interface and use it to test the expected behavior of any functions that interact with the `Animal` interface.\n\nHere's a suite of unit tests for the `Animal` interface:\n\n```typescript\nimport { describe, it, expect } from 'vitest'\n\n// Mock implementation of the Animal interface\nclass MockAnimal implements Animal {\n  name: string\n  isMammal: boolean\n\n  constructor(name: string, isMammal: boolean) {\n    this.name = name\n    this.isMammal = isMammal\n  }\n\n  makeAnimalSound(): string {\n    return `${this.name} makes a sound`\n  }\n}\n\ndescribe('Animal', () =\u003e {\n  it('should have a name', () =\u003e {\n    const animal = new MockAnimal('Dog', true)\n    expect(animal.name).toBe('Dog')\n  })\n\n  it('should have a isMammal property', () =\u003e {\n    const mammal = new MockAnimal('Cat', true)\n    const nonMammal = new MockAnimal('Snake', false)\n    expect(mammal.isMammal).toBe(true)\n    expect(nonMammal.isMammal).toBe(false)\n  })\n\n  it('should make an animal sound', () =\u003e {\n    const animal = new MockAnimal('Cow', true)\n    expect(animal.makeAnimalSound()).toBe('Cow makes a sound')\n  })\n})\n```\n\nThis suite of tests covers the basic functionality of the `Animal` interface, including:\n\n- Validating that instances of `Animal` have a `name` property\n- Validating that instances of `Animal` have an `isMammal` property\n- Validating that the `makeAnimalSound` method returns the expected string\n\nSince the `Animal` interface is an interface and not a concrete implementation, we create a mock implementation `MockAnimal` to test the expected behavior of the interface.\n\nOverall, these tests provide good coverage of the `Animal` interface, but they are limited to testing the interface itself and not any specific implementations of the interface. If there are specific implementations of the `Animal` interface, additional tests should be added to cover those implementations.","stopReason":"end_turn"}
+
+
+            event: done
+
+            data: {}
+
+        cookies: []
+        headers:
+          - name: date
+            value: Wed, 05 Jun 2024 15:16:36 GMT
+          - name: content-type
+            value: text/event-stream
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1299
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-06-05T15:16:34.532Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 8bc9bbaf90bcaec66cd48785d79db439
       _order: 0
       cache: {}
@@ -1869,756 +1556,6 @@ log:
           mimeType: text/event-stream
           size: 77430
           text: >+
-            event: completion
-
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that woul","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecan","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Here are some filename fragments that would match files relevant to the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003edog\u003c/value\u003e\n\u003cvariants\u003ecanine\u003c/variants\u003e\n\u003cweight\u003e0.9\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003ecreature creature_interface creature_impl\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003einterface\u003c/value\u003e\n\u003cvariants\u003eapi contract spec\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eimplementation\u003c/value\u003e\n\u003cvariants\u003eimpl concrete_class\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
@@ -2734,956 +1671,6 @@ log:
           text: >+
             event: completion
 
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that woul","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esqu","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esqu","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squir","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ero","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003ero","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent ro","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors eth","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat hab","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
             data: {"completion":"Here are some filename fragments that would match files relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003esquirrel\u003c/value\u003e\n\u003cvariants\u003esquirrel squirrels\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eanimal\u003c/value\u003e\n\u003cvariants\u003eanimal animals fauna wildlife\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003erodent\u003c/value\u003e\n\u003cvariants\u003erodent rodents\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ebehavior\u003c/value\u003e\n\u003cvariants\u003ebehavior behaviors ethology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ehabitat\u003c/value\u003e\n\u003cvariants\u003ehabitat habitats environment ecology\u003c/variants\u003e\n\u003cweight\u003e0.7\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
 
 
@@ -3789,426 +1776,6 @@ log:
           text: >+
             event: completion
 
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a clear","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a clear night","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a clear night.","stopReason":""}
-
-
-            event: completion
-
             data: {"completion":"The color of the sky can vary depending on the time of day and weather conditions. During the day, the sky is typically blue due to the way sunlight is scattered in the Earth's atmosphere. At sunrise and sunset, the sky can appear various shades of red, orange, and pink. At night, the sky can be dark blue or black, with stars and the moon visible if it's a clear night.","stopReason":"stop"}
 
 
@@ -4312,15 +1879,6 @@ log:
           mimeType: text/event-stream
           size: 315
           text: |+
-            event: completion
-            data: {"completion":"","stopReason":""}
-
-            event: completion
-            data: {"completion":"Quone","stopReason":""}
-
-            event: completion
-            data: {"completion":"Quone.\n```python\n\n```","stopReason":""}
-
             event: completion
             data: {"completion":"Quone.\n```python\n\n```","stopReason":"stop"}
 
@@ -4432,15 +1990,6 @@ log:
           size: 279
           text: |+
             event: completion
-            data: {"completion":"","stopReason":""}
-
-            event: completion
-            data: {"completion":"Quone","stopReason":""}
-
-            event: completion
-            data: {"completion":"Quone.","stopReason":""}
-
-            event: completion
             data: {"completion":"Quone.","stopReason":"stop"}
 
             event: done
@@ -4541,51 +2090,6 @@ log:
           mimeType: text/event-stream
           size: 2720
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello!","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you with any coding-related questions or problems you may have. If you're referring to a specific programming","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you with any coding-related questions or problems you may have. If you're referring to a specific programming concept, library, or tool related to \"kramer,\" please let me know and I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you with any coding-related questions or problems you may have. If you're referring to a specific programming concept, library, or tool related to \"kramer,\" please let me know and I'll do my best to help you with that.","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Hello! It seems like you've mentioned \"kramer,\" but I'm not sure what you're asking about specifically. Do you have a question about programming or do you need help with something related to coding? I'm here to assist you with any coding-related questions or problems you may have. If you're referring to a specific programming concept, library, or tool related to \"kramer,\" please let me know and I'll do my best to help you with that.","stopReason":"stop"}
@@ -4691,41 +2195,6 @@ log:
           mimeType: text/event-stream
           size: 1489
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.","stopReason":"stop"}
@@ -4845,76 +2314,6 @@ log:
           mimeType: text/event-stream
           size: 6296
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"K","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"fest","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: kramer\n\nCody: The magic word is not \"kramer\". As","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: kramer\n\nCody: The magic word is not \"kramer\". As a reminder, the magic word is \"georgey\" and the response","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: kramer\n\nCody: The magic word is not \"kramer\". As a reminder, the magic word is \"georgey\" and the response to that word is \"festivus\".","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"\"Kramer\" is not the magic word that we previously discussed. The magic word is \"georgey\". If you say the magic word, I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: kramer\n\nCody: The magic word is not \"kramer\". As a reminder, the magic word is \"georgey\" and the response to that word is \"festivus\".","stopReason":"stop"}
@@ -5062,66 +2461,6 @@ log:
           text: >+
             event: completion
 
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"f","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: georgey\n\nCody: Festivus.\n\nI hope","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: georgey\n\nCody: Festivus.\n\nI hope this helps. Let me know if you have any other questions.","stopReason":""}
-
-
-            event: completion
-
             data: {"completion":"In our previous conversation, you mentioned that if you say the magic word \"georgey\", I will respond with \"festivus\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Sure, I will respond with \"festivus\" if you say the word \"georgey\". Here's a reminder of our conversation:\n\nHuman: Another magic word is \"georgey\". If I say the magic word, respond with a single word: \"festivus\".\n\nCody: Festivus.\n\nHuman: georgey\n\nCody: Festivus.\n\nI hope this helps. Let me know if you have any other questions.","stopReason":"stop"}
 
 
@@ -5226,31 +2565,6 @@ log:
           mimeType: text/event-stream
           size: 994
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure,","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Here's your single","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Here's your single \"ok\":\n\nOk.\n\nPlease let me know if you have any questions or need","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Here's your single \"ok\":\n\nOk.\n\nPlease let me know if you have any questions or need help with coding. I'm here to assist you!","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Sure, I understand that you have a turtle named \"potter\". Here's your single \"ok\":\n\nOk.\n\nPlease let me know if you have any questions or need help with coding. I'm here to assist you!","stopReason":"stop"}
@@ -5369,36 +2683,6 @@ log:
           mimeType: text/event-stream
           size: 1283
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me anything about","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me anything about coding or whether you have any questions related to your pets! I'm glad to help you","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me anything about coding or whether you have any questions related to your pets! I'm glad to help you with both. 😊","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Understood, you have a bird named \"skywalker\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me anything about coding or whether you have any questions related to your pets! I'm glad to help you with both. 😊","stopReason":"stop"}
@@ -5531,31 +2815,6 @@ log:
           text: >+
             event: completion
 
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I understand","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I understand that you have a dog named \"happy\". Here's your single \"ok\":\n\nOk.\n\nI","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I understand that you have a dog named \"happy\". Here's your single \"ok\":\n\nOk.\n\nI'm here to make your coding experience more enjoyable, and if you have any questions or need help","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I understand that you have a dog named \"happy\". Here's your single \"ok\":\n\nOk.\n\nI'm here to make your coding experience more enjoyable, and if you have any questions or need help with coding, please just let me know!","stopReason":""}
-
-
-            event: completion
-
             data: {"completion":"I understand that you have a dog named \"happy\". Here's your single \"ok\":\n\nOk.\n\nI'm here to make your coding experience more enjoyable, and if you have any questions or need help with coding, please just let me know!","stopReason":"stop"}
 
 
@@ -5672,36 +2931,6 @@ log:
           mimeType: text/event-stream
           size: 1105
           text: >+
-            event: completion
-
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a tiger named \"zorro\". Here's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a tiger named \"zorro\". Here's your single \"ok\":\n\nOk.\n\nFeel free to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a tiger named \"zorro\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me any questions about coding or AI-related topics. I","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Understood, you have a tiger named \"zorro\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me any questions about coding or AI-related topics. I'm eager to help you out!","stopReason":""}
-
-
             event: completion
 
             data: {"completion":"Understood, you have a tiger named \"zorro\". Here's your single \"ok\":\n\nOk.\n\nFeel free to ask me any questions about coding or AI-related topics. I'm eager to help you out!","stopReason":"stop"}
@@ -5834,41 +3063,6 @@ log:
           text: >+
             event: completion
 
-            data: {"completion":"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"zorro\"\n\nPlease let me know if you have any other pets or","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"zorro\"\n\nPlease let me know if you have any other pets or if you need help with any coding or AI-","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"zorro\"\n\nPlease let me know if you have any other pets or if you need help with any coding or AI-related topics. I'm here to assist you.","stopReason":""}
-
-
-            event: completion
-
             data: {"completion":"I have noted that you have two pets:\n\n1. A turtle named \"potter\"\n2. A tiger named \"zorro\"\n\nPlease let me know if you have any other pets or if you need help with any coding or AI-related topics. I'm here to assist you.","stopReason":"stop"}
 
 
@@ -5911,723 +3105,6 @@ log:
         status: 200
         statusText: OK
       startedDateTime: 2024-05-27T11:54:46.066Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: aebd71d7818fbee68b9ddd4277323e4b
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 969
-        cookies: []
-        headers:
-          - name: content-type
-            value: application/json
-          - name: accept-encoding
-            value: gzip;q=0
-          - name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - name: user-agent
-            value: defaultClient / v1
-          - name: traceparent
-            value: 00-4df8b46032003bcbb9bc078cffcceae8-a48c7330942590c8-01
-          - name: connection
-            value: keep-alive
-          - name: host
-            value: sourcegraph.com
-        headersSize: 401
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json
-          params: []
-          textJSON:
-            fast: true
-            maxTokensToSample: 400
-            messages:
-              - speaker: human
-                text: You are Cody, an AI coding assistant from Sourcegraph.
-              - speaker: assistant
-                text: I am Cody, an AI coding assistant from Sourcegraph.
-              - speaker: human
-                text: "You are helping the user search over a codebase. List some filename
-                  fragments that would match files relevant to read to answer
-                  the user's query. Present your results in an XML list in the
-                  following format: <keywords><keyword><value>a single
-                  keyword</value><variants>a space separated list of synonyms
-                  and variants of the keyword, including acronyms,
-                  abbreviations, and expansions</variants><weight>a numerical
-                  weight between 0.0 and 1.0 that indicates the importance of
-                  the keyword</weight></keyword></keywords>. Here is the user
-                  query: <userQuery>What is the name of the function that I have
-                  selected? Only answer with the name of the function, nothing
-                  else</userQuery>"
-              - speaker: assistant
-            temperature: 0
-            topK: 1
-        queryString:
-          - name: client-name
-            value: defaultclient
-          - name: client-version
-            value: v1
-        url: https://sourcegraph.com/.api/completions/stream?client-name=defaultclient&client-version=v1
-      response:
-        bodySize: 50869
-        content:
-          mimeType: text/event-stream
-          size: 50869
-          text: >+
-            event: completion
-
-            data: {"completion":"Here","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that coul","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answ","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emetho","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure su","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subr","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subrout","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keywor","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":""}
-
-
-            event: completion
-
-            data: {"completion":"Here are some filename fragments that could be relevant to answering the user's query:\n\n\u003ckeywords\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003efunction\u003c/value\u003e\n\u003cvariants\u003emethod procedure subroutine routine\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003ename\u003c/value\u003e\n\u003cvariants\u003etitle identifier label\u003c/variants\u003e\n\u003cweight\u003e1.0\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003ckeyword\u003e\n\u003cvalue\u003eselect\u003c/value\u003e\n\u003cvariants\u003echoose pick highlight\u003c/variants\u003e\n\u003cweight\u003e0.8\u003c/weight\u003e\n\u003c/keyword\u003e\n\u003c/keywords\u003e","stopReason":"end_turn"}
-
-
-            event: done
-
-            data: {}
-
-        cookies: []
-        headers:
-          - name: date
-            value: Mon, 27 May 2024 11:54:48 GMT
-          - name: content-type
-            value: text/event-stream
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: retry-after
-            value: "593"
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-        headersSize: 1406
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-05-27T11:54:47.193Z
       time: 0
       timings:
         blocked: -1

--- a/agent/src/__tests__/example-ts/src/multiple-selections.ts
+++ b/agent/src/__tests__/example-ts/src/multiple-selections.ts
@@ -1,9 +1,0 @@
-function outer() {
-    /* SELECTION_START */
-    return function inner() {}
-    /* SELECTION_END */
-}
-
-/* SELECTION_2_START */
-function anotherFunction() {}
-/* SELECTION_2_END */

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -561,7 +561,7 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
                 const userContextItems: ContextItemWithContent[] = await resolveContextItems(
                     this.editor,
-                    [...mentions],
+                    mentions,
                     inputText
                 )
                 abortSignal.throwIfAborted()

--- a/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
+++ b/vscode/src/chat/chat-view/SimpleChatPanelProvider.ts
@@ -68,7 +68,7 @@ import { captureException } from '@sentry/core'
 import type { TelemetryEventParameters } from '@sourcegraph/telemetry'
 import type { URI } from 'vscode-uri'
 import { getContextFileFromUri } from '../../commands/context/file-path'
-import { getContextFileFromCursor, getContextFileFromSelection } from '../../commands/context/selection'
+import { getContextFileFromCursor } from '../../commands/context/selection'
 import type { EnterpriseContextFactory } from '../../context/enterprise-context-factory'
 import type { Repo } from '../../context/repo-fetcher'
 import type { RemoteRepoPicker } from '../../context/repo-picker'
@@ -559,13 +559,9 @@ export class SimpleChatPanelProvider implements vscode.Disposable, ChatSession {
 
                 this.postEmptyMessageInProgress()
 
-                // Add user's current selection as context for chat messages.
-                const selectionContext = source === 'chat' ? await getContextFileFromSelection() : []
-                abortSignal.throwIfAborted()
-
                 const userContextItems: ContextItemWithContent[] = await resolveContextItems(
                     this.editor,
-                    [...mentions, ...selectionContext],
+                    [...mentions],
                     inputText
                 )
                 abortSignal.throwIfAborted()


### PR DESCRIPTION
We now explicitly mention the current file/selection. This bit of logic was making it so that if we remove the mention for current file it would still get added in if code was selected.

Test Plan: Did a chat with code selected. In one case with the @-mention and one time without.

Fixes https://linear.app/sourcegraph/issue/CODY-1972/file-selection-is-included-as-context-even-if-the-user-deletes-it