### PR TITLE
fix inability to copy text in streaming chat response

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 - Chat: Don't append @ when "Add context" is pressed multiple times. [pull/4439](https://github.com/sourcegraph/cody/pull/4439)
 - Chat: Fix an issue where copying code (with right-click or Cmd/Ctrl+C) causes many event logs and may trip rate limits. [pull/4469](https://github.com/sourcegraph/cody/pull/4469)
+- Chat: Fix an issue where it was difficult to copy code from responses that were still streaming in. [pull/4472](https://github.com/sourcegraph/cody/pull/4472)
 
 ### Changed
 


### PR DESCRIPTION
The `usePreserveSelectionOnUpdate` hook is actually not necessary with the new more stable Markdown rendering. Confirmed on macOS and Linux.

Fix https://community.sourcegraph.com/t/copy-while-generating-answer/466/5



## Test plan

Start a chat like `write 50 jokes about fruits in code blocks` and try to copy as the message streams in.