### PR TITLE
Improve 'needs README' context detection

### DIFF
--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -391,39 +391,30 @@ function needsReadmeContext(editor: VSCodeEditor, input: PromptString): boolean 
     const words = stringInput.split(/\W+/).filter(w => w.length > 0)
     const bagOfWords = Object.fromEntries(words.map(w => [w, true]))
 
-    const projectSignifiers = [
-        'project',
-        'repository',
-        'repo',
-        'library',
-        'package',
-        'module',
-        'codebase',
-    ]
-    const questionIndicators = ['what', 'how', 'describe', 'explain', '?']
-
-    const workspaceUri = editor.getWorkspaceRootUri()
-    if (workspaceUri) {
-        const rootBase = workspaceUri.toString().split('/').at(-1)
-        if (rootBase) {
-            const tokens = rootBase.split(/\W+/).filter(w => w.length > 0)
-            for (const token of tokens) {
-                projectSignifiers.push(token.toLowerCase())
-            }
-            projectSignifiers.push(rootBase.toLowerCase())
-        }
-    }
-
     let containsProjectSignifier = false
-    for (const p of projectSignifiers) {
-        if (bagOfWords[p]) {
-            containsProjectSignifier = true
-            break
+    const workspaceName = vscode.workspace.workspaceFolders?.[0]?.name
+    if (workspaceName && new RegExp(`\\b${workspaceName}\\b`, 'i').test(stringInput)) {
+        containsProjectSignifier = true
+    } else {
+        const projectSignifiers = [
+            'project',
+            'repository',
+            'repo',
+            'library',
+            'package',
+            'module',
+            'codebase',
+        ]
+        for (const p of projectSignifiers) {
+            if (bagOfWords[p]) {
+                containsProjectSignifier = true
+                break
+            }
         }
     }
 
     let containsQuestionIndicator = false
-    for (const q of questionIndicators) {
+    for (const q of ['what', 'how', 'describe', 'explain']) {
         if (bagOfWords[q]) {
             containsQuestionIndicator = true
             break

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -393,7 +393,7 @@ function needsReadmeContext(editor: VSCodeEditor, input: PromptString): boolean 
 
     let containsProjectSignifier = false
     const workspaceName = vscode.workspace.workspaceFolders?.[0]?.name
-    if (workspaceName && new RegExp(`\\b${workspaceName}\\b`, 'i').test(stringInput)) {
+    if (workspaceName && stringInput.includes('@' + workspaceName)) {
         containsProjectSignifier = true
     } else {
         const projectSignifiers = [

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -406,7 +406,7 @@ function needsReadmeContext(editor: VSCodeEditor, input: PromptString): boolean 
     if (workspaceUri) {
         const rootBase = workspaceUri.toString().split('/').at(-1)
         if (rootBase) {
-            let tokens = rootBase.split(/\W+/).filter(w => w.length > 0)
+            const tokens = rootBase.split(/\W+/).filter(w => w.length > 0)
             for (const token of tokens) {
                 projectSignifiers.push(token.toLowerCase())
             }

--- a/vscode/src/chat/chat-view/context.ts
+++ b/vscode/src/chat/chat-view/context.ts
@@ -406,6 +406,10 @@ function needsReadmeContext(editor: VSCodeEditor, input: PromptString): boolean 
     if (workspaceUri) {
         const rootBase = workspaceUri.toString().split('/').at(-1)
         if (rootBase) {
+            let tokens = rootBase.split(/\W+/).filter(w => w.length > 0)
+            for (const token of tokens) {
+                projectSignifiers.push(token.toLowerCase())
+            }
             projectSignifiers.push(rootBase.toLowerCase())
         }
     }


### PR DESCRIPTION
This is a tiny fix to our `needsReadmeContext` detection. Previously, we split
the question on punctuation, but did not do the same for the root directory
name. So we would never match if the repo contained a hyphen, etc.

## Test plan

Manually tested the question "what does`@symf-private` do?" repo on the
`symf-private` repo and checked we now include `README.md`.