### PR TITLE
suppress embeddings error notifications

### DIFF
--- a/vscode/src/local-context/local-embeddings.ts
+++ b/vscode/src/local-context/local-embeddings.ts
@@ -425,7 +425,6 @@ export class LocalEmbeddingsController
             this.statusEmitter.fire(this)
         } catch (error: any) {
             logDebug('LocalEmbeddingsController', captureException(error), error)
-            await vscode.window.showErrorMessage(`Cody Embeddings — Error: ${error?.message}`)
         }
     }
 


### PR DESCRIPTION
We don't have a good way to distinguish between which errors users can take action to fix and which they can't. This leads to annoying errors, such as for when the user opens a non-Git repository.

In https://linear.app/sourcegraph/issue/DES-7/show-errors-in-symf-and-embeddings-indexing-and-re-index-ability we will improve error display in the chat UI, where the errors will at least be relevant and not annoying/disruptive.

Fix https://linear.app/sourcegraph/issue/CODY-2088/error-when-opening-vs-code-in-a-subdirectory-of-a-git-repo

Fix https://linear.app/sourcegraph/issue/CODY-2071/bug-cody-embeddings-error-path-to-subdirectory-mono-repo-does-not



## Test plan

Open a non-Git repo folder. Confirm that no embeddings error shows up upon VS Code initial load and when opening chat.