### PR TITLE
enterprise model options link in model selector

### DIFF
--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -1,9 +1,10 @@
 import { type Model, ModelUIGroup } from '@sourcegraph/cody-shared'
 import { clsx } from 'clsx'
-import { BookOpenIcon, ExternalLinkIcon } from 'lucide-react'
+import { BookOpenIcon, BuildingIcon, ExternalLinkIcon } from 'lucide-react'
 import { type FunctionComponent, type ReactNode, useCallback, useMemo } from 'react'
 import type { UserAccountInfo } from '../../Chat'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
+import { useTelemetryRecorder } from '../../utils/telemetry'
 import { chatModelIconComponent } from '../ChatModelIcon'
 import { Command, CommandGroup, CommandItem, CommandLink, CommandList } from '../shadcn/ui/command'
 import { ToolbarPopoverItem } from '../shadcn/ui/toolbar'
@@ -156,6 +157,8 @@ export const ModelSelectField: React.FunctionComponent<{
         [onCloseByEscape]
     )
 
+    const telemetryRecorder = useTelemetryRecorder()
+
     if (!usableModels.length || usableModels.length < 1) {
         return null
     }
@@ -191,6 +194,37 @@ export const ModelSelectField: React.FunctionComponent<{
                                 ))}
                             </CommandGroup>
                         ))}
+                        <CommandGroup heading="Enterprise Model Options">
+                            {ENTERPRISE_MODEL_OPTIONS.map(({ id, url, title }) => (
+                                <CommandLink
+                                    key={id}
+                                    href={url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    onClick={() =>
+                                        telemetryRecorder.recordEvent(
+                                            'cody.modelSelector',
+                                            'clickEnterpriseModelOption',
+                                            { metadata: { [id]: 1 } }
+                                        )
+                                    }
+                                    className={styles.modelTitleWithIcon}
+                                >
+                                    <span className={styles.modelIcon}>
+                                        {/* wider than normal to fit in with provider icons */}
+                                        <BuildingIcon size={16} strokeWidth={2} />{' '}
+                                    </span>
+                                    <span className={styles.modelName}>{title}</span>
+                                    <span className={styles.rightIcon}>
+                                        <ExternalLinkIcon
+                                            size={16}
+                                            strokeWidth={1.25}
+                                            className="tw-opacity-80"
+                                        />
+                                    </span>
+                                </CommandLink>
+                            ))}
+                        </CommandGroup>
                         <CommandGroup>
                             <CommandLink
                                 href="https://sourcegraph.com/docs/cody/clients/install-vscode#supported-llm-models"
@@ -230,6 +264,32 @@ export const ModelSelectField: React.FunctionComponent<{
         </ToolbarPopoverItem>
     )
 }
