### PR TITLE
indicate context used for followup messages

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -6,6 +6,8 @@ This is a log of all notable changes to Cody for VS Code. [Unreleased] changes a
 
 ### Added
 
+- Chat: Followup responses now more clearly indicate that prior context in the thread was used to generate the response. [pull/4479](https://github.com/sourcegraph/cody/pull/4479)
+
 ### Fixed
 
 - Chat: Don't append @ when "Add context" is pressed multiple times. [pull/4439](https://github.com/sourcegraph/cody/pull/4439)

--- a/vscode/test/e2e/chat-context.test.ts
+++ b/vscode/test/e2e/chat-context.test.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test'
+import { createEmptyChatPanel, getContextCell, selectMentionMenuItem, sidebarSignin } from './common'
+import { test } from './helpers'
+
+test('chat followup context', async ({ page, sidebar }) => {
+    await sidebarSignin(page, sidebar)
+
+    // Open chat.
+    const [chatFrame, chatInput] = await createEmptyChatPanel(page)
+
+    await chatInput.fill('@Main.java')
+    await selectMentionMenuItem(chatFrame, 'Main.java')
+    await chatInput.press('Enter')
+
+    const contextCells = getContextCell(chatFrame)
+    expect(contextCells).toHaveCount(1)
+    expect(contextCells.first()).toHaveText(/Context/)
+
+    // No additional context means no context cell.
+    await chatInput.fill('followup1')
+    await chatInput.press('Enter')
+    expect(contextCells).toHaveCount(1)
+
+    // Additional context means another context cell.
+    await chatInput.fill('followup2 @var.go')
+    await selectMentionMenuItem(chatFrame, 'var.go')
+    await chatInput.press('Enter')
+    expect(contextCells).toHaveCount(2)
+    const lastContextCell = contextCells.last()
+    expect(lastContextCell).toHaveText(/new item/)
+    await lastContextCell.click() // expand
+    expect(lastContextCell).toHaveText(/prior/i)
+})

--- a/vscode/webviews/chat/Transcript.tsx
+++ b/vscode/webviews/chat/Transcript.tsx
@@ -153,6 +153,7 @@ const TranscriptInteraction: FunctionComponent<
                     key={`${humanMessage.index}-context`}
                     contextItems={humanMessage.contextFiles}
                     model={assistantMessage?.model}
+                    isForFirstMessage={humanMessage.index === 0}
                 />
             )}
             {assistantMessage && !isContextLoading && (

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.story.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof ContextCell> = {
     decorators: [VSCodeStandaloneComponent],
     args: {
         __storybook__initialOpen: true,
+        isForFirstMessage: true,
     },
 }
 
@@ -56,5 +57,12 @@ export const Default: Story = {
                 range: { start: { line: 1, character: 2 }, end: { line: 5, character: 0 } },
             },
         ],
+    },
+}
+
+export const Followup: Story = {
+    args: {
+        contextItems: [{ type: 'file', uri: URI.file('/foo/bar.go') }],
+        isForFirstMessage: false,
     },
 }

--- a/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
+++ b/vscode/webviews/chat/cells/contextCell/ContextCell.tsx
@@ -1,7 +1,7 @@
 import type { ContextItem, Model } from '@sourcegraph/cody-shared'
 import { pluralize } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
-import { BrainIcon } from 'lucide-react'
+import { BrainIcon, MessagesSquareIcon } from 'lucide-react'
 import type React from 'react'
 import { FileLink } from '../../../components/FileLink'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../components/shadcn/ui/tooltip'
@@ -19,11 +19,12 @@ import styles from './ContextCell.module.css'
 export const ContextCell: React.FunctionComponent<{
     contextItems: ContextItem[] | undefined
     model?: Model['model']
+    isForFirstMessage: boolean
     className?: string
 
     /** For use in storybooks only. */
     __storybook__initialOpen?: boolean
-}> = ({ contextItems, model, className, __storybook__initialOpen }) => {
+}> = ({ contextItems, model, isForFirstMessage, className, __storybook__initialOpen }) => {
     const usedContext: ContextItem[] = []
     const excludedAtContext: ContextItem[] = []
     if (contextItems) {
@@ -37,7 +38,10 @@ export const ContextCell: React.FunctionComponent<{
     }
 
     const itemCount = usedContext.length
-    let contextItemCountLabel = `${itemCount} ${pluralize('item', itemCount)}`
+    let contextItemCountLabel = `${itemCount} ${!isForFirstMessage ? 'new ' : ''}${pluralize(
+        'item',
+        itemCount
+    )}`
     if (excludedAtContext.length) {
         const excludedAtUnit = excludedAtContext.length === 1 ? 'mention' : 'mentions'
         contextItemCountLabel = `${contextItemCountLabel} — ${excludedAtContext.length} ${excludedAtUnit} excluded`
@@ -99,6 +103,14 @@ export const ContextCell: React.FunctionComponent<{
                                 />
                             </li>
                         ))}
+                        {!isForFirstMessage && (
+                            <span
+                                className={clsx(styles.contextItem, 'tw-flex tw-items-center tw-gap-2')}
+                            >
+                                <MessagesSquareIcon size={12} className="tw-ml-1" /> Prior messages and
+                                context in this conversation
+                            </span>
+                        )}
                         <li>
                             <Tooltip>
                                 <TooltipTrigger asChild>


### PR DESCRIPTION
Previously, it was not clear which context was used in followup messages. The way it works is that context used previously in the conversation is automatically used for followups, but only *newly introduced* context is displayed. This was confusing, because it could seem like *only* that newly introduced context was used.

Now, the UI says `X new item` and expands to mention `Prior messages in this thread` for followup message context rows if new context was introduced. If no new context was introduced, there is no context row and the prior conversation context is still used (we assume this is implicit to the user).

Fix https://linear.app/sourcegraph/issue/CODY-2092/show-full-actual-context-used-for-followups

![image](https://github.com/sourcegraph/cody/assets/1976/f78556b8-1c3d-4785-930e-ecfb6ba4b1c7)


## Test plan

CI + new e2e test