### PR TITLE
show version-updated toast above (relative not floating)

### DIFF
--- a/vscode/webviews/Notices/index.module.css
+++ b/vscode/webviews/Notices/index.module.css
@@ -1,8 +1,4 @@
 .notices {
-    position: absolute;
-    top: 0;
-    left: 0;
-    box-sizing: border-box;
     width: 100%;
     padding: 0 15px 0 20px;
     z-index: 1;


### PR DESCRIPTION
Currently the version-updated toast covers up the chat input. This is annoying and confusing. Now, it shows up above in flow. This is more prominent but less annoying IMO. And it's OK for it to be this prominent since it only shows up once every 2 weeks.

Fix https://linear.app/sourcegraph/issue/CODY-2116/move-the-cody-updated-toast-to-the-bottom-of-the-window

![image](https://github.com/sourcegraph/cody/assets/1976/32e95327-a8c4-4dfc-9c2a-3eb18fbe0504)


## Test plan

CI