+
+const ENTERPRISE_MODEL_DOCS_PAGE =
+    'https://sourcegraph.com/docs/cody/clients/enable-cody-enterprise?utm_source=cody.modelSelector'
+
+const ENTERPRISE_MODEL_OPTIONS: { id: string; url: string; title: string }[] = [
+    {
+        id: 'anthropic-account',
+        url: `${ENTERPRISE_MODEL_DOCS_PAGE}#use-your-organizations-anthropic-account`,
+        title: 'Anthropic account',
+    },
+    {
+        id: 'openai-account',
+        url: `${ENTERPRISE_MODEL_DOCS_PAGE}#use-your-organizations-openai-account`,
+        title: 'OpenAI account',
+    },
+    {
+        id: 'amazon-bedrock',
+        url: `${ENTERPRISE_MODEL_DOCS_PAGE}#use-amazon-bedrock-aws`,
+        title: 'Amazon Bedrock',
+    },
+    {
+        id: 'azure-openai-service',
+        url: `${ENTERPRISE_MODEL_DOCS_PAGE}#use-azure-openai-service`,
+        title: 'Azure OpenAI Service',
+    },
+]
 
 const GROUP_ORDER = [
     ModelUIGroup.Accuracy,

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -170,7 +170,7 @@ export const ModelSelectField: React.FunctionComponent<{
             iconEnd={readOnly ? undefined : 'chevron'}
             className={cn('tw-justify-between', className)}
             disabled={readOnly}
-            defaultOpen={__storybook__open}
+            __storybook__open={__storybook__open}
             tooltip={readOnly ? undefined : 'Select a model'}
             aria-label="Select a model"
             popoverContent={close => (

--- a/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
+++ b/vscode/webviews/components/modelSelectField/ModelSelectField.tsx
@@ -5,7 +5,7 @@ import { type FunctionComponent, type ReactNode, useCallback, useMemo } from 're
 import type { UserAccountInfo } from '../../Chat'
 import { getVSCodeAPI } from '../../utils/VSCodeApi'
 import { chatModelIconComponent } from '../ChatModelIcon'
-import { Command, CommandGroup, CommandItem, CommandList } from '../shadcn/ui/command'
+import { Command, CommandGroup, CommandItem, CommandLink, CommandList } from '../shadcn/ui/command'
 import { ToolbarPopoverItem } from '../shadcn/ui/toolbar'
 import { cn } from '../shadcn/utils'
 import styles from './ModelSelectField.module.css'
@@ -192,55 +192,25 @@ export const ModelSelectField: React.FunctionComponent<{
                             </CommandGroup>
                         ))}
                         <CommandGroup>
-                            <CommandItem
-                                onSelect={() => {
-                                    // TODO: When cmdk supports links, use that instead. This
-                                    // workaround is only needed because the link's native onClick
-                                    // is not being fired because cmdk traps it. See
-                                    // https://github.com/pacocoursey/cmdk/issues/258.
-
-                                    const link = document.querySelector<HTMLAnchorElement>(
-                                        `[cmdk-list] a[href=${JSON.stringify(DOCS_URL)}]`
-                                    )
-                                    if (link) {
-                                        // This workaround successfully opens an external link in VS
-                                        // Code webviews (which block `window.open` and plain click
-                                        // MouseEvents) and in browsers.
-                                        link.focus()
-                                        try {
-                                            link.dispatchEvent(
-                                                new MouseEvent('click', {
-                                                    button: 0,
-                                                    ctrlKey: true,
-                                                    metaKey: true,
-                                                })
-                                            )
-                                        } catch (error) {
-                                            console.error(error)
-                                        }
-                                    }
-                                }}
+                            <CommandLink
+                                href="https://sourcegraph.com/docs/cody/clients/install-vscode#supported-llm-models"
+                                target="_blank"
+                                rel="noreferrer"
+                                className={styles.modelTitleWithIcon}
                             >
-                                <a
-                                    href={DOCS_URL}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    className={styles.modelTitleWithIcon}
-                                >
-                                    <span className={styles.modelIcon}>
-                                        {/* wider than normal to fit in with provider icons */}
-                                        <BookOpenIcon size={16} strokeWidth={2} />{' '}
-                                    </span>
-                                    <span className={styles.modelName}>Documentation</span>
-                                    <span className={styles.rightIcon}>
-                                        <ExternalLinkIcon
-                                            size={16}
-                                            strokeWidth={1.25}
-                                            className="tw-opacity-80"
-                                        />
-                                    </span>
-                                </a>
-                            </CommandItem>
+                                <span className={styles.modelIcon}>
+                                    {/* wider than normal to fit in with provider icons */}
+                                    <BookOpenIcon size={16} strokeWidth={2} />{' '}
+                                </span>
+                                <span className={styles.modelName}>Documentation</span>
+                                <span className={styles.rightIcon}>
+                                    <ExternalLinkIcon
+                                        size={16}
+                                        strokeWidth={1.25}
+                                        className="tw-opacity-80"
+                                    />
+                                </span>
+                            </CommandLink>
                         </CommandGroup>
                     </CommandList>
                 </Command>
@@ -260,8 +230,6 @@ export const ModelSelectField: React.FunctionComponent<{
         </ToolbarPopoverItem>
     )
 }
-
-const DOCS_URL = 'https://sourcegraph.com/docs/cody/clients/install-vscode#supported-llm-models'
 
 const GROUP_ORDER = [
     ModelUIGroup.Accuracy,

--- a/vscode/webviews/components/shadcn/ui/command.tsx
+++ b/vscode/webviews/components/shadcn/ui/command.tsx
@@ -152,6 +152,52 @@ const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanE
 }
 CommandShortcut.displayName = 'CommandShortcut'
 
+export const CommandLink: React.FunctionComponent<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+    href,
+    className,
+    children,
+    ...props
+}) => {
+    const linkRef = React.useRef<HTMLAnchorElement>(null)
+    return (
+        <CommandItem
+            onSelect={() => {
+                // TODO: When cmdk supports links, use that instead. This workaround is only needed
+                // because the link's native onClick is not being fired because cmdk traps it. See
+                // https://github.com/pacocoursey/cmdk/issues/258.
+                //
+                // This workaround successfully opens an external link in VS Code webviews (which
+                // block `window.open` and plain click MouseEvents) and in browsers.
+                try {
+                    linkRef.current?.focus()
+                    linkRef.current?.dispatchEvent(
+                        new MouseEvent('click', {
+                            button: 0,
+                            ctrlKey: true,
+                            metaKey: true,
+                        })
+                    )
+                } catch (error) {
+                    console.error(error)
+                }
+            }}
+            asChild
+        >
+            <a
+                {...props}
+                href={href}
+                className={cn(
+                    '!tw-text-foreground aria-selected:!tw-text-accent-foreground hover:!tw-text-accent-foreground',
+                    className
+                )}
+                ref={linkRef}
+            >
+                {children}
+            </a>
+        </CommandItem>
+    )
+}
+
 export {
     Command,
     CommandDialog,


### PR DESCRIPTION
Link to enterprise model and model provider options in the model selector to show the additional options available in Cody Enterprise.

Depends on https://github.com/sourcegraph/docs/pull/396.

![image](https://github.com/sourcegraph/cody/assets/1976/866abba9-57f2-429d-82ad-6d1e5fd33512)


## Test plan

CI