### PR TITLE
Fix an issue where opening the @-mention menu in a followup input would scroll the window to the top

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -11,6 +11,7 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 - Chat: Don't append @ when "Add context" is pressed multiple times. [pull/4439](https://github.com/sourcegraph/cody/pull/4439)
 - Chat: Fix an issue where copying code (with right-click or Cmd/Ctrl+C) causes many event logs and may trip rate limits. [pull/4469](https://github.com/sourcegraph/cody/pull/4469)
 - Chat: Fix an issue where it was difficult to copy code from responses that were still streaming in. [pull/4472](https://github.com/sourcegraph/cody/pull/4472)
+- Chat: Fix an issue where opening the @-mention menu in a followup input would scroll the window to the top. [pull/4475](https://github.com/sourcegraph/cody/pull/4475)
 
 ### Changed
 

--- a/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
+++ b/vscode/webviews/promptEditor/plugins/atMentions/atMentions.tsx
@@ -232,16 +232,7 @@ export default function MentionsPlugin({
             }
             onOpen={menuResolution => {
                 refs.setPositionReference({
-                    getBoundingClientRect: (): DOMRect => {
-                        const range = document.createRange()
-                        const sel = document.getSelection()
-                        if (sel?.anchorNode) {
-                            range.setStart(sel.anchorNode, menuResolution.match?.leadOffset ?? 0)
-                            range.setEnd(sel.anchorNode, sel.anchorOffset)
-                            return range.getBoundingClientRect()
-                        }
-                        throw new Error('no selection anchor')
-                    },
+                    getBoundingClientRect: menuResolution.getRect,
                 })
             }}
             menuRenderFn={(anchorElementRef, itemProps) => {
@@ -254,11 +245,15 @@ export default function MentionsPlugin({
                                 ref={ref => {
                                     refs.setFloating(ref)
                                 }}
-                                style={{
-                                    position: strategy,
-                                    top: y,
-                                    left: x,
-                                }}
+                                style={
+                                    x === 0 && y === 0
+                                        ? { display: 'none' }
+                                        : {
+                                              position: strategy,
+                                              top: y,
+                                              left: x,
+                                          }
+                                }
                                 className={clsx(styles.popover)}
                             >
                                 <MentionMenu


### PR DESCRIPTION
Fix https://linear.app/sourcegraph/issue/CODY-2106/entering-key-when-input-is-at-bottom-causes-scroll-up-to-top



## Test plan

CI