### PR TITLE
fix chat line-height and font-size

### DIFF
--- a/vscode/webviews/chat/ChatMessageContent.module.css
+++ b/vscode/webviews/chat/ChatMessageContent.module.css
@@ -81,7 +81,6 @@
 
 .content {
     word-break: break-word;
-    line-height: 150%;
     text-wrap: wrap;
 }
 


### PR DESCRIPTION
If the VS Code setting `editor.fontSize` was set to 20 (or another large number), the line-height in chat was too small and code lines overlapped each other.

Fix https://community.sourcegraph.com/t/line-height-issue/364

Fix https://linear.app/sourcegraph/issue/CODY-2045/code-line-height-in-chat-is-wrong

![image](https://github.com/sourcegraph/cody/assets/1976/226d3dab-4f36-448b-a334-a570b3f15e05)


## Test plan

Set VS Code setting `editor.fontSize` to 20 and ensure chat code blocks render OK.