### PR TITLE
disable copy event logging on code blocks to fix event log spam

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 ### Fixed
 
 - Chat: Don't append @ when "Add context" is pressed multiple times. [pull/4439](https://github.com/sourcegraph/cody/pull/4439)
+- Chat: Fix an issue where copying code (with right-click or Cmd/Ctrl+C) causes many event logs and may trip rate limits. [pull/4469](https://github.com/sourcegraph/cody/pull/4469)
 
 ### Changed
 

--- a/vscode/webviews/chat/ChatMessageContent.tsx
+++ b/vscode/webviews/chat/ChatMessageContent.tsx
@@ -298,13 +298,6 @@ export const ChatMessageContent: React.FunctionComponent<ChatMessageContentProps
 
                 // Insert the buttons after the pre using insertBefore() because there is no insertAfter()
                 preElement.parentNode.insertBefore(buttons, preElement.nextSibling)
-
-                // capture copy events (right click or keydown) on code block
-                preElement.addEventListener('copy', () => {
-                    if (copyButtonOnSubmit) {
-                        copyButtonOnSubmit(preText, 'Keydown')
-                    }
-                })
             }
         }
     }, [copyButtonOnSubmit, insertButtonOnSubmit, guardrails, displayMarkdown, isMessageLoading])


### PR DESCRIPTION
The better fix would be to not leak event handlers in the useEffect hook, but this is a quick fix.

Fix https://linear.app/sourcegraph/issue/CODY-2102/vs-code-freezes-when-copy-pasting-selected-text-from-code-block-in



## Test plan

CI

Copy code in chat and confirm in the output channel that no event log spam occurs