### PR TITLE
Prefer new enhanced context over historical context

### DIFF
--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -98,7 +98,7 @@ describe('DefaultPrompter', () => {
         let info = await new DefaultPrompter(
             [
                 {
-                    uri: vscode.Uri.file('/user1.go'),
+                    uri: vscode.Uri.file('user1.go'),
                     type: 'file',
                     content: 'import vscode',
                     source: ContextItemSource.User,
@@ -107,7 +107,7 @@ describe('DefaultPrompter', () => {
             () =>
                 Promise.resolve([
                     {
-                        uri: vscode.Uri.file('/enhanced1.ts'),
+                        uri: vscode.Uri.file('enhanced1.ts'),
                         type: 'file',
                         content: 'import vscode',
                     },

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -98,7 +98,7 @@ describe('DefaultPrompter', () => {
         let info = await new DefaultPrompter(
             [
                 {
-                    uri: vscode.Uri.file('user1.go'),
+                    uri: vscode.Uri.file('/user1.go'),
                     type: 'file',
                     content: 'import vscode',
                     source: ContextItemSource.User,
@@ -107,7 +107,7 @@ describe('DefaultPrompter', () => {
             () =>
                 Promise.resolve([
                     {
-                        uri: vscode.Uri.file('enhanced1.ts'),
+                        uri: vscode.Uri.file('/enhanced1.ts'),
                         type: 'file',
                         content: 'import vscode',
                     },
@@ -121,9 +121,9 @@ describe('DefaultPrompter', () => {
         checkPrompt(info.prompt, [
             'You are Cody, an AI coding assistant from Sourcegraph.',
             'I am Cody, an AI coding assistant from Sourcegraph.',
-            'Codebase context from file enhanced1.ts',
+            'enhanced1.ts',
             'Ok.',
-            'Codebase context from file user1.go',
+            'user1.go',
             'Ok.',
             'Hello, world!',
         ])
@@ -151,13 +151,13 @@ describe('DefaultPrompter', () => {
         checkPrompt(info.prompt, [
             'You are Cody, an AI coding assistant from Sourcegraph.',
             'I am Cody, an AI coding assistant from Sourcegraph.',
-            'Codebase context from file enhanced1.ts',
+            'enhanced1.ts',
             'Ok.',
-            'Codebase context from file user1.go',
+            'user1.go',
             'Ok.',
-            'Codebase context from file enhanced2.ts',
+            'enhanced2.ts',
             'Ok.',
-            'Codebase context from file user2.go',
+            'user2.go',
             'Ok.',
             'Hello, world!',
             'Oh hello there.',
@@ -170,8 +170,8 @@ describe('DefaultPrompter', () => {
         for (let i = 0; i < expectedPrefixes.length; i++) {
             const actual = prompt[i].text?.toString()
             const expected = expectedPrefixes[i]
-            if (!actual?.startsWith(expected)) {
-                expect.fail(`Message mismatch: expected ${actual} to start with ${expectedPrefixes[i]}`)
+            if (!actual?.includes(expected)) {
+                expect.fail(`Message mismatch: expected ${actual} to include ${expectedPrefixes[i]}`)
             }
         }
     }

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -113,7 +113,10 @@ describe('DefaultPrompter', () => {
                     },
                 ])
         ).makePrompt(chat, 0)
+
         chat.setLastMessageContext(info.context.used)
+        chat.addBotMessage({ text: ps`Oh hello there.` })
+        chat.addHumanMessage({ text: ps`Hello again!` })
 
         checkPrompt(info.prompt, [
             'You are Cody, an AI coding assistant from Sourcegraph.',
@@ -157,6 +160,8 @@ describe('DefaultPrompter', () => {
             'Codebase context from file user2.go',
             'Ok.',
             'Hello, world!',
+            'Oh hello there.',
+            'Hello again!',
         ])
     })
 

--- a/vscode/src/chat/chat-view/prompt.test.ts
+++ b/vscode/src/chat/chat-view/prompt.test.ts
@@ -128,7 +128,7 @@ describe('DefaultPrompter', () => {
             'Hello, world!',
         ])
 
-        // Second chat message should only include previous message's user-provided context
+        // Second chat should give highest priority to new context (both explicit and enhanced)
         info = await new DefaultPrompter(
             [
                 {
@@ -170,7 +170,9 @@ describe('DefaultPrompter', () => {
         for (let i = 0; i < expectedPrefixes.length; i++) {
             const actual = prompt[i].text?.toString()
             const expected = expectedPrefixes[i]
-            expect(actual?.startsWith(expected)).toBe(true)
+            if (!actual?.startsWith(expected)) {
+                expect.fail(`Message mismatch: expected ${actual} to start with ${expectedPrefixes[i]}`)
+            }
         }
     }
 })

--- a/vscode/src/chat/chat-view/prompt.ts
+++ b/vscode/src/chat/chat-view/prompt.ts
@@ -78,11 +78,6 @@ export class DefaultPrompter {
             // NOTE: Only used for display excluded context from user-specified context items in UI
             context.ignored.push(...newUserContext.ignored.map(c => ({ ...c, isTooLarge: true })))
 
-            // Add user and enhanced context from previous messages (chat transcript)
-            const historyItems = reverseTranscript.flatMap(m => m?.contextFiles).filter(isDefined)
-            const historyContext = await promptBuilder.tryAddContext('history', historyItems.reverse())
-            ignoredContext.transcript += historyContext.ignored.length
-
             // Get new enhanced context from current editor or broader search when enabled
             if (this.getEnhancedContext) {
                 const lastMessage = reverseTranscript[0]
@@ -100,6 +95,11 @@ export class DefaultPrompter {
                 context.used.push(...newEnhancedMessages.added)
                 ignoredContext.enhanced += newEnhancedMessages.ignored.length
             }
+
+            // If there's room left, add context from previous messages (both user-defined and enhanced).
+            const historyItems = reverseTranscript.flatMap(m => m?.contextFiles).filter(isDefined)
+            const historyContext = await promptBuilder.tryAddContext('history', historyItems.reverse())
+            ignoredContext.transcript += historyContext.ignored.length
 
             logDebug(
                 'DefaultPrompter.makePrompt',


### PR DESCRIPTION
Previously, when assembling the prompt we added new enhanced context last, even
after historical context. This PR updates the prompt logic to always place new
context before historical context. Reasoning: the new context is more likely to
be relevant to the user's question, and should be given precedence.

Relates to SPLF-6

## Test plan

Added new case to `prompt.test.ts`. Manually tested long chats in VSCode.
