### PR TITLE
openctx: refactor exposeOpenCtxClient to async function

### DIFF
--- a/vscode/src/context/openctx.ts
+++ b/vscode/src/context/openctx.ts
@@ -5,44 +5,43 @@ import RemoteFileProvider from './openctx/remoteFileSearch'
 import RemoteRepositorySearch from './openctx/remoteRepositorySearch'
 import WebProvider from './openctx/web'
 
-export function exposeOpenCtxClient(
+export async function exposeOpenCtxClient(
     secrets: vscode.SecretStorage,
     config: ConfigurationWithAccessToken
-): void {
+) {
     logDebug('openctx', 'OpenCtx is enabled in Cody')
-    import('@openctx/vscode-lib')
-        .then(({ createController }) => {
-            const providers = [
-                {
-                    providerUri: WebProvider.providerUri,
-                    settings: true,
-                    provider: WebProvider,
-                },
-                {
-                    providerUri: RemoteRepositorySearch.providerUri,
-                    settings: true,
-                    provider: RemoteRepositorySearch,
-                },
-            ]
+    try {
+        const { createController } = await import('@openctx/vscode-lib')
+        const providers = [
+            {
+                providerUri: WebProvider.providerUri,
+                settings: true,
+                provider: WebProvider,
+            },
+            {
+                providerUri: RemoteRepositorySearch.providerUri,
+                settings: true,
+                provider: RemoteRepositorySearch,
+            },
+        ]
 
-            if (config.experimentalNoodle) {
-                providers.push({
-                    providerUri: RemoteFileProvider.providerUri,
-                    settings: true,
-                    provider: RemoteFileProvider,
-                })
-            }
+        if (config.experimentalNoodle) {
+            providers.push({
+                providerUri: RemoteFileProvider.providerUri,
+                settings: true,
+                provider: RemoteFileProvider,
+            })
+        }
 
-            setOpenCtxClient(
-                createController({
-                    outputChannel,
-                    secrets,
-                    features: {},
-                    providers,
-                }).controller.client
-            )
-        })
-        .catch(error => {
-            logDebug('openctx', `Failed to load OpenCtx client: ${error}`)
-        })
+        setOpenCtxClient(
+            createController({
+                outputChannel,
+                secrets,
+                features: {},
+                providers,
+            }).controller.client
+        )
+    } catch (error) {
+        logDebug('openctx', `Failed to load OpenCtx client: ${error}`)
+    }
 }

--- a/vscode/src/main.ts
+++ b/vscode/src/main.ts
@@ -185,7 +185,8 @@ const register = async (
 
     await authProvider.init()
 
-    exposeOpenCtxClient(context.secrets, initialConfig)
+    await exposeOpenCtxClient(context.secrets, initialConfig)
+
     graphqlClient.onConfigurationChange(initialConfig)
     githubClient.onConfigurationChange({ authToken: initialConfig.experimentalGithubAccessToken })
     void featureFlagProvider.syncAuthStatus()
@@ -286,7 +287,7 @@ const register = async (
 
         promises.push(featureFlagProvider.syncAuthStatus())
         graphqlClient.onConfigurationChange(newConfig)
-        exposeOpenCtxClient(secretStorage, newConfig)
+        promises.push(exposeOpenCtxClient(secretStorage, newConfig))
         upstreamHealthProvider.onConfigurationChange(newConfig)
         githubClient.onConfigurationChange({ authToken: initialConfig.experimentalGithubAccessToken })
         promises.push(


### PR DESCRIPTION
This allows initialization to happen concurrently with the other promises in main when the configuration changes. The main motivation for this change is it makes another change I want to make cleaner. View this diff with whitespace changes turned off to see how minimal it actually is.

Test Plan: Started up vscode and still saw OpenCtx providers in chat.
