### PR TITLE
vscode: specify untrusted configuration "openctx.providers"

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1351,6 +1351,13 @@
       }
     }
   },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Cody only uses providers (configured in `openctx.providers`) from trusted workspaces because providers may execute arbitrary code.",
+      "restrictedConfigurations": ["openctx.providers"]
+    }
+  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.20.8",
     "@floating-ui/react": "^0.26.9",


### PR DESCRIPTION
This is specified in the OpenCtx extensions, but when we ported the support over to cody we did not specify this. This is important to specify.

Test Plan: Made a new workspace and opened it and did not trust it to ensure I was in restricted mode. I then successfully used cody with my user configured providers. I added a workspace provider setting and vscode warned me I needed to trust the workspace + the provider did not show up in chat.